### PR TITLE
Prevent SPA fallback for invalid API routes (#911)

### DIFF
--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -352,6 +352,18 @@ public class Program
         });
 #pragma warning restore ASP0014
 
+        // Ensure API routes that weren't handled return 404 instead of falling through to SPA
+        // This prevents the SPA middleware from trying to serve index.html for invalid API routes
+        app.Use(async (context, next) =>
+        {
+            if (context.Request.Path.StartsWithSegments("/api"))
+            {
+                context.Response.StatusCode = 404;
+                return;
+            }
+            await next();
+        });
+
         app.UseSpa(spa =>
         {
             if (builder.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- Added middleware to return 404 for unhandled `/api/*` routes before they fall through to the SPA middleware
- This prevents the error "SPA default page middleware could not return the default page '/index.html' because it was not found" from appearing in logs
- Invalid API routes now properly return HTTP 404 instead of trying to serve the SPA

Fixes #911

## Technical Details
The issue was that when an invalid API route (e.g., `/api/nonexistent`) was requested:
1. The controller middleware didn't handle it (no matching controller)
2. The request fell through to the SPA middleware
3. SPA middleware tried to serve `index.html` as a fallback
4. If `index.html` didn't exist (or during certain edge cases), an error was logged

The fix adds middleware between the endpoint routing and SPA middleware that short-circuits any `/api/*` routes with a 404 response.

## Test plan
- [ ] Request a valid API endpoint (e.g., `/api/events`) → should return data
- [ ] Request an invalid API endpoint (e.g., `/api/nonexistent`) → should return 404
- [ ] Request a frontend route (e.g., `/mydashboard`) → should serve the SPA
- [ ] Verify no "SPA default page middleware" errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)