### PR TITLE
Add Project 36 Marketing Materials and planning updates

### DIFF
--- a/Planning/Projects/Project_06_Backend_Standards.md
+++ b/Planning/Projects/Project_06_Backend_Standards.md
@@ -58,6 +58,13 @@ Unify coding patterns across the backend codebase, upgrade to .NET 10, secure al
 - ✓ Document common patterns in wiki
 - ✓ Create coding standards guide
 
+### Phase 5 - Unit Test Coverage
+- ? Increase test coverage for TrashMob.Shared managers
+- ? Add tests for repository layer
+- ? Add tests for controller validation logic
+- ? Achieve minimum 70% code coverage for business logic
+- ? Integrate coverage reporting in CI/CD
+
 ---
 
 ## Out-of-Scope
@@ -72,7 +79,7 @@ Unify coding patterns across the backend codebase, upgrade to .NET 10, secure al
 ## Success Metrics
 
 ### Quantitative
-- **Code coverage:** Maintain or increase current levels
+- **Code coverage:** Achieve ≥ 70% coverage for TrashMob.Shared managers
 - **Compilation warnings:** Reduce to zero
 - **Security vulnerabilities:** Zero high/critical
 - **API documentation:** 100% of endpoints documented
@@ -222,6 +229,13 @@ Create `CODING_STANDARDS.md`:
 - Write coding standards
 - Create contribution guide
 
+### Phase 5: Unit Test Coverage
+- Add unit tests for managers in TrashMob.Shared
+- Test repository methods with in-memory database
+- Add controller validation tests
+- Configure code coverage reporting (Coverlet)
+- Set up coverage thresholds in CI pipeline
+
 **Note:** Each phase can be picked up by different volunteers independently.
 
 ---
@@ -269,7 +283,7 @@ The following GitHub issues are tracked as part of this project:
 
 ---
 
-**Last Updated:** January 31, 2026
+**Last Updated:** February 3, 2026
 **Owner:** Engineering Lead
 **Status:** In Progress (Phase 1 & 4 complete)
-**Next Review:** When Phase 2 or 3 starts
+**Next Review:** When Phase 2, 3, or 5 starts

