### PR TITLE
Fix partner event requests not showing on dashboard

### DIFF
--- a/TrashMob/client-app/src/components/Partners/partner-event-request-table.tsx
+++ b/TrashMob/client-app/src/components/Partners/partner-event-request-table.tsx
@@ -1,4 +1,4 @@
-import { Ellipsis, Loader2, SquareCheck, SquareX } from 'lucide-react';
+import { AlertCircle, Ellipsis, Loader2, SquareCheck, SquareX } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useQueryClient, useMutation, useQuery } from '@tanstack/react-query';
 import moment from 'moment';
@@ -35,8 +35,15 @@ const useGetEventPartnerLocationServiceStatuses = () => {
 interface PartnerEventRequestTableProps {
     isLoading: boolean;
     data?: DisplayPartnerLocationEventServiceData[];
+    hasError?: boolean;
+    hasAuthError?: boolean;
 }
-export const PartnerEventRequestTable = ({ isLoading, data }: PartnerEventRequestTableProps) => {
+export const PartnerEventRequestTable = ({
+    isLoading,
+    data,
+    hasError,
+    hasAuthError,
+}: PartnerEventRequestTableProps) => {
     const queryClient = useQueryClient();
     const { currentUser } = useLogin();
     const [isUpdating, setIsUpdating] = useState<string | null>(null);
@@ -107,7 +114,28 @@ export const PartnerEventRequestTable = ({ isLoading, data }: PartnerEventReques
                 </TableRow>
             </TableHeader>
             <TableBody>
-                {isLoading ? (
+                {hasAuthError ? (
+                    <TableRow>
+                        <TableCell colSpan={7} className='text-center'>
+                            <div className='flex flex-col items-center gap-2 mx-auto my-4 text-destructive'>
+                                <AlertCircle className='h-8 w-8' />
+                                <span>
+                                    You do not have permission to view event requests for this partner. Please contact a
+                                    site administrator if you believe this is an error.
+                                </span>
+                            </div>
+                        </TableCell>
+                    </TableRow>
+                ) : hasError ? (
+                    <TableRow>
+                        <TableCell colSpan={7} className='text-center'>
+                            <div className='flex flex-col items-center gap-2 mx-auto my-4 text-destructive'>
+                                <AlertCircle className='h-8 w-8' />
+                                <span>An error occurred while loading event requests. Please try again later.</span>
+                            </div>
+                        </TableCell>
+                    </TableRow>
+                ) : isLoading ? (
                     <TableRow>
                         <TableCell colSpan={7} className='text-center'>
                             <Loader2 className='animate-spin mx-auto my-4' />


### PR DESCRIPTION
## Summary
- Fixes #2153 - Partner event requests not showing on dashboard
- The issue was that API errors (specifically 403 Forbidden authorization failures) were being silently ignored
- Users would see "There are no event requests for this partner" instead of an error message

## Root Cause Analysis
1. The partner locations endpoint (`/partnerlocations/getbypartner/{partnerId}`) has no authorization check
2. The event services endpoint (`/partnerlocationeventservices/{partnerLocationId}`) requires `UserIsPartnerUserOrIsAdmin` authorization
3. If a user isn't properly set up as a partner admin, they can access the dashboard but all event service requests fail with 403
4. The frontend silently converted these errors to empty arrays

## Changes
- Add error state detection in partner dashboard index page
- Detect authorization errors (403 Forbidden) specifically
- Update `PartnerEventRequestTable` to display error messages with icons
- Show appropriate message for auth errors vs general errors

## Test plan
- [ ] Navigate to partner dashboard as a partner admin - should see event requests normally
- [ ] Navigate to partner dashboard as a non-partner user - should see authorization error message
- [ ] Verify general API errors are also surfaced with appropriate error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)