### PR TITLE
Add CommunityManager tests (Project 37 Phase 4)

### DIFF
--- a/TrashMob.Shared.Tests/Builders/EventBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/EventBuilder.cs
@@ -134,6 +134,18 @@ namespace TrashMob.Shared.Tests.Builders
             return this;
         }
 
+        public EventBuilder InRegion(string region)
+        {
+            _event.Region = region;
+            return this;
+        }
+
+        public EventBuilder OnDate(DateTimeOffset date)
+        {
+            _event.EventDate = date;
+            return this;
+        }
+
         public EventBuilder WithCoordinates(double latitude, double longitude)
         {
             _event.Latitude = latitude;

--- a/TrashMob.Shared.Tests/Builders/PartnerBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/PartnerBuilder.cs
@@ -1,0 +1,132 @@
+namespace TrashMob.Shared.Tests.Builders
+{
+    using System;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Builder for creating Partner test data with sensible defaults.
+    /// </summary>
+    public class PartnerBuilder
+    {
+        private readonly Partner _partner;
+
+        public PartnerBuilder()
+        {
+            var creatorId = Guid.NewGuid();
+            _partner = new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Partner",
+                PartnerStatusId = (int)PartnerStatusEnum.Active,
+                PartnerTypeId = 1,
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                HomePageEnabled = false,
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+
+        public PartnerBuilder WithId(Guid id)
+        {
+            _partner.Id = id;
+            return this;
+        }
+
+        public PartnerBuilder WithName(string name)
+        {
+            _partner.Name = name;
+            return this;
+        }
+
+        public PartnerBuilder WithSlug(string slug)
+        {
+            _partner.Slug = slug;
+            return this;
+        }
+
+        public PartnerBuilder WithLocation(string city, string region, string country)
+        {
+            _partner.City = city;
+            _partner.Region = region;
+            _partner.Country = country;
+            return this;
+        }
+
+        public PartnerBuilder WithCoordinates(double latitude, double longitude)
+        {
+            _partner.Latitude = latitude;
+            _partner.Longitude = longitude;
+            return this;
+        }
+
+        public PartnerBuilder WithStatus(PartnerStatusEnum status)
+        {
+            _partner.PartnerStatusId = (int)status;
+            return this;
+        }
+
+        public PartnerBuilder AsActive()
+        {
+            _partner.PartnerStatusId = (int)PartnerStatusEnum.Active;
+            return this;
+        }
+
+        public PartnerBuilder AsInactive()
+        {
+            _partner.PartnerStatusId = (int)PartnerStatusEnum.Inactive;
+            return this;
+        }
+
+        public PartnerBuilder WithHomePageEnabled()
+        {
+            _partner.HomePageEnabled = true;
+            return this;
+        }
+
+        public PartnerBuilder WithHomePageDisabled()
+        {
+            _partner.HomePageEnabled = false;
+            return this;
+        }
+
+        public PartnerBuilder WithHomePageDates(DateTimeOffset? startDate, DateTimeOffset? endDate)
+        {
+            _partner.HomePageStartDate = startDate;
+            _partner.HomePageEndDate = endDate;
+            return this;
+        }
+
+        public PartnerBuilder WithBranding(string primaryColor, string secondaryColor)
+        {
+            _partner.BrandingPrimaryColor = primaryColor;
+            _partner.BrandingSecondaryColor = secondaryColor;
+            return this;
+        }
+
+        public PartnerBuilder WithContactInfo(string email, string phone)
+        {
+            _partner.ContactEmail = email;
+            _partner.ContactPhone = phone;
+            return this;
+        }
+
+        public PartnerBuilder WithWebsite(string website)
+        {
+            _partner.Website = website;
+            return this;
+        }
+
+        public PartnerBuilder CreatedBy(Guid userId)
+        {
+            _partner.CreatedByUserId = userId;
+            _partner.LastUpdatedByUserId = userId;
+            return this;
+        }
+
+        public Partner Build() => _partner;
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Communities/CommunityManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Communities/CommunityManagerTests.cs
@@ -1,0 +1,590 @@
+namespace TrashMob.Shared.Tests.Managers.Communities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Communities;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Builders;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class CommunityManagerTests
+    {
+        private readonly Mock<IKeyedRepository<Partner>> _partnerRepository;
+        private readonly Mock<IKeyedRepository<Event>> _eventRepository;
+        private readonly Mock<IKeyedRepository<Team>> _teamRepository;
+        private readonly Mock<IKeyedRepository<LitterReport>> _litterReportRepository;
+        private readonly Mock<IKeyedRepository<LitterImage>> _litterImageRepository;
+        private readonly Mock<IBaseRepository<EventSummary>> _eventSummaryRepository;
+        private readonly CommunityManager _sut;
+
+        public CommunityManagerTests()
+        {
+            _partnerRepository = new Mock<IKeyedRepository<Partner>>();
+            _eventRepository = new Mock<IKeyedRepository<Event>>();
+            _teamRepository = new Mock<IKeyedRepository<Team>>();
+            _litterReportRepository = new Mock<IKeyedRepository<LitterReport>>();
+            _litterImageRepository = new Mock<IKeyedRepository<LitterImage>>();
+            _eventSummaryRepository = new Mock<IBaseRepository<EventSummary>>();
+
+            _sut = new CommunityManager(
+                _partnerRepository.Object,
+                _eventRepository.Object,
+                _teamRepository.Object,
+                _litterReportRepository.Object,
+                _litterImageRepository.Object,
+                _eventSummaryRepository.Object);
+        }
+
+        #region GetEnabledCommunitiesAsync
+
+        [Fact]
+        public async Task GetEnabledCommunitiesAsync_ReturnsOnlyEnabledActiveCommunities()
+        {
+            // Arrange
+            var enabledCommunity = new PartnerBuilder()
+                .WithName("Enabled Community")
+                .WithHomePageEnabled()
+                .AsActive()
+                .Build();
+            var disabledCommunity = new PartnerBuilder()
+                .WithName("Disabled Community")
+                .WithHomePageDisabled()
+                .AsActive()
+                .Build();
+            var inactiveCommunity = new PartnerBuilder()
+                .WithName("Inactive Community")
+                .WithHomePageEnabled()
+                .AsInactive()
+                .Build();
+
+            var partners = new List<Partner> { enabledCommunity, disabledCommunity, inactiveCommunity };
+            _partnerRepository.SetupGet(partners);
+
+            // Act
+            var result = await _sut.GetEnabledCommunitiesAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Enabled Community", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetEnabledCommunitiesAsync_RespectsDateRanges()
+        {
+            // Arrange
+            var now = DateTimeOffset.UtcNow;
+            var activeCommunity = new PartnerBuilder()
+                .WithName("Active Community")
+                .WithHomePageEnabled()
+                .WithHomePageDates(now.AddDays(-30), now.AddDays(30))
+                .AsActive()
+                .Build();
+            var expiredCommunity = new PartnerBuilder()
+                .WithName("Expired Community")
+                .WithHomePageEnabled()
+                .WithHomePageDates(now.AddDays(-60), now.AddDays(-30))
+                .AsActive()
+                .Build();
+            var futureCommunity = new PartnerBuilder()
+                .WithName("Future Community")
+                .WithHomePageEnabled()
+                .WithHomePageDates(now.AddDays(30), now.AddDays(60))
+                .AsActive()
+                .Build();
+
+            var partners = new List<Partner> { activeCommunity, expiredCommunity, futureCommunity };
+            _partnerRepository.SetupGet(partners);
+
+            // Act
+            var result = await _sut.GetEnabledCommunitiesAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Active Community", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetEnabledCommunitiesAsync_WithLocationFilter_ReturnsCommunitiesWithinRadius()
+        {
+            // Arrange
+            // Seattle coordinates: 47.6062, -122.3321
+            var seattleCommunity = new PartnerBuilder()
+                .WithName("Seattle Community")
+                .WithHomePageEnabled()
+                .AsActive()
+                .WithCoordinates(47.6062, -122.3321)
+                .Build();
+
+            // Portland coordinates: 45.5152, -122.6784 (~145 miles from Seattle)
+            var portlandCommunity = new PartnerBuilder()
+                .WithName("Portland Community")
+                .WithHomePageEnabled()
+                .AsActive()
+                .WithCoordinates(45.5152, -122.6784)
+                .Build();
+
+            var partners = new List<Partner> { seattleCommunity, portlandCommunity };
+            _partnerRepository.SetupGet(partners);
+
+            // Act - 50 mile radius from Seattle
+            var result = await _sut.GetEnabledCommunitiesAsync(47.6062, -122.3321, 50);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Seattle Community", resultList[0].Name);
+        }
+
+        #endregion
+
+        #region GetBySlugAsync
+
+        [Fact]
+        public async Task GetBySlugAsync_ReturnsCommunityWhenFound()
+        {
+            // Arrange
+            var community = new PartnerBuilder()
+                .WithName("Seattle Community")
+                .WithSlug("seattle-wa")
+                .WithHomePageEnabled()
+                .AsActive()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+
+            // Act
+            var result = await _sut.GetBySlugAsync("seattle-wa");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Seattle Community", result.Name);
+        }
+
+        [Fact]
+        public async Task GetBySlugAsync_IsCaseInsensitive()
+        {
+            // Arrange
+            var community = new PartnerBuilder()
+                .WithName("Seattle Community")
+                .WithSlug("seattle-wa")
+                .WithHomePageEnabled()
+                .AsActive()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+
+            // Act
+            var result = await _sut.GetBySlugAsync("SEATTLE-WA");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Seattle Community", result.Name);
+        }
+
+        [Fact]
+        public async Task GetBySlugAsync_ReturnsNullWhenNotEnabled()
+        {
+            // Arrange
+            var community = new PartnerBuilder()
+                .WithName("Disabled Community")
+                .WithSlug("disabled")
+                .WithHomePageDisabled()
+                .AsActive()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+
+            // Act
+            var result = await _sut.GetBySlugAsync("disabled");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetBySlugAsync_ReturnsNullWhenExpired()
+        {
+            // Arrange
+            var now = DateTimeOffset.UtcNow;
+            var community = new PartnerBuilder()
+                .WithName("Expired Community")
+                .WithSlug("expired")
+                .WithHomePageEnabled()
+                .WithHomePageDates(now.AddDays(-60), now.AddDays(-30))
+                .AsActive()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+
+            // Act
+            var result = await _sut.GetBySlugAsync("expired");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region IsSlugAvailableAsync
+
+        [Fact]
+        public async Task IsSlugAvailableAsync_ReturnsTrueWhenSlugIsUnique()
+        {
+            // Arrange
+            var existingCommunity = new PartnerBuilder()
+                .WithSlug("existing-slug")
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { existingCommunity });
+
+            // Act
+            var result = await _sut.IsSlugAvailableAsync("new-slug");
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsSlugAvailableAsync_ReturnsFalseWhenSlugExists()
+        {
+            // Arrange
+            var existingCommunity = new PartnerBuilder()
+                .WithSlug("existing-slug")
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { existingCommunity });
+
+            // Act
+            var result = await _sut.IsSlugAvailableAsync("existing-slug");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsSlugAvailableAsync_IsCaseInsensitive()
+        {
+            // Arrange
+            var existingCommunity = new PartnerBuilder()
+                .WithSlug("existing-slug")
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { existingCommunity });
+
+            // Act
+            var result = await _sut.IsSlugAvailableAsync("EXISTING-SLUG");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsSlugAvailableAsync_ReturnsTrueWhenExcludingOwnId()
+        {
+            // Arrange
+            var existingCommunity = new PartnerBuilder()
+                .WithSlug("my-slug")
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { existingCommunity });
+
+            // Act - Check availability while updating the same partner
+            var result = await _sut.IsSlugAvailableAsync("my-slug", existingCommunity.Id);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        #endregion
+
+        #region GetCommunityEventsAsync
+
+        [Fact]
+        public async Task GetCommunityEventsAsync_ReturnsEventsInCommunityLocation()
+        {
+            // Arrange
+            var community = new PartnerBuilder()
+                .WithName("Seattle Community")
+                .WithSlug("seattle-wa")
+                .WithLocation("Seattle", "WA", "United States")
+                .WithHomePageEnabled()
+                .AsActive()
+                .Build();
+
+            var seattleEvent = new EventBuilder()
+                .WithName("Seattle Cleanup")
+                .InCity("Seattle")
+                .InRegion("WA")
+                .OnDate(DateTimeOffset.UtcNow.AddDays(7))
+                .AsActive()
+                .Build();
+            var portlandEvent = new EventBuilder()
+                .WithName("Portland Cleanup")
+                .InCity("Portland")
+                .InRegion("OR")
+                .OnDate(DateTimeOffset.UtcNow.AddDays(7))
+                .AsActive()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+            _eventRepository.SetupGet(new List<Event> { seattleEvent, portlandEvent });
+
+            // Act
+            var result = await _sut.GetCommunityEventsAsync("seattle-wa");
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Seattle Cleanup", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetCommunityEventsAsync_ExcludesCancelledEvents()
+        {
+            // Arrange
+            var community = new PartnerBuilder()
+                .WithName("Seattle Community")
+                .WithSlug("seattle-wa")
+                .WithLocation("Seattle", "WA", "United States")
+                .WithHomePageEnabled()
+                .AsActive()
+                .Build();
+
+            var activeEvent = new EventBuilder()
+                .WithName("Active Event")
+                .InCity("Seattle")
+                .InRegion("WA")
+                .OnDate(DateTimeOffset.UtcNow.AddDays(7))
+                .AsActive()
+                .Build();
+            var cancelledEvent = new EventBuilder()
+                .WithName("Cancelled Event")
+                .InCity("Seattle")
+                .InRegion("WA")
+                .OnDate(DateTimeOffset.UtcNow.AddDays(7))
+                .AsCancelled()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+            _eventRepository.SetupGet(new List<Event> { activeEvent, cancelledEvent });
+
+            // Act
+            var result = await _sut.GetCommunityEventsAsync("seattle-wa");
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Active Event", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetCommunityEventsAsync_ReturnsEmptyWhenCommunityNotFound()
+        {
+            // Arrange
+            _partnerRepository.SetupGet(new List<Partner>());
+
+            // Act
+            var result = await _sut.GetCommunityEventsAsync("nonexistent");
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        #endregion
+
+        #region GetCommunityTeamsAsync
+
+        [Fact]
+        public async Task GetCommunityTeamsAsync_ReturnsTeamsWithinRadius()
+        {
+            // Arrange
+            var community = new PartnerBuilder()
+                .WithName("Seattle Community")
+                .WithSlug("seattle-wa")
+                .WithCoordinates(47.6062, -122.3321)
+                .WithHomePageEnabled()
+                .AsActive()
+                .Build();
+
+            // Tacoma team (~30 miles from Seattle)
+            var tacomaTeam = new TeamBuilder()
+                .WithName("Tacoma Team")
+                .WithCoordinates(47.2529, -122.4443)
+                .AsPublic()
+                .AsActive()
+                .Build();
+
+            // Portland team (~145 miles from Seattle)
+            var portlandTeam = new TeamBuilder()
+                .WithName("Portland Team")
+                .WithCoordinates(45.5152, -122.6784)
+                .AsPublic()
+                .AsActive()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+            _teamRepository.SetupGet(new List<Team> { tacomaTeam, portlandTeam });
+
+            // Act - default 50 mile radius
+            var result = await _sut.GetCommunityTeamsAsync("seattle-wa");
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Tacoma Team", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetCommunityTeamsAsync_ReturnsOnlyPublicActiveTeams()
+        {
+            // Arrange
+            var community = new PartnerBuilder()
+                .WithName("Seattle Community")
+                .WithSlug("seattle-wa")
+                .WithCoordinates(47.6062, -122.3321)
+                .WithHomePageEnabled()
+                .AsActive()
+                .Build();
+
+            var publicTeam = new TeamBuilder()
+                .WithName("Public Team")
+                .WithCoordinates(47.6062, -122.3321)
+                .AsPublic()
+                .AsActive()
+                .Build();
+
+            var privateTeam = new TeamBuilder()
+                .WithName("Private Team")
+                .WithCoordinates(47.6062, -122.3321)
+                .AsPrivate()
+                .AsActive()
+                .Build();
+
+            var inactiveTeam = new TeamBuilder()
+                .WithName("Inactive Team")
+                .WithCoordinates(47.6062, -122.3321)
+                .AsPublic()
+                .AsInactive()
+                .Build();
+
+            _partnerRepository.SetupGet(new List<Partner> { community });
+            _teamRepository.SetupGet(new List<Team> { publicTeam, privateTeam, inactiveTeam });
+
+            // Act
+            var result = await _sut.GetCommunityTeamsAsync("seattle-wa");
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Public Team", resultList[0].Name);
+        }
+
+        #endregion
+
+        #region GetByIdAsync
+
+        [Fact]
+        public async Task GetByIdAsync_ReturnsPartnerWhenFound()
+        {
+            // Arrange
+            var partnerId = Guid.NewGuid();
+            var partner = new PartnerBuilder()
+                .WithId(partnerId)
+                .WithName("Test Partner")
+                .Build();
+
+            _partnerRepository.SetupGetAsync(partner);
+
+            // Act
+            var result = await _sut.GetByIdAsync(partnerId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(partnerId, result.Id);
+        }
+
+        [Fact]
+        public async Task GetByIdAsync_ReturnsNullWhenNotFound()
+        {
+            // Arrange
+            _partnerRepository.Setup(r => r.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            // Act
+            var result = await _sut.GetByIdAsync(Guid.NewGuid());
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region UpdateCommunityContentAsync
+
+        [Fact]
+        public async Task UpdateCommunityContentAsync_UpdatesAllowedFields()
+        {
+            // Arrange
+            var partnerId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var existingPartner = new PartnerBuilder()
+                .WithId(partnerId)
+                .WithName("Original Partner")
+                .Build();
+
+            var updatedPartner = new PartnerBuilder()
+                .WithId(partnerId)
+                .WithName("Updated Partner")
+                .WithBranding("#FF0000", "#00FF00")
+                .WithContactInfo("new@email.com", "555-1234")
+                .Build();
+            updatedPartner.PublicNotes = "New notes";
+            updatedPartner.Tagline = "New tagline";
+
+            _partnerRepository.Setup(r => r.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPartner);
+            _partnerRepository.Setup(r => r.UpdateAsync(It.IsAny<Partner>()))
+                .ReturnsAsync((Partner p) => p);
+
+            // Act
+            var result = await _sut.UpdateCommunityContentAsync(updatedPartner, userId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("New notes", result.PublicNotes);
+            Assert.Equal("New tagline", result.Tagline);
+            Assert.Equal("#FF0000", result.BrandingPrimaryColor);
+            Assert.Equal(userId, result.LastUpdatedByUserId);
+        }
+
+        [Fact]
+        public async Task UpdateCommunityContentAsync_ReturnsNullWhenPartnerNotFound()
+        {
+            // Arrange
+            var partnerId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var updatedPartner = new PartnerBuilder()
+                .WithId(partnerId)
+                .Build();
+
+            _partnerRepository.Setup(r => r.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            // Act
+            var result = await _sut.UpdateCommunityContentAsync(updatedPartner, userId);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

- Add 20 new unit tests covering CommunityManager (community page operations)
- Add PartnerBuilder for creating community/partner test data
- Enhance EventBuilder with `InRegion()` and `OnDate()` methods
- Total test count now: 211 tests (all passing)

### CommunityManager Tests
- `GetEnabledCommunitiesAsync`: filtering by enabled/active status, date ranges, location radius
- `GetBySlugAsync`: slug lookup with case-insensitivity, disabled/expired handling
- `IsSlugAvailableAsync`: uniqueness validation, case-insensitivity, self-exclusion
- `GetCommunityEventsAsync`: location-based event filtering, cancelled event exclusion
- `GetCommunityTeamsAsync`: radius-based team search, public/active team filtering
- `GetByIdAsync`: partner lookup by ID
- `UpdateCommunityContentAsync`: allowed field updates, not found handling

### New Builders
- **PartnerBuilder**: Community/partner test data with slug, home page settings, branding, coordinates

## Test plan
- [x] All 211 tests pass
- [x] Build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)