### PR TITLE
Add mobile unit test project with 33 ViewModel tests

### DIFF
--- a/Planning/MOBILE_APP_MASTER_PLAN.md
+++ b/Planning/MOBILE_APP_MASTER_PLAN.md
@@ -1,0 +1,206 @@
+# Mobile App Master Plan
+
+Unified execution plan combining **Project 4** (Stabilization), **Project 38** (Feature Parity), and all open GitHub issues. Ordered by dependency and impact.
+
+## Current State (as of Feb 2026)
+
+| Item | Status |
+|------|--------|
+| .NET 10 / MAUI 10.0.20 | Done |
+| Sentry.io SDK installed | Done, activated in Release builds (PR #2587) |
+| Global error handling | Done - ExecuteAsync pattern in BaseViewModel (PR #2588) |
+| Styling alignment with web | Done (PR #2586) |
+| Android emulator + Google Maps key | Done (PR #2584) |
+| Event search filters + login fix | Done (PR #2587) |
+| App version display | Done (PR #2587) |
+| Required field indicators | Done (PR #2591) |
+| Save-and-close navigation | Done (PR #2590) |
+| Mobile unit tests | Done - 33 tests (SearchEventsVM, MainVM, BaseVM) |
+| iOS emulator docs | Not done |
+
+## Work Streams (6 Phases)
+
+### Phase 1: Critical Bug Fixes
+**Goal:** Make the app usable again. These bugs are blocking core flows.
+**Effort:** ~1-2 weeks | **Source:** GitHub Issues
+
+| # | Issue | Platform | Severity |
+|---|-------|----------|----------|
+| #2336 | Event search returns no results | Both | **Critical** — core flow broken |
+| #2339 | Home screen not visible | iOS | **Critical** — app unusable |
+| #2332 | Sign out loops forward/backward | iOS | **Critical** — can't switch accounts |
+| #2533 | Black screen after Google login post sign-out | Android | **High** — workaround exists (force close) |
+| #2335 | Litter report photos not saved | iOS | **High** — core flow broken |
+| #2534 | Oversized logo on launch screen | iOS | **Medium** — cosmetic |
+
+**Root cause already identified for #2336:** `SearchEventsViewModel` applies filters cumulatively without resetting to the base event list. Each dropdown filter (country, region, city) re-filters the already-filtered `RawEvents` instead of the original API response. Fix: store original results separately, always filter from the original set.
+
+**Approach:** Fix #2336 first (affects both platforms, root cause known). Then tackle iOS issues — likely need iOS simulator or device for #2339, #2332, #2335. Android #2533 auth issue may share root cause with iOS #2332.
+
+### Phase 2: Activate Observability & Error Handling
+**Goal:** See what's happening in production. Catch errors before users report them.
+**Effort:** ~1 week | **Source:** Project 4 Phases 1-2, Issues #2249, #2247
+
+| Task | Details |
+|------|---------|
+| Activate Sentry logging | Remove/condition `USETEST` flag so `LoggingService` (Sentry) is used in Release builds instead of `DebugLoggingService` |
+| Add `TaskScheduler.UnobservedTaskException` handler | Current global handling misses async exceptions |
+| Add `ExecuteWithErrorHandlingAsync<T>()` to `BaseViewModel` | Wrap all ViewModel commands with try/catch, user-friendly error messages, Sentry breadcrumbs |
+| Wrap all REST service calls | Network failure → user-friendly "check your connection" message with retry option |
+| Add app version display (#2219) | Show version on MorePage (read from `AppInfo.Current.VersionString`) |
+| Verify Sentry dashboards | Confirm crash reports, performance traces, and breadcrumbs flow correctly |
+
+### Phase 3: Testing & Quality Foundation
+**Goal:** Catch regressions before they ship. Build confidence for larger changes.
+**Effort:** ~2 weeks | **Source:** Project 4 Phase 3, Issues #2246, #2248, #2250
+
+| Task | Details |
+|------|---------|
+| Create `TrashMobMobile.Tests` project | xUnit + Moq, targeting ViewModels and Services |
+| Unit tests for ViewModels | Priority: `SearchEventsViewModel`, `MainViewModel`, `AuthService`, `CreateEventViewModel` |
+| Review design patterns (#2248) | Audit MVVM compliance, identify anti-patterns, document conventions |
+| Document minimum OS versions (#2250) | iOS 15.0+, Android API 21+ (already configured in csproj) |
+| Document iOS emulator setup (#2245) | Complement the Android setup from PR #2584 |
+| Document Android emulator setup (#2244) | Update with learnings from PR #2584 (Fast Deployment, SDK paths) |
+| Add required field indicators (#1438) | Visual consistency improvement across all form pages |
+| Save-and-close behavior (#1470) | After saving changes, navigate back to previous page |
+
+### Phase 4: Navigation Redesign & UX Polish
+**Goal:** Modern, intuitive navigation. This **combines** Project 4 Phase 4 with Project 38 Phase 1.
+**Effort:** ~3-4 weeks | **Source:** Both Projects
+
+**Why combine:** Both projects call for navigation redesign and UX refresh. Doing it twice would mean rewriting navigation structure, then rewriting it again. Do it once with the Project 38 target structure.
+
+Current structure (4 tabs):
+```
+Home (map/list) | Dashboard | Location | More
+```
+
+Target structure (5 tabs, Strava-inspired):
+```
+Home (feed) | Explore (map) | + (quick action) | Impact | Profile
+```
+
+| Task | Details |
+|------|---------|
+| Restructure `MainTabsPage.xaml` | 5-tab Shell layout replacing current 4-tab |
+| Build Home feed page | Upcoming events, nearby recommendations, activity cards |
+| Enhance Explore page | Map with layer toggles (events, litter reports), search bar, list/map toggle |
+| Add FAB/Quick Action | Central "+" button: Create Event, Report Litter, Quick Check-in |
+| Build Impact dashboard | Stats cards, achievement previews, leaderboard rank preview |
+| Build Profile page | User info, my events, my reports, settings, sign out |
+| Move Location Preferences | Into Profile > Settings (not its own tab) |
+| Add search filters button (#2337) | Explicit "Apply Filters" button on search screen |
+| Review app store settings (#2251, #2252) | Update screenshots, descriptions, metadata after UX refresh |
+
+### Phase 5: Feature Parity (New Features)
+**Goal:** Bring mobile to parity with key web features.
+**Effort:** ~6-8 weeks | **Source:** Project 38 Phases 2-5
+
+Execute in this order (by backend readiness and user value):
+
+**5A. Teams Integration** (P0 — backend complete)
+- TeamsListPage, TeamDetailPage, MyTeamsPage
+- Browse, join, view team events and stats
+- ~2 weeks
+
+**5B. Event Photos** (P1 — backend Phase 1 complete)
+- Photo gallery on ViewEventPage
+- Camera capture with Before/During/After types
+- Offline upload queue
+- ~2 weeks
+
+**5C. Leaderboards & Achievements** (P1 — backend complete)
+- LeaderboardsPage (Users/Teams/Communities tabs)
+- AchievementsPage (badge grid with progress)
+- ~1.5 weeks
+
+**5D. Attendee Metrics & Impact** (P1 — backend partial)
+- Weight entry on event summaries
+- Personal impact page with charts
+- Individual contribution logging
+- ~1.5 weeks
+- **Depends on:** Project 22 completion for full individual metrics API
+
+### Phase 6: Polish & Release
+**Goal:** Ship quality. Get back in the app stores with confidence.
+**Effort:** ~2 weeks | **Source:** Project 4 Phases 5-6, Project 38 Phase 6-7
+
+| Task | Details |
+|------|---------|
+| Newsletter preferences page | Manage email subscriptions, notification toggles |
+| Team events (limited admin) | Team leads can create team-linked events |
+| Beta release | TestFlight + Google Play Beta, recruit 50-100 testers |
+| Regression testing | Physical device testing matrix (iOS 15-17, Android 8-14) |
+| App store refresh | New screenshots, updated descriptions, promotional graphics |
+| Staged production rollout | 10% → 50% → 100% with crash rate monitoring |
+| Respond to existing reviews | Address concerns, highlight improvements |
+
+## Issue-to-Phase Mapping
+
+| Issue | Phase | Notes |
+|-------|-------|-------|
+| #2336 Event search no results | 1 | Root cause: cumulative filter bug |
+| #2339 Home screen not visible iOS | 1 | |
+| #2332 iOS sign out loops | 1 | |
+| #2533 Black screen after login Android | 1 | |
+| #2335 iOS litter report photos | 1 | |
+| #2534 Oversized logo iOS | 1 | |
+| #2249 Exceptions don't crash app | 2 | Global error handling |
+| #2247 User metrics gathered | 2 | Sentry activation |
+| #2219 App version display | 2 | |
+| #2246 Unit tests | 3 | |
+| #2248 Review design patterns | 3 | |
+| #2250 Document min OS versions | 3 | |
+| #2244 Android emulator docs | 3 | Partially done (PR #2584) |
+| #2245 iOS emulator docs | 3 | |
+| #1438 Required field indicators | 3 | |
+| #1470 Save closes page | 3 | |
+| #2337 Search filters button | 4 | |
+| #2251 Review Apple Store settings | 6 | After UX refresh |
+| #2252 Review Android Store settings | 6 | After UX refresh |
+| #2265 Individual metrics | 5D | Depends on Project 22 |
+| #1291 Secrets management | Done | PR #2584 (Key Vault integration) |
+| #2226 Project 4 tracking | All | Parent issue |
+| #206 Instagram posting | Deferred | Blocked, low priority |
+| #1202 Route tracing | Separate | Project 15, cross-platform |
+
+## Key Decisions
+
+### 1. Combine Project 4 Phase 4 + Project 38 Phase 1
+Both call for navigation redesign and UX refresh. Do it once targeting the Strava-inspired 5-tab layout. This saves ~2-3 weeks of rework.
+
+### 2. Fix bugs before features
+The 6 active bugs are destroying user trust. No point adding teams/photos if users can't sign in or search for events.
+
+### 3. Activate Sentry before major changes
+We need observability in place before the navigation redesign so we can monitor for regressions.
+
+### 4. iOS work needs prioritization
+4 of 6 critical bugs are iOS-specific. Need access to iOS simulator/device or ensure vtserej (who's assigned to most) has capacity.
+
+### 5. Backend dependencies are mostly met
+- Teams API: Complete
+- Event Photos API: Phase 1 complete
+- Leaderboards API: Complete
+- Attendee Metrics API: Partial (may need backend work in parallel)
+
+## Timeline Estimate
+
+| Phase | Duration | Cumulative |
+|-------|----------|------------|
+| 1. Bug Fixes | 1-2 weeks | 1-2 weeks |
+| 2. Observability | 1 week | 2-3 weeks |
+| 3. Testing & Quality | 2 weeks | 4-5 weeks |
+| 4. Navigation Redesign | 3-4 weeks | 7-9 weeks |
+| 5. Feature Parity | 6-8 weeks | 13-17 weeks |
+| 6. Polish & Release | 2 weeks | 15-19 weeks |
+
+**Total: ~4-5 months** for the full plan. Phases 1-3 can be done incrementally with PRs shipping every few days. Phase 4 is the biggest single change.
+
+## What We Can Start Right Now
+
+1. **Fix #2336** (event search filter bug) — root cause identified, can fix immediately
+2. **Activate Sentry** — flip the USETEST flag for Release builds
+3. **Add version display** — simple change to MorePage
+4. **Fix #2533** (Android black screen) — can debug on our emulator

--- a/TrashMobMobile.Tests/Helpers/TestHelpers.cs
+++ b/TrashMobMobile.Tests/Helpers/TestHelpers.cs
@@ -1,0 +1,128 @@
+namespace TrashMobMobile.Tests.Helpers;
+
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+
+/// <summary>
+/// Factory methods for creating test data.
+/// </summary>
+internal static class TestHelpers
+{
+    public static User CreateTestUser(
+        Guid? id = null,
+        string userName = "TestUser",
+        string email = "test@example.com",
+        string city = "Seattle",
+        string region = "WA",
+        string country = "United States",
+        double latitude = 47.6062,
+        double longitude = -122.3321)
+    {
+        return new User
+        {
+            Id = id ?? Guid.NewGuid(),
+            UserName = userName,
+            Email = email,
+            City = city,
+            Region = region,
+            Country = country,
+            Latitude = latitude,
+            Longitude = longitude,
+            TravelLimitForLocalEvents = 20,
+            DateAgreedToTrashMobWaiver = DateTime.UtcNow,
+        };
+    }
+
+    public static Event CreateTestEvent(
+        Guid? id = null,
+        string name = "Test Cleanup",
+        DateTimeOffset? eventDate = null,
+        string city = "Seattle",
+        string region = "WA",
+        string country = "United States",
+        Guid? createdByUserId = null,
+        int eventStatusId = 1,
+        bool isEventPublic = true)
+    {
+        return new Event
+        {
+            Id = id ?? Guid.NewGuid(),
+            Name = name,
+            Description = "Test event description",
+            EventDate = eventDate ?? DateTimeOffset.UtcNow.AddDays(7),
+            City = city,
+            Region = region,
+            Country = country,
+            StreetAddress = "123 Main St",
+            PostalCode = "98101",
+            Latitude = 47.6062,
+            Longitude = -122.3321,
+            CreatedByUserId = createdByUserId ?? Guid.NewGuid(),
+            EventStatusId = eventStatusId,
+            IsEventPublic = isEventPublic,
+            EventTypeId = 1,
+            DurationHours = 2,
+            DurationMinutes = 0,
+            MaxNumberOfParticipants = 50,
+        };
+    }
+
+    public static List<Event> CreateTestEvents(int count, string country = "United States", string region = "WA", string city = "Seattle")
+    {
+        var events = new List<Event>();
+        for (var i = 0; i < count; i++)
+        {
+            events.Add(CreateTestEvent(
+                name: $"Event {i + 1}",
+                eventDate: DateTimeOffset.UtcNow.AddDays(i + 1),
+                city: city,
+                region: region,
+                country: country));
+        }
+
+        return events;
+    }
+
+    public static PaginatedList<Event> ToPaginatedList(this IEnumerable<Event> events)
+    {
+        var list = new PaginatedList<Event>();
+        list.AddRange(events);
+        return list;
+    }
+
+    public static List<Location> CreateTestLocations()
+    {
+        return
+        [
+            new Location { Country = "United States", Region = "WA", City = "Seattle" },
+            new Location { Country = "United States", Region = "WA", City = "Tacoma" },
+            new Location { Country = "United States", Region = "OR", City = "Portland" },
+            new Location { Country = "Canada", Region = "BC", City = "Vancouver" },
+        ];
+    }
+
+    public static Stats CreateTestStats()
+    {
+        return new Stats
+        {
+            TotalParticipants = 1000,
+            TotalBags = 5000,
+            TotalEvents = 200,
+            TotalHours = 3000,
+            TotalLitterReportsSubmitted = 500,
+        };
+    }
+
+    public static LitterReport CreateTestLitterReport(Guid? id = null)
+    {
+        return new LitterReport
+        {
+            Id = id ?? Guid.NewGuid(),
+            Name = "Test Litter Report",
+            Description = "Litter at intersection",
+            LitterReportStatusId = (int)LitterReportStatusEnum.New,
+            CreatedDate = DateTimeOffset.UtcNow,
+            LitterImages = [],
+        };
+    }
+}

--- a/TrashMobMobile.Tests/Stubs/GeolocatorImplementationStub.cs
+++ b/TrashMobMobile.Tests/Stubs/GeolocatorImplementationStub.cs
@@ -1,0 +1,12 @@
+namespace TrashMobMobile;
+
+using TrashMobMobile.Services;
+
+// Stub implementation so the Geolocator static class compiles in tests.
+internal class GeolocatorImplementation : IGeolocator
+{
+    public Task StartListening(IProgress<Location> positionChangedProgress, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/TrashMobMobile.Tests/Stubs/PageStubs.cs
+++ b/TrashMobMobile.Tests/Stubs/PageStubs.cs
@@ -1,0 +1,33 @@
+// Stub classes so linked ViewModel source files compile in the test project.
+
+namespace TrashMobMobile;
+
+using TrashMob.Models;
+
+// App stub - provides the static CurrentUser property used by some ViewModels
+internal partial class App : Application
+{
+    public static User? CurrentUser { get; set; }
+}
+
+// Page stubs for Shell navigation targets (nameof() references)
+internal class ViewEventPage { }
+internal class WelcomePage { }
+internal class MyDashboardPage { }
+internal class CreateLitterReportPage { }
+internal class SearchLitterReportsPage { }
+internal class CreateEventPage { }
+internal class SetUserLocationPreferencePage { }
+internal class SearchEventsPage { }
+internal class CancelEventPage { }
+internal class EditEventPartnerLocationServicesPage { }
+internal class WaiverPage { }
+internal class ViewLitterReportPage { }
+internal class EditEventPage { }
+internal class ViewEventSummaryPage { }
+internal class EditLitterReportPage { }
+internal class EditEventSummaryPage { }
+internal class CreatePickupLocationPage { }
+internal class EditPickupLocationPage { }
+internal class ViewPickupLocationPage { }
+internal class MainTabsPage { }

--- a/TrashMobMobile.Tests/TrashMobMobile.Tests.csproj
+++ b/TrashMobMobile.Tests/TrashMobMobile.Tests.csproj
@@ -1,0 +1,83 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>TrashMobMobile.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.20" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Maui" Version="13.0.0" />
+    <PackageReference Include="Sentry.Maui" Version="6.0.0" />
+    <PackageReference Include="Polly" Version="8.6.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TrashMob.Models\TrashMob.Models.csproj" />
+  </ItemGroup>
+
+  <!-- Link ViewModel source files -->
+  <ItemGroup>
+    <Compile Include="..\TrashMobMobile\ViewModels\*.cs" Link="LinkedSource\ViewModels\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <!-- Link service interfaces -->
+  <ItemGroup>
+    <Compile Include="..\TrashMobMobile\Services\I*.cs" Link="LinkedSource\Services\%(Filename)%(Extension)" />
+    <Compile Include="..\TrashMobMobile\Services\NotificationService.cs" Link="LinkedSource\Services\NotificationService.cs" />
+    <Compile Include="..\TrashMobMobile\Services\Geolocator.cs" Link="LinkedSource\Services\Geolocator.cs" />
+  </ItemGroup>
+
+  <!-- Link extensions (exclude ServiceCollectionExtensions which has DI registration) -->
+  <ItemGroup>
+    <Compile Include="..\TrashMobMobile\Extensions\EventExtensions.cs" Link="LinkedSource\Extensions\EventExtensions.cs" />
+    <Compile Include="..\TrashMobMobile\Extensions\LitterReportExtensions.cs" Link="LinkedSource\Extensions\LitterReportExtensions.cs" />
+    <Compile Include="..\TrashMobMobile\Extensions\UserExtensions.cs" Link="LinkedSource\Extensions\UserExtensions.cs" />
+    <Compile Include="..\TrashMobMobile\Extensions\DisplayUserExtensions.cs" Link="LinkedSource\Extensions\DisplayUserExtensions.cs" />
+    <Compile Include="..\TrashMobMobile\Extensions\StringExtensions.cs" Link="LinkedSource\Extensions\StringExtensions.cs" />
+  </ItemGroup>
+
+  <!-- Link authentication types -->
+  <ItemGroup>
+    <Compile Include="..\TrashMobMobile\Authentication\IAuthService.cs" Link="LinkedSource\Authentication\IAuthService.cs" />
+    <Compile Include="..\TrashMobMobile\Authentication\SignInResult.cs" Link="LinkedSource\Authentication\SignInResult.cs" />
+    <Compile Include="..\TrashMobMobile\Authentication\UserContext.cs" Link="LinkedSource\Authentication\UserContext.cs" />
+    <Compile Include="..\TrashMobMobile\Authentication\UserState.cs" Link="LinkedSource\Authentication\UserState.cs" />
+  </ItemGroup>
+
+  <!-- Link config and models -->
+  <ItemGroup>
+    <Compile Include="..\TrashMobMobile\Config\Settings.cs" Link="LinkedSource\Config\Settings.cs" />
+    <Compile Include="..\TrashMobMobile\DateRanges.cs" Link="LinkedSource\DateRanges.cs" />
+    <Compile Include="..\TrashMobMobile\Models\WaiverVersion.cs" Link="LinkedSource\Models\WaiverVersion.cs" />
+    <Compile Include="..\TrashMobMobile\Models\EventCancellationRequest.cs" Link="LinkedSource\Models\EventCancellationRequest.cs" />
+    <Compile Include="..\TrashMobMobile\Models\ImageUpload.cs" Link="LinkedSource\Models\ImageUpload.cs" />
+    <Compile Include="..\TrashMobMobile\Models\PickupLocationImage.cs" Link="LinkedSource\Models\PickupLocationImage.cs" />
+    <Compile Include="..\TrashMobMobile\Models\EnvelopeRequest.cs" Link="LinkedSource\Models\EnvelopeRequest.cs" />
+    <Compile Include="..\TrashMobMobile\Models\EnvelopeResponse.cs" Link="LinkedSource\Models\EnvelopeResponse.cs" />
+  </ItemGroup>
+
+  <!-- Link global usings and MAUI page base class -->
+  <ItemGroup>
+    <Compile Include="..\TrashMobMobile\GlobalUsings.cs" Link="LinkedSource\GlobalUsings.cs" />
+    <Compile Include="..\TrashMobMobile\Pages\CreateEvent\BaseStepClass.cs" Link="LinkedSource\Pages\CreateEvent\BaseStepClass.cs" />
+  </ItemGroup>
+
+</Project>

--- a/TrashMobMobile.Tests/ViewModels/BaseViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/BaseViewModelTests.cs
@@ -1,0 +1,174 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMobMobile.Services;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+/// <summary>
+/// Tests for BaseViewModel's ExecuteAsync error handling.
+/// Uses a concrete subclass since BaseViewModel is abstract.
+/// </summary>
+public class BaseViewModelTests
+{
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly TestableViewModel sut;
+
+    public BaseViewModelTests()
+    {
+        mockNotificationService = new Mock<INotificationService>();
+        sut = new TestableViewModel(mockNotificationService.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOperationSucceeds_SetsIsBusyDuringExecution()
+    {
+        // Arrange
+        var wasBusyDuringOp = false;
+        Func<Task> operation = () =>
+        {
+            wasBusyDuringOp = sut.IsBusy;
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await sut.RunExecuteAsync(operation, "error");
+
+        // Assert
+        Assert.True(wasBusyDuringOp);
+        Assert.False(sut.IsBusy); // Should be false after completion
+        Assert.False(sut.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOperationThrows_SetsIsError()
+    {
+        // Arrange
+        Func<Task> operation = () => throw new InvalidOperationException("test");
+
+        // Act
+        await sut.RunExecuteAsync(operation, "Something went wrong");
+
+        // Assert
+        Assert.True(sut.IsError);
+        Assert.False(sut.IsBusy);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOperationThrows_NotifiesError()
+    {
+        // Arrange
+        const string errorMessage = "Something went wrong";
+        Func<Task> operation = () => throw new InvalidOperationException("test");
+
+        // Act
+        await sut.RunExecuteAsync(operation, errorMessage);
+
+        // Assert
+        mockNotificationService.Verify(n => n.NotifyError(errorMessage), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTaskCancelled_NotifiesTimeout()
+    {
+        // Arrange
+        Func<Task> operation = () => throw new TaskCanceledException();
+
+        // Act
+        await sut.RunExecuteAsync(operation, "error");
+
+        // Assert
+        mockNotificationService.Verify(
+            n => n.NotifyError("The request timed out. Please try again."),
+            Times.Once);
+        Assert.True(sut.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHttpError_NotifiesWithProvidedMessage()
+    {
+        // Arrange
+        const string errorMessage = "Failed to load events";
+        Func<Task> operation = () => throw new HttpRequestException("network error");
+
+        // Act
+        await sut.RunExecuteAsync(operation, errorMessage);
+
+        // Assert
+        mockNotificationService.Verify(n => n.NotifyError(It.IsAny<string>()), Times.Once);
+        Assert.True(sut.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncT_WhenOperationSucceeds_ReturnsResult()
+    {
+        // Arrange
+        Func<Task<int>> operation = () => Task.FromResult(42);
+
+        // Act
+        var result = await sut.RunExecuteAsync(operation, "error");
+
+        // Assert
+        Assert.Equal(42, result);
+        Assert.False(sut.IsError);
+        Assert.False(sut.IsBusy);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncT_WhenOperationThrows_ReturnsDefault()
+    {
+        // Arrange
+        Func<Task<int>> operation = () => throw new InvalidOperationException("test");
+
+        // Act
+        var result = await sut.RunExecuteAsync(operation, "error");
+
+        // Assert
+        Assert.Equal(0, result);
+        Assert.True(sut.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsyncT_WhenOperationThrowsForRefType_ReturnsNull()
+    {
+        // Arrange
+        Func<Task<string>> operation = () => throw new InvalidOperationException("test");
+
+        // Act
+        var result = await sut.RunExecuteAsync(operation, "error");
+
+        // Assert
+        Assert.Null(result);
+        Assert.True(sut.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ResetsIsErrorOnNewExecution()
+    {
+        // Arrange - first call fails
+        await sut.RunExecuteAsync(() => throw new Exception("fail"), "error");
+        Assert.True(sut.IsError);
+
+        // Act - second call succeeds
+        await sut.RunExecuteAsync(() => Task.CompletedTask, "error");
+
+        // Assert
+        Assert.False(sut.IsError);
+    }
+
+    /// <summary>
+    /// Concrete subclass exposing the protected ExecuteAsync methods for testing.
+    /// </summary>
+    private class TestableViewModel(INotificationService notificationService) : BaseViewModel(notificationService)
+    {
+        public async Task RunExecuteAsync(Func<Task> operation, string errorMessage)
+        {
+            await ExecuteAsync(operation, errorMessage);
+        }
+
+        public async Task<T?> RunExecuteAsync<T>(Func<Task<T>> operation, string errorMessage)
+        {
+            return await ExecuteAsync(operation, errorMessage);
+        }
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/MainViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/MainViewModelTests.cs
@@ -1,0 +1,241 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Authentication;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class MainViewModelTests
+{
+    private readonly Mock<IAuthService> mockAuthService;
+    private readonly Mock<IUserRestService> mockUserRestService;
+    private readonly Mock<IStatsRestService> mockStatsRestService;
+    private readonly Mock<IMobEventManager> mockEventManager;
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly MainViewModel sut;
+    private readonly User testUser;
+
+    public MainViewModelTests()
+    {
+        mockAuthService = new Mock<IAuthService>();
+        mockUserRestService = new Mock<IUserRestService>();
+        mockStatsRestService = new Mock<IStatsRestService>();
+        mockEventManager = new Mock<IMobEventManager>();
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new MainViewModel(
+            mockAuthService.Object,
+            mockUserRestService.Object,
+            mockStatsRestService.Object,
+            mockEventManager.Object,
+            mockLitterReportManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_WhenSignInSucceeds_LoadsUserAndData()
+    {
+        // Arrange
+        SetupSuccessfulSignIn();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal($"Welcome, {testUser.UserName}!", sut.WelcomeMessage);
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task Init_WhenSignInSucceeds_LoadsStatistics()
+    {
+        // Arrange
+        SetupSuccessfulSignIn();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(1000, sut.StatisticsViewModel.TotalAttendees);
+        Assert.Equal(5000, sut.StatisticsViewModel.TotalBags);
+        Assert.Equal(200, sut.StatisticsViewModel.TotalEvents);
+        Assert.Equal(3000, sut.StatisticsViewModel.TotalHours);
+        Assert.Equal(500, sut.StatisticsViewModel.TotalLitterReportsSubmitted);
+    }
+
+    [Fact]
+    public async Task Init_WhenSignInSucceeds_LoadsUpcomingEvents()
+    {
+        // Arrange
+        SetupSuccessfulSignIn();
+        var events = TestHelpers.CreateTestEvents(3);
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(3, sut.UpcomingEvents.Count);
+    }
+
+    [Fact]
+    public async Task Init_WhenSignInSucceeds_SetsUserLocation()
+    {
+        // Arrange
+        SetupSuccessfulSignIn();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.NotNull(sut.UserLocation);
+        Assert.Equal("Seattle", sut.UserLocation.City);
+        Assert.Equal("WA", sut.UserLocation.Region);
+        Assert.Contains("Seattle", sut.UserLocationDisplay);
+    }
+
+    [Fact]
+    public async Task Init_WhenUserHasNoLocation_UsesDefaults()
+    {
+        // Arrange
+        var userWithoutLocation = TestHelpers.CreateTestUser();
+        userWithoutLocation.Latitude = null;
+        userWithoutLocation.Longitude = null;
+
+        mockAuthService.Setup(a => a.SignInSilentAsync(It.IsAny<bool>()))
+            .ReturnsAsync(new SignInResult { Succeeded = true });
+        mockAuthService.Setup(a => a.GetUserEmail()).Returns("test@example.com");
+        mockUserRestService.Setup(u => u.GetUserByEmailAsync(It.IsAny<string>(), It.IsAny<UserContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userWithoutLocation);
+        mockStatsRestService.Setup(s => s.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestHelpers.CreateTestStats());
+        SetupEmptyEventAndLitterMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.NotNull(sut.UserLocation);
+        Assert.Equal(Config.Settings.DefaultTravelDistance, sut.TravelDistance);
+    }
+
+    [Fact]
+    public async Task Init_MarksEventsUserIsAttending()
+    {
+        // Arrange
+        SetupSuccessfulSignIn();
+        var events = TestHelpers.CreateTestEvents(3);
+        var attendingEvent = events[1];
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetEventsUserIsAttending(testUser.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Event> { attendingEvent });
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        var attendingVm = sut.UpcomingEvents.FirstOrDefault(e => e.Id == attendingEvent.Id);
+        Assert.NotNull(attendingVm);
+        Assert.True(attendingVm.IsUserAttending);
+
+        var notAttendingVm = sut.UpcomingEvents.First(e => e.Id != attendingEvent.Id);
+        Assert.False(notAttendingVm.IsUserAttending);
+    }
+
+    [Fact]
+    public async Task MapSelectedCommand_SetsMapState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task ListSelectedCommand_SetsListState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsMapSelected);
+        Assert.True(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task Init_WhenSignInFails_DoesNotLoadData()
+    {
+        // Arrange
+        mockAuthService.Setup(a => a.SignInSilentAsync(It.IsAny<bool>()))
+            .ReturnsAsync(new SignInResult { Succeeded = false });
+        mockStatsRestService.Setup(s => s.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestHelpers.CreateTestStats());
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Null(sut.WelcomeMessage);
+        Assert.Empty(sut.UpcomingEvents);
+    }
+
+    [Fact]
+    public async Task Init_LoadsLitterReports()
+    {
+        // Arrange
+        SetupSuccessfulSignIn();
+        var litterReports = new PaginatedList<LitterReport>
+        {
+            TestHelpers.CreateTestLitterReport(),
+            TestHelpers.CreateTestLitterReport(),
+        };
+        mockLitterReportManager.Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(litterReports);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(2, sut.LitterReports.Count);
+    }
+
+    private void SetupSuccessfulSignIn()
+    {
+        mockAuthService.Setup(a => a.SignInSilentAsync(It.IsAny<bool>()))
+            .ReturnsAsync(new SignInResult { Succeeded = true });
+        mockAuthService.Setup(a => a.GetUserEmail()).Returns("test@example.com");
+        mockUserRestService.Setup(u => u.GetUserByEmailAsync(It.IsAny<string>(), It.IsAny<UserContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testUser);
+        mockStatsRestService.Setup(s => s.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestHelpers.CreateTestStats());
+        SetupEmptyEventAndLitterMocks();
+    }
+
+    private void SetupEmptyEventAndLitterMocks()
+    {
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<Event>());
+        mockEventManager.Setup(m => m.GetEventsUserIsAttending(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Event>());
+        mockLitterReportManager.Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/SearchEventsViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/SearchEventsViewModelTests.cs
@@ -1,0 +1,347 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class SearchEventsViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockEventManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly SearchEventsViewModel sut;
+
+    public SearchEventsViewModelTests()
+    {
+        mockEventManager = new Mock<IMobEventManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new SearchEventsViewModel(
+            mockEventManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_SetsUpDateRanges()
+    {
+        // Arrange
+        SetupDefaultEventManagerMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.UpcomingDateRanges.Count > 0);
+        Assert.True(sut.CompletedDateRanges.Count > 0);
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+        Assert.True(sut.IsUpcomingSelected);
+        Assert.False(sut.IsCompletedSelected);
+    }
+
+    [Fact]
+    public async Task Init_LoadsEventsAndLocations()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.Events.Count > 0);
+        Assert.True(sut.CountryCollection.Count > 0);
+        Assert.True(sut.AreEventsFound);
+        Assert.False(sut.AreNoEventsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithNoEvents_ShowsNoEventsFound()
+    {
+        // Arrange
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<Event>());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Location>());
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Empty(sut.Events);
+        Assert.False(sut.AreEventsFound);
+        Assert.True(sut.AreNoEventsFound);
+    }
+
+    [Fact]
+    public async Task ViewUpcomingCommand_SetsUpcomingState()
+    {
+        // Arrange
+        SetupDefaultEventManagerMocks();
+        await sut.Init();
+
+        // Act
+        await sut.ViewUpcomingCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsUpcomingSelected);
+        Assert.False(sut.IsCompletedSelected);
+    }
+
+    [Fact]
+    public async Task ViewCompletedCommand_SetsCompletedState()
+    {
+        // Arrange
+        SetupDefaultEventManagerMocks();
+        await sut.Init();
+
+        // Act
+        await sut.ViewCompletedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsUpcomingSelected);
+        Assert.True(sut.IsCompletedSelected);
+    }
+
+    [Fact]
+    public async Task MapSelectedCommand_SetsMapState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task ListSelectedCommand_SetsListState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsMapSelected);
+        Assert.True(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task CountryFilter_FiltersEventsToMatchingCountry()
+    {
+        // Arrange
+        var usEvents = TestHelpers.CreateTestEvents(3, country: "United States");
+        var canadaEvents = TestHelpers.CreateTestEvents(2, country: "Canada", region: "BC", city: "Vancouver");
+        var allEvents = usEvents.Concat(canadaEvents).ToList();
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(allEvents.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        await sut.Init();
+        var totalBeforeFilter = sut.Events.Count;
+
+        // Act
+        sut.SelectedCountry = "United States";
+
+        // Assert
+        Assert.Equal(3, sut.Events.Count);
+        Assert.All(sut.Events, e => Assert.Equal("United States", e.Address.Country));
+    }
+
+    [Fact]
+    public async Task RegionFilter_FiltersEventsToMatchingRegion()
+    {
+        // Arrange
+        var waEvents = TestHelpers.CreateTestEvents(2, country: "United States", region: "WA", city: "Seattle");
+        var orEvents = TestHelpers.CreateTestEvents(1, country: "United States", region: "OR", city: "Portland");
+        var allEvents = waEvents.Concat(orEvents).ToList();
+
+        var locations = new List<Location>
+        {
+            new() { Country = "United States", Region = "WA", City = "Seattle" },
+            new() { Country = "United States", Region = "OR", City = "Portland" },
+        };
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(allEvents.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        await sut.Init();
+
+        sut.SelectedCountry = "United States";
+
+        // Act
+        sut.SelectedRegion = "WA";
+
+        // Assert
+        Assert.Equal(2, sut.Events.Count);
+        Assert.All(sut.Events, e => Assert.Equal("WA", e.Address.Region));
+    }
+
+    [Fact]
+    public async Task CityFilter_FiltersEventsToMatchingCity()
+    {
+        // Arrange
+        var seattleEvents = TestHelpers.CreateTestEvents(2, country: "United States", region: "WA", city: "Seattle");
+        var tacomaEvents = TestHelpers.CreateTestEvents(1, country: "United States", region: "WA", city: "Tacoma");
+        var allEvents = seattleEvents.Concat(tacomaEvents).ToList();
+
+        var locations = new List<Location>
+        {
+            new() { Country = "United States", Region = "WA", City = "Seattle" },
+            new() { Country = "United States", Region = "WA", City = "Tacoma" },
+        };
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(allEvents.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        await sut.Init();
+
+        sut.SelectedCountry = "United States";
+        sut.SelectedRegion = "WA";
+
+        // Act
+        sut.SelectedCity = "Seattle";
+
+        // Assert
+        Assert.Equal(2, sut.Events.Count);
+        Assert.All(sut.Events, e => Assert.Equal("Seattle", e.Address.City));
+    }
+
+    [Fact]
+    public async Task ClearSelectionsCommand_ResetsAllFilters()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(5);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        await sut.Init();
+        sut.SelectedCountry = "United States";
+
+        // Act
+        await sut.ClearSelectionsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Null(sut.SelectedCountry);
+        Assert.Null(sut.SelectedRegion);
+        Assert.Null(sut.SelectedCity);
+    }
+
+    [Fact]
+    public async Task CountrySelection_PopulatesRegionCollection()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        var locations = new List<Location>
+        {
+            new() { Country = "United States", Region = "WA", City = "Seattle" },
+            new() { Country = "United States", Region = "OR", City = "Portland" },
+            new() { Country = "Canada", Region = "BC", City = "Vancouver" },
+        };
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        await sut.Init();
+
+        // Act
+        sut.SelectedCountry = "United States";
+
+        // Assert
+        Assert.Equal(2, sut.RegionCollection.Count);
+        Assert.Contains("WA", sut.RegionCollection);
+        Assert.Contains("OR", sut.RegionCollection);
+    }
+
+    [Fact]
+    public async Task RegionSelection_PopulatesCityCollection()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        var locations = new List<Location>
+        {
+            new() { Country = "United States", Region = "WA", City = "Seattle" },
+            new() { Country = "United States", Region = "WA", City = "Tacoma" },
+            new() { Country = "United States", Region = "OR", City = "Portland" },
+        };
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        await sut.Init();
+        sut.SelectedCountry = "United States";
+
+        // Act
+        sut.SelectedRegion = "WA";
+
+        // Assert
+        Assert.Equal(2, sut.CityCollection.Count);
+        Assert.Contains("Seattle", sut.CityCollection);
+        Assert.Contains("Tacoma", sut.CityCollection);
+    }
+
+    [Fact]
+    public async Task CountryChange_ClearsRegionAndCitySelections()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+
+        await sut.Init();
+        sut.SelectedCountry = "United States";
+        sut.SelectedRegion = "WA";
+        sut.SelectedCity = "Seattle";
+
+        // Act
+        sut.SelectedCountry = "Canada";
+
+        // Assert
+        Assert.Null(sut.SelectedRegion);
+        Assert.Null(sut.SelectedCity);
+    }
+
+    private void SetupDefaultEventManagerMocks()
+    {
+        var events = TestHelpers.CreateTestEvents(3);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockEventManager.Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockEventManager.Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+    }
+}

--- a/TrashMobMobileApp.sln
+++ b/TrashMobMobileApp.sln
@@ -1,6 +1,7 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.2.11415.280 d18.0
+VisualStudioVersion = 18.2.11415.280
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrashMob.Models", "TrashMob.Models\TrashMob.Models.csproj", "{B16C277F-2A4B-4479-A62D-E47C67729E7C}"
 EndProject
@@ -11,22 +12,56 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{B2E2E6C5-9
 		MobileAppUserStories.md = MobileAppUserStories.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrashMobMobile.Tests", "TrashMobMobile.Tests\TrashMobMobile.Tests.csproj", "{DACA1F5D-84ED-4886-86C8-378413C43CEF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Debug|x86.Build.0 = Debug|Any CPU
 		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Release|x64.Build.0 = Release|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{B16C277F-2A4B-4479-A62D-E47C67729E7C}.Release|x86.Build.0 = Release|Any CPU
 		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Debug|x64.Build.0 = Debug|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Debug|x86.Build.0 = Debug|Any CPU
 		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Release|x64.ActiveCfg = Release|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Release|x64.Build.0 = Release|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Release|x86.ActiveCfg = Release|Any CPU
+		{509A66EF-B8BB-41B6-B7D3-05A50F8877C5}.Release|x86.Build.0 = Release|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Debug|x64.Build.0 = Debug|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Release|x64.ActiveCfg = Release|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Release|x64.Build.0 = Release|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{DACA1F5D-84ED-4886-86C8-378413C43CEF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- Creates `TrashMobMobile.Tests` project (xUnit + Moq) with 33 passing unit tests covering three priority ViewModels
- Uses linked source files from `TrashMobMobile/` with `<UseMaui>true</UseMaui>` on `net10.0` — no shared library refactor needed
- Updates `MOBILE_APP_MASTER_PLAN.md` to reflect completed Phase 1-3 work

### Test coverage
| Test Class | Tests | What's tested |
|------------|-------|---------------|
| **BaseViewModelTests** | 9 | `ExecuteAsync` error handling: success path, generic exceptions, HTTP errors, timeouts, state resets |
| **SearchEventsViewModelTests** | 13 | Init, cascading location filters (country → region → city), date ranges, map/list toggle, clear filters |
| **MainViewModelTests** | 11 | Auth flow, statistics loading, event + attendance loading, litter reports, user location defaults |

### Approach
The test project compiles ViewModel source via MSBuild `<Compile Include="..">` linked items, with minimal stubs for MAUI page types and the `App` class. This lets us unit-test all business logic without needing a platform emulator.

## Test plan
- [x] `dotnet test TrashMobMobile.Tests/` — 33/33 passing
- [ ] Verify solution opens cleanly in Visual Studio (`TrashMobMobileApp.sln`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)