### PR TITLE
Product planning refinements for 2026

### DIFF
--- a/Planning/Executive_Summary.md
+++ b/Planning/Executive_Summary.md
@@ -277,9 +277,8 @@ Enable sustained growth of TrashMob.eco by strengthening onboarding & safety (mi
 ## Open Strategic Questions
 
 1. **Entra External ID vs Azure B2C:** Final decision pending feature gap analysis and cost comparison (Q1)
-2. **API Gateway/BFF pattern:** Defer to 2027 unless microservices needed
-3. **Mobile app store launch readiness:** Dependent on Project 4 completion
-4. **Monetization billing automation:** Manual for 2026, automated system in 2027
+2. **Mobile app store launch readiness:** Dependent on Project 4 completion
+3. **Monetization billing automation:** Manual for 2026, automated system in 2027
 
 ---
 

--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -67,8 +67,6 @@ Create a modern, scalable, and developer-friendly API layer (v2) that improves r
 
 ## Out-of-Scope
 
-- ? gRPC for internal services (future consideration)
-- ? API Gateway/BFF pattern (Phase 2 evaluation)
 - ? v1 endpoint removal (maintain both versions until mobile apps updated)
 
 ## Success Metrics

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -11,11 +11,9 @@
 ### Core Documents
 
 - **[Executive Summary](./Executive_Summary.md)** - High-level overview, strategic objectives, and 2026 roadmap
-- **[Roadmap & Resourcing](./Roadmap_and_Resourcing.md)** - Quarterly roadmap, team structure, and resource planning
-- **[Operations & Standards](./Operations_and_Standards.md)** - Product operations, metrics, privacy, accessibility
 - **[Risks & Mitigations](./Risks_and_Mitigations.md)** - Cross-project risks and mitigation strategies
 
-### 2026 Projects (25 Total)
+### 2026 Projects (29 Total)
 
 **Note:** Projects are not time-bound. Volunteers pick up work based on priority and availability.
 


### PR DESCRIPTION
## Summary
- Add Total Weight Collected metric (target 50,000 lbs) to Impact Metrics
- Remove Build/Deployment and Security Engineer roles (AI-assisted tooling handles these tasks)
- Add AI/Claude as mitigation for volunteer turnover risk
- Reduce "Two API Versions" risk to Low (no external consumers, can force mobile updates)
- Add callout about AI-assisted coding enabling faster development
- Remove GraphQL, gRPC, and API Gateway/BFF pattern references (not needed)
- Fix broken links in Planning README
- Update project count from 25 to 29

## Test plan
- [ ] Verify all Planning document links work
- [ ] Review Executive Summary changes for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)