### PR TITLE
Fix Strapi component export format

### DIFF
--- a/Strapi/src/components/content/index.ts
+++ b/Strapi/src/components/content/index.ts
@@ -1,5 +1,5 @@
 import requirementItem from './requirement-item.json';
 
 export default {
-  'requirement-item': { schema: requirementItem },
+  'requirement-item': requirementItem,
 };


### PR DESCRIPTION
## Summary
- Remove schema wrapper from component export in index.ts
- Strapi 5 expects components to be exported directly since the JSON already contains `collectionName` and other required properties

Fixes error: `Component index is missing a "collectionName" property`

## Test plan
- [ ] Deploy Strapi container and verify it starts without component errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)