### PR TITLE
Add required field indicators to all mobile form pages

### DIFF
--- a/TrashMobMobile/Pages/CancelEventPage.xaml
+++ b/TrashMobMobile/Pages/CancelEventPage.xaml
@@ -28,14 +28,14 @@
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Event Date" Style="{StaticResource FieldLabel}" />
+                        <Label Text="Event Time" Style="{StaticResource FieldLabel}" />
                         <Border Style="{x:StaticResource RoundBorder}">
                             <Label Text="{Binding EventViewModel.DisplayTime}" FontSize="Small" />
                         </Border>
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Cancellation Reason" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Cancellation Reason" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <Border Style="{x:StaticResource RoundBorder}">
                             <controls:TMEditor Text="{Binding EventViewModel.CancellationReason}">
                                 <controls:TMEditor.Behaviors>

--- a/TrashMobMobile/Pages/ContactUsPage.xaml
+++ b/TrashMobMobile/Pages/ContactUsPage.xaml
@@ -14,7 +14,7 @@
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
                 <Grid RowDefinitions="Auto, Auto, *, Auto">
                     <VerticalStackLayout Grid.Row="0">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
 
                         <controls:TMEntry Text="{Binding Name}" >
                             <controls:TMEntry.Behaviors>
@@ -25,7 +25,7 @@
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Grid.Row="1">
-                        <Label Text="Email" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Email" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
 
                         <controls:TMEntry
                                 Text="{Binding Email}"
@@ -43,7 +43,7 @@
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Message" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Message" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
 
                         <controls:TMEditor
                                 Text="{Binding Message}"

--- a/TrashMobMobile/Pages/CreateEvent/Step1.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step1.xaml
@@ -25,12 +25,12 @@
                                          Grid.ColumnSpan="2"
                                          Margin="0,10"
                                          Spacing="5">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEntry HeightRequest="40"
                             Text="{Binding EventViewModel.Name}" />
                     </VerticalStackLayout>
                     <VerticalStackLayout Grid.Row="1" Margin="0,10">
-                        <Label Text="Event Type" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Type" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMPicker Title="Event Type"
                                            HeightRequest="40"
                                            Margin="0,0,10,0"
@@ -45,7 +45,7 @@
                                          Grid.Column="0"
                                          Margin="0,5,0,10"
                                          Spacing="5">
-                        <Label Text="Event Date" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Date" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMDatePicker HeightRequest="45" Margin="0,0,5,0"
                                    Date="{Binding EventViewModel.EventDateOnly}" />
                     </VerticalStackLayout>
@@ -53,9 +53,9 @@
                           Margin="0,10"
                           ColumnDefinitions="*,*"
                           RowDefinitions="Auto,Auto,Auto">
-                        <Label Text="Start time" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Start time" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMTimePicker Grid.Row="1" Time="{Binding StartTime, Mode=TwoWay}" Margin="0,0,5,0" />
-                        <Label Grid.Column="1" Text="End time" Style="{StaticResource FieldLabel}" />
+                        <Label Grid.Column="1" Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="End time" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMTimePicker Grid.Row="1" Grid.Column="1" Time="{Binding EndTime, Mode=TwoWay}" />
                         <Label x:Name="DurationErrorLabel" Grid.Row="2" Grid.ColumnSpan="2"
                                Style="{StaticResource ErrorLabel}"
@@ -86,7 +86,7 @@
                         </Label>
                     </VerticalStackLayout>
                     <VerticalStackLayout Grid.Row="5" Grid.ColumnSpan="2" Margin="0,10">
-                        <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEditor
                             Placeholder="Describe your event here"
                             MinimumHeightRequest="100"

--- a/TrashMobMobile/Pages/CreateLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/CreateLitterReportPage.xaml
@@ -15,11 +15,11 @@
                 <!--  Litter Report Top  -->
                 <Grid RowDefinitions="Auto, *, Auto">
                     <VerticalStackLayout Grid.Row="0">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEntry Text="{Binding Name}" />
                     </VerticalStackLayout>
                     <VerticalStackLayout Grid.Row="1">
-                        <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEditor Text="{Binding Description}"  HeightRequest="100"/>
                     </VerticalStackLayout>
 

--- a/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
@@ -21,7 +21,7 @@
                         HorizontalOptions="Center" />
                     <Button Text="Take Photo" Clicked="TakePhoto_Clicked" Grid.Row="1" Margin="10" />
                     <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEntry Text="{Binding PickupLocationViewModel.Name}">
                             <controls:TMEntry.Behaviors>
                                 <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
