### PR TITLE
Add pre-build script support for env variable replacement

### DIFF
--- a/TrashMobMobile/TrashMobMobile.Android/Properties/AndroidManifest.xml
+++ b/TrashMobMobile/TrashMobMobile.Android/Properties/AndroidManifest.xml
@@ -6,7 +6,7 @@
 	<uses-feature android:glEsVersion="0x00020000" android:required="true" />
 	
 	<application android:label="TrashMobMobile.Android" android:theme="@style/MainTheme" android:icon="@drawable/TrashMobEco_CircleLogo">
-		<meta-data android:name="com.google.android.geo.API_KEY" android:value="@string.GoogleApiKey" />
+		<meta-data android:name="com.google.android.geo.API_KEY" android:value="GOOGLE_API_KEY" />
 		<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
 	
 		<!-- Necessary for apps that target Android 9.0 or higher -->

--- a/TrashMobMobile/TrashMobMobile.Android/appcenter-pre-build.sh
+++ b/TrashMobMobile/TrashMobMobile.Android/appcenter-pre-build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+echo "Arguments for updating:"
+echo " - AppSecret: $GOOGLE_API_KEY"
+
+# Updating ids
+IdFile=$BUILD_REPOSITORY_LOCALPATH/TrashMobMobile/TrashMobMobile.Android/properties/AndroidManifest.xml
+
+sed -i "s/GOOGLE_API_KEY/$GOOGLE_API_KEY/g" "$IdFile"
+
+# Print out file for reference
+cat $IdFile
+
+echo "Updated secret key!"

--- a/TrashMobMobile/TrashMobMobile.Android/appcenter-pre-build.sh
+++ b/TrashMobMobile/TrashMobMobile.Android/appcenter-pre-build.sh
@@ -6,7 +6,7 @@ echo " - AppSecret: $GOOGLE_API_KEY"
 # Updating ids
 IdFile=$BUILD_REPOSITORY_LOCALPATH/TrashMobMobile/TrashMobMobile.Android/properties/AndroidManifest.xml
 
-sed -i "s/GOOGLE_API_KEY/$GOOGLE_API_KEY/g" "$IdFile"
+sed -i '' "s/GOOGLE_API_KEY/$GOOGLE_API_KEY/g" "$IdFile"
 
 # Print out file for reference
 cat $IdFile


### PR DESCRIPTION
Adds a prebuild script that looks for the GOOGLE_API_KEY env var to be set in the build pipeline and uses that when building the android app to keep the key secure