### PR TITLE
Add HomeFeedPage with upcoming events and litter reports feed

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -12,6 +12,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(CreateEventPage), typeof(CreateEventPage));
         Routing.RegisterRoute(nameof(CreateLitterReportPage), typeof(CreateLitterReportPage));
         Routing.RegisterRoute(nameof(EditEventPage), typeof(EditEventPage));
+        Routing.RegisterRoute(nameof(HomeFeedPage), typeof(HomeFeedPage));
         Routing.RegisterRoute(nameof(EditEventPartnerLocationServicesPage),
             typeof(EditEventPartnerLocationServicesPage));
         Routing.RegisterRoute(nameof(EditEventSummaryPage), typeof(EditEventSummaryPage));

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -66,6 +66,7 @@ public static class MauiProgram
         builder.Services.AddTransient<CreateEventPage>();
         builder.Services.AddTransient<CreateLitterReportPage>();
         builder.Services.AddTransient<EditEventPage>();
+        builder.Services.AddTransient<HomeFeedPage>();
         builder.Services.AddTransient<EditEventPartnerLocationServicesPage>();
         builder.Services.AddTransient<EditEventSummaryPage>();
         builder.Services.AddTransient<EditLitterReportPage>();
@@ -96,6 +97,7 @@ public static class MauiProgram
         builder.Services.AddTransient<EditLitterReportViewModel>();
         builder.Services.AddTransient<EditPickupLocationViewModel>();
         builder.Services.AddTransient<EventSummaryViewModel>();
+        builder.Services.AddTransient<HomeFeedViewModel>();
         builder.Services.AddTransient<LogoutViewModel>();
         builder.Services.AddTransient<MainViewModel>();
         builder.Services.AddTransient<ManageEventPartnersViewModel>();

--- a/TrashMobMobile/Pages/HomeFeedPage.xaml
+++ b/TrashMobMobile/Pages/HomeFeedPage.xaml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:HomeFeedViewModel"
+             x:Class="TrashMobMobile.Pages.HomeFeedPage"
+             Title="Home">
+
+    <RefreshView Command="{Binding RefreshCommand}" IsRefreshing="{Binding IsBusy}">
+        <ScrollView>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+
+                <!-- Welcome Header -->
+                <Label Text="{Binding WelcomeMessage}"
+                       FontFamily="LexendSemibold"
+                       FontSize="Title"
+                       Margin="10,15,10,5" />
+
+                <!-- Upcoming Events Near You -->
+                <Label Text="Upcoming Events"
+                       FontFamily="LexendSemibold"
+                       FontSize="Medium"
+                       Margin="10,15,10,5" />
+
+                <Label Text="No upcoming events found"
+                       IsVisible="{Binding AreNoEventsFound}"
+                       FontSize="Small"
+                       Margin="10,5"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                <CollectionView ItemsSource="{Binding UpcomingEvents}"
+                                SelectionMode="None"
+                                IsVisible="{Binding AreEventsFound}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
+                            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                <Grid ColumnDefinitions="*, Auto" Padding="10,10">
+                                    <VerticalStackLayout Grid.Column="0" Spacing="4">
+                                        <Label Text="{Binding Name}"
+                                               FontFamily="LexendSemibold"
+                                               FontSize="Small" />
+                                        <HorizontalStackLayout Spacing="8">
+                                            <Image MaximumWidthRequest="16" MaximumHeightRequest="16">
+                                                <Image.Source>
+                                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                                     Glyph="{StaticResource IconCalendarCheck}"
+                                                                     Size="16"
+                                                                     Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                                </Image.Source>
+                                            </Image>
+                                            <Label Text="{Binding DisplayDate}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </HorizontalStackLayout>
+                                        <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:HomeFeedViewModel}}, Path=ViewEventCommand}"
+                                        CommandParameter="{Binding .}" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <!-- Nearby Litter Reports -->
+                <Label Text="Recent Litter Reports"
+                       FontFamily="LexendSemibold"
+                       FontSize="Medium"
+                       Margin="10,15,10,5" />
+
+                <Label Text="No recent litter reports"
+                       IsVisible="{Binding AreNoLitterReportsFound}"
+                       FontSize="Small"
+                       Margin="10,5"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                <CollectionView ItemsSource="{Binding NearbyLitterReports}"
+                                SelectionMode="None"
+                                IsVisible="{Binding AreLitterReportsFound}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:LitterReportViewModel">
+                            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                <VerticalStackLayout Padding="10,8" Spacing="2">
+                                    <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                    <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    <Label Text="{Binding Description}" FontSize="Micro" MaxLines="2"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:HomeFeedViewModel}}, Path=ViewLitterReportCommand}"
+                                        CommandParameter="{Binding .}" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+</ContentPage>

--- a/TrashMobMobile/Pages/HomeFeedPage.xaml.cs
+++ b/TrashMobMobile/Pages/HomeFeedPage.xaml.cs
@@ -1,0 +1,19 @@
+namespace TrashMobMobile.Pages;
+
+public partial class HomeFeedPage : ContentPage
+{
+    private readonly HomeFeedViewModel viewModel;
+
+    public HomeFeedPage(HomeFeedViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        BindingContext = this.viewModel;
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init();
+    }
+}

