### PR TITLE
Add nav redesign foundation: icons and QuickActionPopup

### DIFF
--- a/TrashMobMobile/Controls/QuickActionPopup.xaml
+++ b/TrashMobMobile/Controls/QuickActionPopup.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+               x:Class="TrashMobMobile.Controls.QuickActionPopup"
+               Color="Transparent">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="280">
+        <VerticalStackLayout Spacing="16">
+
+            <Label Text="Quick Actions"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Button Text="Create Event"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnCreateEventClicked">
+                <Button.ImageSource>
+                    <FontImageSource FontFamily="GoogleMaterialIcons"
+                                     Glyph="{DynamicResource IconCalendarCheck}"
+                                     Color="{AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}"
+                                     Size="20" />
+                </Button.ImageSource>
+            </Button>
+
+            <Button Text="Report Litter"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnReportLitterClicked">
+                <Button.ImageSource>
+                    <FontImageSource FontFamily="GoogleMaterialIcons"
+                                     Glyph="{DynamicResource IconClipboardText}"
+                                     Color="{AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}"
+                                     Size="20" />
+                </Button.ImageSource>
+            </Button>
+
+            <Button Text="Cancel"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnCancelClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</toolkit:Popup>

--- a/TrashMobMobile/Controls/QuickActionPopup.xaml.cs
+++ b/TrashMobMobile/Controls/QuickActionPopup.xaml.cs
@@ -1,0 +1,33 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Views;
+
+public partial class QuickActionPopup : Popup
+{
+    public const string CreateEvent = "CreateEvent";
+    public const string ReportLitter = "ReportLitter";
+
+    public string? SelectedAction { get; private set; }
+
+    public QuickActionPopup()
+    {
+        InitializeComponent();
+    }
+
+    private async void OnCreateEventClicked(object? sender, EventArgs e)
+    {
+        SelectedAction = CreateEvent;
+        await CloseAsync();
+    }
+
+    private async void OnReportLitterClicked(object? sender, EventArgs e)
+    {
+        SelectedAction = ReportLitter;
+        await CloseAsync();
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        await CloseAsync();
+    }
+}

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -399,7 +399,7 @@
     <!-- <x:String x:Key="IconCommentText">&#xf0188;</x:String> -->
     <!-- <x:String x:Key="IconCommentTextOutline">&#xf0189;</x:String> -->
     <!-- <x:String x:Key="IconCompare">&#xf018a;</x:String> -->
-    <!-- <x:String x:Key="IconCompass">&#xf018b;</x:String> -->
+    <x:String x:Key="IconCompass">&#xf018b;</x:String>
     <!-- <x:String x:Key="IconCompassOutline">&#xf018c;</x:String> -->
     <!-- <x:String x:Key="IconConsole">&#xf018d;</x:String> -->
     <!-- <x:String x:Key="IconCardAccountMail">&#xf018e;</x:String> -->
@@ -1050,7 +1050,7 @@
     <!-- <x:String x:Key="IconSonyPlaystation">&#xf0414;</x:String> -->
     <!-- <x:String x:Key="IconPlus">&#xf0415;</x:String> -->
     <!-- <x:String x:Key="IconPlusBox">&#xf0416;</x:String> -->
-    <!-- <x:String x:Key="IconPlusCircle">&#xf0417;</x:String> -->
+    <x:String x:Key="IconPlusCircle">&#xf0417;</x:String>
     <!-- <x:String x:Key="IconPlusCircleMultipleOutline">&#xf0418;</x:String> -->
     <!-- <x:String x:Key="IconPlusCircleOutline">&#xf0419;</x:String> -->
     <!-- <x:String x:Key="IconPlusNetwork">&#xf041a;</x:String> -->
@@ -1337,7 +1337,7 @@
     <!-- <x:String x:Key="IconTrendingUp">&#xf0535;</x:String> -->
     <!-- <x:String x:Key="IconTriangle">&#xf0536;</x:String> -->
     <!-- <x:String x:Key="IconTriangleOutline">&#xf0537;</x:String> -->
-    <!-- <x:String x:Key="IconTrophy">&#xf0538;</x:String> -->
+    <x:String x:Key="IconTrophy">&#xf0538;</x:String>
     <!-- <x:String x:Key="IconTrophyAward">&#xf0539;</x:String> -->
     <!-- <x:String x:Key="IconTrophyOutline">&#xf053a;</x:String> -->
     <!-- <x:String x:Key="IconTrophyVariant">&#xf053b;</x:String> -->


### PR DESCRIPTION
## Summary
- Uncomment `IconCompass`, `IconPlusCircle`, and `IconTrophy` in GoogleMaterialIcons.xaml for the upcoming 5-tab navigation layout
- Add `QuickActionPopup` control (CommunityToolkit.Maui Popup) with "Create Event" and "Report Litter" action buttons
- This is **Phase 4 PR 1 of 6** for the mobile navigation redesign (4-tab → 5-tab Strava-inspired layout)

## Context
Part of the Navigation Redesign (Phase 4 of the Mobile App Master Plan). This PR adds foundational assets (icons + popup control) without any visible behavior change. The popup will be wired into the center "+" tab in PR 6.

## Test plan
- [x] `dotnet build TrashMobMobile/TrashMobMobile.csproj -f net10.0-android` builds successfully
- [ ] Verify no visual regressions on existing tabs (icons are only used by future PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)