### PR TITLE
Add community bulk email invites (Project 13 Phase 2)

### DIFF
--- a/TrashMob.Shared/Engine/EmailCopy/InviteToJoinCommunity.html
+++ b/TrashMob.Shared/Engine/EmailCopy/InviteToJoinCommunity.html
@@ -1,0 +1,22 @@
+<p>
+    You have been invited to join <strong>{communityName}</strong> on <a href="https://www.trashmob.eco">TrashMob.eco</a>!
+</p>
+<p>
+    {communityName} is part of the TrashMob.eco community platform that makes it easy to organize and participate in neighborhood litter cleanups. Join local volunteers who are working together to make their community cleaner, safer, and more beautiful.
+</p>
+<p>
+    When you join TrashMob.eco and {communityName}, you can:
+</p>
+<ul>
+    <li>Find cleanup events in the {communityName} area</li>
+    <li>Create and lead your own cleanup events</li>
+    <li>Track your volunteer hours and environmental impact</li>
+    <li>Connect with other volunteers in {communityName}</li>
+    <li>Join teams and participate in community programs</li>
+</ul>
+<p>
+    Ready to make a difference? <a href="https://www.trashmob.eco">Sign up today</a> and join your neighbors in making {communityName} cleaner, one piece of litter at a time.
+</p>
+<p>
+    Thank you for considering joining {communityName} and TrashMob.eco. Together, we can make a real difference!
+</p>

--- a/TrashMob.Shared/Engine/NotificationTypeEnum.cs
+++ b/TrashMob.Shared/Engine/NotificationTypeEnum.cs
@@ -189,5 +189,10 @@
         /// Invitation sent to potential volunteers to join TrashMob.
         /// </summary>
         InviteToJoinTrashMob = 37,
+
+        /// <summary>
+        /// Invitation sent to potential volunteers to join a specific community.
+        /// </summary>
+        InviteToJoinCommunity = 38,
     }
 }

