### PR TITLE
Use ephemeral local storage for SQLite database

### DIFF
--- a/Strapi/Dockerfile
+++ b/Strapi/Dockerfile
@@ -34,13 +34,14 @@ COPY --from=build /app/src ./src
 COPY --from=build /app/public ./public
 COPY --from=build /app/tsconfig.json ./tsconfig.json
 
-# Create uploads directory and data directory for SQLite
-RUN mkdir -p /app/public/uploads /data
+# Create uploads directory and local SQLite directory
+# SQLite uses local ephemeral storage (Azure Files SMB has locking issues)
+RUN mkdir -p /app/public/uploads /app/.tmp
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S strapi && \
     adduser -S strapi -u 1001 -G strapi && \
-    chown -R strapi:strapi /app /data
+    chown -R strapi:strapi /app
 
 USER strapi
 

--- a/Strapi/config/database.ts
+++ b/Strapi/config/database.ts
@@ -4,7 +4,10 @@ export default ({ env }) => {
   const connections = {
     sqlite: {
       connection: {
-        filename: env('DATABASE_FILENAME', '.tmp/data.db'),
+        // Use local ephemeral storage for SQLite (Azure Files SMB has locking issues)
+        // Database is small and rebuilt on container restart
+        // Content types are defined in code, only data needs re-entry
+        filename: env('DATABASE_FILENAME', '/app/.tmp/data.db'),
       },
       useNullAsDefault: true,
       pool: {


### PR DESCRIPTION
## Summary
- Move SQLite database to local ephemeral storage (/app/.tmp/data.db)
- Remove strapi-data Azure Files share and volume mount
- Keep Azure Files for uploads only (they persist)

## Context
SQLite has fundamental locking issues with Azure Files (SMB protocol). The "database is locked" error occurs because SMB doesn't support the same file locking semantics that SQLite requires.

## Trade-off
CMS content is rebuilt on container restart. However:
- Content types are defined in code and recreated automatically
- For a low-frequency CMS with minimal content, this is acceptable
- Uploaded media files still persist on Azure Files

## Future Options
If persistent CMS data is needed:
1. Switch to PostgreSQL (recommended for production)
2. Use Azure Blob Storage with blobfuse2 (FUSE mount)

## Test plan
- [ ] Deploy Strapi container to dev environment
- [ ] Verify container starts without database errors
- [ ] Create admin user and test content
- [ ] Verify uploads persist after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)