### PR TITLE
fix: unregister event dialog show wrong name

### DIFF
--- a/TrashMob/client-app/src/pages/MyDashboard/events-table/actions.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/events-table/actions.tsx
@@ -63,7 +63,7 @@ export const EventActions = (props: EventActionsProps) => {
                     </Link>
                 </DropdownMenuItem>
                 {!isEventOwner && !isCompleted ? (
-                    <DropdownMenuItem onClick={() => onUnregisterEvent(event.id, currentUser.userName)}>
+                    <DropdownMenuItem onClick={() => onUnregisterEvent(event.id, event.name)}>
                         <UserRoundX /> Unregister for event
                     </DropdownMenuItem>
                 ) : null}


### PR DESCRIPTION
Fix #2147 

<img width="1237" alt="image" src="https://github.com/user-attachments/assets/8ec3c3c5-7c35-4062-9aec-c6a0fb6de766" />
