### PR TITLE
Fix UserFeedback migration FK cascade conflict

### DIFF
--- a/TrashMob.Shared/Migrations/20260201164845_AddUserFeedback.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260201164845_AddUserFeedback.Designer.cs
@@ -3600,13 +3600,13 @@ namespace TrashMob.Migrations
                     b.HasOne("TrashMob.Models.User", "ReviewedByUser")
                         .WithMany("UserFeedbackReviewed")
                         .HasForeignKey("ReviewedByUserId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.NoAction)
                         .HasConstraintName("FK_UserFeedback_ReviewedByUser");
 
                     b.HasOne("TrashMob.Models.User", "User")
                         .WithMany("UserFeedbackSubmitted")
                         .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.NoAction)
                         .HasConstraintName("FK_UserFeedback_User");
 
                     b.Navigation("CreatedByUser");

--- a/TrashMob.Shared/Migrations/20260201164845_AddUserFeedback.cs
+++ b/TrashMob.Shared/Migrations/20260201164845_AddUserFeedback.cs
@@ -41,23 +41,25 @@ namespace TrashMob.Migrations
                         column: x => x.ReviewedByUserId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.NoAction);
                     table.ForeignKey(
                         name: "FK_UserFeedback_User",
                         column: x => x.UserId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.NoAction);
                     table.ForeignKey(
                         name: "FK_UserFeedback_User_CreatedBy",
                         column: x => x.CreatedByUserId,
                         principalTable: "Users",
-                        principalColumn: "Id");
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.NoAction);
                     table.ForeignKey(
                         name: "FK_UserFeedback_User_LastUpdatedBy",
                         column: x => x.LastUpdatedByUserId,
                         principalTable: "Users",
-                        principalColumn: "Id");
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.NoAction);
                 });
 
             migrationBuilder.CreateIndex(

--- a/TrashMob.Shared/Migrations/MobDbContextModelSnapshot.cs
+++ b/TrashMob.Shared/Migrations/MobDbContextModelSnapshot.cs
@@ -3597,13 +3597,13 @@ namespace TrashMob.Migrations
                     b.HasOne("TrashMob.Models.User", "ReviewedByUser")
                         .WithMany("UserFeedbackReviewed")
                         .HasForeignKey("ReviewedByUserId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.NoAction)
                         .HasConstraintName("FK_UserFeedback_ReviewedByUser");
 
                     b.HasOne("TrashMob.Models.User", "User")
                         .WithMany("UserFeedbackSubmitted")
                         .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.NoAction)
                         .HasConstraintName("FK_UserFeedback_User");
 
                     b.Navigation("CreatedByUser");

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -1828,13 +1828,13 @@
                 entity.HasOne(d => d.User)
                     .WithMany(p => p.UserFeedbackSubmitted)
                     .HasForeignKey(d => d.UserId)
-                    .OnDelete(DeleteBehavior.SetNull)
+                    .OnDelete(DeleteBehavior.NoAction)
                     .HasConstraintName("FK_UserFeedback_User");
 
                 entity.HasOne(d => d.ReviewedByUser)
                     .WithMany(p => p.UserFeedbackReviewed)
                     .HasForeignKey(d => d.ReviewedByUserId)
-                    .OnDelete(DeleteBehavior.SetNull)
+                    .OnDelete(DeleteBehavior.NoAction)
                     .HasConstraintName("FK_UserFeedback_ReviewedByUser");
 
                 entity.HasOne(d => d.CreatedByUser)


### PR DESCRIPTION
## Summary
Fixes the `AddUserFeedback` migration that fails due to SQL Server FK cascade constraint.

## Problem
SQL Server doesn't allow multiple foreign keys to the same table with different cascade behaviors (e.g., `SET NULL`). The UserFeedback table has 4 FKs to the Users table, causing error 1785.

## Solution
Changed `DeleteBehavior.SetNull` to `DeleteBehavior.NoAction` for:
- `UserId` FK
- `ReviewedByUserId` FK

Updated in:
- Migration file
- Migration designer file
- Model snapshot
- DbContext

## Test plan
- [x] Migration applies successfully to dev database

🤖 Generated with [Claude Code](https://claude.com/claude-code)