### PR TITLE
Project 9 Phase 3: Add Team Events API and frontend integration

### DIFF
--- a/TrashMob/Controllers/TeamEventsController.cs
+++ b/TrashMob/Controllers/TeamEventsController.cs
@@ -1,0 +1,254 @@
+namespace TrashMob.Controllers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// Controller for team event associations.
+    /// </summary>
+    [Route("api/teams/{teamId}/events")]
+    public class TeamEventsController(
+        ITeamManager teamManager,
+        ITeamMemberManager teamMemberManager,
+        IKeyedRepository<TeamEvent> teamEventRepository,
+        IKeyedManager<Event> eventManager)
+        : SecureController
+    {
+        /// <summary>
+        /// Gets all events associated with a team.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetTeamEvents(Guid teamId, CancellationToken cancellationToken)
+        {
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team == null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            // Private teams: only members can view events
+            if (!team.IsPublic)
+            {
+                if (!User.Identity.IsAuthenticated)
+                {
+                    return NotFound();
+                }
+
+                var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+                if (!isMember)
+                {
+                    return NotFound();
+                }
+            }
+
+            var teamEvents = await teamEventRepository.Get()
+                .Where(te => te.TeamId == teamId)
+                .Include(te => te.Event)
+                .Select(te => te.Event)
+                .ToListAsync(cancellationToken);
+
+            return Ok(teamEvents);
+        }
+
+        /// <summary>
+        /// Gets upcoming events for a team.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("upcoming")]
+        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetUpcomingTeamEvents(Guid teamId, CancellationToken cancellationToken)
+        {
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team == null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            // Private teams: only members can view events
+            if (!team.IsPublic)
+            {
+                if (!User.Identity.IsAuthenticated)
+                {
+                    return NotFound();
+                }
+
+                var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+                if (!isMember)
+                {
+                    return NotFound();
+                }
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var teamEvents = await teamEventRepository.Get()
+                .Where(te => te.TeamId == teamId)
+                .Include(te => te.Event)
+                .Where(te => te.Event.EventDate >= now && te.Event.EventStatusId != (int)EventStatusEnum.Canceled)
+                .Select(te => te.Event)
+                .OrderBy(e => e.EventDate)
+                .ToListAsync(cancellationToken);
+
+            return Ok(teamEvents);
+        }
+
+        /// <summary>
+        /// Gets past events for a team.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("past")]
+        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetPastTeamEvents(Guid teamId, CancellationToken cancellationToken)
+        {
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team == null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            // Private teams: only members can view events
+            if (!team.IsPublic)
+            {
+                if (!User.Identity.IsAuthenticated)
+                {
+                    return NotFound();
+                }
+
+                var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+                if (!isMember)
+                {
+                    return NotFound();
+                }
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var teamEvents = await teamEventRepository.Get()
+                .Where(te => te.TeamId == teamId)
+                .Include(te => te.Event)
+                .Where(te => te.Event.EventDate < now)
+                .Select(te => te.Event)
+                .OrderByDescending(e => e.EventDate)
+                .ToListAsync(cancellationToken);
+
+            return Ok(teamEvents);
+        }
+
+        /// <summary>
+        /// Links an event to a team. Only team leads can link events.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="eventId">The event ID to link.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("{eventId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamEvent), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> LinkEventToTeam(Guid teamId, Guid eventId, CancellationToken cancellationToken)
+        {
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team == null || !team.IsActive)
+            {
+                return NotFound("Team not found.");
+            }
+
+            // Check if user is a team lead
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            // Check if event exists
+            var eventEntity = await eventManager.GetAsync(eventId, cancellationToken);
+            if (eventEntity == null)
+            {
+                return NotFound("Event not found.");
+            }
+
+            // Check if already linked
+            var existingLink = await teamEventRepository.Get()
+                .FirstOrDefaultAsync(te => te.TeamId == teamId && te.EventId == eventId, cancellationToken);
+
+            if (existingLink != null)
+            {
+                return BadRequest("Event is already linked to this team.");
+            }
+
+            var teamEvent = new TeamEvent
+            {
+                Id = Guid.NewGuid(),
+                TeamId = teamId,
+                EventId = eventId,
+                CreatedByUserId = UserId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = UserId,
+                LastUpdatedDate = DateTimeOffset.UtcNow,
+            };
+
+            var created = await teamEventRepository.AddAsync(teamEvent);
+            return CreatedAtAction(nameof(GetTeamEvents), new { teamId }, created);
+        }
+
+        /// <summary>
+        /// Unlinks an event from a team. Only team leads can unlink events.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="eventId">The event ID to unlink.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpDelete("{eventId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UnlinkEventFromTeam(Guid teamId, Guid eventId, CancellationToken cancellationToken)
+        {
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team == null)
+            {
+                return NotFound("Team not found.");
+            }
+
+            // Check if user is a team lead
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var teamEvent = await teamEventRepository.Get()
+                .FirstOrDefaultAsync(te => te.TeamId == teamId && te.EventId == eventId, cancellationToken);
+
+            if (teamEvent == null)
+            {
+                return NotFound("Event is not linked to this team.");
+            }
+
+            await teamEventRepository.DeleteAsync(teamEvent.Id);
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/client-app/src/components/Models/TeamData.tsx
+++ b/TrashMob/client-app/src/components/Models/TeamData.tsx
@@ -1,0 +1,39 @@
+import { Guid } from 'guid-typescript';
+
+class TeamData {
+    id: string = Guid.createEmpty().toString();
+
+    name: string = '';
+
+    description: string = '';
+
+    logoUrl: string = '';
+
+    isPublic: boolean = true;
+
+    requiresApproval: boolean = false;
+
+    latitude: number | null = null;
+
+    longitude: number | null = null;
+
+    city: string = '';
+
+    region: string = '';
+
+    country: string = '';
+
+    postalCode: string = '';
+
+    isActive: boolean = true;
+
+    createdByUserId: string = Guid.EMPTY;
+
+    createdDate: Date = new Date();
+
+    lastUpdatedByUserId: string = Guid.EMPTY;
+
+    lastUpdatedDate: Date = new Date();
+}
+
+export default TeamData;

--- a/TrashMob/client-app/src/components/Models/TeamEventData.tsx
+++ b/TrashMob/client-app/src/components/Models/TeamEventData.tsx
@@ -1,0 +1,19 @@
+import { Guid } from 'guid-typescript';
+
+class TeamEventData {
+    id: string = Guid.createEmpty().toString();
+
+    teamId: string = Guid.createEmpty().toString();
+
+    eventId: string = Guid.createEmpty().toString();
+
+    createdByUserId: string = Guid.EMPTY;
+
+    createdDate: Date = new Date();
+
+    lastUpdatedByUserId: string = Guid.EMPTY;
+
+    lastUpdatedDate: Date = new Date();
+}
+
+export default TeamEventData;

--- a/TrashMob/client-app/src/components/Models/TeamMemberData.tsx
+++ b/TrashMob/client-app/src/components/Models/TeamMemberData.tsx
@@ -1,0 +1,26 @@
+import { Guid } from 'guid-typescript';
+
+class TeamMemberData {
+    id: string = Guid.createEmpty().toString();
+
+    teamId: string = Guid.createEmpty().toString();
+
+    userId: string = Guid.createEmpty().toString();
+
+    isTeamLead: boolean = false;
+
+    joinedDate: Date = new Date();
+
+    createdByUserId: string = Guid.EMPTY;
+
+    createdDate: Date = new Date();
+
+    lastUpdatedByUserId: string = Guid.EMPTY;
+
+    lastUpdatedDate: Date = new Date();
+
+    // Optional user info for display purposes
+    userName?: string;
+}
+
+export default TeamMemberData;

--- a/TrashMob/client-app/src/pages/MyDashboard/MyTeamsTable.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyTeamsTable.tsx
@@ -1,0 +1,88 @@
+import { Link } from 'react-router';
+import { ColumnDef } from '@tanstack/react-table';
+import { MapPin, Users, Eye, Crown } from 'lucide-react';
+
+import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import TeamData from '@/components/Models/TeamData';
+
+const getLocation = (team: TeamData) => {
+    const parts = [team.city, team.region].filter(Boolean);
+    return parts.join(', ') || '-';
+};
+
+interface MyTeamsTableProps {
+    items: TeamData[];
+    teamsILead: TeamData[];
+}
+
+export const MyTeamsTable = ({ items, teamsILead }: MyTeamsTableProps) => {
+    const leadTeamIds = new Set(teamsILead.map((t) => t.id));
+
+    const columns: ColumnDef<TeamData>[] = [
+        {
+            accessorKey: 'name',
+            header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+            cell: ({ row }) => (
+                <Link to={`/teams/${row.original.id}`} className='text-primary hover:underline font-medium'>
+                    {row.original.name}
+                </Link>
+            ),
+        },
+        {
+            id: 'role',
+            header: 'Role',
+            cell: ({ row }) => {
+                const isLead = leadTeamIds.has(row.original.id);
+                return isLead ? (
+                    <Badge variant='outline' className='bg-primary text-white border-0'>
+                        <Crown className='h-3 w-3 mr-1' /> Lead
+                    </Badge>
+                ) : (
+                    <Badge variant='outline'>Member</Badge>
+                );
+            },
+        },
+        {
+            id: 'location',
+            header: ({ column }) => <DataTableColumnHeader column={column} title='Location' />,
+            cell: ({ row }) => (
+                <div className='flex items-center gap-1'>
+                    <MapPin className='h-4 w-4 text-muted-foreground' />
+                    <span>{getLocation(row.original)}</span>
+                </div>
+            ),
+        },
+        {
+            id: 'visibility',
+            header: 'Visibility',
+            cell: ({ row }) => (
+                <Badge variant={row.original.isPublic ? 'outline' : 'secondary'}>
+                    {row.original.isPublic ? 'Public' : 'Private'}
+                </Badge>
+            ),
+        },
+        {
+            id: 'actions',
+            header: '',
+            cell: ({ row }) => (
+                <Button variant='ghost' size='sm' asChild>
+                    <Link to={`/teams/${row.original.id}`}>
+                        <Eye className='h-4 w-4 mr-1' /> View
+                    </Link>
+                </Button>
+            ),
+        },
+    ];
+
+    if (items.length === 0) {
+        return (
+            <p className='text-muted-foreground text-center py-4'>
+                You are not a member of any teams yet. Browse public teams to join one!
+            </p>
+        );
+    }
+
+    return <DataTable columns={columns} data={items} />;
+};

--- a/TrashMob/client-app/src/pages/MyDashboard/index.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/index.tsx
@@ -4,7 +4,7 @@ import orderBy from 'lodash/orderBy';
 import { Link, useNavigate, useLocation } from 'react-router';
 import { APIProvider } from '@vis.gl/react-google-maps';
 import { useQuery } from '@tanstack/react-query';
-import { Plus } from 'lucide-react';
+import { Plus, Users } from 'lucide-react';
 import { AxiosResponse } from 'axios';
 
 import * as SharingMessages from '@/store/SharingMessages';
@@ -16,6 +16,7 @@ import DisplayPartnershipData from '@/components/Models/DisplayPartnershipData';
 import DisplayPartnerAdminInvitationData from '@/components/Models/DisplayPartnerAdminInvitationData';
 import DisplayPartnerLocationEventData from '@/components/Models/DisplayPartnerLocationEventServiceData';
 import LitterReportData from '@/components/Models/LitterReportData';
+import TeamData from '@/components/Models/TeamData';
 
 import twofigure from '@/components/assets/card/twofigure.svg';
 import calendarclock from '@/components/assets/card/calendarclock.svg';
@@ -39,6 +40,7 @@ import { GetPartnerAdminsForUser } from '@/services/admin';
 import { GetPartnerAdminInvitationsByUser } from '@/services/invitations';
 import { GetEventPickupLocationsByUser, GetPartnerLocationEventServicesByUserId } from '@/services/locations';
 import { GetUserLitterReports } from '@/services/litter-report';
+import { GetMyTeams, GetTeamsILead } from '@/services/teams';
 
 import { useGetGoogleMapApiKey } from '@/hooks/useGetGoogleMapApiKey';
 import { useGetUserEvents } from '@/hooks/useGetUserEvents';
@@ -50,6 +52,7 @@ import { MyPartnersRequestTable } from '@/pages/MyDashboard/MyPartnersRequestTab
 import { PartnerAdminInvitationsTable } from '@/pages/MyDashboard/PartnerAdminInvitationsTable';
 import { MyLitterReportsTable } from '@/pages/MyDashboard/MyLitterReportsTable';
 import { NearbyLitterReportsWidget } from '@/pages/MyDashboard/NearbyLitterReportsWidget';
+import { MyTeamsTable } from '@/pages/MyDashboard/MyTeamsTable';
 
 const isUpcomingEvent = (event: EventData) => new Date(event.eventDate) >= new Date();
 const isPastEvent = (event: EventData) => new Date(event.eventDate) < new Date();
@@ -121,6 +124,20 @@ const MyDashboard: FC<MyDashboardProps> = () => {
     const { data: myLitterReports } = useQuery<AxiosResponse<LitterReportData[]>, unknown, LitterReportData[]>({
         queryKey: GetUserLitterReports({ userId }).key,
         queryFn: GetUserLitterReports({ userId }).service,
+        select: (res) => res.data,
+    });
+
+    // User's Teams
+    const { data: myTeams } = useQuery<AxiosResponse<TeamData[]>, unknown, TeamData[]>({
+        queryKey: GetMyTeams().key,
+        queryFn: GetMyTeams().service,
+        select: (res) => res.data,
+    });
+
+    // Teams user leads
+    const { data: teamsILead } = useQuery<AxiosResponse<TeamData[]>, unknown, TeamData[]>({
+        queryKey: GetTeamsILead().key,
+        queryFn: GetTeamsILead().service,
         select: (res) => res.data,
     });
 
@@ -293,6 +310,25 @@ const MyDashboard: FC<MyDashboardProps> = () => {
                         ) : (
                             <EventsTable events={pastEvents} currentUser={currentUser} />
                         )}
+                    </CardContent>
+                </Card>
+
+                <Card className='mb-4'>
+                    <CardHeader>
+                        <div className='flex flex-row'>
+                            <CardTitle className='grow text-primary'>
+                                <Users className='inline-block h-5 w-5 mr-2' />
+                                My Teams ({(myTeams || []).length})
+                            </CardTitle>
+                            <Button variant='outline' size='sm' asChild>
+                                <Link to='/teams'>Browse Teams</Link>
+                            </Button>
+                        </div>
+                    </CardHeader>
+                    <CardContent>
+                        <div className='overflow-auto'>
+                            <MyTeamsTable items={myTeams || []} teamsILead={teamsILead || []} />
+                        </div>
                     </CardContent>
                 </Card>
 

--- a/TrashMob/client-app/src/services/teams.ts
+++ b/TrashMob/client-app/src/services/teams.ts
@@ -1,0 +1,252 @@
+// Teams API service
+
+import { ApiService } from '.';
+import EventData from '../components/Models/EventData';
+import TeamData from '../components/Models/TeamData';
+import TeamEventData from '../components/Models/TeamEventData';
+import TeamMemberData from '../components/Models/TeamMemberData';
+
+// ============================================================================
+// Team Operations
+// ============================================================================
+
+export type GetPublicTeams_Params = {
+    latitude?: number;
+    longitude?: number;
+    radiusMiles?: number;
+};
+export type GetPublicTeams_Response = TeamData[];
+export const GetPublicTeams = (params?: GetPublicTeams_Params) => ({
+    key: ['/teams', params],
+    service: async () => {
+        const queryParams = new URLSearchParams();
+        if (params?.latitude !== undefined) queryParams.append('latitude', params.latitude.toString());
+        if (params?.longitude !== undefined) queryParams.append('longitude', params.longitude.toString());
+        if (params?.radiusMiles !== undefined) queryParams.append('radiusMiles', params.radiusMiles.toString());
+        const queryString = queryParams.toString();
+        return ApiService('public').fetchData<GetPublicTeams_Response>({
+            url: `/teams${queryString ? `?${queryString}` : ''}`,
+            method: 'get',
+        });
+    },
+});
+
+export type GetTeamById_Params = { teamId: string };
+export type GetTeamById_Response = TeamData;
+export const GetTeamById = (params: GetTeamById_Params) => ({
+    key: ['/teams/', params.teamId],
+    service: async () =>
+        ApiService('public').fetchData<GetTeamById_Response>({
+            url: `/teams/${params.teamId}`,
+            method: 'get',
+        }),
+});
+
+export type GetMyTeams_Response = TeamData[];
+export const GetMyTeams = () => ({
+    key: ['/teams/my'],
+    service: async () =>
+        ApiService('protected').fetchData<GetMyTeams_Response>({
+            url: '/teams/my',
+            method: 'get',
+        }),
+});
+
+export type GetTeamsILead_Response = TeamData[];
+export const GetTeamsILead = () => ({
+    key: ['/teams/my/leading'],
+    service: async () =>
+        ApiService('protected').fetchData<GetTeamsILead_Response>({
+            url: '/teams/my/leading',
+            method: 'get',
+        }),
+});
+
+export type CheckTeamName_Params = { name: string; excludeTeamId?: string };
+export type CheckTeamName_Response = boolean;
+export const CheckTeamName = (params: CheckTeamName_Params) => ({
+    key: ['/teams/check-name', params],
+    service: async () => {
+        const queryParams = new URLSearchParams({ name: params.name });
+        if (params.excludeTeamId) queryParams.append('excludeTeamId', params.excludeTeamId);
+        return ApiService('public').fetchData<CheckTeamName_Response>({
+            url: `/teams/check-name?${queryParams.toString()}`,
+            method: 'get',
+        });
+    },
+});
+
+export type CreateTeam_Body = TeamData;
+export type CreateTeam_Response = TeamData;
+export const CreateTeam = () => ({
+    key: ['/teams', 'create'],
+    service: async (body: CreateTeam_Body) =>
+        ApiService('protected').fetchData<CreateTeam_Response, CreateTeam_Body>({
+            url: '/teams',
+            method: 'post',
+            data: body,
+        }),
+});
+
+export type UpdateTeam_Body = TeamData;
+export type UpdateTeam_Response = TeamData;
+export const UpdateTeam = () => ({
+    key: ['/teams', 'update'],
+    service: async (body: UpdateTeam_Body) =>
+        ApiService('protected').fetchData<UpdateTeam_Response, UpdateTeam_Body>({
+            url: `/teams/${body.id}`,
+            method: 'put',
+            data: body,
+        }),
+});
+
+export type DeactivateTeam_Params = { teamId: string };
+export type DeactivateTeam_Response = void;
+export const DeactivateTeam = () => ({
+    key: ['/teams', 'deactivate'],
+    service: async (params: DeactivateTeam_Params) =>
+        ApiService('protected').fetchData<DeactivateTeam_Response>({
+            url: `/teams/${params.teamId}`,
+            method: 'delete',
+        }),
+});
+
+// ============================================================================
+// Team Member Operations
+// ============================================================================
+
+export type GetTeamMembers_Params = { teamId: string };
+export type GetTeamMembers_Response = TeamMemberData[];
+export const GetTeamMembers = (params: GetTeamMembers_Params) => ({
+    key: ['/teams/', params.teamId, '/members'],
+    service: async () =>
+        ApiService('public').fetchData<GetTeamMembers_Response>({
+            url: `/teams/${params.teamId}/members`,
+            method: 'get',
+        }),
+});
+
+export type GetTeamLeads_Params = { teamId: string };
+export type GetTeamLeads_Response = TeamMemberData[];
+export const GetTeamLeads = (params: GetTeamLeads_Params) => ({
+    key: ['/teams/', params.teamId, '/members/leads'],
+    service: async () =>
+        ApiService('public').fetchData<GetTeamLeads_Response>({
+            url: `/teams/${params.teamId}/members/leads`,
+            method: 'get',
+        }),
+});
+
+export type JoinTeam_Params = { teamId: string };
+export type JoinTeam_Response = TeamMemberData;
+export const JoinTeam = () => ({
+    key: ['/teams/members', 'join'],
+    service: async (params: JoinTeam_Params) =>
+        ApiService('protected').fetchData<JoinTeam_Response>({
+            url: `/teams/${params.teamId}/members/join`,
+            method: 'post',
+        }),
+});
+
+export type AddTeamMember_Params = { teamId: string; userId: string };
+export type AddTeamMember_Response = TeamMemberData;
+export const AddTeamMember = () => ({
+    key: ['/teams/members', 'add'],
+    service: async (params: AddTeamMember_Params) =>
+        ApiService('protected').fetchData<AddTeamMember_Response>({
+            url: `/teams/${params.teamId}/members/${params.userId}`,
+            method: 'post',
+        }),
+});
+
+export type RemoveTeamMember_Params = { teamId: string; userId: string };
+export type RemoveTeamMember_Response = void;
+export const RemoveTeamMember = () => ({
+    key: ['/teams/members', 'remove'],
+    service: async (params: RemoveTeamMember_Params) =>
+        ApiService('protected').fetchData<RemoveTeamMember_Response>({
+            url: `/teams/${params.teamId}/members/${params.userId}`,
+            method: 'delete',
+        }),
+});
+
+export type PromoteToTeamLead_Params = { teamId: string; userId: string };
+export type PromoteToTeamLead_Response = TeamMemberData;
+export const PromoteToTeamLead = () => ({
+    key: ['/teams/members', 'promote'],
+    service: async (params: PromoteToTeamLead_Params) =>
+        ApiService('protected').fetchData<PromoteToTeamLead_Response>({
+            url: `/teams/${params.teamId}/members/${params.userId}/promote`,
+            method: 'put',
+        }),
+});
+
+export type DemoteFromTeamLead_Params = { teamId: string; userId: string };
+export type DemoteFromTeamLead_Response = TeamMemberData;
+export const DemoteFromTeamLead = () => ({
+    key: ['/teams/members', 'demote'],
+    service: async (params: DemoteFromTeamLead_Params) =>
+        ApiService('protected').fetchData<DemoteFromTeamLead_Response>({
+            url: `/teams/${params.teamId}/members/${params.userId}/demote`,
+            method: 'put',
+        }),
+});
+
+// ============================================================================
+// Team Event Operations
+// ============================================================================
+
+export type GetTeamEvents_Params = { teamId: string };
+export type GetTeamEvents_Response = EventData[];
+export const GetTeamEvents = (params: GetTeamEvents_Params) => ({
+    key: ['/teams/', params.teamId, '/events'],
+    service: async () =>
+        ApiService('public').fetchData<GetTeamEvents_Response>({
+            url: `/teams/${params.teamId}/events`,
+            method: 'get',
+        }),
+});
+
+export type GetTeamUpcomingEvents_Params = { teamId: string };
+export type GetTeamUpcomingEvents_Response = EventData[];
+export const GetTeamUpcomingEvents = (params: GetTeamUpcomingEvents_Params) => ({
+    key: ['/teams/', params.teamId, '/events/upcoming'],
+    service: async () =>
+        ApiService('public').fetchData<GetTeamUpcomingEvents_Response>({
+            url: `/teams/${params.teamId}/events/upcoming`,
+            method: 'get',
+        }),
+});
+
+export type GetTeamPastEvents_Params = { teamId: string };
+export type GetTeamPastEvents_Response = EventData[];
+export const GetTeamPastEvents = (params: GetTeamPastEvents_Params) => ({
+    key: ['/teams/', params.teamId, '/events/past'],
+    service: async () =>
+        ApiService('public').fetchData<GetTeamPastEvents_Response>({
+            url: `/teams/${params.teamId}/events/past`,
+            method: 'get',
+        }),
+});
+
+export type LinkEventToTeam_Params = { teamId: string; eventId: string };
+export type LinkEventToTeam_Response = TeamEventData;
+export const LinkEventToTeam = () => ({
+    key: ['/teams/events', 'link'],
+    service: async (params: LinkEventToTeam_Params) =>
+        ApiService('protected').fetchData<LinkEventToTeam_Response>({
+            url: `/teams/${params.teamId}/events/${params.eventId}`,
+            method: 'post',
+        }),
+});
+
+export type UnlinkEventFromTeam_Params = { teamId: string; eventId: string };
+export type UnlinkEventFromTeam_Response = void;
+export const UnlinkEventFromTeam = () => ({
+    key: ['/teams/events', 'unlink'],
+    service: async (params: UnlinkEventFromTeam_Params) =>
+        ApiService('protected').fetchData<UnlinkEventFromTeam_Response>({
+            url: `/teams/${params.teamId}/events/${params.eventId}`,
+            method: 'delete',
+        }),
+});


### PR DESCRIPTION
## Summary
- Add TeamEventsController for linking events to teams with endpoints for listing, linking, and unlinking events
- Add frontend TypeScript models (TeamData, TeamMemberData, TeamEventData)
- Add comprehensive teams.ts service with 16 API functions covering team CRUD, membership, and event operations
- Add MyTeamsTable component showing user's teams with role badges (Lead/Member)
- Integrate "My Teams" section into user dashboard between events and litter reports

## Test plan
- [ ] Verify build passes
- [ ] Verify all 93 backend tests pass
- [ ] Test My Teams section appears on dashboard (empty state when user has no teams)
- [ ] Test teams API endpoints via Swagger
- [ ] Test team event linking/unlinking as team lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)