### PR TITLE
Add unit tests for remaining managers (Project 37 Phase 5 Final)

### DIFF
--- a/TrashMob.Shared.Tests/Builders/LitterReportBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/LitterReportBuilder.cs
@@ -1,0 +1,121 @@
+namespace TrashMob.Shared.Tests.Builders
+{
+    using System;
+    using System.Collections.Generic;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Builder for creating LitterReport test data with sensible defaults.
+    /// </summary>
+    public class LitterReportBuilder
+    {
+        private readonly LitterReport _litterReport;
+
+        public LitterReportBuilder()
+        {
+            var creatorId = Guid.NewGuid();
+            _litterReport = new LitterReport
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test Litter Report",
+                Description = "A test litter report for unit testing",
+                LitterReportStatusId = (int)LitterReportStatusEnum.New,
+                LitterImages = new List<LitterImage>(),
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+
+        public LitterReportBuilder WithId(Guid id)
+        {
+            _litterReport.Id = id;
+            return this;
+        }
+
+        public LitterReportBuilder WithName(string name)
+        {
+            _litterReport.Name = name;
+            return this;
+        }
+
+        public LitterReportBuilder WithDescription(string description)
+        {
+            _litterReport.Description = description;
+            return this;
+        }
+
+        public LitterReportBuilder WithStatus(LitterReportStatusEnum status)
+        {
+            _litterReport.LitterReportStatusId = (int)status;
+            return this;
+        }
+
+        public LitterReportBuilder AsNew()
+        {
+            _litterReport.LitterReportStatusId = (int)LitterReportStatusEnum.New;
+            return this;
+        }
+
+        public LitterReportBuilder AsAssigned()
+        {
+            _litterReport.LitterReportStatusId = (int)LitterReportStatusEnum.Assigned;
+            return this;
+        }
+
+        public LitterReportBuilder AsCleaned()
+        {
+            _litterReport.LitterReportStatusId = (int)LitterReportStatusEnum.Cleaned;
+            return this;
+        }
+
+        public LitterReportBuilder AsCancelled()
+        {
+            _litterReport.LitterReportStatusId = (int)LitterReportStatusEnum.Cancelled;
+            return this;
+        }
+
+        public LitterReportBuilder WithImage(LitterImage image)
+        {
+            _litterReport.LitterImages.Add(image);
+            return this;
+        }
+
+        public LitterReportBuilder WithImages(IEnumerable<LitterImage> images)
+        {
+            foreach (var image in images)
+            {
+                _litterReport.LitterImages.Add(image);
+            }
+            return this;
+        }
+
+        public LitterReportBuilder WithDefaultImage()
+        {
+            _litterReport.LitterImages.Add(new LitterImage
+            {
+                Id = Guid.NewGuid(),
+                LitterReportId = _litterReport.Id,
+                AzureBlobURL = "https://example.com/image.jpg",
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                CreatedByUserId = _litterReport.CreatedByUserId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = _litterReport.CreatedByUserId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            });
+            return this;
+        }
+
+        public LitterReportBuilder CreatedBy(Guid userId)
+        {
+            _litterReport.CreatedByUserId = userId;
+            _litterReport.LastUpdatedByUserId = userId;
+            return this;
+        }
+
+        public LitterReport Build() => _litterReport;
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/ContactRequestManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/ContactRequestManagerTests.cs
@@ -1,0 +1,145 @@
+namespace TrashMob.Shared.Tests.Managers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Engine;
+    using TrashMob.Shared.Managers;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class ContactRequestManagerTests
+    {
+        private readonly Mock<IKeyedRepository<ContactRequest>> _contactRequestRepository;
+        private readonly Mock<IEmailManager> _emailManager;
+        private readonly ContactRequestManager _sut;
+
+        public ContactRequestManagerTests()
+        {
+            _contactRequestRepository = new Mock<IKeyedRepository<ContactRequest>>();
+            _emailManager = new Mock<IEmailManager>();
+
+            // Default email setup
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>())).Returns("Test email content");
+            _emailManager.Setup(e => e.SendTemplatedEmailAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<List<EmailAddress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _sut = new ContactRequestManager(_contactRequestRepository.Object, _emailManager.Object);
+        }
+
+        #region AddAsync
+
+        [Fact]
+        public async Task AddAsync_SetsRequiredFields()
+        {
+            // Arrange
+            var contactRequest = new ContactRequest
+            {
+                Name = "John Doe",
+                Email = "john@example.com",
+                Message = "Hello, I have a question."
+            };
+
+            ContactRequest capturedRequest = null;
+            _contactRequestRepository.Setup(r => r.AddAsync(It.IsAny<ContactRequest>()))
+                .Callback<ContactRequest>(cr => capturedRequest = cr)
+                .ReturnsAsync((ContactRequest cr) => cr);
+
+            // Act
+            var result = await _sut.AddAsync(contactRequest);
+
+            // Assert
+            Assert.NotNull(capturedRequest);
+            Assert.NotEqual(Guid.Empty, capturedRequest.Id);
+            Assert.Equal(Guid.Empty, capturedRequest.CreatedByUserId);
+            Assert.Equal(Guid.Empty, capturedRequest.LastUpdatedByUserId);
+        }
+
+        [Fact]
+        public async Task AddAsync_SendsNotificationEmail()
+        {
+            // Arrange
+            var contactRequest = new ContactRequest
+            {
+                Name = "Jane Doe",
+                Email = "jane@example.com",
+                Message = "Testing contact form"
+            };
+
+            _contactRequestRepository.Setup(r => r.AddAsync(It.IsAny<ContactRequest>()))
+                .ReturnsAsync((ContactRequest cr) => cr);
+
+            // Act
+            await _sut.AddAsync(contactRequest);
+
+            // Assert
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.Is<string>(s => s.Contains("Contact Request")),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.Is<List<EmailAddress>>(list => list.Any(addr => addr.Email == Constants.TrashMobEmailAddress)),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddAsync_ReplacesPlaceholdersInEmail()
+        {
+            // Arrange
+            var contactRequest = new ContactRequest
+            {
+                Name = "Test User",
+                Email = "test@example.com",
+                Message = "My test message"
+            };
+
+            var emailTemplate = "{UserName} - {UserEmail} - {Message}";
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>())).Returns(emailTemplate);
+            _contactRequestRepository.Setup(r => r.AddAsync(It.IsAny<ContactRequest>()))
+                .ReturnsAsync((ContactRequest cr) => cr);
+
+            // Act
+            await _sut.AddAsync(contactRequest);
+
+            // Assert
+            _emailManager.Verify(e => e.GetHtmlEmailCopy(NotificationTypeEnum.ContactRequestReceived.ToString()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddAsync_ReturnsAddedContactRequest()
+        {
+            // Arrange
+            var contactRequest = new ContactRequest
+            {
+                Name = "Return Test",
+                Email = "return@example.com",
+                Message = "Test return value"
+            };
+
+            _contactRequestRepository.Setup(r => r.AddAsync(It.IsAny<ContactRequest>()))
+                .ReturnsAsync((ContactRequest cr) => cr);
+
+            // Act
+            var result = await _sut.AddAsync(contactRequest);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(contactRequest.Name, result.Name);
+            Assert.Equal(contactRequest.Email, result.Email);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/LitterReport/LitterReportManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/LitterReport/LitterReportManagerTests.cs
@@ -1,0 +1,372 @@
+namespace TrashMob.Shared.Tests.Managers.LitterReport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Engine;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Managers.LitterReport;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Poco;
+    using TrashMob.Shared.Tests.Builders;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class LitterReportManagerTests
+    {
+        private readonly Mock<IKeyedRepository<TrashMob.Models.LitterReport>> _litterReportRepository;
+        private readonly Mock<ILitterImageManager> _litterImageManager;
+        private readonly Mock<ILogger<LitterReportManager>> _logger;
+        private readonly Mock<IDbTransaction> _dbTransaction;
+        private readonly Mock<IEmailManager> _emailManager;
+        private readonly Mock<IUserManager> _userManager;
+        private readonly LitterReportManager _sut;
+
+        public LitterReportManagerTests()
+        {
+            _litterReportRepository = new Mock<IKeyedRepository<TrashMob.Models.LitterReport>>();
+            _litterImageManager = new Mock<ILitterImageManager>();
+            _logger = new Mock<ILogger<LitterReportManager>>();
+            _dbTransaction = new Mock<IDbTransaction>();
+            _emailManager = new Mock<IEmailManager>();
+            _userManager = new Mock<IUserManager>();
+
+            // Default setups
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>())).Returns("Test email content");
+            _emailManager.Setup(e => e.SendTemplatedEmailAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<List<EmailAddress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _dbTransaction.Setup(t => t.BeginTransactionAsync()).Returns(Task.CompletedTask);
+            _dbTransaction.Setup(t => t.CommitTransactionAsync()).Returns(Task.CompletedTask);
+            _dbTransaction.Setup(t => t.RollbackTransactionAsync()).Returns(Task.CompletedTask);
+
+            _sut = new LitterReportManager(
+                _litterReportRepository.Object,
+                _litterImageManager.Object,
+                _logger.Object,
+                _dbTransaction.Object,
+                _emailManager.Object,
+                _userManager.Object);
+        }
+
+        #region GetNewLitterReportsAsync
+
+        [Fact]
+        public async Task GetNewLitterReportsAsync_ReturnsOnlyNewReports()
+        {
+            // Arrange
+            var newReport = new LitterReportBuilder().AsNew().WithDefaultImage().Build();
+            var assignedReport = new LitterReportBuilder().AsAssigned().WithDefaultImage().Build();
+            var cleanedReport = new LitterReportBuilder().AsCleaned().WithDefaultImage().Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { newReport, assignedReport, cleanedReport };
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var result = await _sut.GetNewLitterReportsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal((int)LitterReportStatusEnum.New, resultList[0].LitterReportStatusId);
+        }
+
+        #endregion
+
+        #region GetAssignedLitterReportsAsync
+
+        [Fact]
+        public async Task GetAssignedLitterReportsAsync_ReturnsOnlyAssignedReports()
+        {
+            // Arrange
+            var newReport = new LitterReportBuilder().AsNew().WithDefaultImage().Build();
+            var assignedReport = new LitterReportBuilder().AsAssigned().WithDefaultImage().Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { newReport, assignedReport };
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var result = await _sut.GetAssignedLitterReportsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal((int)LitterReportStatusEnum.Assigned, resultList[0].LitterReportStatusId);
+        }
+
+        #endregion
+
+        #region GetCleanedLitterReportsAsync
+
+        [Fact]
+        public async Task GetCleanedLitterReportsAsync_ReturnsOnlyCleanedReports()
+        {
+            // Arrange
+            var newReport = new LitterReportBuilder().AsNew().WithDefaultImage().Build();
+            var cleanedReport = new LitterReportBuilder().AsCleaned().WithDefaultImage().Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { newReport, cleanedReport };
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var result = await _sut.GetCleanedLitterReportsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal((int)LitterReportStatusEnum.Cleaned, resultList[0].LitterReportStatusId);
+        }
+
+        #endregion
+
+        #region GetNotCancelledLitterReportsAsync
+
+        [Fact]
+        public async Task GetNotCancelledLitterReportsAsync_ExcludesCancelledReports()
+        {
+            // Arrange
+            var newReport = new LitterReportBuilder().AsNew().WithDefaultImage().Build();
+            var cancelledReport = new LitterReportBuilder().AsCancelled().WithDefaultImage().Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { newReport, cancelledReport };
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var result = await _sut.GetNotCancelledLitterReportsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.NotEqual((int)LitterReportStatusEnum.Cancelled, resultList[0].LitterReportStatusId);
+        }
+
+        #endregion
+
+        #region GetCancelledLitterReportsAsync
+
+        [Fact]
+        public async Task GetCancelledLitterReportsAsync_ReturnsOnlyCancelledReports()
+        {
+            // Arrange
+            var newReport = new LitterReportBuilder().AsNew().WithDefaultImage().Build();
+            var cancelledReport = new LitterReportBuilder().AsCancelled().WithDefaultImage().Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { newReport, cancelledReport };
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var result = await _sut.GetCancelledLitterReportsAsync();
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal((int)LitterReportStatusEnum.Cancelled, resultList[0].LitterReportStatusId);
+        }
+
+        #endregion
+
+        #region GetUserLitterReportsAsync
+
+        [Fact]
+        public async Task GetUserLitterReportsAsync_ReturnsReportsForUser()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var otherUserId = Guid.NewGuid();
+
+            var userReport = new LitterReportBuilder().CreatedBy(userId).WithDefaultImage().Build();
+            var otherReport = new LitterReportBuilder().CreatedBy(otherUserId).WithDefaultImage().Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { userReport, otherReport };
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var result = await _sut.GetUserLitterReportsAsync(userId);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal(userId, resultList[0].CreatedByUserId);
+        }
+
+        #endregion
+
+        #region GetLitterReportCountsAsync
+
+        [Fact]
+        public async Task GetLitterReportCountsAsync_ReturnsCorrectCounts()
+        {
+            // Arrange
+            var newReport1 = new LitterReportBuilder().AsNew().Build();
+            var newReport2 = new LitterReportBuilder().AsNew().Build();
+            var cleanedReport = new LitterReportBuilder().AsCleaned().Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { newReport1, newReport2, cleanedReport };
+            _litterReportRepository.SetupGet(reports);
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var (totalCount, cleanedCount) = await _sut.GetLitterReportCountsAsync();
+
+            // Assert
+            Assert.Equal(3, totalCount);
+            Assert.Equal(1, cleanedCount);
+        }
+
+        #endregion
+
+        #region GetUserLitterReportCountAsync
+
+        [Fact]
+        public async Task GetUserLitterReportCountAsync_ReturnsCorrectCount()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var userReport1 = new LitterReportBuilder().CreatedBy(userId).Build();
+            var userReport2 = new LitterReportBuilder().CreatedBy(userId).Build();
+            var otherReport = new LitterReportBuilder().CreatedBy(Guid.NewGuid()).Build();
+
+            var reports = new List<TrashMob.Models.LitterReport> { userReport1, userReport2, otherReport };
+            _litterReportRepository.SetupGetWithFilter(reports);
+
+            // Act
+            var result = await _sut.GetUserLitterReportCountAsync(userId);
+
+            // Assert
+            Assert.Equal(2, result);
+        }
+
+        #endregion
+
+        #region AddWithResultAsync
+
+        [Fact]
+        public async Task AddWithResultAsync_FailsWhenLitterReportIsNull()
+        {
+            // Act
+            var result = await _sut.AddWithResultAsync(null, Guid.NewGuid());
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("null", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task AddWithResultAsync_FailsWhenNoImages()
+        {
+            // Arrange
+            var report = new LitterReportBuilder().Build(); // No images
+
+            // Act
+            var result = await _sut.AddWithResultAsync(report, Guid.NewGuid());
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("image", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task AddWithResultAsync_FailsWhenNameIsEmpty()
+        {
+            // Arrange
+            var report = new LitterReportBuilder()
+                .WithName("")
+                .WithDefaultImage()
+                .Build();
+
+            // Act
+            var result = await _sut.AddWithResultAsync(report, Guid.NewGuid());
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("name", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task AddWithResultAsync_SucceedsWithValidData()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var report = new LitterReportBuilder()
+                .WithName("Valid Report")
+                .WithDefaultImage()
+                .Build();
+
+            _litterReportRepository.Setup(r => r.AddAsync(It.IsAny<TrashMob.Models.LitterReport>()))
+                .ReturnsAsync((TrashMob.Models.LitterReport r) => r);
+
+            // Act
+            var result = await _sut.AddWithResultAsync(report, userId);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(result.Data);
+        }
+
+        #endregion
+
+        #region DeleteAsync
+
+        [Fact]
+        public async Task DeleteAsync_ReturnsMinusOneWhenNotFound()
+        {
+            // Arrange
+            var reportId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            _litterReportRepository.Setup(r => r.GetAsync(reportId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TrashMob.Models.LitterReport)null);
+
+            // Act
+            var result = await _sut.DeleteAsync(reportId, userId);
+
+            // Assert
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_SetsStatusToCancelledAndDeletesImages()
+        {
+            // Arrange
+            var reportId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var report = new LitterReportBuilder()
+                .WithId(reportId)
+                .AsNew()
+                .WithDefaultImage()
+                .Build();
+
+            var images = report.LitterImages.ToList();
+
+            _litterReportRepository.Setup(r => r.GetAsync(reportId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(report);
+            _litterReportRepository.Setup(r => r.UpdateAsync(It.IsAny<TrashMob.Models.LitterReport>()))
+                .ReturnsAsync((TrashMob.Models.LitterReport r) => r);
+            _litterImageManager.Setup(m => m.GetByParentIdAsync(reportId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(images);
+            _litterImageManager.Setup(m => m.DeleteAsync(It.IsAny<Guid>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            // Act
+            var result = await _sut.DeleteAsync(reportId, userId);
+
+            // Assert
+            Assert.Equal(1, result);
+            _dbTransaction.Verify(t => t.BeginTransactionAsync(), Times.Once);
+            _dbTransaction.Verify(t => t.CommitTransactionAsync(), Times.Once);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/NonEventUserNotificationManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/NonEventUserNotificationManagerTests.cs
@@ -1,0 +1,112 @@
+namespace TrashMob.Shared.Tests.Managers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class NonEventUserNotificationManagerTests
+    {
+        private readonly Mock<IKeyedRepository<NonEventUserNotification>> _notificationRepository;
+        private readonly NonEventUserNotificationManager _sut;
+
+        public NonEventUserNotificationManagerTests()
+        {
+            _notificationRepository = new Mock<IKeyedRepository<NonEventUserNotification>>();
+            _sut = new NonEventUserNotificationManager(_notificationRepository.Object);
+        }
+
+        #region GetByUserIdAsync
+
+        [Fact]
+        public async Task GetByUserIdAsync_ReturnsNotificationsForUserAndType()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var notificationType = 1;
+            var notification1 = CreateNotification(userId, notificationType);
+            var notification2 = CreateNotification(userId, notificationType);
+            var differentTypeNotification = CreateNotification(userId, 2);
+            var differentUserNotification = CreateNotification(Guid.NewGuid(), notificationType);
+
+            var notifications = new List<NonEventUserNotification>
+            {
+                notification1, notification2, differentTypeNotification, differentUserNotification
+            };
+            _notificationRepository.SetupGetWithFilter(notifications);
+
+            // Act
+            var result = await _sut.GetByUserIdAsync(userId, notificationType);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Equal(2, resultList.Count);
+            Assert.All(resultList, n =>
+            {
+                Assert.Equal(userId, n.UserId);
+                Assert.Equal(notificationType, n.UserNotificationTypeId);
+            });
+        }
+
+        [Fact]
+        public async Task GetByUserIdAsync_ReturnsEmptyWhenNoNotifications()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var notificationType = 1;
+
+            _notificationRepository.SetupGetWithFilter(new List<NonEventUserNotification>());
+
+            // Act
+            var result = await _sut.GetByUserIdAsync(userId, notificationType);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetByUserIdAsync_FiltersCorrectlyByNotificationType()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var type1Notification = CreateNotification(userId, 1);
+            var type2Notification = CreateNotification(userId, 2);
+
+            var notifications = new List<NonEventUserNotification> { type1Notification, type2Notification };
+            _notificationRepository.SetupGetWithFilter(notifications);
+
+            // Act
+            var result = await _sut.GetByUserIdAsync(userId, 2);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal(2, resultList[0].UserNotificationTypeId);
+        }
+
+        #endregion
+
+        private static NonEventUserNotification CreateNotification(Guid userId, int notificationType)
+        {
+            var creatorId = Guid.NewGuid();
+            return new NonEventUserNotification
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                UserNotificationTypeId = notificationType,
+                SentDate = DateTimeOffset.UtcNow,
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Partners/PartnerLocationManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Partners/PartnerLocationManagerTests.cs
@@ -1,0 +1,261 @@
+namespace TrashMob.Shared.Tests.Managers.Partners
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Partners;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Builders;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class PartnerLocationManagerTests
+    {
+        private readonly Mock<IKeyedRepository<PartnerLocation>> _partnerLocationRepository;
+        private readonly PartnerLocationManager _sut;
+
+        public PartnerLocationManagerTests()
+        {
+            _partnerLocationRepository = new Mock<IKeyedRepository<PartnerLocation>>();
+            _sut = new PartnerLocationManager(_partnerLocationRepository.Object);
+        }
+
+        #region GetByParentIdAsync
+
+        [Fact]
+        public async Task GetByParentIdAsync_ReturnsLocationsForPartner()
+        {
+            // Arrange
+            var partnerId = Guid.NewGuid();
+            var location1 = CreatePartnerLocation(partnerId, "Location 1");
+            var location2 = CreatePartnerLocation(partnerId, "Location 2");
+            var otherPartnerLocation = CreatePartnerLocation(Guid.NewGuid(), "Other Location");
+
+            var locations = new List<PartnerLocation> { location1, location2, otherPartnerLocation };
+            _partnerLocationRepository.SetupGet(locations);
+
+            // Act
+            var result = await _sut.GetByParentIdAsync(partnerId, CancellationToken.None);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Equal(2, resultList.Count);
+            Assert.All(resultList, l => Assert.Equal(partnerId, l.PartnerId));
+        }
+
+        [Fact]
+        public async Task GetByParentIdAsync_ReturnsEmptyWhenNoLocations()
+        {
+            // Arrange
+            var partnerId = Guid.NewGuid();
+            var otherPartnerLocation = CreatePartnerLocation(Guid.NewGuid(), "Other Location");
+
+            _partnerLocationRepository.SetupGet(new List<PartnerLocation> { otherPartnerLocation });
+
+            // Act
+            var result = await _sut.GetByParentIdAsync(partnerId, CancellationToken.None);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        #endregion
+
+        #region GetPartnerForLocationAsync
+
+        [Fact]
+        public async Task GetPartnerForLocationAsync_ReturnsPartner()
+        {
+            // Arrange
+            var partner = new PartnerBuilder()
+                .WithName("Test Partner")
+                .AsActive()
+                .Build();
+            var location = CreatePartnerLocation(partner.Id, "Test Location");
+            location.Partner = partner;
+
+            _partnerLocationRepository.SetupGetWithFilter(new List<PartnerLocation> { location });
+
+            // Act
+            var result = await _sut.GetPartnerForLocationAsync(location.Id, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test Partner", result.Name);
+        }
+
+        #endregion
+
+        #region GetNearbyPartnersAsync
+
+        [Fact]
+        public async Task GetNearbyPartnersAsync_ReturnsPartnersWithinRadius()
+        {
+            // Arrange
+            var partner1 = new PartnerBuilder()
+                .WithName("Seattle Partner")
+                .AsActive()
+                .Build();
+            var partner2 = new PartnerBuilder()
+                .WithName("Portland Partner")
+                .AsActive()
+                .Build();
+
+            // Seattle location
+            var seattleLocation = CreatePartnerLocation(partner1.Id, "Seattle Office");
+            seattleLocation.Latitude = 47.6062;
+            seattleLocation.Longitude = -122.3321;
+            seattleLocation.IsActive = true;
+            seattleLocation.Partner = partner1;
+
+            // Portland location (~145 miles from Seattle)
+            var portlandLocation = CreatePartnerLocation(partner2.Id, "Portland Office");
+            portlandLocation.Latitude = 45.5152;
+            portlandLocation.Longitude = -122.6784;
+            portlandLocation.IsActive = true;
+            portlandLocation.Partner = partner2;
+
+            _partnerLocationRepository.SetupGetWithFilter(new List<PartnerLocation> { seattleLocation, portlandLocation });
+
+            // Act - 50 mile radius from Seattle
+            var result = await _sut.GetNearbyPartnersAsync(47.6062, -122.3321, 50, CancellationToken.None);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Seattle Partner", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetNearbyPartnersAsync_ReturnsOnlyActivePartnersWithActiveLocations()
+        {
+            // Arrange
+            var activePartner = new PartnerBuilder()
+                .WithName("Active Partner")
+                .AsActive()
+                .Build();
+            var inactivePartner = new PartnerBuilder()
+                .WithName("Inactive Partner")
+                .AsInactive()
+                .Build();
+
+            var activeLocation = CreatePartnerLocation(activePartner.Id, "Active Location");
+            activeLocation.Latitude = 47.6062;
+            activeLocation.Longitude = -122.3321;
+            activeLocation.IsActive = true;
+            activeLocation.Partner = activePartner;
+
+            var inactiveLocation = CreatePartnerLocation(activePartner.Id, "Inactive Location");
+            inactiveLocation.Latitude = 47.6062;
+            inactiveLocation.Longitude = -122.3321;
+            inactiveLocation.IsActive = false;
+            inactiveLocation.Partner = activePartner;
+
+            var inactivePartnerLocation = CreatePartnerLocation(inactivePartner.Id, "Location");
+            inactivePartnerLocation.Latitude = 47.6062;
+            inactivePartnerLocation.Longitude = -122.3321;
+            inactivePartnerLocation.IsActive = true;
+            inactivePartnerLocation.Partner = inactivePartner;
+
+            _partnerLocationRepository.SetupGetWithFilter(new List<PartnerLocation>
+            {
+                activeLocation, inactiveLocation, inactivePartnerLocation
+            });
+
+            // Act
+            var result = await _sut.GetNearbyPartnersAsync(47.6062, -122.3321, 50, CancellationToken.None);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList);
+            Assert.Equal("Active Partner", resultList[0].Name);
+        }
+
+        [Fact]
+        public async Task GetNearbyPartnersAsync_ReturnsDistinctPartners()
+        {
+            // Arrange
+            var partner = new PartnerBuilder()
+                .WithName("Multi-Location Partner")
+                .AsActive()
+                .Build();
+
+            var location1 = CreatePartnerLocation(partner.Id, "Location 1");
+            location1.Latitude = 47.6062;
+            location1.Longitude = -122.3321;
+            location1.IsActive = true;
+            location1.Partner = partner;
+
+            var location2 = CreatePartnerLocation(partner.Id, "Location 2");
+            location2.Latitude = 47.6100;
+            location2.Longitude = -122.3400;
+            location2.IsActive = true;
+            location2.Partner = partner;
+
+            _partnerLocationRepository.SetupGetWithFilter(new List<PartnerLocation> { location1, location2 });
+
+            // Act
+            var result = await _sut.GetNearbyPartnersAsync(47.6062, -122.3321, 50, CancellationToken.None);
+
+            // Assert
+            var resultList = result.ToList();
+            Assert.Single(resultList); // Same partner, should only appear once
+        }
+
+        [Fact]
+        public async Task GetNearbyPartnersAsync_ExcludesLocationsWithoutCoordinates()
+        {
+            // Arrange
+            var partner = new PartnerBuilder()
+                .WithName("Partner")
+                .AsActive()
+                .Build();
+
+            var locationWithCoords = CreatePartnerLocation(partner.Id, "With Coords");
+            locationWithCoords.Latitude = 47.6062;
+            locationWithCoords.Longitude = -122.3321;
+            locationWithCoords.IsActive = true;
+            locationWithCoords.Partner = partner;
+
+            var locationWithoutCoords = CreatePartnerLocation(partner.Id, "Without Coords");
+            locationWithoutCoords.Latitude = null;
+            locationWithoutCoords.Longitude = null;
+            locationWithoutCoords.IsActive = true;
+            locationWithoutCoords.Partner = partner;
+
+            _partnerLocationRepository.SetupGetWithFilter(new List<PartnerLocation>
+            {
+                locationWithCoords, locationWithoutCoords
+            });
+
+            // Act
+            var result = await _sut.GetNearbyPartnersAsync(47.6062, -122.3321, 50, CancellationToken.None);
+
+            // Assert - should find partner via the location with coords
+            Assert.Single(result);
+        }
+
+        #endregion
+
+        private static PartnerLocation CreatePartnerLocation(Guid partnerId, string name)
+        {
+            var creatorId = Guid.NewGuid();
+            return new PartnerLocation
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Name = name,
+                IsActive = true,
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow,
+                PartnerLocationContacts = new List<PartnerLocationContact>()
+            };
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/WaiverManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/WaiverManagerTests.cs
@@ -1,0 +1,104 @@
+namespace TrashMob.Shared.Tests.Managers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class WaiverManagerTests
+    {
+        private readonly Mock<IKeyedRepository<Waiver>> _waiverRepository;
+        private readonly WaiverManager _sut;
+
+        public WaiverManagerTests()
+        {
+            _waiverRepository = new Mock<IKeyedRepository<Waiver>>();
+            _sut = new WaiverManager(_waiverRepository.Object);
+        }
+
+        #region GetByNameAsync
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsWaiverWhenFound()
+        {
+            // Arrange
+            var waiverName = "TrashMob Waiver";
+            var waiver = new Waiver
+            {
+                Id = Guid.NewGuid(),
+                Name = waiverName,
+                IsWaiverEnabled = true,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = Guid.NewGuid(),
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+
+            _waiverRepository.SetupGetWithFilter(new List<Waiver> { waiver });
+
+            // Act
+            var result = await _sut.GetByNameAsync(waiverName);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(waiverName, result.Name);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_ReturnsNullWhenNotFound()
+        {
+            // Arrange
+            _waiverRepository.SetupGetWithFilter(new List<Waiver>());
+
+            // Act
+            var result = await _sut.GetByNameAsync("Nonexistent Waiver");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetByNameAsync_MatchesExactName()
+        {
+            // Arrange
+            var waiver1 = new Waiver
+            {
+                Id = Guid.NewGuid(),
+                Name = "TrashMob Waiver",
+                IsWaiverEnabled = true,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = Guid.NewGuid(),
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+            var waiver2 = new Waiver
+            {
+                Id = Guid.NewGuid(),
+                Name = "Other Waiver",
+                IsWaiverEnabled = true,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = Guid.NewGuid(),
+                LastUpdatedDate = DateTimeOffset.UtcNow
+            };
+
+            _waiverRepository.SetupGetWithFilter(new List<Waiver> { waiver1, waiver2 });
+
+            // Act
+            var result = await _sut.GetByNameAsync("TrashMob Waiver");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("TrashMob Waiver", result.Name);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

Completes Project 37 - Unit Test Coverage Improvement by adding comprehensive unit tests for the remaining managers:

- **LitterReportManager**: 14 tests covering status filtering (new, assigned, cleaned, cancelled), user reports, counts, add validation, and delete operations
- **WaiverManager**: 3 tests for GetByNameAsync with exact name matching
- **NonEventUserNotificationManager**: 3 tests for user and notification type filtering
- **ContactRequestManager**: 4 tests for required field setting, email notifications, placeholder replacement, and return values
- **PartnerLocationManager**: 7 tests for parent lookup, partner retrieval, and nearby partner search with Haversine distance calculation

Also adds **LitterReportBuilder** for fluent test data creation with status methods (AsNew, AsAssigned, AsCleaned, AsCancelled) and image handling.

### Project 37 Final Stats
| Phase | Tests Added | Focus Areas |
|-------|-------------|-------------|
| Phase 1 | 36 | EventManager |
| Phase 2 | 29 | EventAttendeeManager, TeamManager |
| Phase 3 | 48 | TeamMemberManager, UserManager |
| Phase 4 | 97 | CommunityManager |
| **Phase 5** | **31** | **LitterReport, Waiver, Notification, Contact, Partner** |
| **Total** | **242** | **All core managers** |

## Test plan

- [x] All 242 tests pass locally (`dotnet test`)
- [x] Build succeeds with no errors
- [x] Tests use existing patterns (builders, mock fixtures, TestAsyncEnumerable)
- [ ] CI/CD pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)