--- a/Planning/Projects/Project_36_Marketing_Materials.md
+++ b/Planning/Projects/Project_36_Marketing_Materials.md
@@ -1,0 +1,226 @@
+# Project 36 — Marketing Materials for 2026 Release
+
+| Attribute | Value |
+|-----------|-------|
+| **Status** | Not Started |
+| **Priority** | High |
+| **Risk** | Low |
+| **Size** | Small |
+| **Dependencies** | None |
+
+---
+
+## Business Rationale
+
+With the completion of major features in early 2026, TrashMob needs professional marketing materials to promote the platform, attract new communities, and communicate the value proposition to potential partners. Clear documentation of features, pricing, and enrollment processes will drive community adoption.
+
+---
+
+## Objectives
+
+### Primary Goals
+- **Feature overview document** highlighting all 2026 releases
+- **Community pricing guide** with tier details
+- **Enrollment guide** for new communities
+- **One-pager** for quick partner outreach
+
+### Secondary Goals
+- Social media announcement templates
+- Email campaign content
+- Press release draft
+- Partner presentation deck
+
+---
+
+## Scope
+
+### Phase 1 - Feature Documentation
+- ? Document all completed features from 2026:
+  - **Teams** (Project 9) - User-created volunteer teams with membership, logos, and collective impact tracking
+  - **Community Pages** (Project 10) - Branded partner community pages with custom programs
+  - **Adopt-A-Location** (Project 11) - Location adoption program for recurring cleanups
+  - **Bulk Email Invites** (Project 13) - Admin, community, team, and user invitation system
+  - **Event Co-Leads** (Project 21) - Multiple administrators per event
+  - **Attendee Metrics** (Project 22) - Per-attendee statistics and tracking
+  - **Photo Moderation** (Project 28) - Admin review and flagging system
+  - **Feature Usage Metrics** (Project 29) - Analytics and reporting dashboards
+  - **User Feedback** (Project 34) - In-app feedback collection
+- ? Create feature comparison table (Free vs Community tier)
+- ? Write benefit-focused descriptions for each feature
+
+### Phase 2 - Pricing & Enrollment
+- ? Define community tier pricing structure
+- ? Document what's included at each tier:
+  - **Free Tier:** Basic event creation, volunteer registration, impact tracking
+  - **Community Tier:** Branded pages, custom waivers, bulk invites, analytics dashboards
+- ? Create step-by-step enrollment guide
+- ? Document community admin onboarding process
+- ? Create FAQ for prospective communities
+
+### Phase 3 - Marketing Collateral
+- ? One-page feature overview (PDF)
+- ? Community enrollment flyer
+- ? Social media post templates (Twitter/X, LinkedIn, Facebook)
+- ? Email announcement templates
+- ? Partner presentation slides
+
+---
+
+## Out-of-Scope
+
+- ? Paid advertising campaigns
+- ? Video production
+- ? Website redesign
+- ? Print materials (physical brochures)
+- ? Localized/translated versions
+
+---
+
+## Success Metrics
+
+### Quantitative
+- **Community inquiries:** Track increase after materials release
+- **Enrollment conversion:** % of inquiries that become communities
+- **Document downloads:** Track one-pager and guide downloads
+- **Social engagement:** Likes, shares, clicks on announcements
+
+### Qualitative
+- Positive feedback from partner outreach
+- Clear understanding of features by prospects
+- Reduced questions during enrollment process
+
+---
+
+## Dependencies
+
+### Blockers
+None - all referenced features are complete
+
+### Enables
+- Community growth initiative
+- Partner outreach program
+- Volunteer recruitment campaigns
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| **Pricing not finalized** | Medium | High | Work with business team to confirm tiers before publishing |
+| **Features change post-release** | Low | Low | Version documents; update as needed |
+| **Inconsistent messaging** | Medium | Medium | Single source of truth; review process |
+
+---
+
+## Implementation Plan
+
+### Feature Highlights Document
+
+```markdown
+# TrashMob 2026 - What's New
+
+## Teams
+Create volunteer teams, track collective impact, upload team logos,
+and invite members via email. Perfect for corporate groups, schools,
+and neighborhood associations.
+
+## Community Pages
+Get your own branded TrashMob community page with custom programs,
+dedicated analytics, and professional presence for your city or region.
+
+## Bulk Email Invites
+Grow your volunteer base with bulk invitation tools. Admins can
+invite hundreds, communities can onboard volunteers, and teams can
+recruit members - all with tracking and delivery confirmation.
+
+## Event Co-Leads
+Share event management responsibilities with co-leads who can
+edit event details, manage attendees, and post updates.
+
+## Enhanced Metrics
+Track individual volunteer contributions, view detailed analytics
+dashboards, and export reports for grant applications.
+```
+
+### Pricing Structure (Draft)
+
+| Feature | Free | Community |
+|---------|------|-----------|
+| Event creation | ✓ | ✓ |
+| Volunteer registration | ✓ | ✓ |
+| Basic impact tracking | ✓ | ✓ |
+| Teams | ✓ | ✓ |
+| Branded community page | - | ✓ |
+| Custom waivers | - | ✓ |
+| Bulk email invites (500/day) | - | ✓ |
+| Analytics dashboards | - | ✓ |
+| Priority support | - | ✓ |
+
+**Pricing:** Contact info@trashmob.eco for community tier pricing
+
+### Enrollment Process
+
+1. **Express Interest:** Email info@trashmob.eco or fill out contact form
+2. **Discovery Call:** 30-minute call to understand community needs
+3. **Agreement:** Sign community partner agreement
+4. **Setup:** TrashMob team configures community page and branding
+5. **Training:** 1-hour onboarding session for community admins
+6. **Launch:** Announce community page and begin recruiting volunteers
+
+---
+
+## Deliverables
+
+| Deliverable | Format | Audience |
+|-------------|--------|----------|
+| Feature Overview | Markdown/PDF | All |
+| Pricing Guide | Markdown/PDF | Communities |
+| Enrollment Guide | Markdown/PDF | Prospective communities |
+| One-Pager | PDF | Partner outreach |
+| Social Templates | Text files | Marketing |
+| Email Templates | HTML/Text | Marketing |
+
+---
+
+## Open Questions
+
+1. **What is the community tier pricing?**
+   **Decision:** Pending
+   **Status:** Needs business input
+
+2. **Who reviews marketing materials before release?**
+   **Decision:** Pending
+   **Status:** Needs process definition
+
+3. **Where will materials be hosted?**
+   **Decision:** Pending (website, GitHub, both?)
+   **Status:** Needs decision
+
+4. **Should we create a landing page for communities?**
+   **Decision:** Pending
+   **Status:** Could be separate project
+
+---
+
+## GitHub Issues
+
+The following GitHub issues are tracked as part of this project:
+
+- **TBD** - Create tracking issue when work begins
+
+---
+
+## Related Documents
+
+- **[Project 9 - Teams](./Project_09_Teams.md)** - Teams feature details
+- **[Project 10 - Community Pages](./Project_10_Community_Pages.md)** - Community feature details
+- **[Project 13 - Bulk Email Invites](./Project_13_Bulk_Email_Invites.md)** - Invite system details
+- **[Executive Summary](../Executive_Summary.md)** - Strategic objectives
+
+---
+
+**Last Updated:** February 3, 2026
+**Owner:** Marketing & Product Team
+**Status:** Not Started
+**Next Review:** When pricing decisions are finalized

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -13,7 +13,7 @@
 - **[Executive Summary](./Executive_Summary.md)** - High-level overview, strategic objectives, and 2026 roadmap
 - **[Risks & Mitigations](./Risks_and_Mitigations.md)** - Cross-project risks and mitigation strategies
 
-### 2026 Projects (35 Total)
+### 2026 Projects (36 Total)
 
 **Note:** Projects are not time-bound. Volunteers pick up work based on priority and availability.
 
