### PR TITLE
Add ImpactPage combining personal and community stats

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -17,6 +17,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(EditEventSummaryPage), typeof(EditEventSummaryPage));
         Routing.RegisterRoute(nameof(EditLitterReportPage), typeof(EditLitterReportPage));
         Routing.RegisterRoute(nameof(EditPickupLocationPage), typeof(EditPickupLocationPage));
+        Routing.RegisterRoute(nameof(ImpactPage), typeof(ImpactPage));
         Routing.RegisterRoute(nameof(LogoutPage), typeof(LogoutPage));
         Routing.RegisterRoute(nameof(ManageEventPartnersPage), typeof(ManageEventPartnersPage));
         Routing.RegisterRoute(nameof(MainTabsPage), typeof(MainTabsPage));

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -66,6 +66,7 @@ public static class MauiProgram
         builder.Services.AddTransient<CreateEventPage>();
         builder.Services.AddTransient<CreateLitterReportPage>();
         builder.Services.AddTransient<EditEventPage>();
+        builder.Services.AddTransient<ImpactPage>();
         builder.Services.AddTransient<EditEventPartnerLocationServicesPage>();
         builder.Services.AddTransient<EditEventSummaryPage>();
         builder.Services.AddTransient<EditLitterReportPage>();
@@ -96,6 +97,7 @@ public static class MauiProgram
         builder.Services.AddTransient<EditLitterReportViewModel>();
         builder.Services.AddTransient<EditPickupLocationViewModel>();
         builder.Services.AddTransient<EventSummaryViewModel>();
+        builder.Services.AddTransient<ImpactViewModel>();
         builder.Services.AddTransient<LogoutViewModel>();
         builder.Services.AddTransient<MainViewModel>();
         builder.Services.AddTransient<ManageEventPartnersViewModel>();

--- a/TrashMobMobile/Pages/ImpactPage.xaml
+++ b/TrashMobMobile/Pages/ImpactPage.xaml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ImpactViewModel"
+             x:Class="TrashMobMobile.Pages.ImpactPage"
+             Title="Impact">
+
+    <ScrollView>
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+
+            <!-- Your Impact -->
+            <Label Text="Your Impact"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="5,10,5,0" />
+
+            <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
+                <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *, *, *">
+                    <Image Grid.Row="0" Grid.Column="0" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconCalendarCheck}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="0" Text="{Binding PersonalStats.TotalEvents}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="0" Text="Events"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+
+                    <Image Grid.Row="0" Grid.Column="1" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconTrashCanOutline}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="1" Text="{Binding PersonalStats.TotalBags}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="1" Text="Bags"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+
+                    <Image Grid.Row="0" Grid.Column="2" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconClockOutline}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="2" Text="{Binding PersonalStats.TotalHours}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="2" Text="Hours"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+
+                    <Image Grid.Row="0" Grid.Column="3" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconClipboardText}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="3" Text="{Binding PersonalStats.TotalLitterReportsSubmitted}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="3" Text="Litter Reports"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                </Grid>
+            </Border>
+
+            <!-- Community Impact -->
+            <Label Text="Community Impact"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="5,15,5,0" />
+
+            <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
+                <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *, *, *, *">
+                    <Image Grid.Row="0" Grid.Column="0" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconCalendarCheck}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="0" Text="{Binding CommunityStats.TotalEvents}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="0" Text="Events"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+
+                    <Image Grid.Row="0" Grid.Column="1" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconAccount}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="1" Text="{Binding CommunityStats.TotalAttendees}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="1" Text="Participants"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+
+                    <Image Grid.Row="0" Grid.Column="2" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconTrashCanOutline}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="2" Text="{Binding CommunityStats.TotalBags}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="2" Text="Bags"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+
+                    <Image Grid.Row="0" Grid.Column="3" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconClockOutline}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="3" Text="{Binding CommunityStats.TotalHours}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="3" Text="Hours"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+
+                    <Image Grid.Row="0" Grid.Column="4" MaximumWidthRequest="40">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconClipboardText}"
+                                             Size="50"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Grid.Row="1" Grid.Column="4" Text="{Binding CommunityStats.TotalLitterReportsSubmitted}"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                    <Label Grid.Row="2" Grid.Column="4" Text="Litter Reports"
+                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                </Grid>
+            </Border>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/TrashMobMobile/Pages/ImpactPage.xaml.cs
+++ b/TrashMobMobile/Pages/ImpactPage.xaml.cs
@@ -1,0 +1,19 @@
+namespace TrashMobMobile.Pages;
+
+public partial class ImpactPage : ContentPage
+{
+    private readonly ImpactViewModel viewModel;
+
+    public ImpactPage(ImpactViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        BindingContext = this.viewModel;
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init();
+    }
+}

--- a/TrashMobMobile/ViewModels/ImpactViewModel.cs
+++ b/TrashMobMobile/ViewModels/ImpactViewModel.cs
@@ -1,0 +1,55 @@
+namespace TrashMobMobile.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using TrashMobMobile.Services;
+
+public partial class ImpactViewModel(
+    IStatsRestService statsRestService,
+    INotificationService notificationService,
+    IUserManager userManager) : BaseViewModel(notificationService)
+{
+    [ObservableProperty]
+    private StatisticsViewModel personalStats = new();
+
+    [ObservableProperty]
+    private StatisticsViewModel communityStats = new();
+
+    public async Task Init()
+    {
+        await ExecuteAsync(async () =>
+        {
+            await Task.WhenAll(
+                RefreshPersonalStats(),
+                RefreshCommunityStats());
+        }, "Failed to load impact stats. Please try again.");
+    }
+
+    private async Task RefreshPersonalStats()
+    {
+        var stats = await statsRestService.GetUserStatsAsync(userManager.CurrentUser.Id);
+
+        PersonalStats = new StatisticsViewModel
+        {
+            TotalEvents = stats.TotalEvents,
+            TotalBags = stats.TotalBags,
+            TotalHours = stats.TotalHours,
+            TotalLitterReportsSubmitted = stats.TotalLitterReportsSubmitted,
+            TotalLitterReportsClosed = stats.TotalLitterReportsClosed,
+        };
+    }
+
+    private async Task RefreshCommunityStats()
+    {
+        var stats = await statsRestService.GetStatsAsync();
+
+        CommunityStats = new StatisticsViewModel
+        {
+            TotalAttendees = stats.TotalParticipants,
+            TotalEvents = stats.TotalEvents,
+            TotalBags = stats.TotalBags,
+            TotalHours = stats.TotalHours,
+            TotalLitterReportsSubmitted = stats.TotalLitterReportsSubmitted,
+            TotalLitterReportsClosed = stats.TotalLitterReportsClosed,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ImpactPage` that combines personal stats (from MyDashboardPage) and global community stats (from MainPage) into a single focused view
- Create `ImpactViewModel` that loads both stat sets in parallel via `IStatsRestService`
- Register page + ViewModel in DI and Shell routing
- This is **Phase 4 PR 2 of 6** for the mobile navigation redesign (4-tab → 5-tab layout)

## Context
Part of the Navigation Redesign (Phase 4 of the Mobile App Master Plan). The ImpactPage will become the "Impact" tab in the final 5-tab layout (PR 6). Currently registered as a route only — no tab bar changes yet.

## Test plan
- [x] `dotnet build TrashMobMobile/TrashMobMobile.csproj -f net10.0-android` builds successfully
- [ ] Navigate to ImpactPage and verify both "Your Impact" and "Community Impact" stat cards render
- [ ] Verify stats load correctly from API (personal via user ID, community via public endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)