### PR TITLE
Add JWT secret config for Strapi users-permissions plugin

### DIFF
--- a/Strapi/config/plugins.ts
+++ b/Strapi/config/plugins.ts
@@ -1,3 +1,7 @@
 export default ({ env }) => ({
-  // Enable/disable plugins as needed
+  'users-permissions': {
+    config: {
+      jwtSecret: env('JWT_SECRET') || env('ADMIN_JWT_SECRET'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Add jwtSecret configuration for users-permissions plugin
- Uses JWT_SECRET env var with fallback to ADMIN_JWT_SECRET (already configured in deployment)

Fixes error: `Missing jwtSecret. Please, set configuration variable "jwtSecret" for the users-permissions plugin`

## Test plan
- [ ] Deploy to dev and verify container starts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)