### PR TITLE
Add Teams admin tools for site administrators (Project 9 Phase 6)

### DIFF
--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -87,6 +87,7 @@ import { SiteAdminLayout } from './pages/siteadmin/_layout';
 import { SiteAdminUsers } from './pages/siteadmin/users/page';
 import { SiteAdminEvents } from './pages/siteadmin/events/page';
 import { SiteAdminPartners } from './pages/siteadmin/partners/page';
+import { SiteAdminTeams } from './pages/siteadmin/teams/page';
 import { SiteAdminPartnerRequests } from './pages/siteadmin/partner-requests/page';
 import { SiteAdminJobOpportunities } from './pages/siteadmin/job-opportunities/page';
 import { SiteAdminJobOpportunityCreate } from './pages/siteadmin/job-opportunities/create';
@@ -233,6 +234,7 @@ const AppContent: FC = () => {
                                 <Route path='users' element={<SiteAdminUsers />} />
                                 <Route path='events' element={<SiteAdminEvents />} />
                                 <Route path='partners' element={<SiteAdminPartners />} />
+                                <Route path='teams' element={<SiteAdminTeams />} />
                                 <Route path='litter-reports' element={<SiteAdminLitterReports />} />
                                 <Route path='partner-requests' element={<SiteAdminPartnerRequests />} />
                                 <Route path='job-opportunities' element={<SiteAdminJobOpportunities />}>

--- a/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
@@ -11,6 +11,7 @@ export const SiteAdminLayout = () => {
         { name: 'Manage Users', value: `${pathPrefix}/users` },
         { name: 'Manage Events', value: `${pathPrefix}/events` },
         { name: 'Manage Partners', value: `${pathPrefix}/partners` },
+        { name: 'Manage Teams', value: `${pathPrefix}/teams` },
         { name: 'Manage Litter Reports', value: `${pathPrefix}/litter-reports` },
         { name: 'Manage Partner Requests', value: `${pathPrefix}/partner-requests` },
         { name: 'Manage Job Opportunities', value: `${pathPrefix}/job-opportunities` },

--- a/TrashMob/client-app/src/pages/siteadmin/teams/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/teams/columns.tsx
@@ -1,0 +1,112 @@
+import { Link } from 'react-router';
+import { ColumnDef } from '@tanstack/react-table';
+import { Ellipsis, Eye, Globe, Lock, RotateCcw, Trash2, Users } from 'lucide-react';
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { DataTableColumnHeader } from '@/components/ui/data-table';
+import TeamData from '@/components/Models/TeamData';
+
+interface GetColumnsProps {
+    onDelete: (id: string, name: string) => void;
+    onReactivate: (id: string, name: string) => void;
+}
+
+const getLocation = (team: TeamData) => {
+    const parts = [team.city, team.region, team.country].filter(Boolean);
+    return parts.join(', ') || '-';
+};
+
+export const getColumns = ({ onDelete, onReactivate }: GetColumnsProps): ColumnDef<TeamData>[] => [
+    {
+        accessorKey: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        cell: ({ row }) => (
+            <Link to={`/teams/${row.original.id}`} className='text-primary hover:underline font-medium'>
+                {row.original.name}
+            </Link>
+        ),
+    },
+    {
+        id: 'location',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Location' />,
+        cell: ({ row }) => getLocation(row.original),
+    },
+    {
+        id: 'visibility',
+        header: 'Visibility',
+        cell: ({ row }) =>
+            row.original.isPublic ? (
+                <Badge variant='outline' className='bg-green-100 text-green-800 border-green-300'>
+                    <Globe className='h-3 w-3 mr-1' /> Public
+                </Badge>
+            ) : (
+                <Badge variant='outline' className='bg-gray-100 text-gray-800 border-gray-300'>
+                    <Lock className='h-3 w-3 mr-1' /> Private
+                </Badge>
+            ),
+    },
+    {
+        id: 'status',
+        header: 'Status',
+        cell: ({ row }) =>
+            row.original.isActive ? (
+                <Badge variant='outline' className='bg-green-100 text-green-800 border-green-300'>
+                    Active
+                </Badge>
+            ) : (
+                <Badge variant='outline' className='bg-red-100 text-red-800 border-red-300'>
+                    Inactive
+                </Badge>
+            ),
+    },
+    {
+        accessorKey: 'actions',
+        header: () => <div className='text-right'>Actions</div>,
+        cell: ({ row }) => {
+            const team = row.original;
+            return (
+                <div className='text-right'>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button variant='ghost' size='icon'>
+                                <Ellipsis />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent className='w-56'>
+                            <DropdownMenuItem asChild>
+                                <Link to={`/teams/${team.id}`}>
+                                    <Eye className='h-4 w-4 mr-2' />
+                                    View Team
+                                </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link to={`/teams/${team.id}/edit`}>
+                                    <Users className='h-4 w-4 mr-2' />
+                                    Manage Team
+                                </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            {!team.isActive ? (
+                                <DropdownMenuItem onClick={() => onReactivate(team.id, team.name)}>
+                                    <RotateCcw className='h-4 w-4 mr-2' />
+                                    Reactivate Team
+                                </DropdownMenuItem>
+                            ) : null}
+                            <DropdownMenuItem className='text-destructive' onClick={() => onDelete(team.id, team.name)}>
+                                <Trash2 className='h-4 w-4 mr-2' />
+                                Delete Team
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
+            );
+        },
+    },
+];

--- a/TrashMob/client-app/src/pages/siteadmin/teams/page.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/teams/page.tsx
@@ -1,0 +1,78 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { DataTable } from '@/components/ui/data-table';
+import { getColumns } from './columns';
+import { DeleteTeam, GetAllTeams, ReactivateTeam } from '@/services/teams';
+import { useToast } from '@/hooks/use-toast';
+
+export const SiteAdminTeams = () => {
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+
+    const { data: teams } = useQuery({
+        queryKey: GetAllTeams().key,
+        queryFn: GetAllTeams().service,
+        select: (res) => res.data,
+    });
+
+    const deleteTeam = useMutation({
+        mutationKey: DeleteTeam().key,
+        mutationFn: DeleteTeam().service,
+        onSuccess: () => {
+            toast({
+                variant: 'default',
+                title: 'Team deleted',
+            });
+            queryClient.invalidateQueries({ queryKey: GetAllTeams().key });
+        },
+        onError: () => {
+            toast({
+                variant: 'destructive',
+                title: 'Failed to delete team',
+            });
+        },
+    });
+
+    const reactivateTeam = useMutation({
+        mutationKey: ReactivateTeam().key,
+        mutationFn: ReactivateTeam().service,
+        onSuccess: () => {
+            toast({
+                variant: 'default',
+                title: 'Team reactivated',
+            });
+            queryClient.invalidateQueries({ queryKey: GetAllTeams().key });
+        },
+        onError: () => {
+            toast({
+                variant: 'destructive',
+                title: 'Failed to reactivate team',
+            });
+        },
+    });
+
+    function handleDelete(id: string, name: string) {
+        if (!window.confirm(`Are you sure you want to delete team: ${name}?`)) return;
+        deleteTeam.mutate({ teamId: id });
+    }
+
+    function handleReactivate(id: string, name: string) {
+        if (!window.confirm(`Are you sure you want to reactivate team: ${name}?`)) return;
+        reactivateTeam.mutate({ teamId: id });
+    }
+
+    const columns = getColumns({ onDelete: handleDelete, onReactivate: handleReactivate });
+
+    const len = (teams || []).length;
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Teams ({len})</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <DataTable columns={columns} data={teams || []} />
+            </CardContent>
+        </Card>
+    );
+};

--- a/TrashMob/client-app/src/services/teams.ts
+++ b/TrashMob/client-app/src/services/teams.ts
@@ -10,6 +10,41 @@ import TeamMemberData from '../components/Models/TeamMemberData';
 // Team Operations
 // ============================================================================
 
+// Admin endpoint - returns all teams including private
+export type GetAllTeams_Response = TeamData[];
+export const GetAllTeams = () => ({
+    key: ['/admin/teams'],
+    service: async () =>
+        ApiService('protected').fetchData<GetAllTeams_Response>({
+            url: '/admin/teams',
+            method: 'get',
+        }),
+});
+
+// Admin endpoint - delete team permanently
+export type DeleteTeam_Params = { teamId: string };
+export type DeleteTeam_Response = void;
+export const DeleteTeam = () => ({
+    key: ['/admin/teams', 'delete'],
+    service: async (params: DeleteTeam_Params) =>
+        ApiService('protected').fetchData<DeleteTeam_Response>({
+            url: `/admin/teams/${params.teamId}`,
+            method: 'delete',
+        }),
+});
+
+// Admin endpoint - reactivate a deactivated team
+export type ReactivateTeam_Params = { teamId: string };
+export type ReactivateTeam_Response = TeamData;
+export const ReactivateTeam = () => ({
+    key: ['/admin/teams', 'reactivate'],
+    service: async (params: ReactivateTeam_Params) =>
+        ApiService('protected').fetchData<ReactivateTeam_Response>({
+            url: `/admin/teams/${params.teamId}/reactivate`,
+            method: 'post',
+        }),
+});
+
 export type GetPublicTeams_Params = {
     latitude?: number;
     longitude?: number;


### PR DESCRIPTION
## Summary
- Adds Teams admin page to Site Administration section for managing all teams
- Implements DataTable with name, location, visibility status, and active status columns
- Provides View, Manage, Reactivate, and Delete actions via dropdown menu
- Adds admin API service endpoints (GetAllTeams, DeleteTeam, ReactivateTeam)
- Adds "Manage Teams" tab to admin navigation layout

## Test plan
- [ ] Navigate to /siteadmin/teams as a site admin
- [ ] Verify Teams tab appears in admin navigation
- [ ] Verify team list displays with correct columns (name, location, visibility, status)
- [ ] Test View Team action navigates to team detail page
- [ ] Test Manage Team action navigates to team edit page
- [ ] Test Delete Team shows confirmation and removes team
- [ ] Test Reactivate Team appears only for inactive teams
- [ ] Verify pagination works for large team lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)