### PR TITLE
Add Teams documentation to FAQ, Help, and Getting Started (Project 9 Phase 7)

### DIFF
--- a/TrashMob/client-app/src/pages/faq/page.tsx
+++ b/TrashMob/client-app/src/pages/faq/page.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 import events from '@/components/assets/faq/Event.svg';
 import attendees from '@/components/assets/faq/Attendees.svg';
 import volunteer from '@/components/assets/faq/volunteer.svg';
+import teams from '@/components/assets/card/twofigure.svg';
 import { HeroSection } from '@/components/Customization/HeroSection';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -59,6 +60,41 @@ const faqs = [
             {
                 question: 'Can I change my base location?',
                 answer: 'Yes. Simply go to your <a href="https://www.trashmob.eco/locationpreference">Location Preference</a> page and drag the pin for your current location to wherever you want your base location to be. If you set the notification distance from this point, then you will be notified for any events that are created within that radius of your base location.',
+            },
+        ],
+    },
+    {
+        category: 'Teams',
+        desc: 'Creating and joining teams',
+        icon: teams,
+        questions: [
+            {
+                question: 'What is a Team?',
+                answer: 'A Team is a group of volunteers who work together on cleanup events. Teams can be public (visible to everyone and open for join requests) or private (invite-only). Teams help you organize recurring cleanups with a consistent group, track collective impact, and build community.',
+            },
+            {
+                question: 'How do I create a Team?',
+                answer: 'Go to the <a href="https://www.trashmob.eco/teams">Teams page</a> and click "Create Team". You\'ll need to provide a team name, description, and set your team\'s location. You can also choose whether your team is public or private, and whether new members require approval to join.',
+            },
+            {
+                question: 'What is the difference between public and private Teams?',
+                answer: 'Public teams are visible on the Teams map and in search results. Anyone can request to join a public team. Private teams are invite-only and are not visible on the map or in search results. Only team leads can invite new members to private teams.',
+            },
+            {
+                question: 'How do I join a Team?',
+                answer: 'Browse the <a href="https://www.trashmob.eco/teams">Teams page</a> to find public teams in your area. Click on a team to view its details, then click "Request to Join". The team lead will review your request and approve or decline it. For private teams, you\'ll need an invitation from a team lead.',
+            },
+            {
+                question: 'Can I be on multiple Teams?',
+                answer: 'Yes! There is no limit to the number of teams you can join. This allows you to participate in different cleanup efforts across your community.',
+            },
+            {
+                question: 'What can Team Leads do?',
+                answer: 'Team leads can edit team details, invite new members, approve join requests, promote other members to co-lead status, remove members, and manage team events. A team can have multiple leads to help share the responsibility.',
+            },
+            {
+                question: 'How do I leave a Team?',
+                answer: 'Go to your <a href="https://www.trashmob.eco/mydashboard">Dashboard</a> and find the team in "My Teams". Click on the team, then use the "Leave Team" option. Note: If you are the only team lead, you must either promote another member to lead or contact TrashMob support.',
             },
         ],
     },

