### PR TITLE
Add Azure billing alerts and budget caps (Project 30)

### DIFF
--- a/Deploy/COST_ALERT_RUNBOOK.md
+++ b/Deploy/COST_ALERT_RUNBOOK.md
@@ -1,0 +1,133 @@
+# Cost Alert Runbook
+
+This runbook covers how to respond to billing alerts and perform monthly cost reviews for TrashMob's Azure infrastructure.
+
+## Alert Types
+
+| Alert | Trigger | Urgency | Meaning |
+|-------|---------|---------|---------|
+| **Monthly 50%** | Actual spend exceeds 50% of monthly budget | Low | Informational mid-month checkpoint |
+| **Monthly 75%** | Actual spend exceeds 75% of monthly budget | Medium | Spending is elevated; review resource usage |
+| **Monthly 90%** | Actual spend exceeds 90% of monthly budget | High | Approaching budget limit; take action |
+| **Monthly 100%** | Actual spend exceeds 100% of monthly budget ($500) | Critical | Budget exceeded; investigate immediately |
+| **Grant Expired** | Actual annual spend exceeds $1 | Critical | Microsoft nonprofit grant may have expired or is not being applied |
+
+## Response Procedures
+
+### Low (50% threshold)
+
+1. Note the alert — no immediate action required
+2. Check if spending is on track for the month (e.g., 50% alert at mid-month is normal)
+3. Review Azure Cost Analysis to confirm no unusual resource consumption
+
+### Medium (75% threshold)
+
+1. Open Azure Portal > Cost Management + Billing > Cost Analysis
+2. Filter by resource group (`rg-trashmob-pr-westus2` or `rg-trashmob-dev-westus2`)
+3. Identify which resources are driving the increase
+4. Check for: unexpected scaling, orphaned resources, or misconfigured services
+5. If spending is expected (e.g., seasonal traffic spike), document and monitor
+
+### High (90% threshold)
+
+1. Follow the Medium steps above
+2. Check Container App replica counts — are they scaling beyond expected levels?
+   ```bash
+   az containerapp revision list --name ca-tm-pr-westus2 --resource-group rg-trashmob-pr-westus2 --output table
+   ```
+3. Check SQL Database DTU usage:
+   ```bash
+   az monitor metrics list --resource /subscriptions/<sub-id>/resourceGroups/rg-trashmob-pr-westus2/providers/Microsoft.Sql/servers/sql-tm-pr-westus2/databases/db-tm-pr-westus2 --metric dtu_consumption_percent --interval PT1H
+   ```
+4. Consider reducing non-critical resources (e.g., scale down dev environment)
+
+### Critical (100% threshold — budget exceeded)
+
+1. **Immediately** investigate the cause
+2. Check if the Microsoft nonprofit grant is still active:
+   - Azure Portal > Cost Management + Billing > Billing scopes
+   - Verify the sponsorship/grant is listed and active
+3. If grant is active but costs are high:
+   - Identify the top cost drivers in Cost Analysis
+   - Scale down or stop non-essential resources
+   - Consider pausing the dev environment if only prod is needed
+4. If grant appears expired — see Grant Expiration procedure below
+
+### Critical (Grant Expiration — $1/year threshold)
+
+This alert indicates real charges are being incurred, which should not happen under the Microsoft nonprofit grant.
+
+1. **Immediately** check grant status:
+   - Azure Portal > Cost Management + Billing > Billing scopes
+   - Look for the Microsoft sponsorship/grant subscription
+2. If grant has expired:
+   - Contact Microsoft nonprofit support to request renewal
+   - Scale down all non-production resources to minimize charges
+   - Notify the project owner (joe@trashmob.eco)
+3. If grant is active but charges appear:
+   - Check if any resources are in a subscription NOT covered by the grant
+   - Verify all resource groups are under the correct subscription
+
+## Monthly Cost Review Checklist
+
+Perform this review on the 1st of each month.
+
+- [ ] Open Azure Portal > Cost Management > Cost Analysis
+- [ ] Review previous month's total spend by resource group
+- [ ] Compare to previous months — flag any >20% increase
+- [ ] Check for orphaned resources (disks, IPs, storage accounts not attached to anything)
+- [ ] Review Container App scaling history — are replicas appropriate?
+- [ ] Check SendGrid usage (see below)
+- [ ] Check Google Maps API usage (see below)
+- [ ] Document findings and any actions taken
+
+### Where to check costs
+
+```bash
+# Quick cost summary for last 30 days (production)
+az consumption usage list --start-date $(date -d '-30 days' +%Y-%m-%d) --end-date $(date +%Y-%m-%d) --query "[?contains(instanceName, 'tm-pr')].{Resource:instanceName, Cost:pretaxCost, Currency:currency}" --output table
+
+# Quick cost summary (development)
+az consumption usage list --start-date $(date -d '-30 days' +%Y-%m-%d) --end-date $(date +%Y-%m-%d) --query "[?contains(instanceName, 'tm-dev')].{Resource:instanceName, Cost:pretaxCost, Currency:currency}" --output table
+```
+
+## Third-Party Service Alerts
+
+### SendGrid (Manual Setup)
+
+SendGrid billing alerts must be configured in the SendGrid dashboard.
+
+1. Log into https://app.sendgrid.com
+2. Settings > Account Details > Billing
+3. Under "Billing Alerts", click "Add Alert"
+4. Set alert at 75% of monthly email limit
+5. Set alert at 90% of monthly email limit
+6. Add recipient: joe@trashmob.eco
+7. For daily sending limit: Settings > Mail Settings > Set daily sending limit
+
+### Google Maps Platform (Manual Setup)
+
+Google Maps API billing alerts must be configured in Google Cloud Console.
+
+1. Log into https://console.cloud.google.com
+2. Billing > Budgets & alerts
+3. Click "Create Budget"
+4. Name: "TrashMob Maps API", Amount: $100/month
+5. Set thresholds: 50%, 90%, 100%
+6. Enable email notifications
+7. For request limits: APIs & Services > Quotas > Maps API > Edit Quota > Set daily request limit
+
+## Escalation
+
+| Severity | Response Time | Contact |
+|----------|---------------|---------|
+| Low (50%) | Next business day | Engineering lead reviews at convenience |
+| Medium (75%) | Same business day | Engineering lead investigates |
+| High (90%) | Within 4 hours | Engineering lead takes action |
+| Critical (100% or grant) | Within 1 hour | Engineering lead + project owner notified |
+
+## Related Resources
+
+- **Bicep template:** `Deploy/billingAlerts.bicep`
+- **Project spec:** `Planning/Projects/Project_30_Azure_Billing_Alerts.md`
+- **Risk register:** `Planning/Risks_and_Mitigations.md` (SR-5)

