### PR TITLE
Make Notes field optional on Enable Service dialog

### DIFF
--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/services.enable.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/services.enable.tsx
@@ -198,9 +198,7 @@ export const PartnerServiceEnable = () => {
                     name='notes'
                     render={({ field }) => (
                         <FormItem className='col-span-12'>
-                            <FormLabel tooltip={ToolTips.PartnerLocationPublicNotes} required>
-                                Notes
-                            </FormLabel>
+                            <FormLabel tooltip={ToolTips.PartnerLocationPublicNotes}>Notes</FormLabel>
                             <FormControl>
                                 <Textarea {...field} maxLength={1000} className='h-24' />
                             </FormControl>


### PR DESCRIPTION
## Summary
- Remove required indicator from Notes field on the Enable Service dialog
- The Zod validation already allowed the field to be optional, but the UI incorrectly showed it as required

## Changes
| File | Change |
|------|--------|
| `services.enable.tsx` | Remove `required` prop from Notes FormLabel |

## Test plan
- [ ] Go to Partner Dashboard > Services
- [ ] Click Enable on a service
- [ ] Verify Notes field does NOT have a required indicator (*)
- [ ] Submit the form without entering notes - should succeed

Closes #2172

🤖 Generated with [Claude Code](https://claude.com/claude-code)