--- a/TrashMob/client-app/src/pages/gettingstarted/page.tsx
+++ b/TrashMob/client-app/src/pages/gettingstarted/page.tsx
@@ -160,7 +160,40 @@ export const GettingStarted: React.FC = () => {
                     </div>
                 </div>
             </section>
-            <section className='bg-card py-12! flex flex-col justify-center text-center'>
+            <section className='bg-card'>
+                <div className='container py-24!'>
+                    <div className='flex flex-col md:flex-row gap-8 items-center'>
+                        <div className='w-full md:basis-1/2'>
+                            <h2 className='font-semibold'>Join or Create a Team</h2>
+                            <h4 className='mt-5!'>
+                                Teams help you make a bigger impact by working together with other volunteers in your
+                                community.
+                            </h4>
+                            <p className='font-light'>
+                                Whether you're looking to join an existing group or start your own, Teams make it easy
+                                to organize recurring cleanups, track your collective impact, and build lasting
+                                connections with fellow volunteers.
+                            </p>
+                            <ul className='list-disc pl-8 font-light'>
+                                <li>Find public teams on the Teams map</li>
+                                <li>Track your team's total bags, hours, and events</li>
+                                <li>Coordinate with team leads on cleanup schedules</li>
+                                <li>Build community with like-minded volunteers</li>
+                            </ul>
+                            <Button asChild className='mt-4'>
+                                <Link to='/teams'>Browse Teams</Link>
+                            </Button>
+                        </div>
+                        <div className='w-full md:basis-1/2 flex justify-center'>
+                            <div className='bg-primary/10 rounded-2xl p-12 text-center'>
+                                <div className='text-6xl mb-4'>👥</div>
+                                <p className='text-lg font-medium'>Together, we can make a bigger difference!</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <section className='bg-background py-12! flex flex-col justify-center text-center'>
                 <h2 className='font-semibold'>Ready to go?</h2>
                 <span>Find your first event now.</span>
                 <div className='px-5 mb-5'>

--- a/TrashMob/client-app/src/pages/help/page.tsx
+++ b/TrashMob/client-app/src/pages/help/page.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router';
 import events from '@/components/assets/faq/Event.svg';
 import gloves from '@/components/assets/gloves.svg';
+import teams from '@/components/assets/card/twofigure.svg';
 import { HeroSection } from '@/components/Customization/HeroSection';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -199,6 +200,67 @@ const tabContents = [
                 goodwill within the community, and helping to create a cleaner planet!
             </p>
           `,
+            },
+        ],
+    },
+    {
+        category: 'Teams',
+        desc: 'How to create and manage a team',
+        icon: teams,
+        questions: [
+            {
+                question: 'How to create a Team',
+                answer: `
+                <p>Teams allow you to organize regular cleanup efforts with a consistent group of volunteers. Here's how to get started:</p>
+                <p>First, make sure you are signed in. If you don't have an account, create one by clicking the sign in button.</p>
+                <p>Navigate to the <a href='https://www.trashmob.eco/teams'>Teams page</a> and click the "Create Team" button.</p>
+                <p>Fill in your team details:</p>
+                <ul class="list-disc pl-8">
+                    <li><strong>Team Name:</strong> Choose a unique, descriptive name for your team</li>
+                    <li><strong>Description:</strong> Tell others about your team's focus, meeting frequency, or areas you clean</li>
+                    <li><strong>Location:</strong> Set your team's primary location using the map or search box</li>
+                    <li><strong>Visibility:</strong> Choose Public (visible on map, open for join requests) or Private (invite-only)</li>
+                    <li><strong>Require Approval:</strong> Decide if you want to approve new member requests or allow anyone to join immediately</li>
+                </ul>
+                <p>Click "Create Team" to finish. You'll be automatically added as the team lead.</p>
+                `,
+            },
+            {
+                question: 'Managing your Team',
+                answer: `
+                <p>As a team lead, you have several management capabilities:</p>
+                <h6>Editing Team Details</h6>
+                <p>Go to your team's page and click "Edit Team" to update the name, description, location, or visibility settings.</p>
+                <h6>Managing Members</h6>
+                <p>From the team edit page, you can:</p>
+                <ul class="list-disc pl-8">
+                    <li><strong>View pending join requests:</strong> Approve or decline requests from users who want to join</li>
+                    <li><strong>Promote to Co-Lead:</strong> Give other members lead privileges to help manage the team</li>
+                    <li><strong>Remove members:</strong> Remove members who are no longer active or appropriate for the team</li>
+                </ul>
+                <h6>Tips for Team Leads</h6>
+                <ul class="list-disc pl-8">
+                    <li>Have at least 2 team leads to ensure continuity</li>
+                    <li>Keep your team description up-to-date with meeting schedules</li>
+                    <li>Respond to join requests promptly to keep new volunteers engaged</li>
+                    <li>Consider making your team public to attract more members from your community</li>
+                </ul>
+                `,
+            },
+            {
+                question: 'Joining a Team',
+                answer: `
+                <p>Finding and joining a team is easy:</p>
+                <ol class="list-decimal pl-8">
+                    <li>Go to the <a href='https://www.trashmob.eco/teams'>Teams page</a></li>
+                    <li>Browse the list view or switch to map view to find teams near you</li>
+                    <li>Click on a team to view its details, including description, location, and member count</li>
+                    <li>Click "Request to Join" to submit your request</li>
+                    <li>Wait for a team lead to approve your request (you'll receive an email notification)</li>
+                </ol>
+                <p>Once approved, the team will appear in your dashboard under "My Teams". You can then participate in team events and track your collective impact!</p>
+                <p><strong>Note:</strong> Private teams are not visible in search results. You'll need a direct invitation from a team lead to join a private team.</p>
+                `,
             },
         ],
     },


### PR DESCRIPTION
## Summary
- Adds "Teams" FAQ category with 7 questions covering team basics, creation, joining, visibility, membership, and team lead responsibilities
- Adds "Teams" Help tab with step-by-step guides for creating teams, managing members, and joining teams
- Adds Teams section to Getting Started page highlighting benefits of joining/creating a team with "Browse Teams" CTA

## Test plan
- [ ] Navigate to /faq and verify "Teams" category appears with icon
- [ ] Click Teams category and verify all 7 Q&As are displayed with proper formatting
- [ ] Navigate to /help and verify "Teams" tab appears
- [ ] Click Teams tab and verify all 3 help sections display correctly
- [ ] Navigate to /gettingstarted and verify Teams section appears before "Ready to go?"
- [ ] Verify "Browse Teams" button links to /teams
- [ ] Verify links in FAQ/Help content work correctly (e.g., /teams, /mydashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)