### PR TITLE
Add sponsored adoptions project and update regional communities plan

### DIFF
--- a/Planning/Projects/Project_39_Regional_Communities.md
+++ b/Planning/Projects/Project_39_Regional_Communities.md
@@ -12,14 +12,13 @@
 
 ## Business Rationale
 
-Enable larger government entities (states, provinces, regions) with existing Adopt-a-Highway or similar programs to leverage TrashMob for volunteer coordination. Many state DOTs and regional authorities already have established cleanup programs but lack modern volunteer management tools. This extends the Communities feature to support non-city-based partners, opening TrashMob to a much larger potential user base.
+Enable larger government entities (counties, states, provinces, regions) with existing Adopt-a-Highway or similar programs to leverage TrashMob for volunteer coordination. Many county governments, state DOTs, and regional authorities already have established cleanup and adoption programs but lack modern volunteer management tools. This extends the Communities feature to support non-city-based partners — particularly counties and states — opening TrashMob to a much larger potential user base.
 
 **Example Use Cases:**
-- Minnesota DOT's Adopt-a-Highway program
-- California Coastal Commission cleanup programs
-- Regional watershed authorities
-- State park systems
-- Multi-county environmental districts
+- **Counties:** King County (WA) road adoption program, Hennepin County (MN) park cleanups, Maricopa County (AZ) litter prevention
+- **States:** Minnesota DOT's Adopt-a-Highway program, California Coastal Commission cleanup programs
+- **Regions:** Regional watershed authorities, multi-county environmental districts
+- **Other:** State park systems, county park districts
 
 ---
 
@@ -27,14 +26,16 @@ Enable larger government entities (states, provinces, regions) with existing Ado
 
 ### Primary Goals
 - **Support region-based communities** without requiring a specific city
-- **Flexible geographic scoping** (state, province, county, region)
+- **County-level community pages** with their own branding, events, and adoption programs
+- **County and state adoption programs** — counties can manage Adopt-a-Road, Adopt-a-Park, and similar programs through their community page
+- **Flexible geographic scoping** (county, state, province, region)
 - **Adapted map views** that center on larger geographic areas
-- **Simplified slugs** like `/communities/minnesota` or `/communities/california-coastal`
+- **Simplified slugs** like `/communities/king-county-wa` or `/communities/minnesota`
 
 ### Secondary Goals
-- Sub-region organization (counties within a state program)
-- Integration with existing government volunteer systems
-- Bulk event import from existing programs
+- Sub-region organization (counties within a state program, or cities within a county)
+- Integration with existing government volunteer systems (county public works, state DOTs)
+- Bulk event import from existing county/state programs
 - Custom branding for government partners
 
 ---
@@ -44,26 +45,31 @@ Enable larger government entities (states, provinces, regions) with existing Ado
 ### Phase 1 - Data Model & API
 - [ ] Make Partner.City optional (nullable)
 - [ ] Add Partner.RegionType enum (City, County, State, Province, Region, Country)
+- [ ] Add Partner.CountyName field for county-level communities
 - [ ] Add Partner.GeoBounds field (bounding box for map centering)
 - [ ] Add Partner.CenterLatitude/CenterLongitude for map default position
-- [ ] Update Partner validation to require either City OR RegionType
-- [ ] Update community slug generation to handle region-only partners
+- [ ] Update Partner validation to require either City OR RegionType (County/State/etc.)
+- [ ] Update community slug generation to handle county and region partners
+- [ ] Extend Adopt-a-Location to support county-scoped adoption areas (roads, parks, trails)
 
-### Phase 2 - Map Enhancements
+### Phase 2 - County & State Community Pages
+- [ ] Update community page to display county/region name instead of city
+- [ ] Allow counties to list adoptable locations within their boundaries
+- [ ] County adoption dashboard — manage adopted segments, track volunteer compliance
+- [ ] Adapt "Events near [location]" messaging for counties and regions
+- [ ] Update partner registration flow with county/region selection
+- [ ] Add county/region search and filter on community discovery page
+
+### Phase 3 - Map Enhancements
 - [ ] Calculate appropriate zoom level based on RegionType
 - [ ] Center map on GeoBounds or Center coordinates
 - [ ] Show events within geographic bounds (not just city radius)
