### PR TITLE
Add team logo upload feature (Project 9)

### DIFF
--- a/Planning/Projects/Project_09_Teams.md
+++ b/Planning/Projects/Project_09_Teams.md
@@ -843,12 +843,12 @@ The Teams MVP is complete with the following functionality:
 - ✅ Team events (link events to teams, view team event history)
 - ✅ Teams discovery (map view, list view, team detail pages)
 - ✅ Team photo gallery (upload, view, delete photos)
+- ✅ Team logo upload (avatar/logo displayed on cards, detail page, and map)
 - ✅ My Teams dashboard section
 - ✅ Site admin tools (view all teams, delete, reactivate)
 - ✅ Documentation (FAQ, Help, Getting Started)
 
 **Remaining for Future Enhancements:**
-- Team logo upload (single team avatar/logo distinct from photo gallery)
 - Detailed metrics with sparkline charts (bags, hours, weight trends)
 - Advanced admin moderation tools
 - Team leaderboards (depends on Project 20)

--- a/TrashMob.Models/Enums.cs
+++ b/TrashMob.Models/Enums.cs
@@ -222,6 +222,11 @@ namespace TrashMob.Models
         /// Image associated with a team photo gallery.
         /// </summary>
         TeamPhoto = 5,
+
+        /// <summary>
+        /// Logo/avatar image for a team.
+        /// </summary>
+        TeamLogo = 6,
     }
 
     /// <summary>

--- a/TrashMob/client-app/src/components/teams/team-info-window.tsx
+++ b/TrashMob/client-app/src/components/teams/team-info-window.tsx
@@ -6,12 +6,17 @@ import TeamData from '@/components/Models/TeamData';
 
 interface TeamInfoWindowHeaderProps {
     name: string;
+    logoUrl?: string;
 }
 