@@ -30,7 +30,7 @@
                         </controls:TMEntry>
                     </VerticalStackLayout>
                     <VerticalStackLayout Grid.Row="3">
-                        <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
                             <controls:TMEditor.Behaviors>
                                     <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"

--- a/TrashMobMobile/Pages/EditLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/EditLitterReportPage.xaml
@@ -15,12 +15,12 @@
 
                 <Grid RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="*, *">
                     <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEntry Text="{Binding Name}" />
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Grid.Row="1" Grid.ColumnSpan="2">
-                        <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEditor Text="{Binding Description}" HeightRequest="100"/>
                     </VerticalStackLayout>
                     <VerticalStackLayout Grid.Row="2" Grid.ColumnSpan="2">

--- a/TrashMobMobile/Pages/EditPickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/EditPickupLocationPage.xaml
@@ -14,7 +14,7 @@
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
                 <Grid RowDefinitions="Auto, Auto" ColumnDefinitions="*">
                     <VerticalStackLayout Grid.Row="0">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <Border Style="{x:StaticResource RoundBorder}">
                             <controls:TMEntry Text="{Binding PickupLocationViewModel.Name}">
                                 <controls:TMEntry.Behaviors>
@@ -25,7 +25,7 @@
                         </Border>
                     </VerticalStackLayout>
                     <VerticalStackLayout Grid.Row="1">
-                        <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <Border Style="{x:StaticResource RoundBorder}">
                             <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
                                 <controls:TMEditor.Behaviors>

--- a/TrashMobMobile/Views/EditEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/EditEvent/TabDetails.xaml
@@ -7,39 +7,39 @@
     <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *, *" MaximumWidthRequest="400">
 
         <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="4">
-            <Label Text="Name" Style="{StaticResource FieldLabel}" />
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMEntry Text="{Binding EventViewModel.Name}" />
 
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2">
-            <Label Text="Event Date" Style="{StaticResource FieldLabel}" />
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Date" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMDatePicker Date="{Binding EventViewModel.EventDateOnly, Mode=TwoWay}" />
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2">
-            <Label Text="Event Time" Style="{StaticResource FieldLabel}" />
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Time" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMTimePicker Time="{Binding EventViewModel.EventTime, Mode=TwoWay}" />
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">
-            <Label Text="Duration Hours" Style="{StaticResource FieldLabel}" />
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Duration Hours" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.DurationHours}" />
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2">
-            <Label Text="Duration Minutes" Style="{StaticResource FieldLabel}" />
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Duration Minutes" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.DurationMinutes}" />
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="3" Grid.ColumnSpan="4">
-            <Label Text="Description" Style="{StaticResource FieldLabel}" />
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMEditor Text="{Binding EventViewModel.Description}" />
         </VerticalStackLayout>
 
 
         <VerticalStackLayout Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2">
-            <Label Text="Event Type" Style="{StaticResource FieldLabel}" />
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Type" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMPicker Title="Event Type" ItemsSource="{Binding ETypes}"
                                     SelectedItem="{Binding SelectedEventType, Mode=TwoWay}" />
         </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- Add red asterisk (`*`) indicators next to all required field labels across 8 form pages, using `FormattedString` with the `Destructive` color token (#EF4444)
- Fix mislabeled "Event Date" → "Event Time" on CancelEventPage (was showing time but labeled as date)

### Pages updated
| Page | Required Fields |
|------|----------------|
| ContactUsPage | Name, Email, Message |
| CancelEventPage | Cancellation Reason |
| CreatePickupLocationPage | Name, Description |
| EditPickupLocationPage | Name, Description |
| CreateEvent/Step1 | Name, Event Type, Event Date, Start/End time, Description |
| EditEvent/TabDetails | Name, Event Date, Event Time, Duration Hours/Minutes, Description, Event Type |
| CreateLitterReportPage | Name, Description |
| EditLitterReportPage | Name, Description |

Optional/read-only fields (Max Attendees, Is Event Public, Status, Address fields) are intentionally left without indicators.

## Test plan
- [ ] Open Contact Us page — verify Name, Email, Message show red asterisks
- [ ] Open Create Event wizard — verify required fields on Step 1 have indicators
- [ ] Open Edit Event — verify Details tab required fields have indicators
- [ ] Open Create/Edit Litter Report — verify Name, Description have indicators
- [ ] Open Cancel Event — verify "Cancellation Reason" has indicator, and time label now says "Event Time"
- [ ] Verify optional fields (Max Attendees, Is Event Public) do NOT have indicators

Closes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)