### PR TITLE
Add ExplorePage with unified map of events and litter reports

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -12,6 +12,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(CreateEventPage), typeof(CreateEventPage));
         Routing.RegisterRoute(nameof(CreateLitterReportPage), typeof(CreateLitterReportPage));
         Routing.RegisterRoute(nameof(EditEventPage), typeof(EditEventPage));
+        Routing.RegisterRoute(nameof(ExplorePage), typeof(ExplorePage));
         Routing.RegisterRoute(nameof(EditEventPartnerLocationServicesPage),
             typeof(EditEventPartnerLocationServicesPage));
         Routing.RegisterRoute(nameof(EditEventSummaryPage), typeof(EditEventSummaryPage));

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -66,6 +66,7 @@ public static class MauiProgram
         builder.Services.AddTransient<CreateEventPage>();
         builder.Services.AddTransient<CreateLitterReportPage>();
         builder.Services.AddTransient<EditEventPage>();
+        builder.Services.AddTransient<ExplorePage>();
         builder.Services.AddTransient<EditEventPartnerLocationServicesPage>();
         builder.Services.AddTransient<EditEventSummaryPage>();
         builder.Services.AddTransient<EditLitterReportPage>();
@@ -96,6 +97,7 @@ public static class MauiProgram
         builder.Services.AddTransient<EditLitterReportViewModel>();
         builder.Services.AddTransient<EditPickupLocationViewModel>();
         builder.Services.AddTransient<EventSummaryViewModel>();
+        builder.Services.AddTransient<ExploreViewModel>();
         builder.Services.AddTransient<LogoutViewModel>();
         builder.Services.AddTransient<MainViewModel>();
         builder.Services.AddTransient<ManageEventPartnersViewModel>();

--- a/TrashMobMobile/Pages/ExplorePage.xaml
+++ b/TrashMobMobile/Pages/ExplorePage.xaml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             xmlns:controls="clr-namespace:TrashMobMobile.Controls"
+             x:DataType="viewModels:ExploreViewModel"
+             x:Class="TrashMobMobile.Pages.ExplorePage"
+             Title="Explore">
+
+    <Grid RowDefinitions="Auto, Auto, Auto, *">
+
+        <!-- Layer Toggle Chips -->
+        <HorizontalStackLayout Grid.Row="0" Spacing="8" Margin="10,10,10,5">
+            <Button Text="Events"
+                    Command="{Binding ToggleEventsCommand}"
+                    Style="{StaticResource PrimarySmallButton}" />
+            <Button Text="Litter Reports"
+                    Command="{Binding ToggleLitterReportsCommand}"
+                    Style="{StaticResource SecondarySmallButton}" />
+        </HorizontalStackLayout>
+
+        <!-- Filter Bar -->
+        <Grid Grid.Row="1" ColumnDefinitions="*, *, *, Auto" Margin="5,0">
+            <controls:TMPicker Grid.Column="0" Title="Country"
+                               ItemsSource="{Binding CountryCollection}"
+                               SelectedItem="{Binding SelectedCountry, Mode=TwoWay}" />
+            <controls:TMPicker Grid.Column="1" Title="Region"
+                               ItemsSource="{Binding RegionCollection}"
+                               SelectedItem="{Binding SelectedRegion, Mode=TwoWay}" />
+            <controls:TMPicker Grid.Column="2" Title="City"
+                               ItemsSource="{Binding CityCollection}"
+                               SelectedItem="{Binding SelectedCity, Mode=TwoWay}" />
+            <ImageButton Grid.Column="3"
+                         HeightRequest="24"
+                         WidthRequest="24"
+                         Command="{Binding ClearSelectionsCommand}"
+                         Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconClose}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+        </Grid>
+
+        <!-- Map/List Toggle -->
+        <Grid Grid.Row="2" ColumnDefinitions="6*, *, *" Margin="5">
+            <Label Grid.Column="0" />
+            <ImageButton Grid.Column="1"
+                         HeightRequest="24"
+                         Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
+                         Command="{Binding MapSelectedCommand}" />
+            <ImageButton Grid.Column="2"
+                         HeightRequest="24"
+                         Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
+                         Command="{Binding ListSelectedCommand}" />
+        </Grid>
+
+        <!-- Map View -->
+        <controls:CustomMap Grid.Row="3"
+                            x:Name="exploreMap"
+                            ItemsSource="{Binding Addresses}"
+                            IsVisible="{Binding IsMapSelected}">
+            <maps:Map.ItemTemplate>
+                <DataTemplate x:DataType="viewModels:AddressViewModel">
+                    <controls:CustomPin Location="{Binding Location}"
+                                        Address="{Binding StreetAddress}"
+                                        Label="{Binding DisplayName}"
+                                        AutomationId="{Binding AutomationId}"
+                                        ImageSource="{Binding IconFile}"
+                                        InfoWindowClicked="Pin_InfoWindowClicked" />
+                </DataTemplate>
+            </maps:Map.ItemTemplate>
+        </controls:CustomMap>
+
+        <!-- List View -->
+        <ScrollView Grid.Row="3" IsVisible="{Binding IsListSelected}">
+            <VerticalStackLayout>
+                <Label Text="No results found"
+                       IsVisible="{Binding AreNoItemsFound}"
+                       FontSize="Small"
+                       Margin="10,20"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                <!-- Events List -->
+                <VerticalStackLayout IsVisible="{Binding ShowEvents}">
+                    <Label Text="Events"
+                           FontFamily="LexendSemibold"
+                           FontSize="Small"
+                           Margin="10,10,10,5"
+                           IsVisible="{Binding ShowLitterReports}" />
+                    <CollectionView ItemsSource="{Binding Events}"
+                                    SelectionMode="None">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:EventViewModel">
+                                <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                    <VerticalStackLayout Padding="10,8" Spacing="2">
+                                        <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                        <Label Text="{Binding DisplayDate}" FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ExploreViewModel}}, Path=ViewEventCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    </Border.GestureRecognizers>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+
+                <!-- Litter Reports List -->
+                <VerticalStackLayout IsVisible="{Binding ShowLitterReports}">
+                    <Label Text="Litter Reports"
+                           FontFamily="LexendSemibold"
+                           FontSize="Small"
+                           Margin="10,10,10,5"
+                           IsVisible="{Binding ShowEvents}" />
+                    <CollectionView ItemsSource="{Binding LitterReports}"
+                                    SelectionMode="None">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterReportViewModel">
+                                <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                    <VerticalStackLayout Padding="10,8" Spacing="2">
+                                        <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                        <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding Description}" FontSize="Micro" MaxLines="2"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ExploreViewModel}}, Path=ViewLitterReportCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    </Border.GestureRecognizers>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </VerticalStackLayout>
+        </ScrollView>
+
+        <!-- Loading Overlay -->
+        <BoxView Grid.Row="3"
+                 BackgroundColor="{StaticResource TransparentBlack}"
+                 IsVisible="{Binding IsBusy}" />
+        <ActivityIndicator Grid.Row="3"
+                           IsRunning="{Binding IsBusy}"
+                           IsVisible="{Binding IsBusy}"
+                           VerticalOptions="Center"
+                           HorizontalOptions="Center" />
+    </Grid>
+</ContentPage>

