### PR TITLE
Add MAUI Android dev setup and secure Google Maps key injection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,19 @@
             "type": "coreclr",
             "request": "attach",
             "processId": "${command:azureFunctions.pickProcess}"
+        },
+        {
+            "name": "MAUI Android (Debug)",
+            "type": "dotnet",
+            "request": "launch",
+            "preLaunchTask": "build-maui-android",
+            "project": "${workspaceFolder}/TrashMobMobile/TrashMobMobile.csproj",
+            "configuration": "Debug",
+            "framework": "net10.0-android",
+            "env": {
+                "ANDROID_HOME": "D:\\Android\\android-sdk",
+                "JAVA_HOME": "C:\\Program Files\\Microsoft\\jdk-17.0.18.8-hotspot"
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -76,6 +76,26 @@
 			"command": "host start",
 			"isBackground": true,
 			"problemMatcher": "$func-dotnet-watch"
+		},
+		{
+			"label": "build-maui-android",
+			"command": "dotnet",
+			"args": [
+				"build",
+				"${workspaceFolder}/TrashMobMobile/TrashMobMobile.csproj",
+				"-f",
+				"net10.0-android",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"problemMatcher": "$msCompile",
+			"options": {
+				"env": {
+					"ANDROID_HOME": "D:\\Android\\android-sdk",
+					"JAVA_HOME": "C:\\Program Files\\Microsoft\\jdk-17.0.18.8-hotspot"
+				}
+			}
 		}
 	]
 }

--- a/TrashMobMobile/TrashMobMobile.csproj
+++ b/TrashMobMobile/TrashMobMobile.csproj
@@ -347,6 +347,30 @@
 	  </MauiXaml>
 	</ItemGroup>
 
+  <!-- Inject Google Maps API key into the intermediate AndroidManifest.xml at build time.
+       The key is fetched from Azure Key Vault (dev environment) during local builds.
+       CI uses GitHub secrets to replace the placeholder instead.
+       Override: set GOOGLE_MAPS_API_KEY env var to skip the Key Vault lookup. -->
+  <Target Name="InjectGoogleMapsKey" AfterTargets="_ManifestMerger" BeforeTargets="_CreateBaseApk"
+          Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+    <!-- If GOOGLE_MAPS_API_KEY is already set (env var or MSBuild property), use it directly -->
+    <!-- Otherwise, fetch from Azure Key Vault (requires 'az login') -->
+    <Exec Command="az keyvault secret show --vault-name kv-tm-dev-westus2 --name Android-Google-ApiKey-Dev --query value -o tsv"
+          ConsoleToMsBuild="true"
+          Condition="'$(GOOGLE_MAPS_API_KEY)' == ''"
+          ContinueOnError="true"
+          StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GOOGLE_MAPS_API_KEY" />
+    </Exec>
+    <XmlPoke Condition="'$(GOOGLE_MAPS_API_KEY)' != ''"
+             XmlInputPath="$(IntermediateOutputPath)android\AndroidManifest.xml"
+             Namespaces="&lt;Namespace Prefix='android' Uri='http://schemas.android.com/apk/res/android' /&gt;"
+             Query="/manifest/application/meta-data[@android:name='com.google.android.geo.API_KEY']/@android:value"
+             Value="$(GOOGLE_MAPS_API_KEY)" />
+    <Message Condition="'$(GOOGLE_MAPS_API_KEY)' != ''" Text="Google Maps API key injected successfully" Importance="high" />
+    <Warning Condition="'$(GOOGLE_MAPS_API_KEY)' == ''" Text="Google Maps API key not found. Maps will not work. Set GOOGLE_MAPS_API_KEY env var or run 'az login' with Key Vault access." />
+  </Target>
+
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
     <BundleResource Include="Platforms\iOS\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Add VS Code launch configuration (`MAUI Android (Debug)`) and build task (`build-maui-android`) for debugging the MAUI mobile app on Android emulator
- Add MSBuild target `InjectGoogleMapsKey` that auto-fetches the Google Maps API key from Azure Key Vault (`kv-tm-dev-westus2`, secret `Android-Google-ApiKey-Dev`) at build time
- The key is injected into the **intermediate** `AndroidManifest.xml` only — the source file stays untouched with its `"fill"` placeholder, so no secrets can accidentally be committed

## How it works
1. During Android builds, the `InjectGoogleMapsKey` target runs after manifest merging but before APK packaging
2. If `GOOGLE_MAPS_API_KEY` env var is set, it uses that directly (for CI or manual override)
3. Otherwise, it calls `az keyvault secret show` to fetch from Key Vault (requires `az login`)
4. The key is injected via `XmlPoke` into `$(IntermediateOutputPath)android\AndroidManifest.xml` (in `obj/`, gitignored)
5. If neither source provides a key, a build warning is emitted (non-blocking)

## Test plan
- [x] Build succeeds with `GOOGLE_MAPS_API_KEY` env var override
- [x] Build succeeds with Key Vault auto-fetch (verified real key injected)
- [x] Source `AndroidManifest.xml` remains unchanged (`git diff` clean)
- [x] Intermediate manifest contains the real API key
- [x] App installs and launches on Android emulator
- [x] Verify maps render correctly in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)