### PR TITLE
Align mobile app styling with web design system

### DIFF
--- a/TrashMobMobile/Platforms/Android/Resources/values/colors.xml
+++ b/TrashMobMobile/Platforms/Android/Resources/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-  <color name="colorPrimary">#512BD4</color>
-  <color name="colorPrimaryDark">#2B0B98</color>
-  <color name="colorAccent">#2B0B98</color>
+  <color name="colorPrimary">#005B4C</color>
+  <color name="colorPrimaryDark">#003D33</color>
+  <color name="colorAccent">#005B4C</color>
 </resources>

--- a/TrashMobMobile/Resources/Styles/Colors.xaml
+++ b/TrashMobMobile/Resources/Styles/Colors.xaml
@@ -9,32 +9,29 @@
     <!--Light mode-->
     <Color x:Key="Primary">#005B4C</Color>
     <Color x:Key="PrimaryText">#005B4C</Color>
-    <Color x:Key="PrimaryReverseText">#F8FBF9</Color>
-    <Color x:Key="ContentPrimary">#1E2225</Color>
-    <Color x:Key="Secondary">#F8FBF9</Color>
-    <Color x:Key="SecondaryText">#005B4C</Color>
-    <Color x:Key="SecondaryReverseText">#F8FBF9</Color>
+    <Color x:Key="PrimaryReverseText">#FFFFFF</Color>
+    <Color x:Key="ContentPrimary">#222832</Color>
+    <Color x:Key="Secondary">#F4F4F5</Color>
+    <Color x:Key="SecondaryText">#18181B</Color>
+    <Color x:Key="SecondaryReverseText">#F4F4F5</Color>
     <Color x:Key="Disabled">#C8C8C8</Color>
     <Color x:Key="DisabledText">#A1A1AA</Color>
-    <Color x:Key="Tertiary">#610777</Color>
- 
+    <Color x:Key="Destructive">#EF4444</Color>
+
     <!--Dark mode-->
-    <Color x:Key="PrimaryDark">White</Color>
+    <Color x:Key="PrimaryDark">#5EBD00</Color>
     <Color x:Key="PrimaryDarkText">White</Color>
-    <Color x:Key="PrimaryDarkReverseText">#549187</Color>
-    <Color x:Key="ContentPrimaryDark">#000000</Color>
-    <Color x:Key="SecondaryDark">#c7d762</Color>
-    <Color x:Key="SecondaryDarkText">#c7d762</Color>
-    <Color x:Key="SecondaryDarkReverseText">#549187</Color>
+    <Color x:Key="PrimaryDarkReverseText">#171717</Color>
+    <Color x:Key="ContentPrimaryDark">#FAFAFA</Color>
+    <Color x:Key="SecondaryDark">#262626</Color>
+    <Color x:Key="SecondaryDarkText">#FAFAFA</Color>
+    <Color x:Key="SecondaryDarkReverseText">#262626</Color>
     <Color x:Key="DisabledDark">#404040</Color>
     <Color x:Key="DisabledDarkText">#71717A</Color>
-    <Color x:Key="TertiaryDark">#9559a4</Color>
+    <Color x:Key="DestructiveDark">#7F1D1D</Color>
 
     <Color x:Key="White">White</Color>
     <Color x:Key="Black">Black</Color>
-    <Color x:Key="Magenta">#D600AA</Color>
-    <Color x:Key="MidnightBlue">#190649</Color>
-    <Color x:Key="OffBlack">#1f1f1f</Color>
 
     <Color x:Key="Gray100">#E1E1E1</Color>
     <Color x:Key="Gray200">#C8C8C8</Color>
@@ -47,7 +44,7 @@
 
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}" />
     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource Secondary}" />
