### PR TITLE
Fix event popup showing 'Created By' without username (#2137)

### DIFF
--- a/TrashMob.Models/Event.cs
+++ b/TrashMob.Models/Event.cs
@@ -2,6 +2,7 @@
 
 namespace TrashMob.Models
 {
+    using System.ComponentModel.DataAnnotations.Schema;
     /// <summary>
     /// Represents a cleanup event organized through TrashMob.
     /// </summary>
@@ -167,5 +168,15 @@ namespace TrashMob.Models
         /// Gets or sets the collection of photos uploaded for this event.
         /// </summary>
         public virtual ICollection<EventPhoto> EventPhotos { get; set; }
+
+        /// <summary>
+        /// Gets the username of the user who created the event.
+        /// </summary>
+        /// <remarks>
+        /// This is a computed property that returns the UserName from the CreatedByUser navigation property.
+        /// It is not mapped to a database column.
+        /// </remarks>
+        [NotMapped]
+        public string CreatedByUserName => CreatedByUser?.UserName;
     }
 }

--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -43,6 +43,7 @@
                     (e.EventStatusId == (int)EventStatusEnum.Active || e.EventStatusId == (int)EventStatusEnum.Full)
                     && e.IsEventPublic
                     && e.EventDate >= DateTimeOffset.UtcNow.AddMinutes(-1 * StandardEventWindowInMinutes))
+                .Include(e => e.CreatedByUser)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 
@@ -96,6 +97,7 @@
                                        (filter.Region == null || e.Region == filter.Region) &&
                                        (filter.City == null || e.City == filter.City) &&
                                        (filter.CreatedByUserId == null || e.CreatedByUserId == filter.CreatedByUserId))
+                .Include(e => e.CreatedByUser)
                 .ToListAsync(cancellationToken).ConfigureAwait(false);
         }
 

--- a/TrashMob/client-app/src/components/Map/EventInfoWindowContent/EventDetailInfoWindowContent.tsx
+++ b/TrashMob/client-app/src/components/Map/EventInfoWindowContent/EventDetailInfoWindowContent.tsx
@@ -62,10 +62,7 @@ export const EventDetailInfoWindowContent = (props: EventDetailInfoWindowContent
                 </p>
             </div>
             <div className='flex justify-between mt-2'>
-                <span className='self-end'>
-                    Created by
-                    {createdByUserName}
-                </span>
+                <span className='self-end'>Created by {createdByUserName}</span>
                 <Button variant='outline' className='mr-0' asChild>
                     <a href={eventDetailUrl}>View Details</a>
                 </Button>


### PR DESCRIPTION
## Summary
- Added `CreatedByUserName` computed property to `Event` model using `[NotMapped]` attribute
- Included `CreatedByUser` navigation property in `GetActiveEventsAsync` and `GetFilteredEventsAsync` queries via EF Core `.Include()`
- Fixed missing space between "Created by" and username in frontend popup

Fixes #2137

## Test plan
- [ ] Navigate to the main page map
- [ ] Click on an event marker
- [ ] Verify the popup shows "Created by {username}" with the actual creator's name
- [ ] Verify the spacing looks correct (space between "Created by" and the name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)