--- a/TrashMobMobile/Pages/ExplorePage.xaml.cs
+++ b/TrashMobMobile/Pages/ExplorePage.xaml.cs
@@ -1,0 +1,53 @@
+namespace TrashMobMobile.Pages;
+
+using Microsoft.Maui.Controls.Maps;
+
+public partial class ExplorePage : ContentPage
+{
+    private readonly ExploreViewModel viewModel;
+
+    public ExplorePage(ExploreViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        BindingContext = this.viewModel;
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init();
+    }
+
+    private async void Pin_InfoWindowClicked(object? sender, PinClickedEventArgs e)
+    {
+        if (sender is not Pin p)
+        {
+            return;
+        }
+
+        var automationId = p.AutomationId;
+        if (string.IsNullOrEmpty(automationId))
+        {
+            return;
+        }
+
+        var parts = automationId.Split(':');
+        if (parts.Length < 2)
+        {
+            return;
+        }
+
+        var type = parts[0];
+        var id = parts[1];
+
+        if (type == "Event")
+        {
+            await Shell.Current.GoToAsync($"{nameof(ViewEventPage)}?EventId={id}");
+        }
+        else if (type == "LitterImage")
+        {
+            await Shell.Current.GoToAsync($"{nameof(ViewLitterReportPage)}?LitterReportId={id}");
+        }
+    }
+}

