### PR TITLE
Fix hardcoded trashmob.eco URL in Facebook sharing

### DIFF
--- a/TrashMob/client-app/src/store/ShareUrl.tsx
+++ b/TrashMob/client-app/src/store/ShareUrl.tsx
@@ -10,6 +10,7 @@ export function getTwitterUrl(eventData: EventData): string {
 }
 
 export function getFacebookUrl(eventId: string): string {
-    const eventUrl = `https://www.trashmob.eco/eventdetails/${eventId}`;
+    const { host } = window.location;
+    const eventUrl = `https://${host}/eventdetails/${eventId}`;
     return `https://www.facebook.com/sharer/sharer.php?u=${encodeURI(eventUrl)}&amp;src=sdkpreparse`;
 }


### PR DESCRIPTION
## Summary
- Use `window.location.host` instead of hardcoded `www.trashmob.eco` domain in Facebook share URL
- Matches the existing Twitter sharing implementation
- Ensures share links work correctly in both dev and production environments

## Test plan
- [ ] Share an event to Facebook from dev environment - verify link points to dev URL
- [ ] Share an event to Facebook from prod environment - verify link points to prod URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)