--- a/TrashMob.Shared/Managers/Interfaces/IEmailInviteManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IEmailInviteManager.cs
@@ -51,5 +51,13 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The batch with invites loaded.</returns>
         Task<EmailInviteBatch> GetBatchDetailsAsync(Guid batchId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets email invite batches for a specific community.
+        /// </summary>
+        /// <param name="communityId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A list of batches for the community.</returns>
+        Task<IEnumerable<EmailInviteBatch>> GetCommunityBatchesAsync(Guid communityId, CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMob.Shared/TrashMob.Shared.csproj
+++ b/TrashMob.Shared/TrashMob.Shared.csproj
@@ -44,6 +44,7 @@
     <None Remove="Engine\EmailCopy\AdoptionApplicationRejected.html" />
     <None Remove="Engine\EmailCopy\WaiverExpiringReminder.html" />
     <None Remove="Engine\EmailCopy\InviteToJoinTrashMob.html" />
+    <None Remove="Engine\EmailCopy\InviteToJoinCommunity.html" />
   </ItemGroup>
 
   <ItemGroup>
@@ -84,6 +85,7 @@
     <EmbeddedResource Include="Engine\EmailCopy\AdoptionApplicationRejected.html" />
     <EmbeddedResource Include="Engine\EmailCopy\WaiverExpiringReminder.html" />
     <EmbeddedResource Include="Engine\EmailCopy\InviteToJoinTrashMob.html" />
+    <EmbeddedResource Include="Engine\EmailCopy\InviteToJoinCommunity.html" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TrashMob/Controllers/CommunityInvitesController.cs
+++ b/TrashMob/Controllers/CommunityInvitesController.cs
@@ -1,0 +1,151 @@
+namespace TrashMob.Controllers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// Controller for community email invitation operations.
+    /// Endpoints require community admin privileges.
+    /// </summary>
+    [Authorize]
+    [Route("api/communities/{communityId}/invites")]
+    public class CommunityInvitesController : SecureController
+    {
+        private readonly IEmailInviteManager emailInviteManager;
+        private readonly IKeyedManager<Partner> partnerManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommunityInvitesController"/> class.
+        /// </summary>
+        /// <param name="emailInviteManager">The email invite manager.</param>
+        /// <param name="partnerManager">The partner manager for authorization.</param>
+        public CommunityInvitesController(
+            IEmailInviteManager emailInviteManager,
+            IKeyedManager<Partner> partnerManager)
+        {
+            this.emailInviteManager = emailInviteManager;
+            this.partnerManager = partnerManager;
+        }
+
+        /// <summary>
+        /// Gets all email invite batches for a community.
+        /// </summary>
+        /// <param name="communityId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of batches for the community with summary statistics.</returns>
+        [HttpGet("batches")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<EmailInviteBatch>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetBatches(Guid communityId, CancellationToken cancellationToken = default)
+        {
+            var partner = await partnerManager.GetAsync(communityId, cancellationToken);
+            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
+                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
+
+            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            {
+                return Forbid();
+            }
+
+            var result = await emailInviteManager.GetCommunityBatchesAsync(communityId, cancellationToken).ConfigureAwait(false);
+            TrackEvent(nameof(GetBatches));
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a batch with its individual invite details for a community.
+        /// </summary>
+        /// <param name="communityId">The community (partner) ID.</param>
+        /// <param name="id">Batch ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The batch with invites or 404 if not found.</returns>
+        [HttpGet("batches/{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(EmailInviteBatch), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetBatch(Guid communityId, Guid id, CancellationToken cancellationToken = default)
+        {
+            var partner = await partnerManager.GetAsync(communityId, cancellationToken);
+            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
+                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
+
+            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            {
+                return Forbid();
+            }
+
+            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+
+            if (result == null || result.CommunityId != communityId)
+            {
+                return NotFound();
+            }
+
+            TrackEvent(nameof(GetBatch));
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Creates and sends a new batch of email invites for a community.
+        /// </summary>
+        /// <param name="communityId">The community (partner) ID.</param>
+        /// <param name="request">The batch creation request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created batch with send results.</returns>
+        [HttpPost("batch")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EmailInviteBatch), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> CreateBatch(
+            Guid communityId,
+            [FromBody] CreateEmailInviteBatchRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var partner = await partnerManager.GetAsync(communityId, cancellationToken);
+            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
+                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
+
+            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            {
+                return Forbid();
+            }
+
+            if (request == null || request.Emails == null || !request.Emails.Any())
+            {
+                return BadRequest("Email list is required.");
+            }
+
+            // Create the batch with community context
+            var batch = await emailInviteManager.CreateBatchAsync(
+                request.Emails,
+                UserId,
+                "Community",
+                communityId,
+                null,
+                cancellationToken).ConfigureAwait(false);
+
+            // Process the batch (send emails)
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken).ConfigureAwait(false);
+
+            TrackEvent(nameof(CreateBatch));
+
+            return CreatedAtAction(nameof(GetBatch), new { communityId, id = result.Id }, result);
+        }
+    }
+}

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -64,6 +64,8 @@ import { CommunityDetailPage } from './pages/communities/$slug';
 import { CommunityAdminLayout } from './pages/communities/$slug/admin/_layout';
 import { CommunityAdminDashboard } from './pages/communities/$slug/admin';
 import { CommunityContentEdit } from './pages/communities/$slug/admin/content';
+import { CommunityAdminInvites } from './pages/communities/$slug/admin/invites';
+import { CommunityAdminInviteDetails } from './pages/communities/$slug/admin/invites/$batchId';
 
 /** Partners */
 import { Partnerships } from './pages/partnerships/page';
@@ -248,6 +250,8 @@ const AppContent: FC = () => {
                             <Route path='/communities/:slug/admin' element={<CommunityAdminLayout />}>
                                 <Route index element={<CommunityAdminDashboard />} />
                                 <Route path='content' element={<CommunityContentEdit />} />
+                                <Route path='invites' element={<CommunityAdminInvites />} />
+                                <Route path='invites/:batchId' element={<CommunityAdminInviteDetails />} />
                             </Route>
                         </Route>
                         <Route element={<AuthSideAdminLayout />}>

--- a/TrashMob/client-app/src/pages/communities/$slug/admin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/communities/$slug/admin/_layout.tsx
@@ -26,6 +26,7 @@ export const CommunityAdminLayout = () => {
         { name: 'Edit Content', value: `${pathPrefix}/content` },
         { name: 'Adoptable Areas', value: `${pathPrefix}/areas` },
         { name: 'Adoptions', value: `${pathPrefix}/adoptions` },
+        { name: 'Invites', value: `${pathPrefix}/invites` },
     ];
 
     const handleValueChange = useCallback(

--- a/TrashMob/client-app/src/pages/communities/$slug/admin/invites/$batchId.tsx
+++ b/TrashMob/client-app/src/pages/communities/$slug/admin/invites/$batchId.tsx
@@ -1,0 +1,150 @@
+import { useQuery } from '@tanstack/react-query';
+import { useParams, Link } from 'react-router';
+import { AxiosResponse } from 'axios';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { ArrowLeft, CheckCircle, XCircle, Clock, Mail } from 'lucide-react';
+import { GetCommunityInviteBatchDetails } from '@/services/email-invites';
+import { GetCommunityBySlug } from '@/services/communities';
+import CommunityData from '@/components/Models/CommunityData';
+
+export const CommunityAdminInviteDetails = () => {
+    const { slug, batchId } = useParams<{ slug: string; batchId: string }>();
+
+    const { data: community } = useQuery<AxiosResponse<CommunityData>, unknown, CommunityData>({
+        queryKey: GetCommunityBySlug({ slug: slug! }).key,
+        queryFn: GetCommunityBySlug({ slug: slug! }).service,
+        select: (res) => res.data,
+        enabled: !!slug,
+    });
+
+    const communityId = community?.id || '';
+
+    const { data: batch, isLoading } = useQuery({
+        queryKey: GetCommunityInviteBatchDetails({ communityId, id: batchId! }).key,
+        queryFn: GetCommunityInviteBatchDetails({ communityId, id: batchId! }).service,
+        select: (res) => res.data,
+        enabled: !!communityId && !!batchId,
+    });
+
+    if (isLoading) {
+        return <div className='container py-4'>Loading...</div>;
+    }
+
+    if (!batch) {
+        return <div className='container py-4'>Batch not found</div>;
+    }
+
+    const getStatusBadge = (status: string) => {
+        switch (status) {
+            case 'Sent':
+                return (
+                    <Badge variant='success' className='gap-1'>
+                        <CheckCircle className='h-3 w-3' />
+                        Sent
+                    </Badge>
+                );
+            case 'Failed':
+                return (
+                    <Badge variant='destructive' className='gap-1'>
+                        <XCircle className='h-3 w-3' />
+                        Failed
+                    </Badge>
+                );
+            case 'Pending':
+            default:
+                return (
+                    <Badge variant='outline' className='gap-1'>
+                        <Clock className='h-3 w-3' />
+                        Pending
+                    </Badge>
+                );
+        }
+    };
+
+    return (
+        <div className='container py-6 space-y-6'>
+            <div className='flex items-center gap-4'>
+                <Button variant='ghost' size='icon' asChild>
+                    <Link to={`/communities/${slug}/admin/invites`}>
+                        <ArrowLeft className='h-4 w-4' />
+                    </Link>
+                </Button>
+                <h1 className='text-2xl font-bold'>Batch Details</h1>
+            </div>
+
+            {/* Summary Card */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                        <Mail className='h-5 w-5' />
+                        Batch Summary
+                    </CardTitle>
+                    <CardDescription>Created on {new Date(batch.createdDate).toLocaleString()}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className='grid gap-4 md:grid-cols-5'>
+                        <div>
+                            <p className='text-sm text-muted-foreground'>Total</p>
+                            <p className='text-2xl font-bold'>{batch.totalCount}</p>
+                        </div>
+                        <div>
+                            <p className='text-sm text-muted-foreground'>Sent</p>
+                            <p className='text-2xl font-bold text-green-600'>{batch.sentCount}</p>
+                        </div>
+                        <div>
+                            <p className='text-sm text-muted-foreground'>Failed</p>
+                            <p className='text-2xl font-bold text-red-600'>{batch.failedCount}</p>
+                        </div>
+                        <div>
+                            <p className='text-sm text-muted-foreground'>Status</p>
+                            <p className='mt-1'>{getStatusBadge(batch.status)}</p>
+                        </div>
+                        <div>
+                            <p className='text-sm text-muted-foreground'>Sent By</p>
+                            <p className='text-sm font-medium'>{batch.senderUser?.userName || 'Unknown'}</p>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* Individual Invites */}
+            <Card>
+                <CardHeader>
+                    <CardTitle>Individual Invites</CardTitle>
+                    <CardDescription>{batch.invites?.length || 0} email addresses in this batch</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Email</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead>Sent Date</TableHead>
+                                <TableHead>Error</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {(batch.invites || []).map((invite) => (
+                                <TableRow key={invite.id}>
+                                    <TableCell className='font-mono text-sm'>{invite.email}</TableCell>
+                                    <TableCell>{getStatusBadge(invite.status)}</TableCell>
+                                    <TableCell>
+                                        {invite.sentDate ? new Date(invite.sentDate).toLocaleString() : '-'}
+                                    </TableCell>
+                                    <TableCell className='max-w-xs truncate text-sm text-red-600'>
+                                        {invite.errorMessage || '-'}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
+
+export default CommunityAdminInviteDetails;

--- a/TrashMob/client-app/src/pages/communities/$slug/admin/invites/columns.tsx
+++ b/TrashMob/client-app/src/pages/communities/$slug/admin/invites/columns.tsx
@@ -1,0 +1,82 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { EmailInviteBatch } from '@/services/email-invites';
+import { Badge } from '@/components/ui/badge';
+import { Eye } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Link } from 'react-router';
+
+export const getColumns = (slug: string): ColumnDef<EmailInviteBatch>[] => [
+    {
+        accessorKey: 'createdDate',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Date' />,
+        cell: ({ row }) => {
+            const date = row.getValue('createdDate') as string;
+            return new Date(date).toLocaleString();
+        },
+    },
+    {
+        accessorKey: 'senderUser',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Sent By' />,
+        cell: ({ row }) => {
+            const user = row.original.senderUser;
+            return user?.userName || 'Unknown';
+        },
+    },
+    {
+        accessorKey: 'totalCount',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Total' />,
+    },
+    {
+        accessorKey: 'sentCount',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Sent' />,
+        cell: ({ row }) => {
+            const sent = row.getValue('sentCount') as number;
+            const total = row.original.totalCount;
+            return (
+                <span className={sent === total ? 'text-green-600' : 'text-amber-600'}>
+                    {sent} / {total}
+                </span>
+            );
+        },
+    },
+    {
+        accessorKey: 'failedCount',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Failed' />,
+        cell: ({ row }) => {
+            const failed = row.getValue('failedCount') as number;
+            return failed > 0 ? <span className='text-red-600'>{failed}</span> : <span>0</span>;
+        },
+    },
+    {
+        accessorKey: 'status',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        cell: ({ row }) => {
+            const status = row.getValue('status') as string;
+            switch (status) {
+                case 'Complete':
+                    return <Badge variant='success'>Complete</Badge>;
+                case 'Processing':
+                    return <Badge variant='secondary'>Processing</Badge>;
+                case 'Failed':
+                    return <Badge variant='destructive'>Failed</Badge>;
+                default:
+                    return <Badge variant='outline'>Pending</Badge>;
+            }
+        },
+    },
+    {
+        accessorKey: 'actions',
+        header: 'Actions',
+        cell: ({ row }) => {
+            const batch = row.original;
+            return (
+                <Button variant='ghost' size='icon' asChild>
+                    <Link to={`/communities/${slug}/admin/invites/${batch.id}`}>
+                        <Eye className='h-4 w-4' />
+                    </Link>
+                </Button>
+            );
+        },
+    },
+];

--- a/TrashMob/client-app/src/pages/communities/$slug/admin/invites/index.tsx
+++ b/TrashMob/client-app/src/pages/communities/$slug/admin/invites/index.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { useParams } from 'react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { DataTable } from '@/components/ui/data-table';
+import { Send, Mail } from 'lucide-react';
+
+import { getColumns } from './columns';
+import { GetCommunityInviteBatches, CreateCommunityInviteBatch } from '@/services/email-invites';
+import { GetCommunityBySlug } from '@/services/communities';
+import CommunityData from '@/components/Models/CommunityData';
+
+export const CommunityAdminInvites = () => {
+    const { slug } = useParams<{ slug: string }>() as { slug: string };
+    const queryClient = useQueryClient();
+    const [emailInput, setEmailInput] = useState('');
+    const [error, setError] = useState('');
+
+    const { data: community } = useQuery<AxiosResponse<CommunityData>, unknown, CommunityData>({
+        queryKey: GetCommunityBySlug({ slug }).key,
+        queryFn: GetCommunityBySlug({ slug }).service,
+        select: (res) => res.data,
+        enabled: !!slug,
+    });
+
+    const communityId = community?.id || '';
+
+    const { data: batches } = useQuery({
+        queryKey: GetCommunityInviteBatches({ communityId }).key,
+        queryFn: GetCommunityInviteBatches({ communityId }).service,
+        select: (res) => res.data,
+        enabled: !!communityId,
+    });
+
+    const createBatch = useMutation({
+        mutationKey: CreateCommunityInviteBatch({ communityId }).key,
+        mutationFn: CreateCommunityInviteBatch({ communityId }).service,
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: GetCommunityInviteBatches({ communityId }).key,
+                refetchType: 'all',
+            });
+            setEmailInput('');
+            setError('');
+        },
+        onError: (err: Error) => {
+            setError(err.message || 'Failed to send invites');
+        },
+    });
+
+    const handleSend = () => {
+        setError('');
+
+        // Parse email list (one per line or comma-separated)
+        const emails = emailInput
+            .split(/[\n,]/)
+            .map((e) => e.trim())
+            .filter((e) => e.length > 0);
+
+        if (emails.length === 0) {
+            setError('Please enter at least one email address');
+            return;
+        }
+
+        // Basic email validation
+        const invalidEmails = emails.filter((e) => !e.includes('@'));
+        if (invalidEmails.length > 0) {
+            setError(
+                `Invalid email addresses: ${invalidEmails.slice(0, 3).join(', ')}${invalidEmails.length > 3 ? '...' : ''}`,
+            );
+            return;
+        }
+
+        createBatch.mutate({ emails });
+    };
+
+    const columns = getColumns(slug);
+    const len = (batches || []).length;
+
+    return (
+        <div className='container py-6 space-y-6'>
+            {/* Send Invites Card */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                        <Mail className='h-5 w-5' />
+                        Invite Volunteers to {community?.name}
+                    </CardTitle>
+                    <CardDescription>
+                        Invite potential volunteers to join {community?.name || 'your community'} on TrashMob.eco. Enter
+                        email addresses one per line or comma-separated.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className='space-y-4'>
+                        <div className='space-y-2'>
+                            <Label htmlFor='emails'>Email Addresses</Label>
+                            <Textarea
+                                id='emails'
+                                placeholder='user1@example.com&#10;user2@example.com&#10;user3@example.com'
+                                value={emailInput}
+                                onChange={(e) => setEmailInput(e.target.value)}
+                                rows={6}
+                                className='font-mono text-sm'
+                            />
+                            <p className='text-xs text-muted-foreground'>
+                                Enter one email per line or separate with commas
+                            </p>
+                        </div>
+                        {error ? <p className='text-sm text-red-600'>{error}</p> : null}
+                        <Button onClick={handleSend} disabled={createBatch.isPending || !emailInput.trim()}>
+                            <Send className='mr-2 h-4 w-4' />
+                            {createBatch.isPending ? 'Sending...' : 'Send Invites'}
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* Batch History Card */}
+            <Card>
+                <CardHeader>
+                    <CardTitle>Invite History ({len})</CardTitle>
+                    <CardDescription>Recent bulk invite batches and their status</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <DataTable columns={columns} data={batches || []} />
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
+
+export default CommunityAdminInvites;

--- a/TrashMob/client-app/src/services/email-invites.ts
+++ b/TrashMob/client-app/src/services/email-invites.ts
@@ -78,3 +78,42 @@ export const CreateAdminInviteBatch = () => ({
             data: body,
         }),
 });
+
+// ========================================
+// Community Email Invite Endpoints
+// ========================================
+
+export type GetCommunityInviteBatches_Params = { communityId: string };
+export type GetCommunityInviteBatches_Response = EmailInviteBatch[];
+export const GetCommunityInviteBatches = (params: GetCommunityInviteBatches_Params) => ({
+    key: ['/communities', params.communityId, 'invites/batches'],
+    service: async () =>
+        ApiService('protected').fetchData<GetCommunityInviteBatches_Response>({
+            url: `/communities/${params.communityId}/invites/batches`,
+            method: 'get',
+        }),
+});
+
+export type GetCommunityInviteBatchDetails_Params = { communityId: string; id: string };
+export type GetCommunityInviteBatchDetails_Response = EmailInviteBatch;
+export const GetCommunityInviteBatchDetails = (params: GetCommunityInviteBatchDetails_Params) => ({
+    key: ['/communities', params.communityId, 'invites/batches', params.id],
+    service: async () =>
+        ApiService('protected').fetchData<GetCommunityInviteBatchDetails_Response>({
+            url: `/communities/${params.communityId}/invites/batches/${params.id}`,
+            method: 'get',
+        }),
+});
+
+export type CreateCommunityInviteBatch_Params = { communityId: string };
+export type CreateCommunityInviteBatch_Body = CreateEmailInviteBatchRequest;
+export type CreateCommunityInviteBatch_Response = EmailInviteBatch;
+export const CreateCommunityInviteBatch = (params: CreateCommunityInviteBatch_Params) => ({
+    key: ['/communities', params.communityId, 'invites/batch', 'create'],
+    service: async (body: CreateCommunityInviteBatch_Body) =>
+        ApiService('protected').fetchData<CreateCommunityInviteBatch_Response, CreateCommunityInviteBatch_Body>({
+            url: `/communities/${params.communityId}/invites/batch`,
+            method: 'post',
+            data: body,
+        }),
+});


### PR DESCRIPTION
## Summary

- Enable community admins to send bulk email invitations to potential volunteers
- Invites are attributed to the community with custom email templates mentioning the community name
- Builds on Phase 1 admin invites infrastructure

### Backend Changes
- Add `CommunityInvitesController` with community-scoped endpoints:
  - `GET /api/communities/{communityId}/invites/batches` - List community batches
  - `GET /api/communities/{communityId}/invites/batches/{id}` - Get batch details
  - `POST /api/communities/{communityId}/invites/batch` - Create and send invites
- Add `GetCommunityBatchesAsync` to `EmailInviteManager`
- Add `InviteToJoinCommunity.html` email template with `{communityName}` placeholders
- Add `NotificationTypeEnum.InviteToJoinCommunity` (38)

### Frontend Changes
- Add community invite service endpoints to `email-invites.ts`
- Add "Invites" tab to community admin layout
- Add community admin invites page with form and batch history table
- Add batch details page for viewing individual invite status

## Test plan

- [ ] Navigate to a community admin page (must be community admin)
- [ ] Verify "Invites" tab appears in the community admin navigation
- [ ] Enter test email addresses and click "Send Invites"
- [ ] Verify batch appears in history with correct status
- [ ] Click batch to view individual invite details
- [ ] Verify emails received mention the community name

🤖 Generated with [Claude Code](https://claude.com/claude-code)