### PR TITLE
Remove Privo emails from Project 23 Parental Consent doc

### DIFF
--- a/Planning/Projects/Project_23_Parental_Consent.md
+++ b/Planning/Projects/Project_23_Parental_Consent.md
@@ -194,9 +194,7 @@ public interface IPrivoService
 - Send parental waiver to parent on signup
 
 **Figma access required for Privo team:**
-- devops@privo.com
-- figmadevmode@privo.com
-- ttayloe@privo.com
+*(Contact addresses stored in secure location - not in public repo)*
 
 ---
 


### PR DESCRIPTION
## Summary
Remove Privo.com email addresses from Project_23_Parental_Consent.md (Figma access section).

Missed in the previous PR - these were in the main project doc, not just the integration package.

## Test plan
- [ ] Verify no email addresses remain in planning docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)