### PR TITLE
Add health checks to TrashMob container

### DIFF
--- a/Deploy/containerApp.bicep
+++ b/Deploy/containerApp.bicep
@@ -77,6 +77,30 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               value: '8080'
             }
           ]
+          probes: [
+            {
+              type: 'liveness'
+              httpGet: {
+                path: '/health/live'
+                port: 8080
+              }
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
+            }
+            {
+              type: 'readiness'
+              httpGet: {
+                path: '/health'
+                port: 8080
+              }
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            }
+          ]
         }
       ]
       scale: {

--- a/TrashMob/Dockerfile
+++ b/TrashMob/Dockerfile
@@ -33,11 +33,18 @@ WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
+# Install curl for health checks
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 # Copy published app
 COPY --from=publish /app/publish .
 
 # Set environment variables
 ENV ASPNETCORE_URLS=http://+:8080
 ENV ASPNETCORE_ENVIRONMENT=Production
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl --fail http://localhost:8080/health/live || exit 1
 
 ENTRYPOINT ["dotnet", "TrashMob.dll"]

--- a/TrashMob/TrashMob.csproj
+++ b/TrashMob/TrashMob.csproj
@@ -44,6 +44,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Add ASP.NET Core health check endpoints (`/health` for readiness, `/health/live` for liveness)
- Configure SQL Server database connectivity health check
- Add Azure Container Apps liveness and readiness probes in Bicep deployment
- Add Docker HEALTHCHECK instruction for local development

## Test plan
- [ ] Verify `/health` endpoint returns healthy status with database connectivity
- [ ] Verify `/health/live` endpoint returns healthy without checking dependencies
- [ ] Deploy to test environment and confirm Container Apps probes work correctly
- [ ] Test container locally with Docker to verify HEALTHCHECK works

🤖 Generated with [Claude Code](https://claude.com/claude-code)