-export const TeamInfoWindowHeader = ({ name }: TeamInfoWindowHeaderProps) => {
+export const TeamInfoWindowHeader = ({ name, logoUrl }: TeamInfoWindowHeaderProps) => {
     return (
         <div className='flex items-center gap-2'>
-            <Users className='h-4 w-4' />
+            {logoUrl ? (
+                <img src={logoUrl} alt={`${name} logo`} className='w-6 h-6 rounded object-cover' />
+            ) : (
+                <Users className='h-4 w-4' />
+            )}
             <span className='font-semibold'>{name}</span>
         </div>
     );

--- a/TrashMob/client-app/src/components/teams/teams-map.tsx
+++ b/TrashMob/client-app/src/components/teams/teams-map.tsx
@@ -72,7 +72,7 @@ export const TeamsMap = (props: TeamsMapProps) => {
                 {showingTeam ? (
                     <InfoWindow
                         anchor={markersRef.current[showingTeamId]}
-                        headerContent={<TeamInfoWindowHeader name={showingTeam.name} />}
+                        headerContent={<TeamInfoWindowHeader name={showingTeam.name} logoUrl={showingTeam.logoUrl} />}
                         onClose={() => setShowingTeamId('')}
                     >
                         <TeamInfoWindowContent team={showingTeam} />

--- a/TrashMob/client-app/src/pages/faq/page.tsx
+++ b/TrashMob/client-app/src/pages/faq/page.tsx
@@ -90,11 +90,15 @@ const faqs = [
             },
             {
                 question: 'What can Team Leads do?',
-                answer: 'Team leads can edit team details, invite new members, approve join requests, promote other members to co-lead status, remove members, upload team photos, and manage team events. A team can have multiple leads to help share the responsibility.',
+                answer: 'Team leads can edit team details, invite new members, approve join requests, promote other members to co-lead status, remove members, upload team photos and a team logo, and manage team events. A team can have multiple leads to help share the responsibility.',
             },
             {
                 question: 'How do I upload Team Photos?',
                 answer: 'Team leads can upload photos to showcase their team\'s cleanup activities. Go to your team\'s detail page, click "Manage Team", then scroll to the "Team Photos" section. Click "Upload Photo" to add images (JPEG, PNG, etc., up to 10MB). Photos will be visible on your team\'s public page to help attract new members and celebrate your team\'s impact!',
+            },
+            {
+                question: 'How do I add a Team Logo?',
+                answer: 'Team leads can upload a logo or avatar image for their team. Go to your team\'s detail page, click "Manage Team", then find the "Team Logo" section. Click "Upload Logo" to add an image (recommended: square image, at least 200x200 pixels, up to 5MB). The logo will be displayed on team cards, the team detail page, and map popups.',
             },
             {
                 question: 'How do I leave a Team?',

--- a/TrashMob/client-app/src/pages/help/page.tsx
+++ b/TrashMob/client-app/src/pages/help/page.tsx
@@ -270,6 +270,32 @@ const tabContents = [
                 `,
             },
             {
+                question: 'Team Logo',
+                answer: `
+                <p>Team leads can upload a logo or avatar image to give their team a visual identity.</p>
+                <h6>Uploading a Logo</h6>
+                <ol class="list-decimal pl-8">
+                    <li>Go to your team's page and click "Manage Team" (you must be a team lead)</li>
+                    <li>Find the "Team Logo" section</li>
+                    <li>Click "Upload Logo" and select an image file</li>
+                    <li>The logo will be uploaded and displayed on your team's profile</li>
+                </ol>
+                <h6>Logo Guidelines</h6>
+                <ul class="list-disc pl-8">
+                    <li>Recommended: Square image, at least 200x200 pixels</li>
+                    <li>Maximum file size: 5MB</li>
+                    <li>Supported formats: JPEG, PNG, and other common image formats</li>
+                    <li>Logos are automatically resized for optimal display</li>
+                </ul>
+                <h6>Where the Logo Appears</h6>
+                <ul class="list-disc pl-8">
+                    <li>Team detail page (next to team name)</li>
+                    <li>Teams list page (in the team name column)</li>
+                    <li>Teams map (in the info popup)</li>
+                </ul>
+                `,
+            },
+            {
                 question: 'Joining a Team',
                 answer: `
                 <p>Finding and joining a team is easy:</p>

--- a/TrashMob/client-app/src/pages/teams/$teamId/index.tsx
+++ b/TrashMob/client-app/src/pages/teams/$teamId/index.tsx
@@ -226,10 +226,20 @@ export const TeamDetailPage = () => {
                         <Card>
                             <CardHeader>
                                 <div className='flex items-center justify-between'>
-                                    <CardTitle className='text-2xl flex items-center gap-2'>
-                                        <Users className='h-6 w-6' />
-                                        {team.name}
-                                    </CardTitle>
+                                    <div className='flex items-center gap-4'>
+                                        {team.logoUrl ? (
+                                            <img
+                                                src={team.logoUrl}
+                                                alt={`${team.name} logo`}
+                                                className='w-16 h-16 rounded-lg object-cover border'
+                                            />
+                                        ) : (
+                                            <div className='w-16 h-16 rounded-lg bg-muted flex items-center justify-center'>
+                                                <Users className='h-8 w-8 text-muted-foreground' />
+                                            </div>
+                                        )}
+                                        <CardTitle className='text-2xl'>{team.name}</CardTitle>
+                                    </div>
                                     <div className='flex items-center gap-2'>
                                         {team.isPublic ? (
                                             <Badge

--- a/TrashMob/client-app/src/pages/teams/index.tsx
+++ b/TrashMob/client-app/src/pages/teams/index.tsx
@@ -27,8 +27,19 @@ const columns: ColumnDef<TeamData>[] = [
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Team Name' />,
         cell: ({ row }) => (
-            <Link to={`/teams/${row.original.id}`} className='text-primary hover:underline font-medium'>
-                {row.original.name}
+            <Link to={`/teams/${row.original.id}`} className='flex items-center gap-3 text-primary hover:underline'>
+                {row.original.logoUrl ? (
+                    <img
+                        src={row.original.logoUrl}
+                        alt={`${row.original.name} logo`}
+                        className='w-8 h-8 rounded object-cover'
+                    />
+                ) : (
+                    <div className='w-8 h-8 rounded bg-muted flex items-center justify-center'>
+                        <Users className='h-4 w-4 text-muted-foreground' />
+                    </div>
+                )}
+                <span className='font-medium'>{row.original.name}</span>
             </Link>
         ),
     },

--- a/TrashMob/client-app/src/services/teams.ts
+++ b/TrashMob/client-app/src/services/teams.ts
@@ -340,3 +340,33 @@ export const DeleteTeamPhoto = () => ({
             method: 'delete',
         }),
 });
+
+// ============================================================================
+// Team Logo Operations
+// ============================================================================
+
+export type UploadTeamLogo_Params = { teamId: string };
+export type UploadTeamLogo_Response = TeamData;
+export const UploadTeamLogo = () => ({
+    key: ['/teams/logo', 'upload'],
+    service: async (params: UploadTeamLogo_Params, formData: FormData) =>
+        ApiService('protected').fetchData<UploadTeamLogo_Response>({
+            url: `/teams/${params.teamId}/logo`,
+            method: 'post',
+            data: formData,
+            headers: {
+                'Content-Type': 'multipart/form-data',
+            },
+        }),
+});
+
+export type DeleteTeamLogo_Params = { teamId: string };
+export type DeleteTeamLogo_Response = TeamData;
+export const DeleteTeamLogo = () => ({
+    key: ['/teams/logo', 'delete'],
+    service: async (params: DeleteTeamLogo_Params) =>
+        ApiService('protected').fetchData<DeleteTeamLogo_Response>({
+            url: `/teams/${params.teamId}/logo`,
+            method: 'delete',
+        }),
+});


### PR DESCRIPTION
## Summary
- Adds ability for team leads to upload a logo/avatar image for their team
- Logo is displayed on team cards, detail page, and map popups
- Follows same image upload pattern as team photos (uses ImageTypeEnum.TeamLogo = 6)

## Changes
- **Backend**: Added `POST /teams/{teamId}/logo` and `DELETE /teams/{teamId}/logo` endpoints to TeamsController
- **Frontend services**: Added `UploadTeamLogo` and `DeleteTeamLogo` services
- **Team edit page**: Added logo upload section with preview, change, and delete buttons
- **Team detail page**: Logo displayed next to team name
- **Teams list**: Logo shown in team name column
- **Teams map**: Logo shown in info window header
- **Documentation**: Updated FAQ and Help pages with team logo information
- **Project status**: Updated Project_09_Teams.md to mark logo feature complete

## Test plan
- [ ] Upload a team logo as a team lead
- [ ] Verify logo appears on team edit page with preview
- [ ] Change the logo and verify it updates
- [ ] Delete the logo and verify placeholder appears
- [ ] Verify logo displays on team detail page
- [ ] Verify logo displays in teams list
- [ ] Verify logo displays in map popup
- [ ] Verify non-leads cannot upload/delete logos

🤖 Generated with [Claude Code](https://claude.com/claude-code)