### PR TITLE
Configure database backup retention policies (Project 32)

### DIFF
--- a/Deploy/backupAlerts.bicep
+++ b/Deploy/backupAlerts.bicep
@@ -1,0 +1,120 @@
+// Backup monitoring alerts for Azure SQL Database
+// See Project 32 (Database Backups) for details
+
+param environment string
+param region string
+param alertEmail string = 'info@trashmob.eco'
+
+var actionGroupName = 'ag-tm-${environment}-${region}-backup'
+var alertRuleName = 'alert-tm-${environment}-${region}-backup-health'
+var servers_db_name = 'sql-tm-${environment}-${region}'
+var db_Name = 'db-tm-${environment}-${region}'
+
+// Reference existing SQL database
+resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' existing = {
+  name: servers_db_name
+}
+
+resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-05-01-preview' existing = {
+  parent: sqlServer
+  name: db_Name
+}
+
+// Action group for backup alert notifications
+resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: actionGroupName
+  location: 'global'
+  properties: {
+    groupShortName: 'TMBackup'
+    enabled: true
+    emailReceivers: [
+      {
+        name: 'BackupAlertEmail'
+        emailAddress: alertEmail
+        useCommonAlertSchema: true
+      }
+    ]
+  }
+}
+
+// Alert rule for database availability/health
+// This monitors the database connection success rate which correlates with backup health
+resource databaseHealthAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: alertRuleName
+  location: 'global'
+  properties: {
+    description: 'Alert when database connection failures indicate potential backup issues'
+    severity: 1
+    enabled: true
+    scopes: [
+      sqlDatabase.id
+    ]
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT1H'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'ConnectionFailure'
+          metricName: 'connection_failed'
+          metricNamespace: 'Microsoft.Sql/servers/databases'
+          operator: 'GreaterThan'
+          threshold: 5
+          timeAggregation: 'Total'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      {
+        actionGroupId: actionGroup.id
+      }
+    ]
+  }
+}
+
+// Activity log alert for backup-related service health events
+// Note: Service health alerts require subscription scope
+resource serviceHealthAlert 'Microsoft.Insights/activityLogAlerts@2020-10-01' = {
+  name: 'alert-tm-${environment}-${region}-sql-health'
+  location: 'global'
+  properties: {
+    description: 'Alert for Azure SQL service health issues that may affect backups'
+    enabled: true
+    scopes: [
+      subscription().id
+    ]
+    condition: {
+      allOf: [
+        {
+          field: 'category'
+          equals: 'ServiceHealth'
+        }
+        {
+          field: 'properties.impactedServices[*].ServiceName'
+          containsAny: [
+            'SQL Database'
+            'Azure SQL Database'
+          ]
+        }
+        {
+          field: 'properties.impactedServices[*].ImpactedRegions[*].RegionName'
+          containsAny: [
+            region
+            'Global'
+          ]
+        }
+      ]
+    }
+    actions: {
+      actionGroups: [
+        {
+          actionGroupId: actionGroup.id
+        }
+      ]
+    }
+  }
+}
+
+output actionGroupId string = actionGroup.id
+output alertRuleId string = databaseHealthAlert.id

--- a/Deploy/sqlDatabase.bicep
+++ b/Deploy/sqlDatabase.bicep
@@ -1,11 +1,21 @@
 param environment string
 param region string
 
+// Backup retention settings
+param shortTermRetentionDays int = 14
+param weeklyRetention string = 'P4W'    // Keep weekly backups for 4 weeks
+param monthlyRetention string = 'P12M'  // Keep monthly backups for 12 months
+
 var servers_db_name = 'sql-tm-${environment}-${region}'
 var db_Name = 'db-tm-${environment}-${region}'
 
+resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' existing = {
+  name: servers_db_name
+}
+
 resource servers_db_name_tm 'Microsoft.Sql/servers/databases@2023-05-01-preview' = {
-  name: '${servers_db_name}/${db_Name}'
+  parent: sqlServer
+  name: db_Name
   location: region
   sku: {
     name: 'Basic'
@@ -20,5 +30,29 @@ resource servers_db_name_tm 'Microsoft.Sql/servers/databases@2023-05-01-preview'
     readScale: 'Disabled'
     requestedBackupStorageRedundancy: 'Geo'
     maintenanceConfigurationId: subscriptionResourceId('Microsoft.Maintenance/publicMaintenanceConfigurations', 'SQL_Default')
+  }
+}
+
+// Short-term retention policy (point-in-time restore window)
+// See Project 32 (Database Backups) for details
+resource shortTermRetention 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2023-05-01-preview' = {
+  parent: servers_db_name_tm
+  name: 'default'
+  properties: {
+    retentionDays: shortTermRetentionDays
+    diffBackupIntervalInHours: 24
+  }
+}
+
+// Long-term retention policy (weekly and monthly backups)
+// See Project 32 (Database Backups) for details
+resource longTermRetention 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-05-01-preview' = {
+  parent: servers_db_name_tm
+  name: 'default'
+  properties: {
+    weeklyRetention: weeklyRetention
+    monthlyRetention: monthlyRetention
+    yearlyRetention: 'PT0S'  // Not using yearly retention
+    weekOfYear: 1
   }
 }

