### PR TITLE
Improve local development experience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,12 +76,42 @@ docker build -f TrashMobHourlyJobs/Dockerfile -t trashmob-hourly-jobs:latest .
 
 ## Development Setup
 
+### Prerequisites
 1. Install .NET 10 SDK and Azure CLI
 2. Run `az login` to authenticate
 3. Add your IP to Dev Azure SQL firewall rules
 4. Run: `.\setupdev.ps1 -environment dev -region westus2 -subscription <guid>`
-5. Local API: https://localhost:44332
-6. Swagger: https://localhost:44332/swagger/index.html
+
+### Running Locally
+
+**Full-stack developers** (running both frontend and backend):
+```bash
+# Terminal 1: Start backend
+cd TrashMob
+dotnet run --environment Development
+# API available at https://localhost:44332
+
+# Terminal 2: Start frontend
+cd TrashMob/client-app
+npm start
+# Frontend at http://localhost:3000, API calls proxy to localhost:44332
+```
+
+**UX/Frontend developers** (frontend only, using dev server for API):
+```bash
+cd TrashMob/client-app
+
+# Create .env.local to point to dev server
+echo "VITE_API_URL=https://dev.trashmob.eco/api" > .env.local
+
+npm start
+# Frontend at http://localhost:3000, API calls go to dev.trashmob.eco
+```
+
+### Local URLs
+- **Local API:** https://localhost:44332
+- **Swagger:** https://localhost:44332/swagger/index.html
+- **Frontend (Vite):** http://localhost:3000
 
 ## Key Domain Concepts
 

--- a/TrashMob/client-app/.env
+++ b/TrashMob/client-app/.env
@@ -1,0 +1,4 @@
+# Default environment variables for local development
+# Full-stack devs: Leave VITE_API_URL empty to use localhost backend (via Vite proxy)
+# UX devs: Create .env.local and set VITE_API_URL=https://dev.trashmob.eco/api
+VITE_API_URL=

--- a/TrashMob/client-app/src/config/services.config.ts
+++ b/TrashMob/client-app/src/config/services.config.ts
@@ -1,6 +1,9 @@
 export const Services = Object.freeze({
-    TIMEOUT: 6000,
+    TIMEOUT: 30000, // 30 seconds - needed for slow DB queries from localhost to Azure SQL
     CACHE: { DISABLE: 100, FOR_ONE_MINUTE: 60 * 1000 },
-    BASE_URL: import.meta.env.MODE === 'production' ? '/api' : 'https://dev.trashmob.eco/api',
+    // In production: relative /api hits same origin
+    // In dev: uses VITE_API_URL env var, defaults to /api (proxied to localhost)
+    // UX devs can set VITE_API_URL=https://dev.trashmob.eco/api in .env.local
+    BASE_URL: import.meta.env.VITE_API_URL || '/api',
 });
 export type ServicesType = keyof typeof Services;

--- a/TrashMob/client-app/src/vite-env.d.ts
+++ b/TrashMob/client-app/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/TrashMob/client-app/vite.config.ts
+++ b/TrashMob/client-app/vite.config.ts
@@ -15,6 +15,13 @@ export default defineConfig(() => {
         plugins: [react()],
         server: {
             port: 3000,
+            proxy: {
+                '/api': {
+                    target: 'https://localhost:44332',
+                    changeOrigin: true,
+                    secure: false, // Allow self-signed certs for local dev
+                },
+            },
         },
         test: {
             environment: 'jsdom',


### PR DESCRIPTION
## Summary
- Add Vite proxy to forward `/api` requests to `localhost:44332` for full-stack devs
- Support `VITE_API_URL` env var so UX devs can point to dev server without running backend locally
- Increase API timeout from 6s to 30s (needed for slow localhost-to-Azure SQL queries)
- Add TypeScript types for the new environment variable
- Update CLAUDE.md with setup instructions for both full-stack and UX developers

## Developer Setup

**Full-stack developers** (running both frontend and backend):
```bash
# Terminal 1: Start backend
cd TrashMob && dotnet run --environment Development

# Terminal 2: Start frontend
cd TrashMob/client-app && npm start
# API calls automatically proxy to localhost:44332
```

**UX/Frontend developers** (frontend only):
```bash
cd TrashMob/client-app
echo "VITE_API_URL=https://dev.trashmob.eco/api" > .env.local
npm start
# API calls go directly to dev server
```

## Test plan
- [ ] Run backend + frontend locally, verify API calls work
- [ ] Create `.env.local` with dev URL, verify API calls go to dev server
- [ ] Verify production build still uses relative `/api` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)