### PR TITLE
Remove `<div class="tailwind">` wrapper

### DIFF
--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -126,10 +126,8 @@ const AuthSideAdminLayout = () => {
     const { currentUser, isUserLoaded } = useLogin();
     if (!isUserLoaded)
         return (
-            <div className='tailwind'>
-                <div className='flex justify-center items-center py-16'>
-                    <Loader2 className='animate-spin mr-2' /> Loading
-                </div>
+            <div className='flex justify-center items-center py-16'>
+                <Loader2 className='animate-spin mr-2' /> Loading
             </div>
         );
     if (isUserLoaded && !currentUser.isSiteAdmin) return <em>Access Denied</em>;
@@ -276,10 +274,8 @@ export const App: FC = () => {
     // Show loading while MSAL is initializing
     if (isInitializing || !msalClient) {
         return (
-            <div className='tailwind'>
-                <div className='flex justify-center items-center py-16 min-h-screen'>
-                    <Loader2 className='animate-spin mr-2' /> Loading...
-                </div>
+            <div className='flex justify-center items-center py-16 min-h-screen'>
+                <Loader2 className='animate-spin mr-2' /> Loading...
             </div>
         );
     }
@@ -289,9 +285,7 @@ export const App: FC = () => {
             <MsalProvider instance={msalClient}>
                 <AppContent />
             </MsalProvider>
-            <div className='tailwind'>
-                <Toaster />
-            </div>
+            <Toaster />
             <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
     );

--- a/TrashMob/client-app/src/components/Customization/HeroSection.tsx
+++ b/TrashMob/client-app/src/components/Customization/HeroSection.tsx
@@ -7,19 +7,17 @@ interface HeroSectionProps {
 }
 
 export const HeroSection: FC<HeroSectionProps> = ({ Title, Description }) => (
-    <div className='tailwind'>
-        <div className='bg-primary text-primary-foreground'>
-            <div className='container px-0! md:px-8! relative'>
-                <img
-                    src={globes}
-                    alt='globes'
-                    className='absolute right-0 md:right-8 top-0 bottom-0 h-full mt-0 object-cover opacity-30 md:opacity-100'
-                />
-                <div className='flex flex-row items-stretch relative'>
-                    <div className='flex flex-col justify-center flex-1 pr-12! py-3! xl:py-8! relative z-10 text-center md:text-left!'>
-                        <h1 className='font-bold text-[40px] leading-[50px] mt-10 mb-2'>{Title}</h1>
-                        <p className='font-bold my-4'>{Description}</p>
-                    </div>
+    <div className='bg-primary text-primary-foreground'>
+        <div className='container px-0! md:px-8! relative'>
+            <img
+                src={globes}
+                alt='globes'
+                className='absolute right-0 md:right-8 top-0 bottom-0 h-full mt-0 object-cover opacity-30 md:opacity-100'
+            />
+            <div className='flex flex-row items-stretch relative'>
+                <div className='flex flex-col justify-center flex-1 pr-12! py-3! xl:py-8! relative z-10 text-center md:text-left!'>
+                    <h1 className='font-bold text-[40px] leading-[50px] mt-10 mb-2'>{Title}</h1>
+                    <p className='font-bold my-4'>{Description}</p>
                 </div>
             </div>
         </div>

--- a/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
+++ b/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
@@ -133,53 +133,51 @@ export function AzureSearchLocationInput(props: AzureSearchLocationInputProps) {
     };
 
     return (
-        <div className='tailwind'>
-            <Command
-                ref={commandRef}
-                shouldFilter={false}
-                className={cn('rounded-lg! border md:min-w-[200px] relative', { 'shadow-md': open }, className)}
-            >
-                {renderInput ? (
-                    renderInput(customInputProps)
-                ) : (
-                    <CommandInput
-                        placeholder={placeholder ?? 'Location...'}
-                        value={query}
-                        onValueChange={(value) => setQuery(value)}
-                        onFocus={handleFocus}
-                        className={cn('mb-0!', inputClassName)}
-                    />
+        <Command
+            ref={commandRef}
+            shouldFilter={false}
+            className={cn('rounded-lg! border md:min-w-[200px] relative', { 'shadow-md': open }, className)}
+        >
+            {renderInput ? (
+                renderInput(customInputProps)
+            ) : (
+                <CommandInput
+                    placeholder={placeholder ?? 'Location...'}
+                    value={query}
+                    onValueChange={(value) => setQuery(value)}
+                    onFocus={handleFocus}
+                    className={cn('mb-0!', inputClassName)}
+                />
+            )}
+            <CommandList
+                className={cn(
+                    'hidden [&.cmdk-list-sizer]:w-full',
+                    { flex: showSuggestion && query.length > 1 },
+                    listClassName,
                 )}
-                <CommandList
-                    className={cn(
-                        'hidden [&.cmdk-list-sizer]:w-full',
-                        { flex: showSuggestion && query.length > 1 },
-                        listClassName,
-                    )}
-                >
-                    {isLoading || isFetching ? (
-                        <div className='p-2 text-sm text-gray-500'>Loading...</div>
-                    ) : suggestionGroups.length ? (
-                        suggestionGroups.map((group) => (
-                            <CommandGroup heading={group.groupName} key={group.groupName} className='border-b'>
-                                {group.items.map((item) => (
-                                    <CommandItem
-                                        key={item.id}
-                                        value={item.id}
-                                        className='font-light py-3! cursor-pointer'
-                                        onSelect={handleSelectSuggestion}
-                                    >
-                                        {item.displayAddress}
-                                    </CommandItem>
-                                ))}
-                            </CommandGroup>
-                        ))
-                    ) : query.length > 1 ? (
-                        <div className='p-2 text-sm text-gray-500'>No results found.</div>
-                    ) : null}
-                </CommandList>
-            </Command>
-        </div>
+            >
+                {isLoading || isFetching ? (
+                    <div className='p-2 text-sm text-gray-500'>Loading...</div>
+                ) : suggestionGroups.length ? (
+                    suggestionGroups.map((group) => (
+                        <CommandGroup heading={group.groupName} key={group.groupName} className='border-b'>
+                            {group.items.map((item) => (
+                                <CommandItem
+                                    key={item.id}
+                                    value={item.id}
+                                    className='font-light py-3! cursor-pointer'
+                                    onSelect={handleSelectSuggestion}
+                                >
+                                    {item.displayAddress}
+                                </CommandItem>
+                            ))}
+                        </CommandGroup>
+                    ))
+                ) : query.length > 1 ? (
+                    <div className='p-2 text-sm text-gray-500'>No results found.</div>
+                ) : null}
+            </CommandList>
+        </Command>
     );
 }
 

--- a/TrashMob/client-app/src/components/SiteFooter/SiteFooter.tsx
+++ b/TrashMob/client-app/src/components/SiteFooter/SiteFooter.tsx
@@ -19,7 +19,7 @@ export const SiteFooter = () => {
     ];
 
     return (
-        <footer className='tailwind'>
+        <footer>
             <div className='bg-[#212529] relative py-10! overflow-hidden'>
                 <Logo
                     className='w-[900px] absolute z-0 left-[20%] md:left-[40%] inset-y-1/2 -translate-y-100 opacity-10'

--- a/TrashMob/client-app/src/components/SiteHeader/SiteHeader.tsx
+++ b/TrashMob/client-app/src/components/SiteHeader/SiteHeader.tsx
@@ -19,44 +19,42 @@ export const SiteHeader = (props: SiteHeaderProps) => {
     const [show, setShow] = React.useState<boolean>(false);
 
     return (
-        <div className='tailwind'>
-            <div className='border-b shadow-md shadow-black/10 bg-white py-4'>
-                <div className='container'>
-                    <div className='flex items-center flex-wrap flex-row'>
-                        <a className='-ml-2 grow lg:grow-0' href='/'>
-                            <Logo className='w-[165px]' />
-                        </a>
-                        <Button
-                            className='lg:hidden w-10 h-10 [&_svg]:size-6'
-                            variant='outline'
-                            aria-label='Toggle menu'
-                            onClick={() => setShow(!show)}
-                        >
-                            <Menu strokeWidth={1} />
-                        </Button>
-                        <Divider className='ml-4! hidden lg:block' />
-                        <div
-                            className={cn(
-                                'flex flex-1 px-4!',
-                                'overflow-hidden transition-all duration-300',
-                                'items-start justify-between flex-col basis-full',
-                                'lg:items-center lg:justify-between lg:flex-row lg:basis-0',
-                                'lg:max-h-none',
-                                {
-                                    'max-h-84': show,
-                                    'max-h-0': !show,
-                                },
-                            )}
-                        >
-                            <MainNav className='flex-1 py-4! lg:py-0!' isUserLoaded={isUserLoaded} />
-                            <div className={cn('flex flex-row gap-4')}>
-                                <Button asChild className='flex md:hidden xl:flex'>
-                                    <Link to='/events/create'>
-                                        <Plus /> Create an Event
-                                    </Link>
-                                </Button>
-                                <UserNav currentUser={currentUser} isUserLoaded={isUserLoaded} />
-                            </div>
+        <div className='border-b shadow-md shadow-black/10 bg-white py-4'>
+            <div className='container'>
+                <div className='flex items-center flex-wrap flex-row'>
+                    <a className='-ml-2 grow lg:grow-0' href='/'>
+                        <Logo className='w-[165px]' />
+                    </a>
+                    <Button
+                        className='lg:hidden w-10 h-10 [&_svg]:size-6'
+                        variant='outline'
+                        aria-label='Toggle menu'
+                        onClick={() => setShow(!show)}
+                    >
+                        <Menu strokeWidth={1} />
+                    </Button>
+                    <Divider className='ml-4! hidden lg:block' />
+                    <div
+                        className={cn(
+                            'flex flex-1 px-4!',
+                            'overflow-hidden transition-all duration-300',
+                            'items-start justify-between flex-col basis-full',
+                            'lg:items-center lg:justify-between lg:flex-row lg:basis-0',
+                            'lg:max-h-none',
+                            {
+                                'max-h-84': show,
+                                'max-h-0': !show,
+                            },
+                        )}
+                    >
+                        <MainNav className='flex-1 py-4! lg:py-0!' isUserLoaded={isUserLoaded} />
+                        <div className={cn('flex flex-row gap-4')}>
+                            <Button asChild className='flex md:hidden xl:flex'>
+                                <Link to='/events/create'>
+                                    <Plus /> Create an Event
+                                </Link>
+                            </Button>
+                            <UserNav currentUser={currentUser} isUserLoaded={isUserLoaded} />
                         </div>
                     </div>
                 </div>

--- a/TrashMob/client-app/src/components/partner-requests/partner-request-form.tsx
+++ b/TrashMob/client-app/src/components/partner-requests/partner-request-form.tsx
@@ -207,276 +207,272 @@ export const PartnerRequestForm: React.FC<PartnerRequestFormProps> = (props) => 
     }
 
     return (
-        <div className='tailwind'>
-            <div className='container py-12!'>
-                <Card className=''>
-                    <CardHeader>
-                        <CardTitle className='text-4xl text-primary'>{title}</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        {mode === PartnerRequestMode.SEND && (
-                            <p>
-                                Use this form to send an informational note to a potential TrashMob.eco partner in your
-                                community. Fill out as much detail as you can and TrashMob.eco will reach out to the
-                                email address provided with an information packet to see if they would like to become a
-                                TrashMob.eco Partner!
-                            </p>
-                        )}
-                        {mode === PartnerRequestMode.REQUEST && (
-                            <p>
-                                Use this form to request to become a TrashMob.eco partner. TrashMob.eco site
-                                adminsitrators will review your request, and either approve it, or reach out to you for
-                                more information. If approved, you will be sent a Welcome email with instructions on how
-                                to complete setup of your partnership.
-                            </p>
-                        )}
+        <div className='container py-12!'>
+            <Card className=''>
+                <CardHeader>
+                    <CardTitle className='text-4xl text-primary'>{title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    {mode === PartnerRequestMode.SEND && (
                         <p>
-                            If connecting with a government partner, the department responsible for managing waste and
-                            maintaining cleanliness in a community is often a part of the public works department,
-                            environmental services division, or a similar agency. You can find contact information for
-                            these organizations by searching online or by calling the city's main government phone
-                            number and asking for the appropriate department.
+                            Use this form to send an informational note to a potential TrashMob.eco partner in your
+                            community. Fill out as much detail as you can and TrashMob.eco will reach out to the email
+                            address provided with an information packet to see if they would like to become a
+                            TrashMob.eco Partner!
                         </p>
-                    </CardContent>
-                    <CardContent>
-                        <TooltipProvider delayDuration={0}>
-                            <Form {...form}>
-                                <form onSubmit={form.handleSubmit(onSubmit)} className='grid grid-cols-12 gap-4'>
-                                    <FormField
-                                        control={form.control}
-                                        name='name'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-6'>
-                                                <Tooltip>
-                                                    <TooltipTrigger>
-                                                        <FormLabel>Partner Name</FormLabel>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent className='max-w-64'>
-                                                        {ToolTips.PartnerRequestName}
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                                <FormControl>
-                                                    <Input {...field} />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='partnerTypeId'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-6'>
-                                                <Tooltip>
-                                                    <TooltipTrigger>
-                                                        <FormLabel>Type</FormLabel>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent className='max-w-64'>
-                                                        {ToolTips.PartnerType}
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                                <FormControl>
-                                                    <RadioGroup
-                                                        onValueChange={field.onChange}
-                                                        defaultValue={field.value}
-                                                        className='flex flex-row space-y-1 h-9 items-center'
+                    )}
+                    {mode === PartnerRequestMode.REQUEST && (
+                        <p>
+                            Use this form to request to become a TrashMob.eco partner. TrashMob.eco site adminsitrators
+                            will review your request, and either approve it, or reach out to you for more information.
+                            If approved, you will be sent a Welcome email with instructions on how to complete setup of
+                            your partnership.
+                        </p>
+                    )}
+                    <p>
+                        If connecting with a government partner, the department responsible for managing waste and
+                        maintaining cleanliness in a community is often a part of the public works department,
+                        environmental services division, or a similar agency. You can find contact information for these
+                        organizations by searching online or by calling the city's main government phone number and
+                        asking for the appropriate department.
+                    </p>
+                </CardContent>
+                <CardContent>
+                    <TooltipProvider delayDuration={0}>
+                        <Form {...form}>
+                            <form onSubmit={form.handleSubmit(onSubmit)} className='grid grid-cols-12 gap-4'>
+                                <FormField
+                                    control={form.control}
+                                    name='name'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-6'>
+                                            <Tooltip>
+                                                <TooltipTrigger>
+                                                    <FormLabel>Partner Name</FormLabel>
+                                                </TooltipTrigger>
+                                                <TooltipContent className='max-w-64'>
+                                                    {ToolTips.PartnerRequestName}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                            <FormControl>
+                                                <Input {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='partnerTypeId'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-6'>
+                                            <Tooltip>
+                                                <TooltipTrigger>
+                                                    <FormLabel>Type</FormLabel>
+                                                </TooltipTrigger>
+                                                <TooltipContent className='max-w-64'>
+                                                    {ToolTips.PartnerType}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                            <FormControl>
+                                                <RadioGroup
+                                                    onValueChange={field.onChange}
+                                                    defaultValue={field.value}
+                                                    className='flex flex-row space-y-1 h-9 items-center'
+                                                >
+                                                    <FormItem className='flex items-center space-x-3 space-y-0'>
+                                                        <FormControl>
+                                                            <RadioGroupItem value={PartnerType.GOVERNMENT} />
+                                                        </FormControl>
+                                                        <FormLabel className='font-normal'>Government</FormLabel>
+                                                    </FormItem>
+                                                    <FormItem className='flex items-center space-x-3 space-y-0'>
+                                                        <FormControl>
+                                                            <RadioGroupItem value={PartnerType.BUSINESS} />
+                                                        </FormControl>
+                                                        <FormLabel className='font-normal'>Business</FormLabel>
+                                                    </FormItem>
+                                                </RadioGroup>
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='email'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-6'>
+                                            <Tooltip>
+                                                <TooltipTrigger>
+                                                    <FormLabel>Email</FormLabel>
+                                                </TooltipTrigger>
+                                                <TooltipContent className='max-w-64'>
+                                                    {mode === PartnerRequestMode.SEND
+                                                        ? ToolTips.PartnerRequestInviteEmail
+                                                        : ToolTips.PartnerRequestEmail}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                            <FormControl>
+                                                <Input {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='website'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-6'>
+                                            <Tooltip>
+                                                <TooltipTrigger>
+                                                    <FormLabel>Website</FormLabel>
+                                                </TooltipTrigger>
+                                                <TooltipContent className='max-w-64'>
+                                                    {ToolTips.PartnerRequestWebsite}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                            <FormControl>
+                                                <Input {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='phone'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-6'>
+                                            <Tooltip>
+                                                <TooltipTrigger>
+                                                    <FormLabel>Phone</FormLabel>
+                                                </TooltipTrigger>
+                                                <TooltipContent className='max-w-64'>
+                                                    {mode === PartnerRequestMode.SEND
+                                                        ? ToolTips.PartnerRequestInvitePhone
+                                                        : ToolTips.PartnerRequestPhone}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                            <FormControl>
+                                                <PhoneInput
+                                                    country='us'
+                                                    value={field.value}
+                                                    onChange={field.onChange}
+                                                    inputClass='flex h-9 w-full! rounded-md border border-input bg-transparent pr-3 py-1 text-base shadow-xs '
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='notes'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-12'>
+                                            <Tooltip>
+                                                <TooltipTrigger>
+                                                    <FormLabel>Notes</FormLabel>
+                                                </TooltipTrigger>
+                                                <TooltipContent className='max-w-64'>
+                                                    {mode === PartnerRequestMode.SEND
+                                                        ? ToolTips.PartnerRequestInviteNotes
+                                                        : ToolTips.PartnerRequestNotes}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                            <FormControl>
+                                                <Textarea {...field} maxLength={2048} className='h-24' />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='location'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-12'>
+                                            <FormLabel>Choose a location!</FormLabel>
+                                            <FormControl>
+                                                <div className='relative w-full'>
+                                                    <GoogleMap
+                                                        defaultCenter={userPreferredLocation ?? undefined}
+                                                        onClick={handleClickMap}
                                                     >
-                                                        <FormItem className='flex items-center space-x-3 space-y-0'>
-                                                            <FormControl>
-                                                                <RadioGroupItem value={PartnerType.GOVERNMENT} />
-                                                            </FormControl>
-                                                            <FormLabel className='font-normal'>Government</FormLabel>
-                                                        </FormItem>
-                                                        <FormItem className='flex items-center space-x-3 space-y-0'>
-                                                            <FormControl>
-                                                                <RadioGroupItem value={PartnerType.BUSINESS} />
-                                                            </FormControl>
-                                                            <FormLabel className='font-normal'>Business</FormLabel>
-                                                        </FormItem>
-                                                    </RadioGroup>
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='email'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-6'>
-                                                <Tooltip>
-                                                    <TooltipTrigger>
-                                                        <FormLabel>Email</FormLabel>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent className='max-w-64'>
-                                                        {mode === PartnerRequestMode.SEND
-                                                            ? ToolTips.PartnerRequestInviteEmail
-                                                            : ToolTips.PartnerRequestEmail}
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                                <FormControl>
-                                                    <Input {...field} />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='website'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-6'>
-                                                <Tooltip>
-                                                    <TooltipTrigger>
-                                                        <FormLabel>Website</FormLabel>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent className='max-w-64'>
-                                                        {ToolTips.PartnerRequestWebsite}
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                                <FormControl>
-                                                    <Input {...field} />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='phone'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-6'>
-                                                <Tooltip>
-                                                    <TooltipTrigger>
-                                                        <FormLabel>Phone</FormLabel>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent className='max-w-64'>
-                                                        {mode === PartnerRequestMode.SEND
-                                                            ? ToolTips.PartnerRequestInvitePhone
-                                                            : ToolTips.PartnerRequestPhone}
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                                <FormControl>
-                                                    <PhoneInput
-                                                        country='us'
-                                                        value={field.value}
-                                                        onChange={field.onChange}
-                                                        inputClass='flex h-9 w-full! rounded-md border border-input bg-transparent pr-3 py-1 text-base shadow-xs '
-                                                    />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='notes'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-12'>
-                                                <Tooltip>
-                                                    <TooltipTrigger>
-                                                        <FormLabel>Notes</FormLabel>
-                                                    </TooltipTrigger>
-                                                    <TooltipContent className='max-w-64'>
-                                                        {mode === PartnerRequestMode.SEND
-                                                            ? ToolTips.PartnerRequestInviteNotes
-                                                            : ToolTips.PartnerRequestNotes}
-                                                    </TooltipContent>
-                                                </Tooltip>
-                                                <FormControl>
-                                                    <Textarea {...field} maxLength={2048} className='h-24' />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='location'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-12'>
-                                                <FormLabel>Choose a location!</FormLabel>
-                                                <FormControl>
-                                                    <div className='relative w-full'>
-                                                        <GoogleMap
-                                                            defaultCenter={userPreferredLocation ?? undefined}
-                                                            onClick={handleClickMap}
-                                                        >
-                                                            <Marker
-                                                                position={field.value}
-                                                                draggable
-                                                                onDragEnd={handleMarkerDragEnd}
+                                                        <Marker
+                                                            position={field.value}
+                                                            draggable
+                                                            onDragEnd={handleMarkerDragEnd}
+                                                        />
+                                                    </GoogleMap>
+                                                    {azureSubscriptionKey ? (
+                                                        <div style={{ position: 'absolute', top: 8, left: 8 }}>
+                                                            <AzureSearchLocationInput
+                                                                azureKey={azureSubscriptionKey}
+                                                                onSelectLocation={handleSelectSearchLocation}
                                                             />
-                                                        </GoogleMap>
-                                                        {azureSubscriptionKey ? (
-                                                            <div style={{ position: 'absolute', top: 8, left: 8 }}>
-                                                                <AzureSearchLocationInput
-                                                                    azureKey={azureSubscriptionKey}
-                                                                    onSelectLocation={handleSelectSearchLocation}
-                                                                />
-                                                            </div>
-                                                        ) : null}
-                                                    </div>
-                                                </FormControl>
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='streetAddress'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-12'>
-                                                <FormLabel>Street Address</FormLabel>
-                                                <FormControl>
-                                                    <Input {...field} disabled />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='city'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-6'>
-                                                <FormLabel>City</FormLabel>
-                                                <FormControl>
-                                                    <Input {...field} disabled />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <FormField
-                                        control={form.control}
-                                        name='postalCode'
-                                        render={({ field }) => (
-                                            <FormItem className='col-span-6'>
-                                                <FormLabel>Postal Code</FormLabel>
-                                                <FormControl>
-                                                    <Input {...field} disabled />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )}
-                                    />
-                                    <div className='col-span-12 flex justify-end gap-2'>
-                                        <Button variant='secondary' onClick={handleCancel}>
-                                            Cancel
-                                        </Button>
-                                        <Button type='submit' disabled={createPartnerRequest.isLoading}>
-                                            {createPartnerRequest.isLoading ? (
-                                                <Loader2 className='animate-spin' />
-                                            ) : null}
-                                            Submit
-                                        </Button>
-                                    </div>
-                                </form>
-                            </Form>
-                        </TooltipProvider>
-                    </CardContent>
-                </Card>
-            </div>
+                                                        </div>
+                                                    ) : null}
+                                                </div>
+                                            </FormControl>
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='streetAddress'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-12'>
+                                            <FormLabel>Street Address</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} disabled />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='city'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-6'>
+                                            <FormLabel>City</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} disabled />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='postalCode'
+                                    render={({ field }) => (
+                                        <FormItem className='col-span-6'>
+                                            <FormLabel>Postal Code</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} disabled />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <div className='col-span-12 flex justify-end gap-2'>
+                                    <Button variant='secondary' onClick={handleCancel}>
+                                        Cancel
+                                    </Button>
+                                    <Button type='submit' disabled={createPartnerRequest.isLoading}>
+                                        {createPartnerRequest.isLoading ? <Loader2 className='animate-spin' /> : null}
+                                        Submit
+                                    </Button>
+                                </div>
+                            </form>
+                        </Form>
+                    </TooltipProvider>
+                </CardContent>
+            </Card>
         </div>
     );
 };

--- a/TrashMob/client-app/src/components/ui/dialog.tsx
+++ b/TrashMob/client-app/src/components/ui/dialog.tsx
@@ -33,23 +33,21 @@ const DialogContent = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
     <DialogPortal>
-        <div className='tailwind'>
-            <DialogOverlay />
-            <DialogPrimitive.Content
-                ref={ref}
-                className={cn(
-                    'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
-                    className,
-                )}
-                {...props}
-            >
-                {children}
-                <DialogPrimitive.Close className='absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
-                    <Cross2Icon className='h-4 w-4' />
-                    <span className='sr-only'>Close</span>
-                </DialogPrimitive.Close>
-            </DialogPrimitive.Content>
-        </div>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+            <DialogPrimitive.Close className='absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
+                <Cross2Icon className='h-4 w-4' />
+                <span className='sr-only'>Close</span>
+            </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
     </DialogPortal>
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
@@ -60,19 +58,17 @@ const DialogPlainContent = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
     <DialogPortal>
-        <div className='tailwind'>
-            <DialogOverlay />
-            <DialogPrimitive.Content
-                ref={ref}
-                className={cn(
-                    'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
-                    className,
-                )}
-                {...props}
-            >
-                {children}
-            </DialogPrimitive.Content>
-        </div>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+        </DialogPrimitive.Content>
     </DialogPortal>
 ));
 DialogPlainContent.displayName = DialogPrimitive.Content.displayName;

--- a/TrashMob/client-app/src/components/ui/dropdown-menu.tsx
+++ b/TrashMob/client-app/src/components/ui/dropdown-menu.tsx
@@ -57,18 +57,16 @@ const DropdownMenuContent = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
     <DropdownMenuPrimitive.Portal>
-        <div className='tailwind'>
-            <DropdownMenuPrimitive.Content
-                ref={ref}
-                sideOffset={sideOffset}
-                className={cn(
-                    'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
-                    'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-                    className,
-                )}
-                {...props}
-            />
-        </div>
+        <DropdownMenuPrimitive.Content
+            ref={ref}
+            sideOffset={sideOffset}
+            className={cn(
+                'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+                'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+                className,
+            )}
+            {...props}
+        />
     </DropdownMenuPrimitive.Portal>
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;

--- a/TrashMob/client-app/src/components/ui/popover.tsx
+++ b/TrashMob/client-app/src/components/ui/popover.tsx
@@ -14,18 +14,16 @@ const PopoverContent = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
     <PopoverPrimitive.Portal>
-        <div className='tailwind'>
-            <PopoverPrimitive.Content
-                ref={ref}
-                align={align}
-                sideOffset={sideOffset}
-                className={cn(
-                    'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-                    className,
-                )}
-                {...props}
-            />
-        </div>
+        <PopoverPrimitive.Content
+            ref={ref}
+            align={align}
+            sideOffset={sideOffset}
+            className={cn(
+                'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+                className,
+            )}
+            {...props}
+        />
     </PopoverPrimitive.Portal>
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;

--- a/TrashMob/client-app/src/components/ui/select.tsx
+++ b/TrashMob/client-app/src/components/ui/select.tsx
@@ -62,31 +62,29 @@ const SelectContent = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className, children, position = 'popper', ...props }, ref) => (
     <SelectPrimitive.Portal>
-        <div className='tailwind'>
-            <SelectPrimitive.Content
-                ref={ref}
+        <SelectPrimitive.Content
+            ref={ref}
+            className={cn(
+                'relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+                position === 'popper' &&
+                    'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+                className,
+            )}
+            position={position}
+            {...props}
+        >
+            <SelectScrollUpButton />
+            <SelectPrimitive.Viewport
                 className={cn(
-                    'relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+                    'p-1',
                     position === 'popper' &&
-                        'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-                    className,
+                        'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)',
                 )}
-                position={position}
-                {...props}
             >
-                <SelectScrollUpButton />
-                <SelectPrimitive.Viewport
-                    className={cn(
-                        'p-1',
-                        position === 'popper' &&
-                            'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)',
-                    )}
-                >
-                    {children}
-                </SelectPrimitive.Viewport>
-                <SelectScrollDownButton />
-            </SelectPrimitive.Content>
-        </div>
+                {children}
+            </SelectPrimitive.Viewport>
+            <SelectScrollDownButton />
+        </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
 ));
 SelectContent.displayName = SelectPrimitive.Content.displayName;

--- a/TrashMob/client-app/src/components/ui/toast.tsx
+++ b/TrashMob/client-app/src/components/ui/toast.tsx
@@ -41,11 +41,7 @@ const Toast = React.forwardRef<
     React.ElementRef<typeof ToastPrimitives.Root>,
     React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
-    return (
-        <div className='tailwind'>
-            <ToastPrimitives.Root ref={ref} className={cn(toastVariants({ variant }), className)} {...props} />
-        </div>
-    );
+    return <ToastPrimitives.Root ref={ref} className={cn(toastVariants({ variant }), className)} {...props} />;
 });
 Toast.displayName = ToastPrimitives.Root.displayName;
 

--- a/TrashMob/client-app/src/components/ui/tooltip.tsx
+++ b/TrashMob/client-app/src/components/ui/tooltip.tsx
@@ -14,17 +14,15 @@ const TooltipContent = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
     <TooltipPrimitive.Portal>
-        <div className='tailwind'>
-            <TooltipPrimitive.Content
-                ref={ref}
-                sideOffset={sideOffset}
-                className={cn(
-                    'z-50 overflow-hidden rounded-md bg-black px-3! py-1! text-xs text-white animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-                    className,
-                )}
-                {...props}
-            />
-        </div>
+        <TooltipPrimitive.Content
+            ref={ref}
+            sideOffset={sideOffset}
+            className={cn(
+                'z-50 overflow-hidden rounded-md bg-black px-3! py-1! text-xs text-white animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+                className,
+            )}
+            {...props}
+        />
     </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;

--- a/TrashMob/client-app/src/pages/MyDashboard/index.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/index.tsx
@@ -155,7 +155,7 @@ const MyDashboard: FC<MyDashboardProps> = () => {
     };
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Dashboard' Description="See how much you've done!" />
             <div className='container mt-12! pb-12!'>
                 {eventToShare ? (

--- a/TrashMob/client-app/src/pages/_home/index.tsx
+++ b/TrashMob/client-app/src/pages/_home/index.tsx
@@ -6,12 +6,12 @@ import { WhatIsTrashmobSection } from './whatistrashmob-section';
 
 export const Home = () => {
     return (
-        <div className='tailwind'>
+        <>
             <HeroSection />
             <WhatIsTrashmobSection />
             <StatsSection />
             <EventSection />
             <GettingStartSection />
-        </div>
+        </>
     );
 };

--- a/TrashMob/client-app/src/pages/aboutus/page.tsx
+++ b/TrashMob/client-app/src/pages/aboutus/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 
 export const AboutUs: React.FC = () => {
     return (
-        <div className='tailwind'>
+        <div>
             <div className='mt-1 bg-card px-8'>
                 <div className='max-w-6xl mx-auto grid grid-cols-12'>
                     <div className='col-span-12 lg:col-span-5 pb-20 space-y-4'>

--- a/TrashMob/client-app/src/pages/board/page.tsx
+++ b/TrashMob/client-app/src/pages/board/page.tsx
@@ -53,7 +53,7 @@ const boards = [
 
 export const Board: React.FC = () => {
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Board of Directors' Description='Meet our team!' />
             <div className='container my-5 pb-5'>
                 {boards.map((board) => (

--- a/TrashMob/client-app/src/pages/contactus/index.tsx
+++ b/TrashMob/client-app/src/pages/contactus/index.tsx
@@ -78,7 +78,7 @@ export const ContactUs = () => {
     );
 
     return (
-        <div className='tailwind'>
+        <div>
             <div className='w-full max-w-xl mx-auto py-16'>
                 <Card>
                     <CardHeader>

--- a/TrashMob/client-app/src/pages/deletemydata/index.tsx
+++ b/TrashMob/client-app/src/pages/deletemydata/index.tsx
@@ -30,7 +30,7 @@ export const DeleteMyData: FC<DeleteMyDataProps> = (props) => {
     };
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection
                 Title='Delete your account?'
                 Description='TrashMob members are making the world a better place!'

--- a/TrashMob/client-app/src/pages/eventdetails/$eventId/page.tsx
+++ b/TrashMob/client-app/src/pages/eventdetails/$eventId/page.tsx
@@ -88,7 +88,7 @@ export const EventDetails: FC<EventDetailsProps> = () => {
     });
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='View Events' Description='Learn, join, and inspire.' />
             {!isDataLoaded ? (
                 <p>

--- a/TrashMob/client-app/src/pages/events/$eventId/delete.tsx
+++ b/TrashMob/client-app/src/pages/events/$eventId/delete.tsx
@@ -76,7 +76,7 @@ export const CancelEvent: React.FC = () => {
     const cancellationReason = form.watch('cancellationReason');
 
     return (
-        <div className='tailwind'>
+        <div>
             {event ? (
                 <ShareToSocialsDialog
                     eventToShare={event}

--- a/TrashMob/client-app/src/pages/events/_layout.tsx
+++ b/TrashMob/client-app/src/pages/events/_layout.tsx
@@ -9,7 +9,7 @@ interface ManageEventDashboardLayoutProps {
 
 export const ManageEventDashboardLayout = (props: PropsWithChildren<ManageEventDashboardLayoutProps>) => {
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Manage Event' Description='We can’t wait to see the results.' />
             <section className=''>
                 <div className='container'>

--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
@@ -202,7 +202,7 @@ export const EditEventSummary = () => {
     const isOwner = event.createdByUserId === currentUser.id;
     const isSubmitting = createEventSummary.isLoading || updateEventSummary.isLoading;
     return (
-        <div className='tailwind'>
+        <div>
             <div className='max-w-2xl mx-auto py-8 space-y-8'>
                 <Card>
                     <CardHeader>

--- a/TrashMob/client-app/src/pages/faq/page.tsx
+++ b/TrashMob/client-app/src/pages/faq/page.tsx
@@ -100,7 +100,7 @@ export const Faq: React.FC = () => {
     const faqGroup = faqs.find((group) => group.category === selectedGroupKey);
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='FAQ' Description='We’ve got you covered.' />
             <div className='container mx-auto my-5 pt-5 space-y-4'>
                 <div className='flex flex-col sm:flex-row gap-4'>

--- a/TrashMob/client-app/src/pages/gettingstarted/page.tsx
+++ b/TrashMob/client-app/src/pages/gettingstarted/page.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 
 export const GettingStarted: React.FC = () => {
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Getting Started' Description='Tips and tricks to get you out there.' />
             <section className='bg-card py-5! px-4!'>
                 <h2 className='font-semibold text-center text-[40px] mt-10 mb-2'>The Basics</h2>

--- a/TrashMob/client-app/src/pages/help/page.tsx
+++ b/TrashMob/client-app/src/pages/help/page.tsx
@@ -209,7 +209,7 @@ export const Help: React.FC = () => {
     const tabContent = tabContents.find((tab) => tab.category === selectedTab);
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Site Help' Description='Answering your questions!' />
             <div className='container mx-auto my-5 pt-5 space-y-4'>
                 <div className='flex flex-col sm:flex-row gap-4'>

--- a/TrashMob/client-app/src/pages/locationpreference/index.tsx
+++ b/TrashMob/client-app/src/pages/locationpreference/index.tsx
@@ -229,7 +229,7 @@ export const LocationPreference = () => {
     if (!user) return null;
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Set your location' Description='Get notified for events near you!' />
             <div className='container mx-auto py-5'>
                 <Card>

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/_layout.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/_layout.tsx
@@ -27,7 +27,7 @@ export const PartnerLayout = () => {
     );
 
     return (
-        <div className='tailwind'>
+        <div>
             <div className='container mx-auto my-4'>
                 <Tabs value={location.pathname} onValueChange={handleValueChange}>
                     <TabsList className='w-full h-14'>

--- a/TrashMob/client-app/src/pages/partnerrequestdetails/page.tsx
+++ b/TrashMob/client-app/src/pages/partnerrequestdetails/page.tsx
@@ -66,7 +66,7 @@ export const PartnerRequestDetails: React.FC = () => {
     }
 
     return (
-        <div className='tailwind'>
+        <div>
             <div className='container grid grid-cols-12 space-x-4 my-8'>
                 <div className='col-span-4'>
                     <Card className='h-full'>

--- a/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
@@ -27,7 +27,7 @@ export const SiteAdminLayout = () => {
     );
 
     return (
-        <div className='tailwind'>
+        <div>
             <div className='container mx-auto my-4'>
                 <h1 className='scroll-m-20 pb-4 text-3xl font-light tracking-tight first:mt-0'>Site Administration</h1>
                 <Tabs value={location.pathname} onValueChange={handleValueChange}>

--- a/TrashMob/client-app/src/pages/termsofservice/index.tsx
+++ b/TrashMob/client-app/src/pages/termsofservice/index.tsx
@@ -10,7 +10,7 @@ export class TermsOfServiceVersion {
 
 export const TermsOfService: FC = () => {
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Terms of Service' Description='Transparency matters to us.' />
             <div className='py-5 mx-auto container'>
                 <h5 className='font-semibold mt-5'>1. Terms</h5>

--- a/TrashMob/client-app/src/pages/volunteeropportunities/index.tsx
+++ b/TrashMob/client-app/src/pages/volunteeropportunities/index.tsx
@@ -16,7 +16,7 @@ export const VolunteerOpportunities: React.FC = () => {
     });
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Recruiting' Description='We’d love to have you join us.' />
             <div className='container mx-auto'>
                 <div className='grid grid-cols-12 gap-4'>

--- a/TrashMob/client-app/src/pages/waivers/page.tsx
+++ b/TrashMob/client-app/src/pages/waivers/page.tsx
@@ -64,7 +64,7 @@ const Waivers: React.FC<WaiversProps> = () => {
     if (!isUserLoaded) return null;
 
     return (
-        <div className='tailwind'>
+        <div>
             <HeroSection Title='Waiver' Description='Safety first!' />
             <div className='container prose space-y-4 py-12'>
                 <h2 className='font-medium text-3xl'>TrashMob.eco Waiver</h2>


### PR DESCRIPTION
.tailwind was used to separate bootstrap components/pages with tailwind components/pages.
Now all bootstrap components/pages has been removed, we can safely remove these .tailwind wrapper and let tailwind apply to all codebase by default