@@ -35,7 +35,7 @@
 | [Project 8 - Waivers V3](./Projects/Project_08_Waivers_V3.md) | Community waivers, minors coverage | In Progress (Phase 1-4 Complete) |
 | [Project 9 - Teams](./Projects/Project_09_Teams.md) | User-created teams MVP | ✅ Complete |
 | [Project 10 - Community Pages](./Projects/Project_10_Community_Pages.md) | Branded partner community pages | ✅ Complete |
-| [Project 13 - Bulk Email Invites](./Projects/Project_13_Bulk_Email_Invites.md) | Scale email invitations | In Progress (Phase 1 Complete) |
+| [Project 13 - Bulk Email Invites](./Projects/Project_13_Bulk_Email_Invites.md) | Scale email invitations | ✅ Complete |
 | [Project 23 - Parental Consent](./Projects/Project_23_Parental_Consent.md) | Privo.com integration for minors | Planning in Progress |
 | [Project 24 - API v2 Modernization](./Projects/Project_24_API_v2_Modernization.md) | Pagination, error handling, auto-generated clients | Not Started |
 
@@ -62,6 +62,12 @@
 | [Project 33 - Localization](./Projects/Project_33_Localization.md) | Multi-language support | Deprioritized |
 | [Project 34 - User Feedback](./Projects/Project_34_User_Feedback.md) | In-app feedback widget | ✅ Complete |
 | [Project 35 - Partner Location Map](./Projects/Project_35_Partner_Location_Map.md) | Partner locations on map | Not Started |
+
+#### High Priority (Marketing & Growth)
+
+| Project | Description | Status |
+|---------|-------------|--------|
+| [Project 36 - Marketing Materials](./Projects/Project_36_Marketing_Materials.md) | 2026 release marketing, pricing, enrollment | Not Started |
 
 #### Low Priority (Nice-to-Have)
 
@@ -109,9 +115,10 @@
 
 ### Engagement & Growth
 - [Project 12 - In-App Messaging](./Projects/Project_12_In_App_Messaging.md)
-- [Project 13 - Bulk Email Invites](./Projects/Project_13_Bulk_Email_Invites.md)
+- [Project 13 - Bulk Email Invites](./Projects/Project_13_Bulk_Email_Invites.md) ✅
 - [Project 20 - Gamification](./Projects/Project_20_Gamification.md)
 - [Project 34 - User Feedback](./Projects/Project_34_User_Feedback.md) ✅
+- [Project 36 - Marketing Materials](./Projects/Project_36_Marketing_Materials.md)
 
 ---
 
@@ -119,15 +126,15 @@
 
 | Status | Count | Projects |
 |--------|-------|----------|
-| ✅ **Complete** | 15 | Projects 3, 7, 9, 10, 11, 16, 17, 21, 26, 27, 28, 29, 32, 34 |
-| **In Progress** | 4 | Projects 6, 8 (Phase 1-4 Complete), 13 (Phase 1 Complete), 22 (Phase 1-3 Complete) |
+| ✅ **Complete** | 16 | Projects 3, 7, 9, 10, 11, 13, 16, 17, 21, 26, 27, 28, 29, 32, 34 |
+| **In Progress** | 3 | Projects 6, 8 (Phase 1-4 Complete), 22 (Phase 1-3 Complete) |
 | **Developers Engaged** | 1 | Project 4 |
 | **Ready for Review** | 2 | Projects 2, 5 |
 | **Planning** | 4 | Projects 1, 15, 18, 23 |
-| **Not Started** | 8 | Projects 12, 14, 19, 20, 24, 25, 30, 31, 35 |
+| **Not Started** | 9 | Projects 12, 14, 19, 20, 24, 25, 30, 31, 35, 36 |
 | **Deprioritized** | 1 | Project 33 |
 
-**Total:** 35 project specifications documented
+**Total:** 36 project specifications documented
 
 ---
 
@@ -200,6 +207,6 @@ All new features should consider adding feature usage tracking. See [Project 29 
 
 ---
 
-**Last Updated:** February 2, 2026
+**Last Updated:** February 3, 2026
 **Maintained By:** Product & Engineering Team
 **Next Review:** End of Q1 2026


### PR DESCRIPTION
## Summary
- Add **Project 36: Marketing Materials** for 2026 release with feature documentation, pricing guide, and enrollment process
- Add **Phase 5 (Unit Test Coverage)** to Project 6 Backend Standards
- Update **Project 13 Bulk Email Invites** status to Complete in README
- Update project counts (now 36 total, 16 complete)

## Changes
- `Planning/Projects/Project_36_Marketing_Materials.md` - New project covering:
  - Feature documentation for all 2026 releases
  - Community pricing structure (draft)
  - Step-by-step enrollment guide
  - Marketing collateral deliverables
- `Planning/Projects/Project_06_Backend_Standards.md` - Added Phase 5 for unit test coverage
- `Planning/README.md` - Updated statuses and counts

## Test plan
- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)