### PR TITLE
Add EventAttendeeManager and TeamManager tests (Project 37 Phase 2)

### DIFF
--- a/TrashMob.Shared.Tests/Builders/TeamBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/TeamBuilder.cs
@@ -67,6 +67,25 @@ namespace TrashMob.Shared.Tests.Builders
             return this;
         }
 
+        public TeamBuilder AsPublic()
+        {
+            _team.IsPublic = true;
+            return this;
+        }
+
+        public TeamBuilder AsPrivate()
+        {
+            _team.IsPublic = false;
+            return this;
+        }
+
+        public TeamBuilder WithCoordinates(double latitude, double longitude)
+        {
+            _team.Latitude = latitude;
+            _team.Longitude = longitude;
+            return this;
+        }
+
         public TeamBuilder CreatedBy(Guid userId)
         {
             _team.CreatedByUserId = userId;

--- a/TrashMob.Shared.Tests/Builders/TeamMemberBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/TeamMemberBuilder.cs
@@ -1,0 +1,75 @@
+namespace TrashMob.Shared.Tests.Builders
+{
+    using System;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Builder for creating TeamMember test data with sensible defaults.
+    /// </summary>
+    public class TeamMemberBuilder
+    {
+        private readonly TeamMember _teamMember;
+
+        public TeamMemberBuilder()
+        {
+            var creatorId = Guid.NewGuid();
+            _teamMember = new TeamMember
+            {
+                Id = Guid.NewGuid(),
+                TeamId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                IsTeamLead = false,
+                JoinedDate = DateTimeOffset.UtcNow.AddDays(-30),
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow.AddDays(-30),
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+
+        public TeamMemberBuilder WithId(Guid id)
+        {
+            _teamMember.Id = id;
+            return this;
+        }
+
+        public TeamMemberBuilder WithTeamId(Guid teamId)
+        {
+            _teamMember.TeamId = teamId;
+            return this;
+        }
+
+        public TeamMemberBuilder WithUserId(Guid userId)
+        {
+            _teamMember.UserId = userId;
+            return this;
+        }
+
+        public TeamMemberBuilder AsTeamLead()
+        {
+            _teamMember.IsTeamLead = true;
+            return this;
+        }
+
+        public TeamMemberBuilder AsRegularMember()
+        {
+            _teamMember.IsTeamLead = false;
+            return this;
+        }
+
+        public TeamMemberBuilder JoinedOn(DateTimeOffset joinedDate)
+        {
+            _teamMember.JoinedDate = joinedDate;
+            return this;
+        }
+
+        public TeamMemberBuilder CreatedBy(Guid userId)
+        {
+            _teamMember.CreatedByUserId = userId;
+            _teamMember.LastUpdatedByUserId = userId;
+            return this;
+        }
+
+        public TeamMember Build() => _teamMember;
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Events/EventAttendeeManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventAttendeeManagerTests.cs
@@ -1,0 +1,627 @@
+namespace TrashMob.Shared.Tests.Managers.Events
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Engine;
+    using TrashMob.Shared.Managers.Events;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Poco;
+    using TrashMob.Shared.Tests.Builders;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="EventAttendeeManager"/>.
+    /// </summary>
+    public class EventAttendeeManagerTests
+    {
+        private readonly Mock<IBaseRepository<EventAttendee>> _attendeeRepository;
+        private readonly Mock<IKeyedRepository<Event>> _eventRepository;
+        private readonly Mock<IEmailManager> _emailManager;
+        private readonly EventAttendeeManager _sut;
+
+        public EventAttendeeManagerTests()
+        {
+            _attendeeRepository = new Mock<IBaseRepository<EventAttendee>>();
+            _eventRepository = new Mock<IKeyedRepository<Event>>();
+            _emailManager = new Mock<IEmailManager>();
+
+            // Default setup for email manager
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>())).Returns("Test email content");
+            _emailManager.Setup(e => e.SendTemplatedEmailAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<List<EmailAddress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _sut = new EventAttendeeManager(
+                _attendeeRepository.Object,
+                _eventRepository.Object,
+                _emailManager.Object);
+        }
+
+        #region GetEventsUserIsAttendingAsync Tests
+
+        [Fact]
+        public async Task GetEventsUserIsAttendingAsync_ReturnsEventsUserIsAttending()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId1 = Guid.NewGuid();
+            var eventId2 = Guid.NewGuid();
+
+            var attendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId1).ForUser(userId).Build(),
+                new EventAttendeeBuilder().ForEvent(eventId2).ForUser(userId).Build()
+            };
+
+            var event1 = new EventBuilder()
+                .WithId(eventId1)
+                .WithName("Beach Cleanup")
+                .AsActive()
+                .InTheFuture()
+                .Build();
+
+            var event2 = new EventBuilder()
+                .WithId(eventId2)
+                .WithName("Park Cleanup")
+                .AsActive()
+                .InTheFuture()
+                .Build();
+
+            var events = new List<Event> { event1, event2 };
+
+            _attendeeRepository.SetupGetWithFilter(attendees);
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetEventsUserIsAttendingAsync(userId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Equal(2, resultList.Count);
+        }
+
+        [Fact]
+        public async Task GetEventsUserIsAttendingAsync_ExcludesCanceledEvents()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId1 = Guid.NewGuid();
+            var eventId2 = Guid.NewGuid();
+
+            var attendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId1).ForUser(userId).Build(),
+                new EventAttendeeBuilder().ForEvent(eventId2).ForUser(userId).Build()
+            };
+
+            var activeEvent = new EventBuilder()
+                .WithId(eventId1)
+                .WithName("Active Event")
+                .AsActive()
+                .Build();
+
+            var canceledEvent = new EventBuilder()
+                .WithId(eventId2)
+                .WithName("Canceled Event")
+                .AsCancelled()
+                .Build();
+
+            var events = new List<Event> { activeEvent, canceledEvent };
+
+            _attendeeRepository.SetupGetWithFilter(attendees);
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetEventsUserIsAttendingAsync(userId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Active Event", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetEventsUserIsAttendingAsync_WithFutureEventsOnly_ReturnsFutureEvents()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId1 = Guid.NewGuid();
+            var eventId2 = Guid.NewGuid();
+
+            var attendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId1).ForUser(userId).Build(),
+                new EventAttendeeBuilder().ForEvent(eventId2).ForUser(userId).Build()
+            };
+
+            var futureEvent = new EventBuilder()
+                .WithId(eventId1)
+                .WithName("Future Event")
+                .AsActive()
+                .InTheFuture()
+                .Build();
+
+            var pastEvent = new EventBuilder()
+                .WithId(eventId2)
+                .WithName("Past Event")
+                .AsActive()
+                .InThePast()
+                .Build();
+
+            var events = new List<Event> { futureEvent, pastEvent };
+
+            _attendeeRepository.SetupGetWithFilter(attendees);
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetEventsUserIsAttendingAsync(userId, futureEventsOnly: true);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Future Event", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetEventsUserIsAttendingAsync_WhenNotAttendingAny_ReturnsEmpty()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var attendees = new List<EventAttendee>();
+
+            _attendeeRepository.SetupGetWithFilter(attendees);
+
+            // Act
+            var result = await _sut.GetEventsUserIsAttendingAsync(userId);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        #endregion
+
+        #region GetCanceledEventsUserIsAttendingAsync Tests
+
+        [Fact]
+        public async Task GetCanceledEventsUserIsAttendingAsync_ReturnsCanceledEventsOnly()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId1 = Guid.NewGuid();
+            var eventId2 = Guid.NewGuid();
+
+            var attendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId1).ForUser(userId).Build(),
+                new EventAttendeeBuilder().ForEvent(eventId2).ForUser(userId).Build()
+            };
+
+            var activeEvent = new EventBuilder()
+                .WithId(eventId1)
+                .WithName("Active Event")
+                .AsActive()
+                .Build();
+
+            var canceledEvent = new EventBuilder()
+                .WithId(eventId2)
+                .WithName("Canceled Event")
+                .AsCancelled()
+                .Build();
+
+            var events = new List<Event> { activeEvent, canceledEvent };
+
+            _attendeeRepository.SetupGetWithFilter(attendees);
+            _eventRepository.SetupGetWithFilter(events);
+
+            // Act
+            var result = await _sut.GetCanceledEventsUserIsAttendingAsync(userId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Canceled Event", resultList[0].Name);
+        }
+
+        #endregion
+
+        #region IsEventLeadAsync Tests
+
+        [Fact]
+        public async Task IsEventLeadAsync_WhenUserIsLead_ReturnsTrue()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsEventLead()
+                .Build();
+
+            var attendees = new List<EventAttendee> { attendee };
+            _attendeeRepository.SetupGetWithFilter(attendees);
+
+            // Act
+            var result = await _sut.IsEventLeadAsync(eventId, userId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsEventLeadAsync_WhenUserIsEventCreator_ReturnsTrue()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsRegularAttendee()
+                .Build();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .CreatedBy(userId)
+                .Build();
+
+            var attendees = new List<EventAttendee> { attendee };
+            _attendeeRepository.SetupGetWithFilter(attendees);
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            // Act
+            var result = await _sut.IsEventLeadAsync(eventId, userId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsEventLeadAsync_WhenUserIsNotLead_ReturnsFalse()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var creatorId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsRegularAttendee()
+                .Build();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .CreatedBy(creatorId)
+                .Build();
+
+            var attendees = new List<EventAttendee> { attendee };
+            _attendeeRepository.SetupGetWithFilter(attendees);
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            // Act
+            var result = await _sut.IsEventLeadAsync(eventId, userId);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        #endregion
+
+        #region GetEventLeadsAsync Tests
+
+        [Fact]
+        public async Task GetEventLeadsAsync_ReturnsOnlyLeads()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var leadId = Guid.NewGuid();
+            var regularId = Guid.NewGuid();
+
+            var lead = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(leadId)
+                .AsEventLead()
+                .Build();
+
+            var regularAttendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(regularId)
+                .AsRegularAttendee()
+                .Build();
+
+            var attendees = new List<EventAttendee> { lead, regularAttendee };
+
+            _attendeeRepository.SetupGetWithFilter(attendees);
+
+            // Act
+            var result = await _sut.GetEventLeadsAsync(eventId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal(leadId, resultList[0].UserId);
+        }
+
+        #endregion
+
+        #region PromoteToLeadAsync Tests
+
+        [Fact]
+        public async Task PromoteToLeadAsync_SetsUserAsLead()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var promoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var user = new UserBuilder().WithId(userId).WithEmail("user@test.com").Build();
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(user)
+                .AsRegularAttendee()
+                .Build();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Beach Cleanup")
+                .Build();
+
+            // No existing leads
+            var emptyLeads = new List<EventAttendee>();
+            var attendees = new List<EventAttendee> { attendee };
+
+            // Setup for count query (no leads)
+            _attendeeRepository.Setup(r => r.Get(It.Is<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(
+                    expr => true), It.IsAny<bool>()))
+                .Returns((System.Linq.Expressions.Expression<Func<EventAttendee, bool>> predicate, bool _) =>
+                {
+                    // Return empty for lead count, then attendee for lookup
+                    return new TestAsyncEnumerable<EventAttendee>(
+                        attendees.AsQueryable().Where(predicate.Compile()));
+                });
+
+            _attendeeRepository.Setup(r => r.UpdateAsync(It.IsAny<EventAttendee>()))
+                .ReturnsAsync((EventAttendee ea) => ea);
+
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            // Act
+            var result = await _sut.PromoteToLeadAsync(eventId, userId, promoterUserId);
+
+            // Assert
+            Assert.True(result.IsEventLead);
+            _attendeeRepository.Verify(r => r.UpdateAsync(It.Is<EventAttendee>(ea =>
+                ea.UserId == userId && ea.IsEventLead == true)), Times.Once);
+        }
+
+        [Fact]
+        public async Task PromoteToLeadAsync_WhenMaxLeadsReached_ThrowsException()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var promoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            // 5 existing leads
+            var existingLeads = Enumerable.Range(0, 5).Select(_ =>
+                new EventAttendeeBuilder()
+                    .ForEvent(eventId)
+                    .AsEventLead()
+                    .Build())
+                .ToList();
+
+            _attendeeRepository.SetupGetWithFilter(existingLeads);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.PromoteToLeadAsync(eventId, userId, promoterUserId));
+        }
+
+        [Fact]
+        public async Task PromoteToLeadAsync_WhenUserNotAttendee_ThrowsException()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var promoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var emptyAttendees = new List<EventAttendee>();
+            _attendeeRepository.SetupGetWithFilter(emptyAttendees);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.PromoteToLeadAsync(eventId, userId, promoterUserId));
+        }
+
+        [Fact]
+        public async Task PromoteToLeadAsync_WhenAlreadyLead_ThrowsException()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var promoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsEventLead()
+                .Build();
+
+            var attendees = new List<EventAttendee> { attendee };
+            _attendeeRepository.SetupGetWithFilter(attendees);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.PromoteToLeadAsync(eventId, userId, promoterUserId));
+        }
+
+        [Fact]
+        public async Task PromoteToLeadAsync_SendsNotificationEmail()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var promoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var user = new UserBuilder().WithId(userId).WithEmail("user@test.com").Build();
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(user)
+                .AsRegularAttendee()
+                .Build();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Beach Cleanup")
+                .Build();
+
+            var attendees = new List<EventAttendee> { attendee };
+
+            _attendeeRepository.Setup(r => r.Get(It.IsAny<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(), It.IsAny<bool>()))
+                .Returns((System.Linq.Expressions.Expression<Func<EventAttendee, bool>> predicate, bool _) =>
+                    new TestAsyncEnumerable<EventAttendee>(attendees.AsQueryable().Where(predicate.Compile())));
+
+            _attendeeRepository.Setup(r => r.UpdateAsync(It.IsAny<EventAttendee>()))
+                .ReturnsAsync((EventAttendee ea) => ea);
+
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            // Act
+            await _sut.PromoteToLeadAsync(eventId, userId, promoterUserId);
+
+            // Assert
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.Is<string>(s => s.Contains("co-lead")),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.Is<List<EmailAddress>>(list => list.Any(a => a.Email == "user@test.com")),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+
+        #region DemoteFromLeadAsync Tests
+
+        [Fact]
+        public async Task DemoteFromLeadAsync_RemovesLeadStatus()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var demoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var otherLeadId = Guid.NewGuid();
+
+            var user = new UserBuilder().WithId(userId).WithEmail("user@test.com").Build();
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(user)
+                .AsEventLead()
+                .Build();
+
+            var otherLead = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(otherLeadId)
+                .AsEventLead()
+                .Build();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Beach Cleanup")
+                .Build();
+
+            var attendees = new List<EventAttendee> { attendee, otherLead };
+
+            _attendeeRepository.Setup(r => r.Get(It.IsAny<System.Linq.Expressions.Expression<Func<EventAttendee, bool>>>(), It.IsAny<bool>()))
+                .Returns((System.Linq.Expressions.Expression<Func<EventAttendee, bool>> predicate, bool _) =>
+                    new TestAsyncEnumerable<EventAttendee>(attendees.AsQueryable().Where(predicate.Compile())));
+
+            _attendeeRepository.Setup(r => r.UpdateAsync(It.IsAny<EventAttendee>()))
+                .ReturnsAsync((EventAttendee ea) => ea);
+
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            // Act
+            var result = await _sut.DemoteFromLeadAsync(eventId, userId, demoterUserId);
+
+            // Assert
+            Assert.False(result.IsEventLead);
+            _attendeeRepository.Verify(r => r.UpdateAsync(It.Is<EventAttendee>(ea =>
+                ea.UserId == userId && ea.IsEventLead == false)), Times.Once);
+        }
+
+        [Fact]
+        public async Task DemoteFromLeadAsync_WhenLastLead_ThrowsException()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var demoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsEventLead()
+                .Build();
+
+            // Only 1 lead
+            var attendees = new List<EventAttendee> { attendee };
+            _attendeeRepository.SetupGetWithFilter(attendees);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.DemoteFromLeadAsync(eventId, userId, demoterUserId));
+        }
+
+        [Fact]
+        public async Task DemoteFromLeadAsync_WhenUserNotLead_ThrowsException()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var demoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var otherLeadId = Guid.NewGuid();
+
+            var regularAttendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsRegularAttendee()
+                .Build();
+
+            var otherLead = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(otherLeadId)
+                .AsEventLead()
+                .Build();
+
+            var attendees = new List<EventAttendee> { regularAttendee, otherLead };
+            _attendeeRepository.SetupGetWithFilter(attendees);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.DemoteFromLeadAsync(eventId, userId, demoterUserId));
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Teams/TeamManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Teams/TeamManagerTests.cs
@@ -1,0 +1,419 @@
+namespace TrashMob.Shared.Tests.Managers.Teams
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Teams;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Builders;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class TeamManagerTests
+    {
+        private readonly Mock<IKeyedRepository<Team>> _teamRepository;
+        private readonly Mock<IKeyedRepository<TeamMember>> _teamMemberRepository;
+        private readonly TeamManager _sut;
+
+        public TeamManagerTests()
+        {
+            _teamRepository = new Mock<IKeyedRepository<Team>>();
+            _teamMemberRepository = new Mock<IKeyedRepository<TeamMember>>();
+
+            _sut = new TeamManager(
+                _teamRepository.Object,
+                _teamMemberRepository.Object);
+        }
+
+        #region GetPublicTeamsAsync
+
+        [Fact]
+        public async Task GetPublicTeamsAsync_ReturnsOnlyPublicActiveTeams()
+        {
+            // Arrange
+            var publicTeam = new TeamBuilder()
+                .WithName("Public Team")
+                .AsPublic()
+                .AsActive()
+                .Build();
+            var privateTeam = new TeamBuilder()
+                .WithName("Private Team")
+                .AsPrivate()
+                .AsActive()
+                .Build();
+            var inactiveTeam = new TeamBuilder()
+                .WithName("Inactive Team")
+                .AsPublic()
+                .AsInactive()
+                .Build();
+
+            var teams = new List<Team> { publicTeam, privateTeam, inactiveTeam };
+            _teamRepository.SetupGet(teams);
+
+            // Act
+            var result = await _sut.GetPublicTeamsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal(publicTeam.Id, resultList[0].Id);
+        }
+
+        [Fact]
+        public async Task GetPublicTeamsAsync_WithLocationFilter_ReturnsTeamsWithinRadius()
+        {
+            // Arrange
+            // Seattle coordinates: 47.6062, -122.3321
+            var seattleTeam = new TeamBuilder()
+                .WithName("Seattle Team")
+                .AsPublic()
+                .AsActive()
+                .WithCoordinates(47.6062, -122.3321)
+                .Build();
+
+            // Portland coordinates: 45.5152, -122.6784 (~145 miles from Seattle)
+            var portlandTeam = new TeamBuilder()
+                .WithName("Portland Team")
+                .AsPublic()
+                .AsActive()
+                .WithCoordinates(45.5152, -122.6784)
+                .Build();
+
+            // Tacoma coordinates: 47.2529, -122.4443 (~30 miles from Seattle)
+            var tacomaTeam = new TeamBuilder()
+                .WithName("Tacoma Team")
+                .AsPublic()
+                .AsActive()
+                .WithCoordinates(47.2529, -122.4443)
+                .Build();
+
+            var teams = new List<Team> { seattleTeam, portlandTeam, tacomaTeam };
+            _teamRepository.SetupGet(teams);
+
+            // Act - 50 mile radius from Seattle
+            var result = await _sut.GetPublicTeamsAsync(47.6062, -122.3321, 50);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Equal(2, resultList.Count);
+            Assert.Contains(resultList, t => t.Name == "Seattle Team");
+            Assert.Contains(resultList, t => t.Name == "Tacoma Team");
+            Assert.DoesNotContain(resultList, t => t.Name == "Portland Team");
+        }
+
+        [Fact]
+        public async Task GetPublicTeamsAsync_WithLocationFilter_ExcludesTeamsWithoutCoordinates()
+        {
+            // Arrange
+            var teamWithCoords = new TeamBuilder()
+                .WithName("Team With Coords")
+                .AsPublic()
+                .AsActive()
+                .WithCoordinates(47.6062, -122.3321)
+                .Build();
+
+            var teamWithoutCoords = new TeamBuilder()
+                .WithName("Team Without Coords")
+                .AsPublic()
+                .AsActive()
+                .Build();
+            // Ensure no coordinates
+            teamWithoutCoords.Latitude = null;
+            teamWithoutCoords.Longitude = null;
+
+            var teams = new List<Team> { teamWithCoords, teamWithoutCoords };
+            _teamRepository.SetupGet(teams);
+
+            // Act
+            var result = await _sut.GetPublicTeamsAsync(47.6062, -122.3321, 100);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Team With Coords", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetPublicTeamsAsync_WithNoLocationFilter_ReturnsAllPublicTeams()
+        {
+            // Arrange
+            var team1 = new TeamBuilder().WithName("Team 1").AsPublic().AsActive().Build();
+            var team2 = new TeamBuilder().WithName("Team 2").AsPublic().AsActive().Build();
+
+            var teams = new List<Team> { team1, team2 };
+            _teamRepository.SetupGet(teams);
+
+            // Act
+            var result = await _sut.GetPublicTeamsAsync();
+
+            // Assert
+            Assert.Equal(2, result.Count());
+        }
+
+        #endregion
+
+        #region GetTeamsByUserAsync
+
+        [Fact]
+        public async Task GetTeamsByUserAsync_ReturnsActiveTeamsUserBelongsTo()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var team1 = new TeamBuilder().WithName("Team 1").AsActive().Build();
+            var team2 = new TeamBuilder().WithName("Team 2").AsActive().Build();
+            var inactiveTeam = new TeamBuilder().WithName("Inactive").AsInactive().Build();
+
+            var membership1 = new TeamMemberBuilder()
+                .WithTeamId(team1.Id)
+                .WithUserId(userId)
+                .Build();
+            var membership2 = new TeamMemberBuilder()
+                .WithTeamId(team2.Id)
+                .WithUserId(userId)
+                .Build();
+            var inactiveMembership = new TeamMemberBuilder()
+                .WithTeamId(inactiveTeam.Id)
+                .WithUserId(userId)
+                .Build();
+
+            var teams = new List<Team> { team1, team2, inactiveTeam };
+            var memberships = new List<TeamMember> { membership1, membership2, inactiveMembership };
+
+            _teamRepository.SetupGet(teams);
+            _teamMemberRepository.SetupGet(memberships);
+
+            // Act
+            var result = await _sut.GetTeamsByUserAsync(userId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Equal(2, resultList.Count);
+            Assert.Contains(resultList, t => t.Name == "Team 1");
+            Assert.Contains(resultList, t => t.Name == "Team 2");
+            Assert.DoesNotContain(resultList, t => t.Name == "Inactive");
+        }
+
+        [Fact]
+        public async Task GetTeamsByUserAsync_ReturnsEmptyWhenUserHasNoTeams()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var otherUserId = Guid.NewGuid();
+
+            var team = new TeamBuilder().WithName("Other Team").AsActive().Build();
+            var membership = new TeamMemberBuilder()
+                .WithTeamId(team.Id)
+                .WithUserId(otherUserId)
+                .Build();
+
+            _teamRepository.SetupGet(new List<Team> { team });
+            _teamMemberRepository.SetupGet(new List<TeamMember> { membership });
+
+            // Act
+            var result = await _sut.GetTeamsByUserAsync(userId);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        #endregion
+
+        #region GetTeamsUserLeadsAsync
+
+        [Fact]
+        public async Task GetTeamsUserLeadsAsync_ReturnsOnlyTeamsWhereUserIsLead()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var leadTeam = new TeamBuilder().WithName("Lead Team").AsActive().Build();
+            var memberTeam = new TeamBuilder().WithName("Member Team").AsActive().Build();
+
+            var leadMembership = new TeamMemberBuilder()
+                .WithTeamId(leadTeam.Id)
+                .WithUserId(userId)
+                .AsTeamLead()
+                .Build();
+            var memberMembership = new TeamMemberBuilder()
+                .WithTeamId(memberTeam.Id)
+                .WithUserId(userId)
+                .AsRegularMember()
+                .Build();
+
+            var teams = new List<Team> { leadTeam, memberTeam };
+            var memberships = new List<TeamMember> { leadMembership, memberMembership };
+
+            _teamRepository.SetupGet(teams);
+            _teamMemberRepository.SetupGet(memberships);
+
+            // Act
+            var result = await _sut.GetTeamsUserLeadsAsync(userId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Lead Team", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetTeamsUserLeadsAsync_ExcludesInactiveTeams()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var activeTeam = new TeamBuilder().WithName("Active Team").AsActive().Build();
+            var inactiveTeam = new TeamBuilder().WithName("Inactive Team").AsInactive().Build();
+
+            var activeMembership = new TeamMemberBuilder()
+                .WithTeamId(activeTeam.Id)
+                .WithUserId(userId)
+                .AsTeamLead()
+                .Build();
+            var inactiveMembership = new TeamMemberBuilder()
+                .WithTeamId(inactiveTeam.Id)
+                .WithUserId(userId)
+                .AsTeamLead()
+                .Build();
+
+            var teams = new List<Team> { activeTeam, inactiveTeam };
+            var memberships = new List<TeamMember> { activeMembership, inactiveMembership };
+
+            _teamRepository.SetupGet(teams);
+            _teamMemberRepository.SetupGet(memberships);
+
+            // Act
+            var result = await _sut.GetTeamsUserLeadsAsync(userId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Active Team", resultList[0].Name);
+        }
+
+        #endregion
+
+        #region IsTeamNameAvailableAsync
+
+        [Fact]
+        public async Task IsTeamNameAvailableAsync_ReturnsTrueWhenNameIsUnique()
+        {
+            // Arrange
+            var existingTeam = new TeamBuilder().WithName("Existing Team").Build();
+            _teamRepository.SetupGet(new List<Team> { existingTeam });
+
+            // Act
+            var result = await _sut.IsTeamNameAvailableAsync("New Team");
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsTeamNameAvailableAsync_ReturnsFalseWhenNameExists()
+        {
+            // Arrange
+            var existingTeam = new TeamBuilder().WithName("Existing Team").Build();
+            _teamRepository.SetupGet(new List<Team> { existingTeam });
+
+            // Act
+            var result = await _sut.IsTeamNameAvailableAsync("Existing Team");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsTeamNameAvailableAsync_IsCaseInsensitive()
+        {
+            // Arrange
+            var existingTeam = new TeamBuilder().WithName("Existing Team").Build();
+            _teamRepository.SetupGet(new List<Team> { existingTeam });
+
+            // Act
+            var result = await _sut.IsTeamNameAvailableAsync("EXISTING TEAM");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsTeamNameAvailableAsync_ReturnsTrueWhenExcludingOwnId()
+        {
+            // Arrange
+            var existingTeam = new TeamBuilder().WithName("My Team").Build();
+            _teamRepository.SetupGet(new List<Team> { existingTeam });
+
+            // Act - Check if name is available while updating the same team
+            var result = await _sut.IsTeamNameAvailableAsync("My Team", existingTeam.Id);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsTeamNameAvailableAsync_TrimsWhitespace()
+        {
+            // Arrange
+            var existingTeam = new TeamBuilder().WithName("Test Team").Build();
+            _teamRepository.SetupGet(new List<Team> { existingTeam });
+
+            // Act
+            var result = await _sut.IsTeamNameAvailableAsync("  Test Team  ");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        #endregion
+
+        #region GetByNameAsync
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsTeamWhenFound()
+        {
+            // Arrange
+            var team = new TeamBuilder().WithName("Find Me").Build();
+            _teamRepository.SetupGet(new List<Team> { team });
+
+            // Act
+            var result = await _sut.GetByNameAsync("Find Me");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(team.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsNullWhenNotFound()
+        {
+            // Arrange
+            var team = new TeamBuilder().WithName("Other Team").Build();
+            _teamRepository.SetupGet(new List<Team> { team });
+
+            // Act
+            var result = await _sut.GetByNameAsync("Not Found");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_IsCaseInsensitive()
+        {
+            // Arrange
+            var team = new TeamBuilder().WithName("Test Team").Build();
+            _teamRepository.SetupGet(new List<Team> { team });
+
+            // Act
+            var result = await _sut.GetByNameAsync("TEST TEAM");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(team.Id, result.Id);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

- Add 33 new unit tests covering EventAttendeeManager (17 tests) and TeamManager (16 tests)
- Add TeamMemberBuilder for creating test data
- Enhance TeamBuilder with public/private and coordinate methods

### EventAttendeeManager Tests
- `GetEventsUserIsAttendingAsync`: filtering by user, multiple events, empty scenarios
- `GetCanceledEventsUserIsAttendingAsync`: canceled event filtering
- `IsEventLeadAsync`: creator vs co-lead vs attendee detection
- `GetEventLeadsAsync`: returns all leads (creator + co-leads)
- `PromoteToLeadAsync`: validation for max 5 co-leads, already-lead scenarios
- `DemoteFromLeadAsync`: validation ensuring at least 1 lead remains

### TeamManager Tests
- `GetPublicTeamsAsync`: public/active filtering, radius-based location search
- `GetTeamsByUserAsync`: user membership with active team filter
- `GetTeamsUserLeadsAsync`: lead-only filtering
- `IsTeamNameAvailableAsync`: uniqueness, case-insensitivity, whitespace handling
- `GetByNameAsync`: lookup by name with case-insensitivity

## Test plan
- [x] All 151 tests pass
- [x] Build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)