### PR TITLE
Add Azure AD B2C secrets to Key Vault for container deployments

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -88,6 +88,16 @@ jobs:
               minReplicas=1 \
               maxReplicas=3
 
+      - name: Ensure Azure AD B2C secrets exist
+        run: |
+          echo "Setting Azure AD B2C configuration for dev environment..."
+          # These secrets override appsettings.json values
+          # The -- in secret names maps to : in .NET configuration (e.g., AzureAdB2C:Instance)
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--Instance" --value "https://trashmobdev.b2clogin.com/"
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--ClientId" --value "7e44c032-7c3d-43a1-8ea7-f0a14a93bce2"
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--Domain" --value "trashmobdev.onmicrosoft.com"
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--SignUpSignInPolicyId" --value "B2C_1A_TM_SIGNUP_SIGNIN"
+
       - name: Grant Key Vault Access
         run: |
           echo "Getting Container App managed identity..."

--- a/.github/workflows/release_ca-tm-pr-westus2.yml
+++ b/.github/workflows/release_ca-tm-pr-westus2.yml
@@ -88,6 +88,16 @@ jobs:
               minReplicas=2 \
               maxReplicas=10
 
+      - name: Ensure Azure AD B2C secrets exist
+        run: |
+          echo "Setting Azure AD B2C configuration for production environment..."
+          # These secrets override appsettings.json values
+          # The -- in secret names maps to : in .NET configuration (e.g., AzureAdB2C:Instance)
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--Instance" --value "https://trashmob.b2clogin.com/"
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--ClientId" --value "ca9c62c2-fdcb-4d07-b049-cdf66e874dfc"
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--Domain" --value "trashmob.onmicrosoft.com"
+          az keyvault secret set --vault-name ${{ env.KEY_VAULT_NAME }} --name "AzureAdB2C--SignUpSignInPolicyId" --value "B2C_1A_TM_SIGNUP_SIGNIN"
+
       - name: Grant Key Vault Access
         run: |
           echo "Getting Container App managed identity..."

--- a/Deploy/deployInfra.ps1
+++ b/Deploy/deployInfra.ps1
@@ -67,6 +67,24 @@ az keyvault secret set --vault-name $keyVaultName --name TMDBServerConnectionStr
 az keyvault secret set --vault-name $keyVaultName --name StorageAccountKey --value $storageKey
 az keyvault secret set --vault-name $keyVaultName --name sendGridApiKey --value $sendGridApiKey
 
+# Set Azure AD B2C configuration based on environment
+# These secrets override appsettings.json values for the deployed environment
+# The -- in secret names maps to : in .NET configuration (e.g., AzureAdB2C:Instance)
+Write-Host "Setting Azure AD B2C configuration secrets..." -ForegroundColor Green
+if ($environment -eq "dev") {
+    # Dev environment uses trashmobdev B2C tenant
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--Instance" --value "https://trashmobdev.b2clogin.com/"
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--ClientId" --value "7e44c032-7c3d-43a1-8ea7-f0a14a93bce2"
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--Domain" --value "trashmobdev.onmicrosoft.com"
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--SignUpSignInPolicyId" --value "B2C_1A_TM_SIGNUP_SIGNIN"
+} else {
+    # Production environment uses trashmob B2C tenant (values from appsettings.json)
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--Instance" --value "https://trashmob.b2clogin.com/"
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--ClientId" --value "ca9c62c2-fdcb-4d07-b049-cdf66e874dfc"
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--Domain" --value "trashmob.onmicrosoft.com"
+    az keyvault secret set --vault-name $keyVaultName --name "AzureAdB2C--SignUpSignInPolicyId" --value "B2C_1A_TM_SIGNUP_SIGNIN"
+}
+
 # Set the webapp to the correct keyvaulturi
 az webapp config appsettings set --name $appServiceName --resource-group $rgName --settings "VaultUri=https://$keyVaultName.vault.azure.net"
 


### PR DESCRIPTION
## Summary
- Fix 401 authentication errors on dev container app by adding B2C configuration to Key Vault
- Container apps use `ASPNETCORE_ENVIRONMENT=Production` which loads `appsettings.json` (production B2C settings)
- This causes token validation failures when dev container validates tokens from dev B2C tenant

## Changes
- `Deploy/deployInfra.ps1`: Add environment-specific B2C secrets during infrastructure setup
- `.github/workflows/container_ca-tm-dev-westus2.yml`: Ensure dev B2C secrets exist on every deployment
- `.github/workflows/release_ca-tm-pr-westus2.yml`: Ensure prod B2C secrets exist on every deployment

## Key Vault Secrets Added
| Secret Name | Dev Value | Prod Value |
|-------------|-----------|------------|
| `AzureAdB2C--Instance` | `https://trashmobdev.b2clogin.com/` | `https://trashmob.b2clogin.com/` |
| `AzureAdB2C--ClientId` | `7e44c032-7c3d-43a1-8ea7-f0a14a93bce2` | `ca9c62c2-fdcb-4d07-b049-cdf66e874dfc` |
| `AzureAdB2C--Domain` | `trashmobdev.onmicrosoft.com` | `trashmob.onmicrosoft.com` |
| `AzureAdB2C--SignUpSignInPolicyId` | `B2C_1A_TM_SIGNUP_SIGNIN` | `B2C_1A_TM_SIGNUP_SIGNIN` |

The `--` in secret names is mapped by .NET's Azure Key Vault configuration provider to `:` for nested configuration.

## Test plan
- [ ] Merge PR to trigger dev container deployment
- [ ] Verify B2C secrets are created in `kv-tm-dev-westus2`
- [ ] Test authentication with dev B2C token against dev container app
- [ ] Verify no 401 errors on valid tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)