-    <SolidColorBrush x:Key="TertiaryBrush" Color="{StaticResource Tertiary}" />
+    <SolidColorBrush x:Key="DestructiveBrush" Color="{StaticResource Destructive}" />
     <SolidColorBrush x:Key="WhiteBrush" Color="{StaticResource White}" />
     <SolidColorBrush x:Key="BlackBrush" Color="{StaticResource Black}" />
 
@@ -60,8 +57,17 @@
     <SolidColorBrush x:Key="Gray900Brush" Color="{StaticResource Gray900}" />
     <SolidColorBrush x:Key="Gray950Brush" Color="{StaticResource Gray950}" />
 
-    <Color x:Key="PageBackgroundLight">White</Color>
-    <Color x:Key="PageBackgroundDark">#1F1F1F</Color>
+    <Color x:Key="PageBackgroundLight">#F5F6F8</Color>
+    <Color x:Key="PageBackgroundDark">#0A0A0A</Color>
+
+    <Color x:Key="CardLight">#FFFFFF</Color>
+    <Color x:Key="CardDark">#0A0A0A</Color>
+    <Color x:Key="BorderLight">#E5E5E5</Color>
+    <Color x:Key="BorderDark">#262626</Color>
+    <Color x:Key="MutedLight">#E3E5E8</Color>
+    <Color x:Key="MutedForegroundLight">#737373</Color>
+    <Color x:Key="MutedDark">#262626</Color>
+    <Color x:Key="MutedForegroundDark">#A3A3A3</Color>
 
     <Color x:Key="TransparentBlack">#50000000</Color>
 

--- a/TrashMobMobile/Resources/Styles/Styles.xaml
+++ b/TrashMobMobile/Resources/Styles/Styles.xaml
@@ -26,10 +26,12 @@
 
     <Style x:Key="RoundBorder" TargetType="Border">
         <Setter Property="Stroke"
-                Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-        <Setter Property="StrokeShape" Value="RoundRectangle 15" />
+                Value="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}" />
+        <Setter Property="StrokeShape" Value="RoundRectangle 8" />
         <Setter Property="StrokeThickness" Value="1" />
-        <Setter Property="Padding" Value="10" />
+        <Setter Property="BackgroundColor"
+                Value="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}" />
+        <Setter Property="Padding" Value="12" />
         <Setter Property="Margin" Value="5,0,5,0" />
     </Style>
 
@@ -55,7 +57,7 @@
         <Setter Property="Padding" Value="14,10" />
         <Setter Property="MinimumHeightRequest" Value="44" />
         <Setter Property="MinimumWidthRequest" Value="44" />
-        <Setter Property="Margin" Value="10" />
+        <Setter Property="Margin" Value="8" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
                 <VisualStateGroup x:Name="CommonStates">
@@ -92,7 +94,7 @@
             </VisualStateGroupList>
         </Setter>
         <Setter Property="HeightRequest" Value="48" />
-        <Setter Property="CornerRadius" Value="20" />
+        <Setter Property="CornerRadius" Value="8" />
     </Style>
 
     <Style x:Key="SecondaryLargeButton" TargetType="Button">
@@ -113,13 +115,13 @@
             </VisualStateGroupList>
         </Setter>
         <Setter Property="HeightRequest" Value="48" />
-        <Setter Property="CornerRadius" Value="20" />
+        <Setter Property="CornerRadius" Value="8" />
     </Style>
 
     <Style x:Key="PrimarySmallButton" TargetType="Button">
         <Setter Property="HeightRequest" Value="40" />
         <Setter Property="Padding" Value="5,5" />
-        <Setter Property="CornerRadius" Value="5" />
+        <Setter Property="CornerRadius" Value="6" />
         <Setter Property="FontSize" Value="Micro" />
         <Setter Property="LineBreakMode" Value="WordWrap" />
         <Setter Property="Margin" Value="5" />
@@ -132,7 +134,7 @@
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource SecondaryText}, Dark={StaticResource SecondaryDarkText}}" />
         <Setter Property="HeightRequest" Value="40" />
         <Setter Property="Padding" Value="5,5" />
