### PR TITLE
Add content type index files for Strapi 5

### DIFF
--- a/Strapi/src/api/getting-started/content-types/getting-started/index.ts
+++ b/Strapi/src/api/getting-started/content-types/getting-started/index.ts
@@ -1,0 +1,5 @@
+import schema from './schema.json';
+
+export default {
+  schema,
+};

--- a/Strapi/src/api/getting-started/routes/getting-started.ts
+++ b/Strapi/src/api/getting-started/routes/getting-started.ts
@@ -1,22 +1,3 @@
-export default {
-  routes: [
-    {
-      method: 'GET',
-      path: '/getting-started',
-      handler: 'getting-started.find',
-      config: {
-        auth: false,
-      },
-    },
-    {
-      method: 'PUT',
-      path: '/getting-started',
-      handler: 'getting-started.update',
-    },
-    {
-      method: 'DELETE',
-      path: '/getting-started',
-      handler: 'getting-started.delete',
-    },
-  ],
-};
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::getting-started.getting-started');

--- a/Strapi/src/api/hero-section/content-types/hero-section/index.ts
+++ b/Strapi/src/api/hero-section/content-types/hero-section/index.ts
@@ -1,0 +1,5 @@
+import schema from './schema.json';
+
+export default {
+  schema,
+};

--- a/Strapi/src/api/hero-section/routes/hero-section.ts
+++ b/Strapi/src/api/hero-section/routes/hero-section.ts
@@ -1,22 +1,3 @@
-export default {
-  routes: [
-    {
-      method: 'GET',
-      path: '/hero-section',
-      handler: 'hero-section.find',
-      config: {
-        auth: false,
-      },
-    },
-    {
-      method: 'PUT',
-      path: '/hero-section',
-      handler: 'hero-section.update',
-    },
-    {
-      method: 'DELETE',
-      path: '/hero-section',
-      handler: 'hero-section.delete',
-    },
-  ],
-};
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::hero-section.hero-section');

--- a/Strapi/src/api/what-is-trashmob/content-types/what-is-trashmob/index.ts
+++ b/Strapi/src/api/what-is-trashmob/content-types/what-is-trashmob/index.ts
@@ -1,0 +1,5 @@
+import schema from './schema.json';
+
+export default {
+  schema,
+};

--- a/Strapi/src/api/what-is-trashmob/routes/what-is-trashmob.ts
+++ b/Strapi/src/api/what-is-trashmob/routes/what-is-trashmob.ts
@@ -1,22 +1,3 @@
-export default {
-  routes: [
-    {
-      method: 'GET',
-      path: '/what-is-trashmob',
-      handler: 'what-is-trashmob.find',
-      config: {
-        auth: false,
-      },
-    },
-    {
-      method: 'PUT',
-      path: '/what-is-trashmob',
-      handler: 'what-is-trashmob.update',
-    },
-    {
-      method: 'DELETE',
-      path: '/what-is-trashmob',
-      handler: 'what-is-trashmob.delete',
-    },
-  ],
-};
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::what-is-trashmob.what-is-trashmob');


### PR DESCRIPTION
## Summary
- Add index.ts files for each content type to properly export schemas
- Revert routes to use createCoreRouter factory (now that content types are properly exported)

## Context
Strapi 5 with TypeScript requires content types to be explicitly exported via index.ts files. Without this, the content type schema isn't registered when controllers and routes try to reference it, causing:
```
TypeError: Cannot read properties of undefined (reading 'kind')
```

## Changes
Added `index.ts` for:
- `hero-section`
- `what-is-trashmob`
- `getting-started`

Each exports the schema.json so Strapi can properly register the content type.

## Test plan
- [ ] Deploy Strapi container to dev environment
- [ ] Verify container starts without content type errors
- [ ] Verify API endpoints respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)