### PR TITLE
Add unit test infrastructure and EventManager tests (Project 37 Phase 1)

### DIFF
--- a/TrashMob.Shared.Tests/Builders/EventAttendeeBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/EventAttendeeBuilder.cs
@@ -1,0 +1,86 @@
+namespace TrashMob.Shared.Tests.Builders
+{
+    using System;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Builder for creating EventAttendee test data with sensible defaults.
+    /// </summary>
+    public class EventAttendeeBuilder
+    {
+        private readonly EventAttendee _eventAttendee;
+
+        public EventAttendeeBuilder()
+        {
+            var userId = Guid.NewGuid();
+            _eventAttendee = new EventAttendee
+            {
+                EventId = Guid.NewGuid(),
+                UserId = userId,
+                SignUpDate = DateTimeOffset.UtcNow,
+                CanceledDate = null,
+                IsEventLead = false,
+                CreatedByUserId = userId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = userId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+
+        public EventAttendeeBuilder ForEvent(Guid eventId)
+        {
+            _eventAttendee.EventId = eventId;
+            return this;
+        }
+
+        public EventAttendeeBuilder ForEvent(Event evt)
+        {
+            _eventAttendee.EventId = evt.Id;
+            _eventAttendee.Event = evt;
+            return this;
+        }
+
+        public EventAttendeeBuilder ForUser(Guid userId)
+        {
+            _eventAttendee.UserId = userId;
+            _eventAttendee.CreatedByUserId = userId;
+            _eventAttendee.LastUpdatedByUserId = userId;
+            return this;
+        }
+
+        public EventAttendeeBuilder ForUser(User user)
+        {
+            _eventAttendee.UserId = user.Id;
+            _eventAttendee.User = user;
+            _eventAttendee.CreatedByUserId = user.Id;
+            _eventAttendee.LastUpdatedByUserId = user.Id;
+            return this;
+        }
+
+        public EventAttendeeBuilder WithSignUpDate(DateTimeOffset signUpDate)
+        {
+            _eventAttendee.SignUpDate = signUpDate;
+            return this;
+        }
+
+        public EventAttendeeBuilder AsCancelled()
+        {
+            _eventAttendee.CanceledDate = DateTimeOffset.UtcNow;
+            return this;
+        }
+
+        public EventAttendeeBuilder AsEventLead()
+        {
+            _eventAttendee.IsEventLead = true;
+            return this;
+        }
+
+        public EventAttendeeBuilder AsRegularAttendee()
+        {
+            _eventAttendee.IsEventLead = false;
+            return this;
+        }
+
+        public EventAttendee Build() => _eventAttendee;
+    }
+}

--- a/TrashMob.Shared.Tests/Builders/EventBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/EventBuilder.cs
@@ -1,0 +1,178 @@
+namespace TrashMob.Shared.Tests.Builders
+{
+    using System;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Builder for creating Event test data with sensible defaults.
+    /// </summary>
+    public class EventBuilder
+    {
+        private readonly Event _event;
+
+        public EventBuilder()
+        {
+            var creatorId = Guid.NewGuid();
+            _event = new Event
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Cleanup Event",
+                Description = "A test cleanup event for unit testing",
+                EventDate = DateTimeOffset.UtcNow.AddDays(7),
+                DurationHours = 2,
+                DurationMinutes = 0,
+                EventTypeId = 1, // Cleanup
+                EventStatusId = 1, // Active
+                StreetAddress = "123 Test Street",
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                PostalCode = "98101",
+                Latitude = 47.6062,
+                Longitude = -122.3321,
+                MaxNumberOfParticipants = 20,
+                IsEventPublic = true,
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+
+        public EventBuilder WithId(Guid id)
+        {
+            _event.Id = id;
+            return this;
+        }
+
+        public EventBuilder WithName(string name)
+        {
+            _event.Name = name;
+            return this;
+        }
+
+        public EventBuilder WithDescription(string description)
+        {
+            _event.Description = description;
+            return this;
+        }
+
+        public EventBuilder WithEventDate(DateTimeOffset eventDate)
+        {
+            _event.EventDate = eventDate;
+            return this;
+        }
+
+        public EventBuilder InThePast()
+        {
+            _event.EventDate = DateTimeOffset.UtcNow.AddDays(-7);
+            return this;
+        }
+
+        public EventBuilder InTheFuture(int days = 7)
+        {
+            _event.EventDate = DateTimeOffset.UtcNow.AddDays(days);
+            return this;
+        }
+
+        public EventBuilder WithDuration(int hours, int minutes = 0)
+        {
+            _event.DurationHours = hours;
+            _event.DurationMinutes = minutes;
+            return this;
+        }
+
+        public EventBuilder WithEventType(int eventTypeId)
+        {
+            _event.EventTypeId = eventTypeId;
+            return this;
+        }
+
+        public EventBuilder WithStatus(int statusId)
+        {
+            _event.EventStatusId = statusId;
+            return this;
+        }
+
+        public EventBuilder AsActive()
+        {
+            _event.EventStatusId = 1;
+            return this;
+        }
+
+        public EventBuilder AsCancelled(string reason = "Test cancellation")
+        {
+            _event.EventStatusId = 3;
+            _event.CancellationReason = reason;
+            return this;
+        }
+
+        public EventBuilder AsCompleted()
+        {
+            _event.EventStatusId = 4; // Complete status
+            _event.EventDate = DateTimeOffset.UtcNow.AddDays(-1);
+            return this;
+        }
+
+        public EventBuilder AsFull()
+        {
+            _event.EventStatusId = 2; // Full status
+            return this;
+        }
+
+        public EventBuilder WithLocation(string city, string region, string country)
+        {
+            _event.City = city;
+            _event.Region = region;
+            _event.Country = country;
+            return this;
+        }
+
+        public EventBuilder InCity(string city)
+        {
+            _event.City = city;
+            return this;
+        }
+
+        public EventBuilder WithCoordinates(double latitude, double longitude)
+        {
+            _event.Latitude = latitude;
+            _event.Longitude = longitude;
+            return this;
+        }
+
+        public EventBuilder WithAddress(string streetAddress, string postalCode)
+        {
+            _event.StreetAddress = streetAddress;
+            _event.PostalCode = postalCode;
+            return this;
+        }
+
+        public EventBuilder WithMaxParticipants(int max)
+        {
+            _event.MaxNumberOfParticipants = max;
+            return this;
+        }
+
+        public EventBuilder AsPrivate()
+        {
+            _event.IsEventPublic = false;
+            return this;
+        }
+
+        public EventBuilder AsPublic()
+        {
+            _event.IsEventPublic = true;
+            return this;
+        }
+
+        public EventBuilder CreatedBy(Guid userId)
+        {
+            _event.CreatedByUserId = userId;
+            _event.LastUpdatedByUserId = userId;
+            return this;
+        }
+
+        public Event Build() => _event;
+    }
+}

--- a/TrashMob.Shared.Tests/Builders/TeamBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/TeamBuilder.cs
@@ -1,0 +1,79 @@
+namespace TrashMob.Shared.Tests.Builders
+{
+    using System;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Builder for creating Team test data with sensible defaults.
+    /// </summary>
+    public class TeamBuilder
+    {
+        private readonly Team _team;
+
+        public TeamBuilder()
+        {
+            var creatorId = Guid.NewGuid();
+            _team = new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Team",
+                Description = "A test team for unit testing",
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                IsActive = true,
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+
+        public TeamBuilder WithId(Guid id)
+        {
+            _team.Id = id;
+            return this;
+        }
+
+        public TeamBuilder WithName(string name)
+        {
+            _team.Name = name;
+            return this;
+        }
+
+        public TeamBuilder WithDescription(string description)
+        {
+            _team.Description = description;
+            return this;
+        }
+
+        public TeamBuilder WithLocation(string city, string region, string country)
+        {
+            _team.City = city;
+            _team.Region = region;
+            _team.Country = country;
+            return this;
+        }
+
+        public TeamBuilder AsInactive()
+        {
+            _team.IsActive = false;
+            return this;
+        }
+
+        public TeamBuilder AsActive()
+        {
+            _team.IsActive = true;
+            return this;
+        }
+
+        public TeamBuilder CreatedBy(Guid userId)
+        {
+            _team.CreatedByUserId = userId;
+            _team.LastUpdatedByUserId = userId;
+            return this;
+        }
+
+        public Team Build() => _team;
+    }
+}

--- a/TrashMob.Shared.Tests/Builders/UserBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/UserBuilder.cs
@@ -1,0 +1,120 @@
+namespace TrashMob.Shared.Tests.Builders
+{
+    using System;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Builder for creating User test data with sensible defaults.
+    /// </summary>
+    public class UserBuilder
+    {
+        private readonly User _user;
+
+        public UserBuilder()
+        {
+            var id = Guid.NewGuid();
+            _user = new User
+            {
+                Id = id,
+                ObjectId = Guid.NewGuid(),
+                UserName = $"testuser_{id:N}".Substring(0, 20),
+                Email = $"test_{id:N}@example.com".Substring(0, 40),
+                NameIdentifier = $"nameid_{id:N}",
+                SourceSystemUserName = $"source_{id:N}",
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                PostalCode = "98101",
+                Latitude = 47.6062,
+                Longitude = -122.3321,
+                TravelLimitForLocalEvents = 25,
+                IsSiteAdmin = false,
+                PrefersMetric = false,
+                ShowOnLeaderboards = true,
+                AchievementNotificationsEnabled = true,
+                MemberSince = DateTimeOffset.UtcNow.AddMonths(-6),
+                CreatedByUserId = id,
+                CreatedDate = DateTimeOffset.UtcNow.AddMonths(-6),
+                LastUpdatedByUserId = id,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+
+        public UserBuilder WithId(Guid id)
+        {
+            _user.Id = id;
+            return this;
+        }
+
+        public UserBuilder WithUserName(string userName)
+        {
+            _user.UserName = userName;
+            return this;
+        }
+
+        public UserBuilder WithEmail(string email)
+        {
+            _user.Email = email;
+            return this;
+        }
+
+        public UserBuilder WithCity(string city)
+        {
+            _user.City = city;
+            return this;
+        }
+
+        public UserBuilder WithRegion(string region)
+        {
+            _user.Region = region;
+            return this;
+        }
+
+        public UserBuilder WithCountry(string country)
+        {
+            _user.Country = country;
+            return this;
+        }
+
+        public UserBuilder WithLocation(double latitude, double longitude)
+        {
+            _user.Latitude = latitude;
+            _user.Longitude = longitude;
+            return this;
+        }
+
+        public UserBuilder AsSiteAdmin()
+        {
+            _user.IsSiteAdmin = true;
+            return this;
+        }
+
+        public UserBuilder WithWaiverSigned(string version = "1.0")
+        {
+            _user.DateAgreedToTrashMobWaiver = DateTimeOffset.UtcNow.AddDays(-30);
+            _user.TrashMobWaiverVersion = version;
+            return this;
+        }
+
+        public UserBuilder WithTravelLimit(int miles)
+        {
+            _user.TravelLimitForLocalEvents = miles;
+            return this;
+        }
+
+        public UserBuilder HiddenFromLeaderboards()
+        {
+            _user.ShowOnLeaderboards = false;
+            return this;
+        }
+
+        public UserBuilder CreatedBy(Guid userId)
+        {
+            _user.CreatedByUserId = userId;
+            _user.LastUpdatedByUserId = userId;
+            return this;
+        }
+
+        public User Build() => _user;
+    }
+}

--- a/TrashMob.Shared.Tests/Fixtures/MockRepositoryExtensions.cs
+++ b/TrashMob.Shared.Tests/Fixtures/MockRepositoryExtensions.cs
@@ -1,0 +1,261 @@
+namespace TrashMob.Shared.Tests.Fixtures
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.Query;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// Extension methods for setting up mock repositories with test data.
+    /// </summary>
+    public static class MockRepositoryExtensions
+    {
+        /// <summary>
+        /// Sets up the Get method to return a queryable from the provided data.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupGet<T>(
+            this Mock<IKeyedRepository<T>> mock,
+            IEnumerable<T> data) where T : KeyedModel
+        {
+            var queryable = new TestAsyncEnumerable<T>(data);
+            mock.Setup(r => r.Get()).Returns(queryable);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up the Get method with expression filter to return filtered queryable.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupGetWithFilter<T>(
+            this Mock<IKeyedRepository<T>> mock,
+            IEnumerable<T> data) where T : KeyedModel
+        {
+            mock.Setup(r => r.Get(It.IsAny<Expression<Func<T, bool>>>(), It.IsAny<bool>()))
+                .Returns((Expression<Func<T, bool>> predicate, bool _) =>
+                    new TestAsyncEnumerable<T>(data.AsQueryable().Where(predicate)));
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up GetAsync to return a specific entity by ID.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupGetAsync<T>(
+            this Mock<IKeyedRepository<T>> mock,
+            T entity) where T : KeyedModel
+        {
+            mock.Setup(r => r.GetAsync(entity.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entity);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up GetAsync to return entities from a collection by ID lookup.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupGetAsync<T>(
+            this Mock<IKeyedRepository<T>> mock,
+            IEnumerable<T> data) where T : KeyedModel
+        {
+            mock.Setup(r => r.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid id, CancellationToken _) =>
+                    data.FirstOrDefault(e => e.Id == id));
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up GetWithNoTrackingAsync to return a specific entity by ID.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupGetWithNoTrackingAsync<T>(
+            this Mock<IKeyedRepository<T>> mock,
+            T entity) where T : KeyedModel
+        {
+            mock.Setup(r => r.GetWithNoTrackingAsync(entity.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entity);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up GetWithNoTrackingAsync to return entities from a collection by ID lookup.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupGetWithNoTrackingAsync<T>(
+            this Mock<IKeyedRepository<T>> mock,
+            IEnumerable<T> data) where T : KeyedModel
+        {
+            mock.Setup(r => r.GetWithNoTrackingAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid id, CancellationToken _) =>
+                    data.FirstOrDefault(e => e.Id == id));
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up AddAsync to return the entity that was added.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupAddAsync<T>(
+            this Mock<IKeyedRepository<T>> mock) where T : KeyedModel
+        {
+            mock.Setup(r => r.AddAsync(It.IsAny<T>()))
+                .ReturnsAsync((T entity) => entity);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up UpdateAsync to return the entity that was updated.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupUpdateAsync<T>(
+            this Mock<IKeyedRepository<T>> mock) where T : KeyedModel
+        {
+            mock.Setup(r => r.UpdateAsync(It.IsAny<T>()))
+                .ReturnsAsync((T entity) => entity);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up DeleteAsync to return 1 (success).
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupDeleteAsync<T>(
+            this Mock<IKeyedRepository<T>> mock) where T : KeyedModel
+        {
+            mock.Setup(r => r.DeleteAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(1);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up all common repository methods with the provided data.
+        /// </summary>
+        public static Mock<IKeyedRepository<T>> SetupAll<T>(
+            this Mock<IKeyedRepository<T>> mock,
+            IEnumerable<T> data) where T : KeyedModel
+        {
+            return mock
+                .SetupGet(data)
+                .SetupGetWithFilter(data)
+                .SetupGetAsync(data)
+                .SetupGetWithNoTrackingAsync(data)
+                .SetupAddAsync()
+                .SetupUpdateAsync()
+                .SetupDeleteAsync();
+        }
+
+        /// <summary>
+        /// Sets up Get method for IBaseRepository to return a queryable from the provided data.
+        /// </summary>
+        public static Mock<IBaseRepository<T>> SetupGet<T>(
+            this Mock<IBaseRepository<T>> mock,
+            IEnumerable<T> data) where T : BaseModel
+        {
+            var queryable = new TestAsyncEnumerable<T>(data);
+            mock.Setup(r => r.Get()).Returns(queryable);
+            return mock;
+        }
+
+        /// <summary>
+        /// Sets up Get method with expression filter for IBaseRepository.
+        /// </summary>
+        public static Mock<IBaseRepository<T>> SetupGetWithFilter<T>(
+            this Mock<IBaseRepository<T>> mock,
+            IEnumerable<T> data) where T : BaseModel
+        {
+            mock.Setup(r => r.Get(It.IsAny<Expression<Func<T, bool>>>(), It.IsAny<bool>()))
+                .Returns((Expression<Func<T, bool>> predicate, bool _) =>
+                    new TestAsyncEnumerable<T>(data.AsQueryable().Where(predicate)));
+            return mock;
+        }
+    }
+
+    /// <summary>
+    /// An IQueryable implementation that supports async enumeration for testing.
+    /// </summary>
+    internal class TestAsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+    {
+        public TestAsyncEnumerable(IEnumerable<T> enumerable) : base(enumerable) { }
+        public TestAsyncEnumerable(Expression expression) : base(expression) { }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+        }
+
+        IQueryProvider IQueryable.Provider => new TestAsyncQueryProvider<T>(this);
+    }
+
+    /// <summary>
+    /// An async enumerator that wraps a synchronous enumerator for testing.
+    /// </summary>
+    internal class TestAsyncEnumerator<T> : IAsyncEnumerator<T>
+    {
+        private readonly IEnumerator<T> _inner;
+
+        public TestAsyncEnumerator(IEnumerator<T> inner)
+        {
+            _inner = inner;
+        }
+
+        public T Current => _inner.Current;
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            return new ValueTask<bool>(_inner.MoveNext());
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _inner.Dispose();
+            return new ValueTask();
+        }
+    }
+
+    /// <summary>
+    /// A query provider that supports async query execution for testing.
+    /// </summary>
+    internal class TestAsyncQueryProvider<TEntity> : IAsyncQueryProvider
+    {
+        private readonly IQueryProvider _inner;
+
+        internal TestAsyncQueryProvider(IQueryProvider inner)
+        {
+            _inner = inner;
+        }
+
+        public IQueryable CreateQuery(Expression expression)
+        {
+            return new TestAsyncEnumerable<TEntity>(expression);
+        }
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        {
+            return new TestAsyncEnumerable<TElement>(expression);
+        }
+
+        public object Execute(Expression expression)
+        {
+            return _inner.Execute(expression);
+        }
+
+        public TResult Execute<TResult>(Expression expression)
+        {
+            return _inner.Execute<TResult>(expression);
+        }
+
+        public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = default)
+        {
+            var expectedResultType = typeof(TResult).GetGenericArguments()[0];
+            var executionResult = typeof(IQueryProvider)
+                .GetMethod(
+                    name: nameof(IQueryProvider.Execute),
+                    genericParameterCount: 1,
+                    types: [typeof(Expression)])
+                ?.MakeGenericMethod(expectedResultType)
+                .Invoke(this, [expression]);
+
+            return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
+                ?.MakeGenericMethod(expectedResultType)
+                .Invoke(null, [executionResult]);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
@@ -1,0 +1,628 @@
+namespace TrashMob.Shared.Tests.Managers.Events
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Engine;
+    using TrashMob.Shared.Managers.Events;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Poco;
+    using TrashMob.Shared.Tests.Builders;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="EventManager"/>.
+    /// </summary>
+    public class EventManagerTests
+    {
+        private readonly Mock<IKeyedRepository<Event>> _eventRepository;
+        private readonly Mock<IEventAttendeeManager> _eventAttendeeManager;
+        private readonly Mock<IBaseRepository<EventAttendee>> _eventAttendeeRepository;
+        private readonly Mock<IEventLitterReportManager> _eventLitterReportManager;
+        private readonly Mock<IMapManager> _mapManager;
+        private readonly Mock<IEmailManager> _emailManager;
+        private readonly EventManager _sut;
+
+        public EventManagerTests()
+        {
+            _eventRepository = new Mock<IKeyedRepository<Event>>();
+            _eventAttendeeManager = new Mock<IEventAttendeeManager>();
+            _eventAttendeeRepository = new Mock<IBaseRepository<EventAttendee>>();
+            _eventLitterReportManager = new Mock<IEventLitterReportManager>();
+            _mapManager = new Mock<IMapManager>();
+            _emailManager = new Mock<IEmailManager>();
+
+            // Default setup for common dependencies
+            // Return the event date formatted as ISO 8601 string (parseable as DateTimeOffset)
+            _mapManager.Setup(m => m.GetTimeForPointAsync(It.IsAny<Tuple<double, double>>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync((Tuple<double, double> _, DateTimeOffset eventDate) => eventDate.ToString("o"));
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>())).Returns("Test email content");
+            _emailManager.Setup(e => e.SendTemplatedEmailAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<List<EmailAddress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _sut = new EventManager(
+                _eventRepository.Object,
+                _eventAttendeeManager.Object,
+                _eventAttendeeRepository.Object,
+                _eventLitterReportManager.Object,
+                _mapManager.Object,
+                _emailManager.Object);
+        }
+
+        #region GetActiveEventsAsync Tests
+
+        [Fact]
+        public async Task GetActiveEventsAsync_ReturnsOnlyActivePublicFutureEvents()
+        {
+            // Arrange
+            var activeEvent = new EventBuilder()
+                .WithName("Active Event")
+                .AsActive()
+                .InTheFuture()
+                .AsPublic()
+                .Build();
+
+            var canceledEvent = new EventBuilder()
+                .WithName("Canceled Event")
+                .AsCancelled()
+                .InTheFuture()
+                .AsPublic()
+                .Build();
+
+            var privateEvent = new EventBuilder()
+                .WithName("Private Event")
+                .AsActive()
+                .InTheFuture()
+                .AsPrivate()
+                .Build();
+
+            var pastEvent = new EventBuilder()
+                .WithName("Past Event")
+                .AsActive()
+                .InThePast()
+                .AsPublic()
+                .Build();
+
+            var events = new List<Event> { activeEvent, canceledEvent, privateEvent, pastEvent };
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetActiveEventsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Active Event", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetActiveEventsAsync_ReturnsFullEvents()
+        {
+            // Arrange
+            var fullEvent = new EventBuilder()
+                .WithName("Full Event")
+                .AsFull()
+                .InTheFuture()
+                .AsPublic()
+                .Build();
+
+            var events = new List<Event> { fullEvent };
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetActiveEventsAsync();
+
+            // Assert
+            Assert.Single(result);
+            Assert.Equal("Full Event", result.First().Name);
+        }
+
+        [Fact]
+        public async Task GetActiveEventsAsync_ReturnsEmpty_WhenNoActiveEvents()
+        {
+            // Arrange
+            var events = new List<Event>();
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetActiveEventsAsync();
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        #endregion
+
+        #region GetCompletedEventsAsync Tests
+
+        [Fact]
+        public async Task GetCompletedEventsAsync_ReturnsPastNonCanceledEvents()
+        {
+            // Arrange
+            var completedEvent = new EventBuilder()
+                .WithName("Completed Event")
+                .AsActive()
+                .InThePast()
+                .Build();
+
+            var canceledPastEvent = new EventBuilder()
+                .WithName("Canceled Past Event")
+                .AsCancelled()
+                .InThePast()
+                .Build();
+
+            var futureEvent = new EventBuilder()
+                .WithName("Future Event")
+                .AsActive()
+                .InTheFuture()
+                .Build();
+
+            var events = new List<Event> { completedEvent, canceledPastEvent, futureEvent };
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetCompletedEventsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Completed Event", resultList[0].Name);
+        }
+
+        #endregion
+
+        #region GetUserEventsAsync Tests
+
+        [Fact]
+        public async Task GetUserEventsAsync_ReturnsEventsCreatedByUser()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var otherUserId = Guid.NewGuid();
+
+            var userEvent = new EventBuilder()
+                .WithName("User's Event")
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+
+            var otherUserEvent = new EventBuilder()
+                .WithName("Other User's Event")
+                .CreatedBy(otherUserId)
+                .AsActive()
+                .Build();
+
+            var canceledUserEvent = new EventBuilder()
+                .WithName("User's Canceled Event")
+                .CreatedBy(userId)
+                .AsCancelled()
+                .Build();
+
+            var events = new List<Event> { userEvent, otherUserEvent, canceledUserEvent };
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetUserEventsAsync(userId, false);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("User's Event", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetUserEventsAsync_WithFutureEventsOnly_ReturnsFutureEvents()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+
+            var futureUserEvent = new EventBuilder()
+                .WithName("Future Event")
+                .CreatedBy(userId)
+                .AsActive()
+                .InTheFuture()
+                .Build();
+
+            var pastUserEvent = new EventBuilder()
+                .WithName("Past Event")
+                .CreatedBy(userId)
+                .AsActive()
+                .InThePast()
+                .Build();
+
+            var events = new List<Event> { futureUserEvent, pastUserEvent };
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetUserEventsAsync(userId, true);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Future Event", resultList[0].Name);
+        }
+
+        #endregion
+
+        #region GetCanceledUserEventsAsync Tests
+
+        [Fact]
+        public async Task GetCanceledUserEventsAsync_ReturnsCanceledEventsCreatedByUser()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+
+            var canceledUserEvent = new EventBuilder()
+                .WithName("Canceled Event")
+                .CreatedBy(userId)
+                .AsCancelled()
+                .Build();
+
+            var activeUserEvent = new EventBuilder()
+                .WithName("Active Event")
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+
+            var events = new List<Event> { canceledUserEvent, activeUserEvent };
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetCanceledUserEventsAsync(userId, false);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Canceled Event", resultList[0].Name);
+        }
+
+        #endregion
+
+        #region AddAsync Tests
+
+        [Fact]
+        public async Task AddAsync_CreatesEventAndRegistersCreatorAsAttendee()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var newEvent = new EventBuilder()
+                .WithName("New Beach Cleanup")
+                .CreatedBy(userId)
+                .Build();
+
+            _eventRepository.SetupAddAsync();
+            _eventAttendeeManager.Setup(m => m.AddAsync(It.IsAny<EventAttendee>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EventAttendee ea, Guid _, CancellationToken _) => ea);
+
+            // Act
+            var result = await _sut.AddAsync(newEvent, userId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("New Beach Cleanup", result.Name);
+            _eventAttendeeManager.Verify(m => m.AddAsync(
+                It.Is<EventAttendee>(ea => ea.UserId == userId && ea.EventId == newEvent.Id),
+                userId,
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddAsync_SendsNewEventNotificationEmail()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var newEvent = new EventBuilder()
+                .WithName("Community Cleanup")
+                .CreatedBy(userId)
+                .Build();
+
+            _eventRepository.SetupAddAsync();
+            _eventAttendeeManager.Setup(m => m.AddAsync(It.IsAny<EventAttendee>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EventAttendee ea, Guid _, CancellationToken _) => ea);
+
+            // Act
+            await _sut.AddAsync(newEvent, userId);
+
+            // Assert
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                "New Event Alert",
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+
+        #region DeleteAsync Tests
+
+        [Fact]
+        public async Task DeleteAsync_SetsEventStatusToCanceled()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var existingEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Event to Cancel")
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+
+            _eventRepository.SetupGetAsync(existingEvent);
+            _eventRepository.SetupUpdateAsync();
+            _eventLitterReportManager.Setup(m => m.GetByParentIdAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventLitterReport>());
+
+            var emptyAttendees = new TestAsyncEnumerable<EventAttendee>(new List<EventAttendee>());
+            _eventAttendeeRepository.Setup(r => r.Get(It.IsAny<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(), It.IsAny<bool>()))
+                .Returns(emptyAttendees);
+
+            // Act
+            var result = await _sut.DeleteAsync(eventId, "Event canceled due to weather", userId, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1, result);
+            _eventRepository.Verify(r => r.UpdateAsync(It.Is<Event>(e =>
+                e.Id == eventId &&
+                e.EventStatusId == (int)EventStatusEnum.Canceled &&
+                e.CancellationReason == "Event canceled due to weather")), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_RemovesAssociatedLitterReports()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var litterReportId1 = Guid.NewGuid();
+            var litterReportId2 = Guid.NewGuid();
+
+            var existingEvent = new EventBuilder()
+                .WithId(eventId)
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+
+            var litterReports = new List<EventLitterReport>
+            {
+                new EventLitterReport { EventId = eventId, LitterReportId = litterReportId1 },
+                new EventLitterReport { EventId = eventId, LitterReportId = litterReportId2 }
+            };
+
+            _eventRepository.SetupGetAsync(existingEvent);
+            _eventRepository.SetupUpdateAsync();
+            _eventLitterReportManager.Setup(m => m.GetByParentIdAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(litterReports);
+            _eventLitterReportManager.Setup(m => m.Delete(eventId, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var emptyAttendees = new TestAsyncEnumerable<EventAttendee>(new List<EventAttendee>());
+            _eventAttendeeRepository.Setup(r => r.Get(It.IsAny<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(), It.IsAny<bool>()))
+                .Returns(emptyAttendees);
+
+            // Act
+            await _sut.DeleteAsync(eventId, "Cleanup complete", userId, CancellationToken.None);
+
+            // Assert
+            _eventLitterReportManager.Verify(m => m.Delete(eventId, litterReportId1, It.IsAny<CancellationToken>()), Times.Once);
+            _eventLitterReportManager.Verify(m => m.Delete(eventId, litterReportId2, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_SendsCancellationEmailToAllAttendees()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var attendeeId1 = Guid.NewGuid();
+            var attendeeId2 = Guid.NewGuid();
+
+            var existingEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Beach Cleanup")
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+
+            var user1 = new UserBuilder().WithId(attendeeId1).WithEmail("user1@test.com").Build();
+            var user2 = new UserBuilder().WithId(attendeeId2).WithEmail("user2@test.com").Build();
+
+            var attendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId).ForUser(user1).Build(),
+                new EventAttendeeBuilder().ForEvent(eventId).ForUser(user2).Build()
+            };
+            attendees[0].User = user1;
+            attendees[1].User = user2;
+
+            _eventRepository.SetupGetAsync(existingEvent);
+            _eventRepository.SetupUpdateAsync();
+            _eventLitterReportManager.Setup(m => m.GetByParentIdAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventLitterReport>());
+
+            var mockQueryable = new TestAsyncEnumerable<EventAttendee>(attendees);
+            _eventAttendeeRepository.Setup(r => r.Get(It.IsAny<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(), It.IsAny<bool>()))
+                .Returns(mockQueryable);
+
+            // Act
+            await _sut.DeleteAsync(eventId, "Weather issues", userId, CancellationToken.None);
+
+            // Assert
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                "A TrashMob.eco event you were scheduled to attend has been cancelled!",
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.Is<List<EmailAddress>>(list => list.Any(a => a.Email == "user1@test.com")),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                "A TrashMob.eco event you were scheduled to attend has been cancelled!",
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.Is<List<EmailAddress>>(list => list.Any(a => a.Email == "user2@test.com")),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+
+        #region UpdateAsync Tests
+
+        [Fact]
+        public async Task UpdateAsync_WithNoSignificantChanges_DoesNotSendEmail()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var existingEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Park Cleanup")
+                .CreatedBy(userId)
+                .InCity("Seattle")
+                .Build();
+
+            var updatedEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Park Cleanup - Updated Description")
+                .CreatedBy(userId)
+                .InCity("Seattle")
+                .Build();
+            updatedEvent.EventDate = existingEvent.EventDate;
+            updatedEvent.Country = existingEvent.Country;
+            updatedEvent.Region = existingEvent.Region;
+            updatedEvent.PostalCode = existingEvent.PostalCode;
+            updatedEvent.StreetAddress = existingEvent.StreetAddress;
+
+            _eventRepository.SetupGetWithNoTrackingAsync(existingEvent);
+            _eventRepository.SetupUpdateAsync();
+
+            // Act
+            await _sut.UpdateAsync(updatedEvent, userId);
+
+            // Assert - No email should be sent for just name/description changes
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_WithDateChange_SendsUpdateEmailToAttendees()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var attendeeId = Guid.NewGuid();
+
+            var existingEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Park Cleanup")
+                .CreatedBy(userId)
+                .Build();
+
+            var updatedEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Park Cleanup")
+                .CreatedBy(userId)
+                .Build();
+            updatedEvent.EventDate = existingEvent.EventDate.AddDays(1); // Date changed
+
+            var user = new UserBuilder().WithId(attendeeId).WithEmail("attendee@test.com").Build();
+            var attendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId).ForUser(user).Build()
+            };
+            attendees[0].User = user;
+
+            _eventRepository.SetupGetWithNoTrackingAsync(existingEvent);
+            _eventRepository.SetupUpdateAsync();
+
+            var mockQueryable = new TestAsyncEnumerable<EventAttendee>(attendees);
+            _eventAttendeeRepository.Setup(r => r.Get(It.IsAny<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(), It.IsAny<bool>()))
+                .Returns(mockQueryable);
+
+            // Act
+            await _sut.UpdateAsync(updatedEvent, userId);
+
+            // Assert
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                "A TrashMob.eco event you were scheduled to attend has been updated!",
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.Is<List<EmailAddress>>(list => list.Any(a => a.Email == "attendee@test.com")),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_WithLocationChange_SendsUpdateEmailToAttendees()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var attendeeId = Guid.NewGuid();
+
+            var existingEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Park Cleanup")
+                .CreatedBy(userId)
+                .InCity("Seattle")
+                .Build();
+
+            var updatedEvent = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Park Cleanup")
+                .CreatedBy(userId)
+                .InCity("Bellevue") // City changed
+                .Build();
+            updatedEvent.EventDate = existingEvent.EventDate;
+
+            var user = new UserBuilder().WithId(attendeeId).WithEmail("attendee@test.com").Build();
+            var attendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId).ForUser(user).Build()
+            };
+            attendees[0].User = user;
+
+            _eventRepository.SetupGetWithNoTrackingAsync(existingEvent);
+            _eventRepository.SetupUpdateAsync();
+
+            var mockQueryable = new TestAsyncEnumerable<EventAttendee>(attendees);
+            _eventAttendeeRepository.Setup(r => r.Get(It.IsAny<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(), It.IsAny<bool>()))
+                .Returns(mockQueryable);
+
+            // Act
+            await _sut.UpdateAsync(updatedEvent, userId);
+
+            // Assert
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                "A TrashMob.eco event you were scheduled to attend has been updated!",
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
+++ b/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MockQueryable.Moq" Version="7.0.3" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Summary
- Establishes test data builders for core entities (User, Event, Team, EventAttendee)
- Creates mock repository fixtures with async queryable support for EF Core testing
- Adds 15 comprehensive EventManager unit tests covering key business logic
- Adds MockQueryable.Moq package for async LINQ mocking support

## Test Coverage
- **EventManager**: 15 new tests covering GetActiveEventsAsync, GetCompletedEventsAsync, GetUserEventsAsync, GetCanceledUserEventsAsync, AddAsync, DeleteAsync, UpdateAsync

## Test plan
- [x] All 118 unit tests pass (103 existing + 15 new)
- [x] Build succeeds with no warnings
- [x] New builders follow established patterns in codebase

Part of Project 37 - Unit Test Coverage Improvement (Phase 1: Infrastructure)

Generated with [Claude Code](https://claude.com/claude-code)