### PR TITLE
Fix event completion timing to use start time + duration (#2109)

### DIFF
--- a/TrashMob/client-app/src/pages/MyDashboard/index.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/index.tsx
@@ -8,6 +8,7 @@ import { Plus, Users } from 'lucide-react';
 import { AxiosResponse } from 'axios';
 
 import { getEventShareableContent, getEventShareMessage } from '@/lib/sharing-messages';
+import { isCompletedEvent } from '@/lib/event-helpers';
 
 import EventData from '@/components/Models/EventData';
 import PickupLocationData from '@/components/Models/PickupLocationData';
@@ -58,8 +59,10 @@ import { MyImpactCard } from '@/pages/MyDashboard/MyImpactCard';
 import { InviteFriendsCard } from '@/pages/MyDashboard/InviteFriendsCard';
 import { MyNewsletterPreferencesCard } from '@/pages/MyDashboard/MyNewsletterPreferencesCard';
 
-const isUpcomingEvent = (event: EventData) => new Date(event.eventDate) >= new Date();
-const isPastEvent = (event: EventData) => new Date(event.eventDate) < new Date();
+// An event is upcoming if it hasn't finished yet (start time + duration > now)
+const isUpcomingEvent = (event: EventData) => !isCompletedEvent(event);
+// An event is past/completed when start time + duration has passed
+const isPastEvent = (event: EventData) => isCompletedEvent(event);
 
 interface MyDashboardProps {}
 


### PR DESCRIPTION
## Summary
- Events on MyDashboard now move to "Completed Events" when `startTime + duration` has passed
- Previously, events moved to completed when the calendar day changed
- Now uses the existing `isCompletedEvent` helper from `event-helpers.ts` which correctly calculates: `eventDate + durationHours + durationMinutes`

Fixes #2109

## Test plan
- [ ] Create an event scheduled for today with a 1-hour duration
- [ ] Go to MyDashboard before the event's end time (start + duration)
- [ ] Verify the event appears in "Upcoming events"
- [ ] Wait until after the event's end time
- [ ] Refresh the page and verify the event has moved to "Completed events"

🤖 Generated with [Claude Code](https://claude.com/claude-code)