### PR TITLE
Use ephemeral local storage for SQLite - fix database locking

### DIFF
--- a/Strapi/src/api/getting-started/routes/getting-started.ts
+++ b/Strapi/src/api/getting-started/routes/getting-started.ts
@@ -1,3 +1,22 @@
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::getting-started.getting-started');
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/getting-started',
+      handler: 'getting-started.find',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/getting-started',
+      handler: 'getting-started.update',
+    },
+    {
+      method: 'DELETE',
+      path: '/getting-started',
+      handler: 'getting-started.delete',
+    },
+  ],
+};

--- a/Strapi/src/api/hero-section/routes/hero-section.ts
+++ b/Strapi/src/api/hero-section/routes/hero-section.ts
@@ -1,3 +1,22 @@
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::hero-section.hero-section');
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/hero-section',
+      handler: 'hero-section.find',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/hero-section',
+      handler: 'hero-section.update',
+    },
+    {
+      method: 'DELETE',
+      path: '/hero-section',
+      handler: 'hero-section.delete',
+    },
+  ],
+};

--- a/Strapi/src/api/what-is-trashmob/routes/what-is-trashmob.ts
+++ b/Strapi/src/api/what-is-trashmob/routes/what-is-trashmob.ts
@@ -1,3 +1,22 @@
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::what-is-trashmob.what-is-trashmob');
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/what-is-trashmob',
+      handler: 'what-is-trashmob.find',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/what-is-trashmob',
+      handler: 'what-is-trashmob.update',
+    },
+    {
+      method: 'DELETE',
+      path: '/what-is-trashmob',
+      handler: 'what-is-trashmob.delete',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Move SQLite database to local ephemeral storage (/app/.tmp/data.db)
- Remove strapi-data Azure Files share (SQLite has locking issues with SMB)
- Keep Azure Files for uploads only (they persist)

## Root Cause
SQLite has fundamental locking issues with Azure Files (SMB protocol). The "database is locked" error occurs because SMB doesn't support the file locking semantics that SQLite requires.

## Solution
Use local ephemeral storage for SQLite database:
- Database is small and schema is defined in code
- Content types are recreated automatically on restart
- Uploaded media files persist on Azure Files

## Trade-off
CMS content (text entries) need to be re-entered after container restart. For a low-frequency CMS, this is acceptable.

## Future Options
If persistent CMS data is needed:
1. Switch to PostgreSQL (recommended for production)
2. Use Azure Blob Storage with blobfuse2

## Test plan
- [ ] Deploy Strapi container to dev environment
- [ ] Verify container starts without database errors
- [ ] Create admin user and test content
- [ ] Verify uploads persist after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)