### PR TITLE
Remove hardcoded B2C config from appsettings.json

### DIFF
--- a/TrashMob/appsettings.json
+++ b/TrashMob/appsettings.json
@@ -1,14 +1,4 @@
 {
-  "ApplicationInsights": {
-    "ConnectionString": "InstrumentationKey=ec91a9f1-e582-4d33-a80c-5451f53a8991;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/"
-  },
-  "AzureAdB2C": {
-    "Instance": "https://trashmob.b2clogin.com/",
-    "ClientId": "ca9c62c2-fdcb-4d07-b049-cdf66e874dfc",
-    "FrontendClientId": "0a1647a4-c758-4964-904f-a9b66958c071",
-    "Domain": "trashmob.onmicrosoft.com",
-    "SignUpSignInPolicyId": "B2C_1A_TM_SIGNUP_SIGNIN"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- Remove hardcoded production B2C and Application Insights settings from `appsettings.json`
- These settings were overriding environment variables set by deployment, causing dev to use production B2C client IDs

## Root Cause
The `appsettings.json` file had production B2C settings hardcoded. Due to the configuration loading order in `Program.cs`, these values were being loaded AFTER environment variables, overriding them.

## Fix
Remove the environment-specific settings from `appsettings.json`. They now come from:
- **Azure Container Apps**: Environment variables set by Bicep templates
- **Local development**: `appsettings.Development.json` (unchanged, has dev values)

## Test plan
- [ ] Merge to main and verify dev deployment succeeds
- [ ] Verify `/api/config` returns dev B2C client ID (`e46d67ba-fe46-40f4-b222-2f982b2bb112`)
- [ ] Verify sign-in works on dev.trashmob.eco

🤖 Generated with [Claude Code](https://claude.com/claude-code)