### PR TITLE
Add Teams link to main navigation

### DIFF
--- a/TrashMob/client-app/src/components/SiteHeader/MainNav.tsx
+++ b/TrashMob/client-app/src/components/SiteHeader/MainNav.tsx
@@ -9,7 +9,7 @@ import {
     NavigationMenuTrigger,
     navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu';
-import { MapPin, CalendarPlus, Gauge, Map, BookOpen, HelpCircle, ShoppingBag, List } from 'lucide-react';
+import { MapPin, CalendarPlus, Gauge, Map, BookOpen, HelpCircle, ShoppingBag, List, Users } from 'lucide-react';
 import React from 'react';
 
 interface ListItemProps extends React.ComponentPropsWithoutRef<'a'> {
@@ -86,6 +86,16 @@ export const MainNav = ({ className, isUserLoaded, ...props }: MainNavProps) => 
                         <NavigationMenuItem>
                             <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
                                 <a href='/#events'>Events</a>
+                            </NavigationMenuLink>
+                        </NavigationMenuItem>
+
+                        {/* Teams - Direct Link */}
+                        <NavigationMenuItem>
+                            <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+                                <Link to='/teams'>
+                                    <Users className='h-4 w-4 mr-1' />
+                                    Teams
+                                </Link>
                             </NavigationMenuLink>
                         </NavigationMenuItem>
 
@@ -186,6 +196,7 @@ export const MainNav = ({ className, isUserLoaded, ...props }: MainNavProps) => 
             {/* Mobile Navigation - Flat list */}
             <div className='flex flex-col gap-1 lg:hidden w-full'>
                 <MobileNavItem to='/#events'>Events</MobileNavItem>
+                <MobileNavItem to='/teams'>Teams</MobileNavItem>
                 <div className='border-l-2 border-muted pl-3 ml-2 space-y-1'>
                     <p className='text-xs text-muted-foreground uppercase tracking-wide pt-1'>Take Action</p>
                     <MobileNavItem to='/litterreports/create'>Report Litter</MobileNavItem>


### PR DESCRIPTION
## Summary
- Adds Teams direct link with icon (Users) in desktop navigation after Events
- Adds Teams link to mobile navigation menu
- Makes the Teams feature discoverable from the main site navigation

## Test plan
- [ ] Verify Teams link appears in desktop navigation with Users icon
- [ ] Verify Teams link works and navigates to /teams page
- [ ] Verify Teams link appears in mobile navigation menu
- [ ] Verify mobile Teams link works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)