--- a/Deploy/billingAlerts.bicep
+++ b/Deploy/billingAlerts.bicep
@@ -1,0 +1,135 @@
+// Azure billing alerts and budget caps for cost management
+// See Project 30 (Azure Billing Caps & Alerts) for details
+
+@description('Environment identifier (dev, pr)')
+param environment string
+
+@description('Azure region for deployment')
+param region string
+
+@description('Email address for billing alert notifications')
+param alertEmail string = 'joe@trashmob.eco'
+
+@description('Monthly budget amount in USD')
+param monthlyBudgetAmount int = 500
+
+@description('Annual grant monitor threshold in USD - alerts if actual spend exceeds this amount')
+param grantBudgetAmount int = 1
+
+var actionGroupName = 'ag-tm-${environment}-${region}-billing'
+var monthlyBudgetName = 'budget-tm-${environment}-${region}-monthly'
+var grantMonitorBudgetName = 'budget-tm-${environment}-${region}-grant'
+
+// Action group for billing alert notifications
+resource billingActionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: actionGroupName
+  location: 'global'
+  properties: {
+    groupShortName: 'TMBilling'
+    enabled: true
+    emailReceivers: [
+      {
+        name: 'BillingAlertEmail'
+        emailAddress: alertEmail
+        useCommonAlertSchema: true
+      }
+    ]
+  }
+}
+
+// Monthly budget with alerts at 50%, 75%, 90%, and 100% thresholds
+resource monthlyBudget 'Microsoft.Consumption/budgets@2023-11-01' = {
+  name: monthlyBudgetName
+  properties: {
+    category: 'Cost'
+    amount: monthlyBudgetAmount
+    timeGrain: 'Monthly'
+    timePeriod: {
+      startDate: '2026-02-01'
+      endDate: '2027-01-31'
+    }
+    notifications: {
+      Actual_GreaterThan_50_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 50
+        thresholdType: 'Actual'
+        contactEmails: [
+          alertEmail
+        ]
+        contactGroups: [
+          billingActionGroup.id
+        ]
+      }
+      Actual_GreaterThan_75_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 75
+        thresholdType: 'Actual'
+        contactEmails: [
+          alertEmail
+        ]
+        contactGroups: [
+          billingActionGroup.id
+        ]
+      }
+      Actual_GreaterThan_90_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 90
+        thresholdType: 'Actual'
+        contactEmails: [
+          alertEmail
+        ]
+        contactGroups: [
+          billingActionGroup.id
+        ]
+      }
+      Actual_GreaterThan_100_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 100
+        thresholdType: 'Actual'
+        contactEmails: [
+          alertEmail
+        ]
+        contactGroups: [
+          billingActionGroup.id
+        ]
+      }
+    }
+  }
+}
+
+// Annual $1 budget to detect Microsoft nonprofit grant expiration
+// Any charge above $1/year likely means the grant has expired or is not being applied
+resource grantMonitorBudget 'Microsoft.Consumption/budgets@2023-11-01' = {
+  name: grantMonitorBudgetName
+  properties: {
+    category: 'Cost'
+    amount: grantBudgetAmount
+    timeGrain: 'Annually'
+    timePeriod: {
+      startDate: '2026-02-01'
+      endDate: '2027-01-31'
+    }
+    notifications: {
+      Grant_May_Have_Expired: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 100
+        thresholdType: 'Actual'
+        contactEmails: [
+          alertEmail
+        ]
+        contactGroups: [
+          billingActionGroup.id
+        ]
+      }
+    }
+  }
+}
+
+output actionGroupId string = billingActionGroup.id
+output monthlyBudgetId string = monthlyBudget.id
+output grantMonitorBudgetId string = grantMonitorBudget.id

