### PR TITLE
Add ProfilePage consolidating events, reports, and settings

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -21,6 +21,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(ManageEventPartnersPage), typeof(ManageEventPartnersPage));
         Routing.RegisterRoute(nameof(MainTabsPage), typeof(MainTabsPage));
         Routing.RegisterRoute(nameof(MyDashboardPage), typeof(MyDashboardPage));
+        Routing.RegisterRoute(nameof(ProfilePage), typeof(ProfilePage));
         Routing.RegisterRoute(nameof(MorePage), typeof(MorePage));
         Routing.RegisterRoute(nameof(SearchEventsPage), typeof(SearchEventsPage));
         Routing.RegisterRoute(nameof(SearchLitterReportsPage), typeof(SearchLitterReportsPage));

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -74,6 +74,7 @@ public static class MauiProgram
         builder.Services.AddTransient<MainPage>();
         builder.Services.AddTransient<ManageEventPartnersPage>();
         builder.Services.AddTransient<MyDashboardPage>();
+        builder.Services.AddTransient<ProfilePage>();
         builder.Services.AddTransient<SearchEventsPage>();
         builder.Services.AddTransient<SearchLitterReportsPage>();
         builder.Services.AddTransient<SetUserLocationPreferencePage>();
@@ -100,6 +101,7 @@ public static class MauiProgram
         builder.Services.AddTransient<MainViewModel>();
         builder.Services.AddTransient<ManageEventPartnersViewModel>();
         builder.Services.AddTransient<MyDashboardViewModel>();
+        builder.Services.AddTransient<ProfileViewModel>();
         builder.Services.AddTransient<SearchEventsViewModel>();
         builder.Services.AddTransient<SearchLitterReportsViewModel>();
         builder.Services.AddTransient<SocialMediaShareViewModel>();

