### PR TITLE
Remove component index.ts for Strapi auto-discovery

### DIFF
--- a/Strapi/src/components/content/index.ts
+++ b/Strapi/src/components/content/index.ts
@@ -1,5 +1,0 @@
-import requirementItem from './requirement-item.json';
-
-export default {
-  'requirement-item': requirementItem,
-};


### PR DESCRIPTION
## Summary
- Remove component index.ts file that was causing "collectionName property" errors
- With `resolveJsonModule: true` in tsconfig.json (from PR #2410), Strapi can now auto-discover component JSON files
- Tested locally: Strapi starts successfully with this change

## Context
The component index.ts was added to help Strapi find components, but it was formatted in a way that caused the error. With the tsconfig changes, Strapi can discover JSON components directly.

## Test plan
- [x] Verified Strapi starts locally without the index.ts
- [ ] Deploy to dev and verify container starts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)