-- [ ] Update event filtering to work with regional boundaries
-
-### Phase 3 - UI Updates
-- [ ] Update community page to display region name instead of city
-- [ ] Adapt "Events near [location]" messaging for regions
-- [ ] Update partner registration flow to allow region selection
-- [ ] Add region search/filter on community discovery page
+- [ ] Update event filtering to work with county/regional boundaries
+- [ ] Show adoptable locations on county community map
 
 ### Phase 4 - Sub-Regions (Future)
-- [ ] Parent/child relationship for communities (e.g., Minnesota -> Hennepin County)
-- [ ] Hierarchical event aggregation
+- [ ] Parent/child relationship for communities (e.g., Minnesota -> Hennepin County -> City of Minneapolis)
+- [ ] Hierarchical event aggregation (county rolls up to state)
 - [ ] Delegated administration for sub-regions
 
 ---
@@ -81,14 +87,16 @@ Enable larger government entities (states, provinces, regions) with existing Ado
 ## Success Metrics
 
 ### Quantitative
-- **Regional partners onboarded:** >= 5 state-level programs in first year
+- **County partners onboarded:** >= 10 county programs in first year
+- **State/regional partners onboarded:** >= 5 state-level programs in first year
+- **Adoption programs created:** >= 15 county/state adoption programs in first year
 - **Events created under regional programs:** >= 100 in first 6 months
 - **Volunteer reach expansion:** 25% increase in geographic coverage
 
 ### Qualitative
-- Government partners find the platform easy to use
-- No confusion between city-based and region-based communities
-- Seamless experience for volunteers in regional programs
+- County and state partners find the platform easy to use
+- No confusion between city-based, county-based, and region-based communities
+- Seamless experience for volunteers in county/regional adoption programs
 
 ---
 
@@ -99,7 +107,9 @@ Enable larger government entities (states, provinces, regions) with existing Ado
 - **Project 11 (Adopt-A-Location):** Location infrastructure needed (currently complete)
 
 ### Enables
+- County government partnerships (public works, parks departments)
 - State DOT partnerships
+- County and state adoption programs (Adopt-a-Road, Adopt-a-Park)
 - Large-scale environmental programs
 - Government grant applications requiring volunteer management
 
@@ -154,22 +164,31 @@ public enum RegionType
 
 **Slug Generation:**
 - City-based: `/communities/{state}-{city}` (e.g., `/communities/wa-seattle`)
-- Region-based: `/communities/{region}` (e.g., `/communities/minnesota`)
+- County-based: `/communities/{county}-{state}` (e.g., `/communities/king-county-wa`)
+- State/Region-based: `/communities/{region}` (e.g., `/communities/minnesota`)
 
 **Event Filtering:**
 - For city communities: filter by radius from city center
-- For regional communities: filter by bounding box or state/region field
+- For county communities: filter by county bounding box
+- For state/regional communities: filter by bounding box or state/region field
+
+**Adoption Programs:**
+- Counties can create adoptable locations (road segments, parks, trails) within their bounds
+- Volunteers/teams claim adoptable locations through the county community page
+- County admins manage adoption compliance (cleanup frequency, reporting)
 
 ### Web UX Changes
 
 **Community Page:**
-- Display region name prominently when RegionType is not City
-- Adjust "X events in [location]" to show region name
+- Display county/region name prominently when RegionType is not City
+- Adjust "X events in [location]" to show county/region name
 - Map initializes at appropriate zoom level for region size
+- County pages show an "Adopt a Location" section listing available segments
 
 **Partner Registration:**
-- Step to choose "City-based" or "Regional" community
-- For regional: dropdown for RegionType, text field for region name
+- Step to choose community scope: City, County, State/Province, or Region
+- For county: state selector + county name, with optional bounding box
+- For state/region: dropdown for RegionType, text field for region name
 - Optional: map tool to define custom bounding box
 
 ### Mobile App Changes
@@ -199,15 +218,20 @@ public enum RegionType
    **Owner:** Product
    **Due:** Before Phase 2
 
-2. **Should regional communities require government verification?**
+2. **Should county/regional communities require government verification?**
    **Recommendation:** Yes, add verification flag and manual approval for RegionType >= County
    **Owner:** Product + Legal
    **Due:** Before launch
 
-3. **How do we prevent slug conflicts (e.g., "minnesota" city vs state)?**
-   **Recommendation:** Region-based slugs use state abbreviation prefix: `/communities/mn` for state, `/communities/mn-minnesota` if there's a city named Minnesota
+3. **How do we prevent slug conflicts (e.g., "minnesota" city vs state, or multiple "Washington County" in different states)?**
+   **Recommendation:** County slugs include state abbreviation: `/communities/king-county-wa`. State slugs use abbreviation: `/communities/mn`.
    **Owner:** Engineering
    **Due:** Phase 1