-        <Setter Property="CornerRadius" Value="5" />
+        <Setter Property="CornerRadius" Value="6" />
         <Setter Property="LineBreakMode" Value="WordWrap" />
         <Setter Property="Margin" Value="5" />
         <Setter Property="FontSize" Value="Micro" />
@@ -482,10 +484,10 @@
     </Style>
 
     <Style TargetType="Shadow">
-        <Setter Property="Radius" Value="15" />
-        <Setter Property="Opacity" Value="0.5" />
-        <Setter Property="Brush" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource White}}" />
-        <Setter Property="Offset" Value="10,10" />
+        <Setter Property="Radius" Value="4" />
+        <Setter Property="Opacity" Value="0.08" />
+        <Setter Property="Brush" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+        <Setter Property="Offset" Value="0,2" />
     </Style>
 
     <Style TargetType="Slider">
@@ -596,11 +598,11 @@
                 Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray200}}" />
         <Setter Property="Shell.NavBarHasShadow" Value="False" />
         <Setter Property="Shell.TabBarBackgroundColor"
-                Value="{AppThemeBinding Light={StaticResource DarkTextBase}, Dark={StaticResource LightTextBase}}" />
+                Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource LightTextBase}}" />
         <Setter Property="Shell.TabBarForegroundColor"
-                Value="{AppThemeBinding Light={StaticResource Magenta}, Dark={StaticResource White}}" />
+                Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
         <Setter Property="Shell.TabBarTitleColor"
-                Value="{AppThemeBinding Light={StaticResource Magenta}, Dark={StaticResource White}}" />
+                Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
         <Setter Property="Shell.TabBarUnselectedColor"
                 Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
     </Style>
@@ -609,16 +611,16 @@
         <Setter Property="BarBackgroundColor"
                 Value="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}" />
         <Setter Property="BarTextColor"
-                Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
+                Value="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource White}}" />
         <Setter Property="IconColor"
-                Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource White}}" />
+                Value="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource White}}" />
     </Style>
 
     <Style TargetType="TabbedPage">
         <Setter Property="BarBackgroundColor"
                 Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray950}}" />
         <Setter Property="BarTextColor"
-                Value="{AppThemeBinding Light={StaticResource Magenta}, Dark={StaticResource White}}" />
+                Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
         <Setter Property="UnselectedTabColor"
                 Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray950}}" />
         <Setter Property="SelectedTabColor"
@@ -627,7 +629,7 @@
 
     <Style TargetType="VerticalStackLayout">
         <Setter Property="Spacing" Value="5" />
-        <Setter Property="Margin" Value="10" />
+        <Setter Property="Margin" Value="8" />
     </Style>
 
     <Style x:Key="OuterVerticalStack" TargetType="VerticalStackLayout">


### PR DESCRIPTION
## Summary
- Replace off-brand magenta tab bar and .NET MAUI default purple with brand teal
- Update dark mode primary from white to lime green (#5EBD00) to match web dark theme
- Normalize backgrounds, button radii, card borders, and shadows to match web design tokens
- Add semantic color tokens (Card, Border, Muted, Destructive) and remove 6 unused off-brand colors

## Files Changed
- `TrashMobMobile/Resources/Styles/Colors.xaml` — color token updates
- `TrashMobMobile/Resources/Styles/Styles.xaml` — component style updates
- `TrashMobMobile/Platforms/Android/Resources/values/colors.xml` — Android platform colors

## Test plan
- [ ] Build MAUI Android and deploy to emulator
- [ ] Verify tab bar shows teal selected icons (no magenta)
- [ ] Verify page background is warm off-white (#F5F6F8), not pure white
- [ ] Verify cards have gray borders with 8px radius
- [ ] Verify buttons are consistently rounded (not pill-shaped)
- [ ] Verify Android status bar chrome is teal, not purple
- [ ] Test dark mode if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)