### PR TITLE
Fix Strapi CMS configuration for admin panel access

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -25,6 +25,7 @@ env:
   REGION: westus2
   CUSTOM_DOMAIN_NAME: dev.trashmob.eco
   MANAGED_CERTIFICATE_NAME: dev-trashmob-eco-cert
+  STRAPI_CONTAINER_APP_NAME: ca-strapi-tm-dev-westus2
 
 jobs:
   build-and-deploy:
@@ -69,6 +70,29 @@ jobs:
           docker push $IMAGE_TAG
           docker push $IMAGE_TAG_LATEST
 
+      - name: Get Strapi FQDN
+        id: get-strapi
+        run: |
+          # Check if Strapi container app exists
+          STRAPI_EXISTS=$(az containerapp show \
+            --name ${{ env.STRAPI_CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --query name \
+            -o tsv 2>/dev/null || echo "")
+
+          if [ -n "$STRAPI_EXISTS" ]; then
+            STRAPI_FQDN=$(az containerapp show \
+              --name ${{ env.STRAPI_CONTAINER_APP_NAME }} \
+              --resource-group ${{ env.RESOURCE_GROUP }} \
+              --query properties.configuration.ingress.fqdn \
+              -o tsv)
+            echo "Strapi FQDN: $STRAPI_FQDN"
+            echo "strapi_url=https://$STRAPI_FQDN" >> $GITHUB_OUTPUT
+          else
+            echo "Strapi container app not found. CMS will be disabled."
+            echo "strapi_url=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Deploy to Azure Container Apps
         run: |
           SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"
@@ -90,7 +114,8 @@ jobs:
               minReplicas=1 \
               maxReplicas=3 \
               customDomainName=${{ env.CUSTOM_DOMAIN_NAME }} \
-              managedCertificateName=${{ env.MANAGED_CERTIFICATE_NAME }}
+              managedCertificateName=${{ env.MANAGED_CERTIFICATE_NAME }} \
+              strapiBaseUrl="${{ steps.get-strapi.outputs.strapi_url }}"
 
       # Note: Azure AD B2C configuration is now set via environment variables in containerApp.bicep
       # The B2C settings are public configuration values (not secrets) determined by the 'environment' parameter

--- a/Deploy/containerApp.bicep
+++ b/Deploy/containerApp.bicep
@@ -8,7 +8,7 @@ param storageAccountName string
 param environment string
 param minReplicas int = 1
 param maxReplicas int = 3
-param strapiContainerAppName string = ''
+param strapiBaseUrl string = ''
 
 // Custom domain configuration (optional)
 // The managed certificate must be created separately before deployment
@@ -142,7 +142,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             // Strapi CMS integration
             {
               name: 'StrapiBaseUrl'
-              value: strapiContainerAppName != '' ? 'http://${strapiContainerAppName}' : ''
+              value: strapiBaseUrl
             }
           ]
           probes: [

--- a/Deploy/containerAppStrapi.bicep
+++ b/Deploy/containerAppStrapi.bicep
@@ -43,7 +43,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
     managedEnvironmentId: containerAppsEnvironmentId
     configuration: {
       ingress: {
-        external: false  // Internal only - accessed via TrashMob API proxy
+        external: true  // External access needed for admin panel (Strapi has built-in authentication)
         targetPort: 1337
         transport: 'auto'
         allowInsecure: false


### PR DESCRIPTION
## Summary
- Make Strapi container externally accessible (was internal-only)
- Update workflow to look up Strapi FQDN dynamically  
- Pass full HTTPS URL to main container app deployment
- Gracefully handle case where Strapi container doesn't exist

## Problem
When clicking "Open CMS Admin Panel" in Site Administration, users see "CMS is not configured" because:
1. The `StrapiBaseUrl` environment variable wasn't being passed to the main container
2. The Strapi container had internal-only ingress, so even if configured, the admin panel URL couldn't be accessed from a browser

## Solution
- Changed Strapi to external ingress (it has built-in admin authentication)
- Updated the deployment workflow to look up the Strapi FQDN dynamically
- Pass the full `https://` URL to the main container app

## Test plan
- [ ] Merge to main and let workflow deploy
- [ ] Verify Strapi container is redeployed with external ingress
- [ ] Verify main container app has `StrapiBaseUrl` set
- [ ] Test "Open CMS Admin Panel" in Site Administration

🤖 Generated with [Claude Code](https://claude.com/claude-code)