--- a/Deploy/sqlDatabaseStrapi.bicep
+++ b/Deploy/sqlDatabaseStrapi.bicep
@@ -1,11 +1,21 @@
 param environment string
 param region string
 
+// Backup retention settings
+param shortTermRetentionDays int = 14
+param weeklyRetention string = 'P4W'    // Keep weekly backups for 4 weeks
+param monthlyRetention string = 'P12M'  // Keep monthly backups for 12 months
+
 var servers_db_name = 'sql-tm-${environment}-${region}'
 var db_Name = 'db-strapi-${environment}-${region}'
 
+resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' existing = {
+  name: servers_db_name
+}
+
 resource strapiDatabase 'Microsoft.Sql/servers/databases@2023-05-01-preview' = {
-  name: '${servers_db_name}/${db_Name}'
+  parent: sqlServer
+  name: db_Name
   location: region
   sku: {
     name: 'Basic'
@@ -20,6 +30,30 @@ resource strapiDatabase 'Microsoft.Sql/servers/databases@2023-05-01-preview' = {
     readScale: 'Disabled'
     requestedBackupStorageRedundancy: 'Geo'
     maintenanceConfigurationId: subscriptionResourceId('Microsoft.Maintenance/publicMaintenanceConfigurations', 'SQL_Default')
+  }
+}
+
+// Short-term retention policy (point-in-time restore window)
+// See Project 32 (Database Backups) for details
+resource shortTermRetention 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2023-05-01-preview' = {
+  parent: strapiDatabase
+  name: 'default'
+  properties: {
+    retentionDays: shortTermRetentionDays
+    diffBackupIntervalInHours: 24
+  }
+}
+
+// Long-term retention policy (weekly and monthly backups)
+// See Project 32 (Database Backups) for details
+resource longTermRetention 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-05-01-preview' = {
+  parent: strapiDatabase
+  name: 'default'
+  properties: {
+    weeklyRetention: weeklyRetention
+    monthlyRetention: monthlyRetention
+    yearlyRetention: 'PT0S'  // Not using yearly retention
+    weekOfYear: 1
   }
 }
 

--- a/Planning/Projects/Project_32_Database_Backups.md
+++ b/Planning/Projects/Project_32_Database_Backups.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | Not Started |
+| **Status** | In Progress |
 | **Priority** | High |
 | **Risk** | Low |
 | **Size** | Small |
@@ -216,15 +216,19 @@ az sql db ltr-backup restore --dest-database trashmob-db-restored \
 
 ---
 
-**Last Updated:** January 31, 2026
+**Last Updated:** February 1, 2026
 **Owner:** Engineering Lead
-**Status:** Not Started
-**Next Review:** When volunteer available
+**Status:** In Progress
+**Next Review:** After Phase 1 complete
 
 ---
 
 ## Changelog
 
+- **2026-02-01:** Implemented Phase 1 - configured 14-day PITR and weekly/monthly LTR for production database
+- **2026-02-01:** Created backupAlerts.bicep and deployed monitoring alerts
+- **2026-02-01:** Updated sqlDatabase.bicep and sqlDatabaseStrapi.bicep with backup retention policies
+- **2026-02-01:** Added restore procedures documentation to CLAUDE.md
 - **2026-01-31:** Converted open questions to decisions (12-month retention, migrate Strapi to Azure SQL, defer cross-region replication)
 - **2026-01-31:** Clarified Strapi uses SQLite with ephemeral storage in dev deployment
 - **2026-01-31:** Confirmed all scope items


### PR DESCRIPTION
## Summary
- Configure automated database backup retention policies for production Azure SQL database
- Add backup monitoring alerts infrastructure
- Document restore procedures for disaster recovery

## Changes

### Backup Configuration (Already Applied to Production)
- **Short-term retention:** 14 days (point-in-time restore capability)
- **Long-term retention:** Weekly backups for 4 weeks, monthly for 12 months
- **Geo-redundant backup storage:** Already configured

### New Bicep Templates
- **Deploy/backupAlerts.bicep** - Action group and metric alerts for database health monitoring
- Updated **Deploy/sqlDatabase.bicep** - Backup retention policies as Infrastructure-as-Code
- Updated **Deploy/sqlDatabaseStrapi.bicep** - Same backup policies for Strapi database

### Documentation Updates
- **CLAUDE.md** - Added Database Backups & Restore section with procedures
- **CLAUDE.md** - Added Key Vault RBAC documentation (for Project 26)
- **Project 32** - Updated status to In Progress

## Test Plan
- [x] Backup policies applied to production database via Azure CLI
- [x] Verified short-term and long-term retention settings
- [x] Deployed alert infrastructure to production
- [x] Bicep templates validated with `az bicep build`
- [ ] Perform test restore (tracked in #2485)

## Related
- Project 32: Database Backups
- Issue #2485: Test database backup and restore procedures

🤖 Generated with [Claude Code](https://claude.com/claude-code)