--- a/TrashMobMobile/ViewModels/HomeFeedViewModel.cs
+++ b/TrashMobMobile/ViewModels/HomeFeedViewModel.cs
@@ -1,0 +1,124 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Extensions;
+using TrashMobMobile.Services;
+
+public partial class HomeFeedViewModel(
+    IMobEventManager mobEventManager,
+    ILitterReportManager litterReportManager,
+    INotificationService notificationService,
+    IUserManager userManager) : BaseViewModel(notificationService)
+{
+    private readonly IMobEventManager mobEventManager = mobEventManager;
+    private readonly ILitterReportManager litterReportManager = litterReportManager;
+    private readonly IUserManager userManager = userManager;
+
+    [ObservableProperty]
+    private string welcomeMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool areEventsFound;
+
+    [ObservableProperty]
+    private bool areNoEventsFound = true;
+
+    [ObservableProperty]
+    private bool areLitterReportsFound;
+
+    [ObservableProperty]
+    private bool areNoLitterReportsFound = true;
+
+    public ObservableCollection<EventViewModel> UpcomingEvents { get; } = [];
+
+    public ObservableCollection<LitterReportViewModel> NearbyLitterReports { get; } = [];
+
+    public async Task Init()
+    {
+        await ExecuteAsync(async () =>
+        {
+            var user = userManager.CurrentUser;
+            WelcomeMessage = $"Welcome, {user.UserName}!";
+
+            await Task.WhenAll(
+                RefreshUpcomingEvents(),
+                RefreshNearbyLitterReports());
+        }, "Failed to load feed. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task Refresh()
+    {
+        await Init();
+    }
+
+    [RelayCommand]
+    private async Task ViewEvent(EventViewModel? eventVm)
+    {
+        if (eventVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewEventPage)}?EventId={eventVm.Id}");
+    }
+
+    [RelayCommand]
+    private async Task ViewLitterReport(LitterReportViewModel? reportVm)
+    {
+        if (reportVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewLitterReportPage)}?LitterReportId={reportVm.Id}");
+    }
+
+    private async Task RefreshUpcomingEvents()
+    {
+        var filter = new EventFilter
+        {
+            StartDate = DateTimeOffset.UtcNow,
+            EndDate = DateTimeOffset.UtcNow.AddMonths(3),
+            PageIndex = 0,
+            PageSize = 20,
+        };
+
+        var events = await mobEventManager.GetFilteredEventsAsync(filter);
+
+        UpcomingEvents.Clear();
+        foreach (var mobEvent in events.Where(e => !e.IsCompleted()).OrderBy(e => e.EventDate).Take(10))
+        {
+            UpcomingEvents.Add(mobEvent.ToEventViewModel(userManager.CurrentUser.Id));
+        }
+
+        AreEventsFound = UpcomingEvents.Count > 0;
+        AreNoEventsFound = !AreEventsFound;
+    }
+
+    private async Task RefreshNearbyLitterReports()
+    {
+        var filter = new LitterReportFilter
+        {
+            StartDate = DateTimeOffset.UtcNow.AddMonths(-3),
+            EndDate = DateTimeOffset.UtcNow,
+        };
+
+        var reports = await litterReportManager.GetLitterReportsAsync(filter, ImageSizeEnum.Thumb, true);
+
+        NearbyLitterReports.Clear();
+        foreach (var report in reports.OrderByDescending(r => r.CreatedDate).Take(5))
+        {
+            NearbyLitterReports.Add(report.ToLitterReportViewModel(NotificationService));
+        }
+
+        AreLitterReportsFound = NearbyLitterReports.Count > 0;
+        AreNoLitterReportsFound = !AreLitterReportsFound;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HomeFeedPage` — a simplified feed showing a welcome header, upcoming events, and recent litter reports
- Create `HomeFeedViewModel` loading upcoming events (next 3 months, top 10) and recent litter reports (last 3 months, top 5)
- Pull-to-refresh support via `RefreshView` binding
- No map, stats, or action buttons (those move to Explore, Impact, and FAB tabs)
- This is **Phase 4 PR 5 of 6** for the mobile navigation redesign

## Context
Part of the Navigation Redesign (Phase 4 of the Mobile App Master Plan). The HomeFeedPage will become the "Home" tab in the final 5-tab layout (PR 6), replacing the overloaded MainPage as the landing screen.

## Test plan
- [x] `dotnet build TrashMobMobile/TrashMobMobile.csproj -f net10.0-android` builds successfully
- [ ] Navigate to HomeFeedPage and verify welcome message shows user name
- [ ] Verify upcoming events list loads and displays event cards
- [ ] Tap an event card to navigate to ViewEventPage
- [ ] Verify recent litter reports load
- [ ] Pull down to refresh and verify data reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)