### PR TITLE
Add admin litter reports page (Phase 3 admin tools)

### DIFF
--- a/Planning/Projects/Project_03_Litter_Reporting_Web.md
+++ b/Planning/Projects/Project_03_Litter_Reporting_Web.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress |
+| **Status** | Complete |
 | **Priority** | Moderate |
 | **Risk** | Low |
 | **Size** | Medium |
@@ -54,7 +54,7 @@ Achieve feature parity between mobile and web for litter reporting. Currently, u
 - ✅ Delete existing reports (creator or admin) - PR #2439
 - ✅ Change status (New → Assigned → Cleaned → Cancelled) - PR #2439
 - ✅ Associate with events - PR #2445
-- ☐ Admin moderation tools
+- ✅ Admin moderation tools - PR #2455
 
 ### Phase 4 - Integration
 - ✅ Weekly digest emails for new reports - PR #2451
@@ -444,12 +444,13 @@ No changes required (already implemented).
 | [#2442](https://github.com/TrashMob-eco/TrashMob/pull/2442) | Add create litter report form with photo upload (Phase 2) | Merged |
 | [#2445](https://github.com/TrashMob-eco/TrashMob/pull/2445) | Add litter report association to Event Summary page (Phase 6) | Merged |
 | [#2451](https://github.com/TrashMob-eco/TrashMob/pull/2451) | Add Phase 4 integration features (Phase 4) | Merged |
-| [#2452](https://github.com/TrashMob-eco/TrashMob/pull/2452) | Auto-update litter report status on event summary submission | Pending |
+| [#2452](https://github.com/TrashMob-eco/TrashMob/pull/2452) | Auto-update litter report status on event summary submission | Merged |
+| [#2455](https://github.com/TrashMob-eco/TrashMob/pull/2455) | Add admin litter reports page (Phase 3 admin tools) | Pending |
 
 ### Summary
 - **Phase 1 (Viewing):** ✅ Complete - List page, detail page, map integration with toggle/legend, navigation link
 - **Phase 2 (Creation):** ✅ Complete - Create form, photo upload, location picker (PR #2442)
-- **Phase 3 (Management):** 🔄 Partial - Edit/delete/status/event association complete, admin tools pending
+- **Phase 3 (Management):** ✅ Complete - Edit/delete/status/event association, admin moderation page (PR #2455)
 - **Phase 4 (Integration):** ✅ Complete - Email notifications, dashboard widget, event creation from report (PR #2451)
 - **Phase 5 (MyDashboard):** ✅ Complete - My reports section, edit/delete actions, stats metric
 - **Phase 6 (Event Summary):** ✅ Complete - Show/add/remove litter reports, auto-update status (PRs #2445, #2452)

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -88,6 +88,7 @@ import { SiteAdminJobOpportunityEdit } from './pages/siteadmin/job-opportunities
 import { SiteAdminEmailTemplates } from './pages/siteadmin/email-templates';
 import { SiteAdminSendNotification } from './pages/siteadmin/send-notification';
 import { SiteAdminContent } from './pages/siteadmin/content';
+import { SiteAdminLitterReports } from './pages/siteadmin/litter-reports/page';
 import { NoMatch } from './pages/nomatch';
 
 const queryClient = new QueryClient();
@@ -224,6 +225,7 @@ const AppContent: FC = () => {
                                 <Route path='users' element={<SiteAdminUsers />} />
                                 <Route path='events' element={<SiteAdminEvents />} />
                                 <Route path='partners' element={<SiteAdminPartners />} />
+                                <Route path='litter-reports' element={<SiteAdminLitterReports />} />
                                 <Route path='partner-requests' element={<SiteAdminPartnerRequests />} />
                                 <Route path='job-opportunities' element={<SiteAdminJobOpportunities />}>
                                     <Route path=':jobId/edit' element={<SiteAdminJobOpportunityEdit />} />

--- a/TrashMob/client-app/src/components/litter-reports/litter-report-status-badge.tsx
+++ b/TrashMob/client-app/src/components/litter-reports/litter-report-status-badge.tsx
@@ -1,0 +1,29 @@
+import { Badge } from '@/components/ui/badge';
+import { LitterReportStatusEnum } from '@/components/Models/LitterReportStatus';
+
+interface LitterReportStatusBadgeProps {
+    statusId: number;
+}
+
+export const LitterReportStatusBadge = ({ statusId }: LitterReportStatusBadgeProps) => {
+    switch (statusId) {
+        case LitterReportStatusEnum.New:
+            return <Badge variant='destructive'>New</Badge>;
+        case LitterReportStatusEnum.Assigned:
+            return (
+                <Badge variant='default' className='bg-yellow-500'>
+                    Assigned
+                </Badge>
+            );
+        case LitterReportStatusEnum.Cleaned:
+            return <Badge variant='success'>Cleaned</Badge>;
+        case LitterReportStatusEnum.Cancelled:
+            return (
+                <Badge variant='secondary' className='bg-gray-500 text-white'>
+                    Cancelled
+                </Badge>
+            );
+        default:
+            return <Badge variant='outline'>Unknown</Badge>;
+    }
+};

--- a/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
@@ -11,6 +11,7 @@ export const SiteAdminLayout = () => {
         { name: 'Manage Users', value: `${pathPrefix}/users` },
         { name: 'Manage Events', value: `${pathPrefix}/events` },
         { name: 'Manage Partners', value: `${pathPrefix}/partners` },
+        { name: 'Manage Litter Reports', value: `${pathPrefix}/litter-reports` },
         { name: 'Manage Partner Requests', value: `${pathPrefix}/partner-requests` },
         { name: 'Manage Job Opportunities', value: `${pathPrefix}/job-opportunities` },
         // { name: 'View Executive Summary', value: `${pathPrefix}/executive-summary` },

--- a/TrashMob/client-app/src/pages/siteadmin/litter-reports/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/litter-reports/columns.tsx
@@ -1,0 +1,92 @@
+import { Link } from 'react-router';
+import { ColumnDef } from '@tanstack/react-table';
+import { Ellipsis, Eye, Pencil, Trash2 } from 'lucide-react';
+import { LitterReportStatusBadge } from '@/components/litter-reports/litter-report-status-badge';
+import LitterReportData from '@/components/Models/LitterReportData';
+import moment from 'moment';
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { DataTableColumnHeader } from '@/components/ui/data-table';
+
+export const columns: ColumnDef<LitterReportData>[] = [
+    {
+        accessorKey: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        cell: ({ row }) => {
+            const name = row.getValue('name') as string;
+            return <span className='font-medium'>{name || 'Unnamed Report'}</span>;
+        },
+    },
+    {
+        accessorKey: 'litterReportStatusId',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        cell: ({ row }) => {
+            return <LitterReportStatusBadge statusId={row.getValue('litterReportStatusId')} />;
+        },
+    },
+    {
+        accessorKey: 'createdDate',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Created' />,
+        cell: ({ row }) => {
+            const date = row.getValue('createdDate');
+            return date ? moment(date as Date).format('lll') : '-';
+        },
+    },
+    {
+        accessorKey: 'createdByUserName',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Created By' />,
+        cell: ({ row }) => {
+            return row.getValue('createdByUserName') || '-';
+        },
+    },
+    {
+        accessorKey: 'litterImages',
+        header: 'Images',
+        cell: ({ row }) => {
+            const images = row.original.litterImages || [];
+            return images.length;
+        },
+    },
+    {
+        accessorKey: 'actions',
+        header: 'Actions',
+        cell: ({ row }) => {
+            const litterReport = row.original;
+
+            return (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button variant='ghost' size='icon'>
+                            <Ellipsis />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className='w-56'>
+                        <DropdownMenuItem asChild>
+                            <Link to={`/litterreports/${litterReport.id}`}>
+                                <Eye />
+                                View Report
+                            </Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem asChild>
+                            <Link to={`/litterreports/${litterReport.id}/edit`}>
+                                <Pencil />
+                                Edit Report
+                            </Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem asChild>
+                            <Link to={`/litterreports/${litterReport.id}/delete`}>
+                                <Trash2 />
+                                Delete Report
+                            </Link>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            );
+        },
+    },
+];

--- a/TrashMob/client-app/src/pages/siteadmin/litter-reports/page.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/litter-reports/page.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { DataTable } from '@/components/ui/data-table';
+import { columns } from './columns';
+import { GetLitterReports } from '@/services/litter-report';
+
+export const SiteAdminLitterReports = () => {
+    const { data: litterReports, isLoading } = useQuery({
+        queryKey: GetLitterReports().key,
+        queryFn: GetLitterReports().service,
+        select: (res) => res.data,
+    });
+
+    const len = litterReports?.length ?? 0;
+
+    if (isLoading) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className='text-primary'>Litter Reports</CardTitle>
+                </CardHeader>
+                <CardContent>Loading...</CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className='text-primary'>Litter Reports ({len})</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <DataTable columns={columns} data={litterReports || []} />
+            </CardContent>
+        </Card>
+    );
+};


### PR DESCRIPTION
## Summary
- Adds a "Manage Litter Reports" tab to the site admin section
- Creates a DataTable view showing all litter reports with status, creator, and image count
- Provides admin actions to view, edit, and delete any litter report
- Creates a reusable LitterReportStatusBadge component for consistent status display

This completes Phase 3 (Management) of Project 3 - Litter Reporting Web.

## Test plan
- [ ] Navigate to `/siteadmin/litter-reports` as a site admin
- [ ] Verify the "Manage Litter Reports" tab appears in the navigation
- [ ] Verify all litter reports are displayed in the table
- [ ] Verify status badges display correctly (New=red, Assigned=yellow, Cleaned=green, Cancelled=grey)
- [ ] Verify "View Report" action navigates to the report detail page
- [ ] Verify "Edit Report" action navigates to the edit page
- [ ] Verify "Delete Report" action navigates to the delete confirmation page

🤖 Generated with [Claude Code](https://claude.ai/code)