+
+5. **Can counties define custom adoption zones or do they use pre-set boundaries?**
+   **Recommendation:** Start with county bounding boxes from census data; allow manual adjustment. Custom polygon boundaries deferred to v2.
+   **Owner:** Engineering
+   **Due:** Phase 2
 
 4. **Should we support custom polygon boundaries?**
    **Recommendation:** Not for v1; bounding box is sufficient. Add polygon support if needed for coastal/watershed programs
@@ -224,7 +248,7 @@ public enum RegionType
 
 ---
 
-**Last Updated:** February 3, 2026
+**Last Updated:** February 8, 2026
 **Owner:** Product Team
 **Status:** Not Started
 **Next Review:** When government partnership opportunities are identified

--- a/Planning/Projects/Project_41_Sponsored_Adoptions.md
+++ b/Planning/Projects/Project_41_Sponsored_Adoptions.md
@@ -1,0 +1,273 @@
+# Project 41 — Sponsored Adoptions & Professional Cleanup Tracking
+
+| Attribute | Value |
+|-----------|-------|
+| **Status** | Not Started |
+| **Priority** | Medium |
+| **Risk** | Medium |
+| **Size** | Large |
+| **Dependencies** | Project 11 (Adopt-A-Location), Project 39 (Regional Communities) |
+
+---
+
+## Business Rationale
+
+Many adoption programs (Adopt-a-Highway, Adopt-a-Road, etc.) allow businesses or individuals to **sponsor** a segment by paying a fee. The sponsor's name goes on the sign, but the actual cleanup work is performed by a **professional third-party company** hired by the community or the sponsor — not by volunteers. Currently, TrashMob only models volunteer-based adoption where the adopting team does the cleanup work themselves.
+
+Communities (especially counties and states) need TrashMob to track both models side-by-side:
+- **Volunteer adoptions** — teams adopt an area and do the cleanup themselves (existing model)
+- **Sponsored adoptions** — a sponsor pays for an area and a professional company handles the cleanup
+
+The professional companies need to log their work (pickup dates, weight removed, photos) for compliance tracking, but this work should **not** count toward volunteer leaderboards, impact stats, or gamification — it's paid professional work, not volunteering.
+
+**Example Scenarios:**
+- A local car dealership sponsors a 2-mile highway segment; a professional litter service cleans it monthly
+- A county's Adopt-a-Road program has 40% sponsor-funded segments and 60% volunteer segments
+- A state DOT contracts with three cleanup companies and needs to track which segments each company services
+- A sponsor wants to see reports showing their adopted segment is being maintained
+
+---
+
+## Objectives
+
+### Primary Goals
+- **Track sponsored adoptions** separately from volunteer adoptions
+- **Professional company accounts** — companies can log cleanup activity on their assigned segments
+- **Compliance tracking** — communities verify that professional companies are meeting cleanup schedules
+- **Exclude from volunteer metrics** — sponsored/professional work does not appear on leaderboards, volunteer stats, or gamification
+- **Sponsor visibility** — sponsors see reports on their adopted segments
+
+### Secondary Goals
+- Invoice/payment tracking for sponsor fees (or integration point for external billing)
+- Sponsor recognition on community pages (logo, name on map)
+- Professional company performance dashboards
+- Contract management (company ↔ community agreements)
+
+---
+
+## Scope
+
+### Phase 1 — Data Model & Roles
+
+- [ ] Add `AdoptionType` enum: `Volunteer`, `Sponsored`
+- [ ] Add `Sponsor` entity (name, contact, logo, linked adoptable areas)
+- [ ] Add `ProfessionalCompany` entity (name, contact, assigned segments)
+- [ ] Add `ProfessionalCleanupLog` entity (date, segment, company, weight collected, bags, duration, photos, notes)
+- [ ] New role: **Professional Company User** — can log cleanup activity on assigned segments only
+- [ ] New role: **Sponsor Viewer** — read-only access to reports for their sponsored segments
+- [ ] Flag on adoption records: `isSponsoredAdoption` to distinguish from volunteer adoptions
+- [ ] Ensure professional cleanup logs are excluded from volunteer stats aggregation (StatsData, leaderboards, SiteMetrics)
+
+### Phase 2 — Community Admin Tools
+
+- [ ] Community admins can mark an adoptable area as "Sponsored"
+- [ ] Assign a sponsor to a sponsored area
+- [ ] Assign a professional company to service sponsored areas
+- [ ] Set cleanup schedule/frequency requirements for professional companies
+- [ ] Compliance dashboard: which sponsored segments are overdue for cleanup
+- [ ] View professional cleanup logs with photos and metrics
+
+### Phase 3 — Professional Company Portal
+
+- [ ] Professional company users can view their assigned segments
+- [ ] Log a cleanup: date, segment, weight collected, bags, duration, before/after photos
+- [ ] View their cleanup history and upcoming schedule
+- [ ] Receive reminders for upcoming scheduled cleanups
+- [ ] Mobile-friendly data entry (companies work in the field)
+
+### Phase 4 — Sponsor Portal
+
+- [ ] Sponsors can view their adopted segments on a map
+- [ ] See cleanup history and compliance status
+- [ ] Download reports (PDF) for their records or marketing
+- [ ] Sponsor recognition on community page (optional, community-controlled)
+
+### Phase 5 — Reporting & Analytics (Future)
+
+- [ ] Community-level report: volunteer vs sponsored adoption breakdown
+- [ ] Cost-per-mile or cost-per-segment analytics for budgeting
+- [ ] Professional company comparison metrics (for communities with multiple contractors)
+- [ ] Annual summary reports for government compliance
+
+---
+
+## Out-of-Scope
+
+- Payment processing (sponsors pay communities directly; TrashMob doesn't handle money)
+- Bidding/procurement workflows for professional company contracts
+- GPS tracking of professional cleanup crews
+- Integration with specific state DOT systems
+- Volunteer-to-sponsor conversion workflows
+
+---
+
+## Key Design Decisions
+
+### Leaderboard & Stats Exclusion
+
+Professional cleanup data is tracked in a separate `ProfessionalCleanupLog` table, not through the existing `EventSummary` pipeline. This provides a clean separation:
+
+| Data Source | Counts Toward Leaderboards | Visible in Stats | Visible in Community Reports |
+|---|---|---|---|
+| Volunteer events/summaries | Yes | Yes | Yes |
+| Professional cleanup logs | **No** | **No** (separate "Sponsored" section) | Yes (labeled as sponsored) |
+
+### Account Types
+
+| Role | Can Log Cleanups | Can View Reports | Can Manage Adoptions | Appears on Leaderboard |
+|---|---|---|---|---|
+| Volunteer/Team | Via events | Own stats | Apply for adoption | Yes |
+| Professional Company User | Via cleanup log | Own assigned segments | No | **No** |
+| Sponsor Viewer | No | Own sponsored segments | No | **No** |
+| Community Admin | No (manages) | All segments | Full control | N/A |
+
+---
+
+## Success Metrics
+
+### Quantitative
+- **Sponsored adoptions tracked:** >= 50 segments in first year
+- **Professional companies onboarded:** >= 10 companies
+- **Compliance logs submitted:** >= 200 cleanup logs in first 6 months
+- **Sponsor satisfaction:** >= 80% find reports useful
+
+### Qualitative
+- Communities can manage mixed volunteer/sponsor programs in a single platform
+- Professional companies find data entry quick and field-friendly
+- No pollution of volunteer stats with professional work
+- Sponsors feel recognized and informed
+
+---
+
+## Dependencies
+
+### Blockers
+- **Project 11 (Adopt-A-Location):** Adoptable area infrastructure (complete)
+- **Project 39 (Regional Communities):** County/state communities that run adoption programs
+
+### Enables
+- Government adoption program partnerships (county/state DOTs)
+- Revenue model for community subscriptions (sponsor management as premium feature)
+- Complete adoption program coverage (volunteer + sponsored)
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| **Data entry burden on companies** | High | Medium | Mobile-optimized quick-log form; minimal required fields |
+| **Sponsors expect payment integration** | Medium | Low | Clear messaging that TrashMob tracks adoption, not payments; provide invoice reference field |
+| **Professional data leaking into volunteer stats** | Low | High | Separate data tables; query-level filtering; automated tests to verify exclusion |
+| **Complex role permissions** | Medium | Medium | Start with simple roles; use existing auth patterns from Partner admin |
+| **Low adoption by professional companies** | Medium | Medium | Make data entry as frictionless as possible; offer email-based log submission |
+
+---
+
+## Implementation Plan
+
+### Data Model
+
+```
+Sponsor
+├── Id (Guid)
+├── Name
+├── ContactEmail
+├── ContactPhone
+├── LogoUrl
+├── CommunityId (FK → Community)
+├── CreatedDate, LastUpdatedDate
+
+ProfessionalCompany
+├── Id (Guid)
+├── Name
+├── ContactEmail
+├── ContactPhone
+├── CommunityId (FK → Community)
+├── CreatedDate, LastUpdatedDate
+
+ProfessionalCompanyUser
+├── UserId (FK → User)
+├── ProfessionalCompanyId (FK → ProfessionalCompany)
+
+SponsoredAdoption
+├── Id (Guid)
+├── AdoptableAreaId (FK → AdoptableArea)
+├── SponsorId (FK → Sponsor)
+├── ProfessionalCompanyId (FK → ProfessionalCompany)
+├── StartDate, EndDate
+├── CleanupFrequencyDays
+├── Status (Active, Expired, Terminated)
+
+ProfessionalCleanupLog
+├── Id (Guid)
+├── SponsoredAdoptionId (FK → SponsoredAdoption)
+├── ProfessionalCompanyId (FK → ProfessionalCompany)
+├── CleanupDate
+├── DurationMinutes
+├── BagsCollected
+├── WeightInPounds
+├── WeightInKilograms
+├── Notes
+├── CreatedByUserId
+├── CreatedDate
+```
+
+### API Endpoints
+
+```
+# Community admin
+POST   /api/communities/{id}/sponsors
+POST   /api/communities/{id}/professional-companies
+POST   /api/communities/{id}/sponsored-adoptions
+GET    /api/communities/{id}/sponsored-adoptions/compliance
+
+# Professional company
+GET    /api/professional-companies/{id}/assignments
+POST   /api/professional-companies/{id}/cleanup-logs
+GET    /api/professional-companies/{id}/cleanup-logs
+
+# Sponsor
+GET    /api/sponsors/{id}/adoptions
+GET    /api/sponsors/{id}/adoptions/{adoptionId}/reports
+```
+
+---
+
+## Open Questions
+
+1. **Should professional companies be able to self-register, or must communities invite them?**
+   **Recommendation:** Community invitation only (maintains trust and control)
+   **Owner:** Product
+   **Due:** Before Phase 2
+
+2. **How do we handle a company that services segments across multiple communities?**
+   **Recommendation:** Company entity is per-community; a real-world company creates separate accounts per community they work with. Revisit if cross-community companies become common.
+   **Owner:** Engineering
+   **Due:** Phase 1
+
+3. **Should sponsor names be visible on the public community map?**
+   **Recommendation:** Community-controlled toggle per sponsored adoption. Default: visible.
+   **Owner:** Product
+   **Due:** Phase 4
+
+4. **Do we need a separate mobile app experience for professional companies?**
+   **Recommendation:** No. Use the web app with a mobile-optimized cleanup log form. Evaluate native app support based on demand.
+   **Owner:** Product
+   **Due:** After Phase 3 launch
+
+---
+
+## Related Documents
+
+- **[Project 11 - Adopt-A-Location](./Project_11_Adopt_A_Location.md)** — Volunteer adoption infrastructure
+- **[Project 39 - Regional Communities](./Project_39_Regional_Communities.md)** — County/state community pages
+- **[Project 10 - Community Pages](./Project_10_Community_Pages.md)** — Base community feature
+- **[Project 20 - Gamification](./Project_20_Gamification.md)** — Leaderboard system (must exclude professional data)
+
+---
+
+**Last Updated:** February 8, 2026
+**Owner:** Product Team
+**Status:** Not Started
+**Next Review:** When county/state adoption partnerships are in progress


### PR DESCRIPTION
## Summary
- **New Project 41: Sponsored Adoptions & Professional Cleanup Tracking** — Tracks sponsor-funded adoptions where professional companies (not volunteers) handle cleanup. Professional cleanup data is stored separately and excluded from volunteer leaderboards, stats, and gamification. Covers data model, roles, community admin tools, company portal, and sponsor reporting across 5 phases.
- **Updated Project 39: Regional Communities** — Added county-level community pages and adoption programs. Counties can now create community pages, manage Adopt-a-Road/Adopt-a-Park programs, and track volunteer compliance through their community page.

## Test plan
- [ ] Review Project 41 for completeness and alignment with adoption program requirements
- [ ] Review Project 39 updates for consistency with existing community/partner architecture
- [ ] Verify no conflicts with other in-progress planning documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)