--- a/TrashMobMobile/ViewModels/ExploreViewModel.cs
+++ b/TrashMobMobile/ViewModels/ExploreViewModel.cs
@@ -1,0 +1,333 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Extensions;
+using TrashMobMobile.Services;
+
+public partial class ExploreViewModel(
+    IMobEventManager mobEventManager,
+    ILitterReportManager litterReportManager,
+    INotificationService notificationService,
+    IUserManager userManager) : BaseViewModel(notificationService)
+{
+    private readonly IMobEventManager mobEventManager = mobEventManager;
+    private readonly ILitterReportManager litterReportManager = litterReportManager;
+    private readonly IUserManager userManager = userManager;
+
+    private IEnumerable<TrashMob.Models.Poco.Location> locations = [];
+    private IEnumerable<Event> allEvents = [];
+    private IEnumerable<Event> rawEvents = [];
+
+    private string? selectedCity;
+    private string? selectedCountry;
+    private string? selectedRegion;
+
+    [ObservableProperty]
+    private AddressViewModel userLocation = new();
+
+    [ObservableProperty]
+    private bool isMapSelected;
+
+    [ObservableProperty]
+    private bool isListSelected;
+
+    [ObservableProperty]
+    private bool showEvents = true;
+
+    [ObservableProperty]
+    private bool showLitterReports = true;
+
+    [ObservableProperty]
+    private bool areItemsFound;
+
+    [ObservableProperty]
+    private bool areNoItemsFound;
+
+    public ObservableCollection<EventViewModel> Events { get; } = [];
+
+    public ObservableCollection<LitterReportViewModel> LitterReports { get; } = [];
+
+    public ObservableCollection<AddressViewModel> Addresses { get; } = [];
+
+    public ObservableCollection<string> CountryCollection { get; } = [];
+
+    public ObservableCollection<string> RegionCollection { get; } = [];
+
+    public ObservableCollection<string> CityCollection { get; } = [];
+
+    public string? SelectedCountry
+    {
+        get => selectedCountry;
+        set
+        {
+            selectedCountry = value;
+            OnPropertyChanged();
+            HandleCountrySelected();
+        }
+    }
+
+    public string? SelectedRegion
+    {
+        get => selectedRegion;
+        set
+        {
+            selectedRegion = value;
+            OnPropertyChanged();
+            HandleRegionSelected();
+        }
+    }
+
+    public string? SelectedCity
+    {
+        get => selectedCity;
+        set
+        {
+            selectedCity = value;
+            OnPropertyChanged();
+            RebuildAddresses();
+        }
+    }
+
+    public async Task Init()
+    {
+        await ExecuteAsync(async () =>
+        {
+            IsMapSelected = true;
+            IsListSelected = false;
+            UserLocation = userManager.CurrentUser.GetAddress();
+
+            await Task.WhenAll(
+                RefreshEvents(),
+                RefreshLitterReports());
+
+            RebuildAddresses();
+        }, "Failed to load explore data. Please try again.");
+    }
+
+    [RelayCommand]
+    private Task MapSelected()
+    {
+        IsMapSelected = true;
+        IsListSelected = false;
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private Task ListSelected()
+    {
+        IsMapSelected = false;
+        IsListSelected = true;
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private void ToggleEvents()
+    {
+        ShowEvents = !ShowEvents;
+        RebuildAddresses();
+    }
+
+    [RelayCommand]
+    private void ToggleLitterReports()
+    {
+        ShowLitterReports = !ShowLitterReports;
+        RebuildAddresses();
+    }
+
+    [RelayCommand]
+    private async Task ViewEvent(EventViewModel? eventVm)
+    {
+        if (eventVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewEventPage)}?EventId={eventVm.Id}");
+    }
+
+    [RelayCommand]
+    private async Task ViewLitterReport(LitterReportViewModel? reportVm)
+    {
+        if (reportVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewLitterReportPage)}?LitterReportId={reportVm.Id}");
+    }
+
+    [RelayCommand]
+    private async Task ClearSelections()
+    {
+        IsBusy = true;
+
+        SelectedCountry = null;
+        SelectedRegion = null;
+        SelectedCity = null;
+
+        await Task.WhenAll(
+            RefreshEvents(),
+            RefreshLitterReports());
+
+        RebuildAddresses();
+
+        IsBusy = false;
+    }
+
+    private async Task RefreshEvents()
+    {
+        var startDate = DateTimeOffset.UtcNow;
+        var endDate = DateTimeOffset.UtcNow.AddMonths(3);
+
+        locations = await mobEventManager.GetLocationsByTimeRangeAsync(startDate, endDate);
+
+        CountryCollection.Clear();
+        RegionCollection.Clear();
+        CityCollection.Clear();
+
+        if (locations != null && locations.Any())
+        {
+            foreach (var country in locations.Select(l => l.Country).Distinct())
+            {
+                if (!string.IsNullOrEmpty(country))
+                {
+                    CountryCollection.Add(country);
+                }
+            }
+        }
+
+        var eventFilter = new EventFilter
+        {
+            StartDate = startDate,
+            EndDate = endDate,
+            PageIndex = 0,
+            PageSize = 100,
+        };
+
+        var events = await mobEventManager.GetFilteredEventsAsync(eventFilter);
+        allEvents = events.Where(e => !e.IsCompleted()).ToList();
+        rawEvents = allEvents;
+
+        Events.Clear();
+        foreach (var mobEvent in rawEvents.OrderBy(e => e.EventDate))
+        {
+            Events.Add(mobEvent.ToEventViewModel(userManager.CurrentUser.Id));
+        }
+    }
+
+    private async Task RefreshLitterReports()
+    {
+        var filter = new LitterReportFilter
+        {
+            StartDate = DateTimeOffset.UtcNow.AddMonths(-6),
+            EndDate = DateTimeOffset.UtcNow,
+        };
+
+        var reports = await litterReportManager.GetLitterReportsAsync(filter, ImageSizeEnum.Thumb, true);
+
+        LitterReports.Clear();
+        foreach (var report in reports.OrderByDescending(r => r.CreatedDate))
+        {
+            LitterReports.Add(report.ToLitterReportViewModel(NotificationService));
+        }
+    }
+
+    private void RebuildAddresses()
+    {
+        Addresses.Clear();
+
+        if (ShowEvents)
+        {
+            IEnumerable<Event> filtered = allEvents;
+
+            if (!string.IsNullOrEmpty(selectedCountry))
+            {
+                filtered = filtered.Where(e => e.Country == selectedCountry);
+            }
+
+            if (!string.IsNullOrEmpty(selectedRegion))
+            {
+                filtered = filtered.Where(e => e.Region == selectedRegion);
+            }
+
+            if (!string.IsNullOrEmpty(selectedCity))
+            {
+                filtered = filtered.Where(e => e.City == selectedCity);
+            }
+
+            rawEvents = filtered;
+
+            Events.Clear();
+            foreach (var mobEvent in rawEvents.OrderBy(e => e.EventDate))
+            {
+                var vm = mobEvent.ToEventViewModel(userManager.CurrentUser.Id);
+                Events.Add(vm);
+                Addresses.Add(vm.Address);
+            }
+        }
+
+        if (ShowLitterReports)
+        {
+            foreach (var report in LitterReports)
+            {
+                foreach (var image in report.LitterImageViewModels)
+                {
+                    Addresses.Add(image.Address);
+                }
+            }
+        }
+
+        AreItemsFound = Addresses.Count > 0;
+        AreNoItemsFound = !AreItemsFound;
+    }
+
+    private void HandleCountrySelected()
+    {
+        selectedRegion = null;
+        OnPropertyChanged(nameof(SelectedRegion));
+        selectedCity = null;
+        OnPropertyChanged(nameof(SelectedCity));
+
+        RegionCollection.Clear();
+
+        if (locations != null && !string.IsNullOrEmpty(selectedCountry))
+        {
+            foreach (var region in locations.Where(l => l.Country == selectedCountry).Select(l => l.Region).Distinct())
+            {
+                if (!string.IsNullOrEmpty(region))
+                {
+                    RegionCollection.Add(region);
+                }
+            }
+        }
+
+        RebuildAddresses();
+    }
+
+    private void HandleRegionSelected()
+    {
+        selectedCity = null;
+        OnPropertyChanged(nameof(SelectedCity));
+
+        CityCollection.Clear();
+
+        if (locations != null && !string.IsNullOrEmpty(selectedCountry) && !string.IsNullOrEmpty(selectedRegion))
+        {
+            foreach (var city in locations.Where(l => l.Country == selectedCountry && l.Region == selectedRegion).Select(l => l.City).Distinct())
+            {
+                if (!string.IsNullOrEmpty(city))
+                {
+                    CityCollection.Add(city);
+                }
+            }
+        }
+
+        RebuildAddresses();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ExplorePage` that combines events and litter report pins on a single map
- Create `ExploreViewModel` with toggleable event/litter report layers (`ShowEvents`, `ShowLitterReports`)
- Cascading country/region/city filters for event discovery
- Map/list view toggle with tap-to-navigate on both views
- Pin click handler parses `AutomationId` format (`Event:id` / `LitterImage:id`) for type-differentiated navigation
- This is **Phase 4 PR 4 of 6** for the mobile navigation redesign

## Context
Part of the Navigation Redesign (Phase 4 of the Mobile App Master Plan). The ExplorePage will become the "Explore" tab in the final 5-tab layout (PR 6), replacing SearchEventsPage as the primary map-based discovery interface.

## Test plan
- [x] `dotnet build TrashMobMobile/TrashMobMobile.csproj -f net10.0-android` builds successfully
- [ ] Navigate to ExplorePage and verify map loads with event and litter report pins
- [ ] Toggle Events layer on/off and verify pins update
- [ ] Toggle Litter Reports layer on/off and verify pins update
- [ ] Test cascading filters (select country → regions populate, select region → cities populate)
- [ ] Tap event pin → navigates to ViewEventPage
- [ ] Tap litter report pin → navigates to ViewLitterReportPage
- [ ] Switch to list view and tap items for navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)