--- a/TrashMobMobile/Pages/ProfilePage.xaml
+++ b/TrashMobMobile/Pages/ProfilePage.xaml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ProfileViewModel"
+             x:Class="TrashMobMobile.Pages.ProfilePage"
+             Title="Profile">
+
+    <ScrollView>
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+
+            <!-- User Header -->
+            <Border Style="{x:StaticResource RoundBorder}" Margin="5,10,5,5">
+                <VerticalStackLayout Spacing="4" Padding="5">
+                    <Label Text="{Binding UserName}"
+                           FontFamily="LexendSemibold"
+                           FontSize="Large" />
+                    <Label Text="{Binding UserEmail}"
+                           FontSize="Small"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <Label Text="{Binding MemberSince}"
+                           FontSize="Micro"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Location Preference -->
+            <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
+                <Grid ColumnDefinitions="*, Auto" Padding="5">
+                    <VerticalStackLayout Grid.Column="0" Spacing="2">
+                        <Label Text="Location Preference"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small" />
+                        <Label Text="{Binding LocationSummary}"
+                               FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                    <Button Grid.Column="1"
+                            Text="Edit"
+                            Command="{Binding EditLocationCommand}"
+                            Style="{StaticResource SecondarySmallButton}" />
+                </Grid>
+            </Border>
+
+            <!-- My Events Section -->
+            <Label Text="My Events"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="5,15,5,5" />
+
+            <HorizontalStackLayout Spacing="8" Margin="5,0">
+                <Button Text="Upcoming"
+                        Command="{Binding ShowUpcomingEventsCommand}"
+                        Style="{StaticResource PrimarySmallButton}" />
+                <Button Text="Completed"
+                        Command="{Binding ShowCompletedEventsCommand}"
+                        Style="{StaticResource SecondarySmallButton}" />
+            </HorizontalStackLayout>
+
+            <!-- Upcoming Events List -->
+            <VerticalStackLayout IsVisible="{Binding ShowUpcoming}">
+                <Label Text="No upcoming events"
+                       IsVisible="{Binding AreNoUpcomingEventsFound}"
+                       FontSize="Small"
+                       Margin="10,10"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                <CollectionView ItemsSource="{Binding UpcomingEvents}"
+                                SelectionMode="None"
+                                IsVisible="{Binding AreUpcomingEventsFound}"
+                                MaximumHeightRequest="300">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
+                            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                <VerticalStackLayout Padding="10,8" Spacing="2">
+                                    <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                    <Label Text="{Binding DisplayDate}" FontSize="Micro"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewEventCommand}"
+                                        CommandParameter="{Binding .}" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </VerticalStackLayout>
+
+            <!-- Completed Events List -->
+            <VerticalStackLayout IsVisible="{Binding ShowCompleted}">
+                <Label Text="No completed events"
+                       IsVisible="{Binding AreNoCompletedEventsFound}"
+                       FontSize="Small"
+                       Margin="10,10"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                <CollectionView ItemsSource="{Binding CompletedEvents}"
+                                SelectionMode="None"
+                                IsVisible="{Binding AreCompletedEventsFound}"
+                                MaximumHeightRequest="300">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
+                            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                <VerticalStackLayout Padding="10,8" Spacing="2">
+                                    <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                    <Label Text="{Binding DisplayDate}" FontSize="Micro"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewEventCommand}"
+                                        CommandParameter="{Binding .}" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </VerticalStackLayout>
+
+            <!-- My Litter Reports Section -->
+            <Label Text="My Litter Reports"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="5,15,5,5" />
+
+            <Label Text="No litter reports"
+                   IsVisible="{Binding AreNoLitterReportsFound}"
+                   FontSize="Small"
+                   Margin="10,5"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+            <CollectionView ItemsSource="{Binding LitterReports}"
+                            SelectionMode="None"
+                            IsVisible="{Binding AreLitterReportsFound}"
+                            MaximumHeightRequest="250">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="viewModels:LitterReportViewModel">
+                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                            <VerticalStackLayout Padding="10,8" Spacing="2">
+                                <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding Description}" FontSize="Micro" MaxLines="2"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <Border.GestureRecognizers>
+                                <TapGestureRecognizer
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewLitterReportCommand}"
+                                    CommandParameter="{Binding .}" />
+                            </Border.GestureRecognizers>
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <!-- Settings Section -->
+            <Label Text="Settings"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="5,15,5,5" />
+
+            <VerticalStackLayout Spacing="8" Margin="5,0">
+                <Button Text="Privacy Policy"
+                        Command="{Binding OpenPrivacyPolicyCommand}"
+                        Style="{StaticResource SecondaryLargeButton}"
+                        ContentLayout="Left, 12"
+                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconBinoculars}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                <Button Text="Terms of Service"
+                        Command="{Binding OpenTermsOfServiceCommand}"
+                        Style="{StaticResource SecondaryLargeButton}"
+                        ContentLayout="Left, 12"
+                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconFileDocument}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                <Button Text="Sign Waiver"
+                        Command="{Binding SignWaiverCommand}"
+                        Style="{StaticResource SecondaryLargeButton}"
+                        ContentLayout="Left, 12"
+                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconSignatureText}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                <Button Text="Contact Us"
+                        Command="{Binding ContactUsCommand}"
+                        Style="{StaticResource SecondaryLargeButton}"
+                        ContentLayout="Left, 12"
+                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmail}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+            </VerticalStackLayout>
+
+            <!-- Sign Out -->
+            <Button Text="Sign Out"
+                    Command="{Binding SignOutCommand}"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Margin="5,20,5,5" />
+
+            <!-- Version -->
+            <Label x:Name="VersionLabel"
+                   FontSize="Micro"
+                   HorizontalTextAlignment="Center"
+                   Margin="0,5,0,20"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <!-- Loading Overlay -->
+            <BoxView BackgroundColor="{StaticResource TransparentBlack}"
+                     IsVisible="{Binding IsBusy}"
+                     VerticalOptions="Fill"
+                     HorizontalOptions="Fill" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}"
+                               IsVisible="{Binding IsBusy}"
+                               VerticalOptions="Center"
+                               HorizontalOptions="Center" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/TrashMobMobile/Pages/ProfilePage.xaml.cs
+++ b/TrashMobMobile/Pages/ProfilePage.xaml.cs
@@ -1,0 +1,20 @@
+namespace TrashMobMobile.Pages;
+
+public partial class ProfilePage : ContentPage
+{
+    private readonly ProfileViewModel viewModel;
+
+    public ProfilePage(ProfileViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        BindingContext = this.viewModel;
+        VersionLabel.Text = $"Version {AppInfo.Current.VersionString} ({AppInfo.Current.BuildString})";
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init();
+    }
+}