--- a/Deploy/deployInfra.ps1
+++ b/Deploy/deployInfra.ps1
@@ -90,6 +90,10 @@ az deployment group create --template-file ".\containerRegistry.bicep" -g $rgNam
 Write-Host "Deploying Container Apps Environment..." -ForegroundColor Green
 az deployment group create --template-file ".\containerAppsEnvironment.bicep" -g $rgName --parameters containerAppsEnvironmentName=$containerAppsEnvironmentName region=$region logAnalyticsWorkspaceName=$logAnalyticsWorkspaceName environment=$environment
 
+# Deploy Billing Alerts and Budget Caps
+Write-Host "Deploying Billing Alerts..." -ForegroundColor Green
+az deployment group create --template-file ".\billingAlerts.bicep" -g $rgName --parameters environment=$environment region=$region
+
 # Note: Container App and Container App Job deployments will be done via GitHub Actions with actual container images
 # Uncomment the following lines after container images are built and pushed to the registry
 # Write-Host "Deploying Container App for Web Application..." -ForegroundColor Green

--- a/Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md
+++ b/Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md
@@ -65,7 +65,22 @@ az deployment group create \
   --parameters environment=pr region=westus2
 ```
 
-#### 2.3 KeyVault RBAC (Already Completed)
+#### 2.3 Billing Alerts & Budget Caps (Project 30)
+```bash
+az deployment group create \
+  --resource-group rg-trashmob-pr-westus2 \
+  --template-file Deploy/billingAlerts.bicep \
+  --parameters environment=pr region=westus2
+```
+
+**Manual steps after deployment (one-time setup):**
+
+- [ ] **SendGrid alerts:** Log into https://app.sendgrid.com > Settings > Billing > Add alerts at 75% and 90% of monthly email limit (recipient: joe@trashmob.eco)
+- [ ] **Google Maps API alerts:** Log into https://console.cloud.google.com > Billing > Budgets & alerts > Create budget "TrashMob Maps API" at $100/month with 50%, 90%, 100% thresholds
+
+See `Deploy/COST_ALERT_RUNBOOK.md` for full response procedures and monthly review checklist.
+
+#### 2.4 KeyVault RBAC (Already Completed)
 PR #2482 migrated KeyVault from access policies to RBAC. Verify this is working correctly.
 
 ### 3. Strapi CMS (Optional)
@@ -226,6 +241,7 @@ Database migrations do NOT have automatic rollback. If critical issues:
 | OpenTelemetry | Project 27 | Migrated from App Insights SDK |
 | KeyVault RBAC | Project 26 | Migrated from access policies |
 | Database Backups | Project 32 | Configured retention policies |
+| Billing Alerts | Project 30 | Azure budget caps, grant monitor, cost runbook |
 | Job Opportunities Markdown | Issue #2215 | Markdown editor for job listings admin |
 
 ---

--- a/Planning/Projects/Project_30_Azure_Billing_Alerts.md
+++ b/Planning/Projects/Project_30_Azure_Billing_Alerts.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | Not Started |
+| **Status** | In Progress |
 | **Priority** | Medium |
 | **Risk** | Low |
 | **Size** | Small |
@@ -244,7 +244,7 @@ gcloud services api-keys update KEY_ID \
 
 **Last Updated:** January 31, 2026
 **Owner:** Engineering Lead
-**Status:** Not Started
+**Status:** In Progress
 **Next Review:** When volunteer available
 
 ---
@@ -254,3 +254,4 @@ gcloud services api-keys update KEY_ID \
 - **2026-01-31:** Added $500 hard spending cap requirement
 - **2026-01-31:** Added $1/year threshold alert for Microsoft nonprofit grant expiration detection
 - **2026-01-31:** Converted open questions to decisions; confirmed all scope items
+- **2026-02-06:** Phase 1 implemented: billingAlerts.bicep, deployInfra.ps1 updated, COST_ALERT_RUNBOOK.md created


### PR DESCRIPTION
## Summary
- **Bicep template** (`Deploy/billingAlerts.bicep`): Monthly $500 budget with alerts at 50/75/90/100% thresholds, plus a $1/year grant monitor that fires if real charges appear (detects Microsoft nonprofit grant expiration)
- **Cost alert runbook** (`Deploy/COST_ALERT_RUNBOOK.md`): Response procedures for each alert severity, monthly cost review checklist, manual setup steps for SendGrid and Google Maps alerts, escalation paths
- **Deployment integration**: Added billing alerts deployment to `deployInfra.ps1` and production deployment checklist

## Test plan
- [x] Bicep template compiles successfully (`az bicep build`)
- [ ] Deploy to dev environment: `az deployment group create --resource-group rg-trashmob-dev-westus2 --template-file Deploy/billingAlerts.bicep --parameters environment=dev region=westus2`
- [ ] Verify budgets appear in Azure Portal > Cost Management > Budgets
- [ ] Configure SendGrid alerts per runbook instructions
- [ ] Configure Google Maps API alerts per runbook instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)