--- a/TrashMobMobile/ViewModels/ProfileViewModel.cs
+++ b/TrashMobMobile/ViewModels/ProfileViewModel.cs
@@ -1,0 +1,234 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Extensions;
+using TrashMobMobile.Services;
+
+public partial class ProfileViewModel(
+    IMobEventManager mobEventManager,
+    ILitterReportManager litterReportManager,
+    INotificationService notificationService,
+    IUserManager userManager) : BaseViewModel(notificationService)
+{
+    private readonly IMobEventManager mobEventManager = mobEventManager;
+    private readonly ILitterReportManager litterReportManager = litterReportManager;
+    private readonly IUserManager userManager = userManager;
+
+    [ObservableProperty]
+    private string userName = string.Empty;
+
+    [ObservableProperty]
+    private string userEmail = string.Empty;
+
+    [ObservableProperty]
+    private string memberSince = string.Empty;
+
+    [ObservableProperty]
+    private string locationSummary = string.Empty;
+
+    [ObservableProperty]
+    private bool showUpcoming = true;
+
+    [ObservableProperty]
+    private bool showCompleted;
+
+    [ObservableProperty]
+    private bool areUpcomingEventsFound;
+
+    [ObservableProperty]
+    private bool areNoUpcomingEventsFound = true;
+
+    [ObservableProperty]
+    private bool areCompletedEventsFound;
+
+    [ObservableProperty]
+    private bool areNoCompletedEventsFound = true;
+
+    [ObservableProperty]
+    private bool areLitterReportsFound;
+
+    [ObservableProperty]
+    private bool areNoLitterReportsFound = true;
+
+    public ObservableCollection<EventViewModel> UpcomingEvents { get; } = [];
+
+    public ObservableCollection<EventViewModel> CompletedEvents { get; } = [];
+
+    public ObservableCollection<LitterReportViewModel> LitterReports { get; } = [];
+
+    public async Task Init()
+    {
+        await ExecuteAsync(async () =>
+        {
+            var user = userManager.CurrentUser;
+            UserName = user.UserName ?? string.Empty;
+            UserEmail = user.Email ?? string.Empty;
+            MemberSince = user.MemberSince.HasValue
+                ? $"Member since {user.MemberSince.Value:MMMM yyyy}"
+                : string.Empty;
+
+            var locationParts = new List<string>();
+            if (!string.IsNullOrEmpty(user.City))
+            {
+                locationParts.Add(user.City);
+            }
+
+            if (!string.IsNullOrEmpty(user.Region))
+            {
+                locationParts.Add(user.Region);
+            }
+
+            if (!string.IsNullOrEmpty(user.Country))
+            {
+                locationParts.Add(user.Country);
+            }
+
+            LocationSummary = locationParts.Count > 0
+                ? string.Join(", ", locationParts)
+                : "No location set";
+
+            await Task.WhenAll(
+                RefreshUpcomingEvents(),
+                RefreshCompletedEvents(),
+                RefreshLitterReports());
+        }, "Failed to load profile. Please try again.");
+    }
+
+    [RelayCommand]
+    private void ShowUpcomingEvents()
+    {
+        ShowUpcoming = true;
+        ShowCompleted = false;
+    }
+
+    [RelayCommand]
+    private void ShowCompletedEvents()
+    {
+        ShowUpcoming = false;
+        ShowCompleted = true;
+    }
+
+    [RelayCommand]
+    private async Task ViewEvent(EventViewModel? eventVm)
+    {
+        if (eventVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewEventPage)}?EventId={eventVm.Id}");
+    }
+
+    [RelayCommand]
+    private async Task ViewLitterReport(LitterReportViewModel? reportVm)
+    {
+        if (reportVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewLitterReportPage)}?LitterReportId={reportVm.Id}");
+    }
+
+    [RelayCommand]
+    private async Task EditLocation()
+    {
+        await Shell.Current.GoToAsync(nameof(SetUserLocationPreferencePage));
+    }
+
+    [RelayCommand]
+    private async Task OpenPrivacyPolicy()
+    {
+        await Browser.Default.OpenAsync("https://www.trashmob.eco/privacypolicy", BrowserLaunchMode.SystemPreferred);
+    }
+
+    [RelayCommand]
+    private async Task OpenTermsOfService()
+    {
+        await Browser.Default.OpenAsync("https://www.trashmob.eco/termsofservice", BrowserLaunchMode.SystemPreferred);
+    }
+
+    [RelayCommand]
+    private async Task SignWaiver()
+    {
+        await Shell.Current.GoToAsync(nameof(WaiverPage));
+    }
+
+    [RelayCommand]
+    private async Task ContactUs()
+    {
+        await Shell.Current.GoToAsync(nameof(ContactUsPage));
+    }
+
+    [RelayCommand]
+    private async Task SignOut()
+    {
+        await Shell.Current.GoToAsync(nameof(LogoutPage));
+    }
+
+    private async Task RefreshUpcomingEvents()
+    {
+        var filter = new EventFilter
+        {
+            StartDate = DateTimeOffset.UtcNow,
+            EndDate = DateTimeOffset.UtcNow.AddYears(1),
+        };
+
+        var events = await mobEventManager.GetUserEventsAsync(filter, userManager.CurrentUser.Id);
+
+        UpcomingEvents.Clear();
+        foreach (var e in events)
+        {
+            UpcomingEvents.Add(e.ToEventViewModel(userManager.CurrentUser.Id));
+        }
+
+        AreUpcomingEventsFound = UpcomingEvents.Count > 0;
+        AreNoUpcomingEventsFound = !AreUpcomingEventsFound;
+    }
+
+    private async Task RefreshCompletedEvents()
+    {
+        var filter = new EventFilter
+        {
+            StartDate = DateTimeOffset.UtcNow.AddYears(-1),
+            EndDate = DateTimeOffset.UtcNow,
+        };
+
+        var events = await mobEventManager.GetUserEventsAsync(filter, userManager.CurrentUser.Id);
+
+        CompletedEvents.Clear();
+        foreach (var e in events)
+        {
+            CompletedEvents.Add(e.ToEventViewModel(userManager.CurrentUser.Id));
+        }
+
+        AreCompletedEventsFound = CompletedEvents.Count > 0;
+        AreNoCompletedEventsFound = !AreCompletedEventsFound;
+    }
+
+    private async Task RefreshLitterReports()
+    {
+        var filter = new LitterReportFilter
+        {
+            StartDate = DateTimeOffset.UtcNow.AddYears(-1),
+            EndDate = DateTimeOffset.UtcNow,
+        };
+
+        var reports = await litterReportManager.GetLitterReportsAsync(filter, ImageSizeEnum.Thumb, true);
+
+        LitterReports.Clear();
+        foreach (var r in reports)
+        {
+            LitterReports.Add(r.ToLitterReportViewModel(NotificationService));
+        }
+
+        AreLitterReportsFound = LitterReports.Count > 0;
+        AreNoLitterReportsFound = !AreLitterReportsFound;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ProfilePage` that consolidates user info, events, litter reports, location preference, settings links, and sign out into a single scrollable view
- Create `ProfileViewModel` with upcoming/completed event toggle using button commands (no Sharpnado dependency)
- User header shows name, email, and member-since date
- Location preference section with "Edit" button linking to existing `SetUserLocationPreferencePage`
- Settings section with Privacy Policy, Terms of Service, Sign Waiver, and Contact Us buttons (matches MorePage functionality)
- This is **Phase 4 PR 3 of 6** for the mobile navigation redesign

## Context
Part of the Navigation Redesign (Phase 4 of the Mobile App Master Plan). The ProfilePage will become the "Profile" tab in the final 5-tab layout (PR 6), replacing MyDashboardPage and MorePage as tab content.

## Test plan
- [x] `dotnet build TrashMobMobile/TrashMobMobile.csproj -f net10.0-android` builds successfully
- [ ] Navigate to ProfilePage and verify user header displays correctly
- [ ] Toggle between Upcoming and Completed events
- [ ] Tap an event to navigate to ViewEventPage
- [ ] Tap a litter report to navigate to ViewLitterReportPage
- [ ] Verify all settings links work (Privacy, Terms, Waiver, Contact)
- [ ] Verify Sign Out navigates to LogoutPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)