### PR TITLE
Add professional company portal (Project 41 Phase 3)

### DIFF
--- a/TrashMob/Controllers/ProfessionalCompanyPortalController.cs
+++ b/TrashMob/Controllers/ProfessionalCompanyPortalController.cs
@@ -1,0 +1,47 @@
+namespace TrashMob.Controllers
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// Portal endpoints for professional company users.
+    /// </summary>
+    [Route("api/professional-companies")]
+    [ApiController]
+    public class ProfessionalCompanyPortalController : SecureController
+    {
+        private readonly IProfessionalCompanyUserManager companyUserManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProfessionalCompanyPortalController"/> class.
+        /// </summary>
+        /// <param name="companyUserManager">The professional company user manager.</param>
+        public ProfessionalCompanyPortalController(IProfessionalCompanyUserManager companyUserManager)
+        {
+            this.companyUserManager = companyUserManager;
+        }
+
+        /// <summary>
+        /// Gets all professional companies the authenticated user is assigned to.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("mine")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ProfessionalCompany>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMyCompanies(CancellationToken cancellationToken)
+        {
+            var companies = await companyUserManager.GetCompaniesByUserIdAsync(UserId, cancellationToken);
+            return Ok(companies);
+        }
+    }
+}

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -186,6 +186,20 @@ const PartnerCommunitySponsoredAdoptionEdit = lazy(() =>
     })),
 );
 
+/** Company Dashboard - Lazy loaded (professional company portal) */
+const CompanyDashboardLayout = lazy(() =>
+    import('./pages/companydashboard/$companyId/_layout').then((m) => ({ default: m.CompanyDashboardLayout })),
+);
+const CompanyDashboard = lazy(() =>
+    import('./pages/companydashboard/$companyId').then((m) => ({ default: m.CompanyDashboard })),
+);
+const CompanyLogCleanup = lazy(() =>
+    import('./pages/companydashboard/$companyId/log-cleanup').then((m) => ({ default: m.CompanyLogCleanup })),
+);
+const CompanyCleanupHistory = lazy(() =>
+    import('./pages/companydashboard/$companyId/history').then((m) => ({ default: m.CompanyCleanupHistory })),
+);
+
 /** Partner Dashboard - Lazy loaded (partner admin pages) */
 const PartnerIndex = lazy(() =>
     import('./pages/partnerdashboard/$partnerId').then((m) => ({ default: m.PartnerIndex })),
@@ -509,6 +523,18 @@ const AppContent: FC = () => {
                                         element={<PartnerCommunitySponsoredAdoptionEdit />}
                                     />
                                 </Route>
+                            </Route>
+                            <Route
+                                path='companydashboard/:companyId'
+                                element={
+                                    <Suspense fallback={<LazyLoadingFallback />}>
+                                        <CompanyDashboardLayout />
+                                    </Suspense>
+                                }
+                            >
+                                <Route index element={<CompanyDashboard />} />
+                                <Route path='log-cleanup' element={<CompanyLogCleanup />} />
+                                <Route path='history' element={<CompanyCleanupHistory />} />
                             </Route>
 
                             <Route path='/cancelevent/:eventId' element={<CancelEvent />} />

--- a/TrashMob/client-app/src/components/Models/ProfessionalCleanupLogData.tsx
+++ b/TrashMob/client-app/src/components/Models/ProfessionalCleanupLogData.tsx
@@ -19,6 +19,14 @@ class ProfessionalCleanupLogData {
 
     notes: string = '';
 
+    sponsoredAdoption?: {
+        id: string;
+        adoptableArea?: {
+            id: string;
+            name: string;
+        };
+    };
+
     createdByUserId: string = Guid.EMPTY;
 
     createdDate: Date = new Date();

--- a/TrashMob/client-app/src/pages/MyDashboard/MyCompaniesTable.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyCompaniesTable.tsx
@@ -1,0 +1,56 @@
+import { Link } from 'react-router';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import ProfessionalCompanyData from '@/components/Models/ProfessionalCompanyData';
+import { Ellipsis, Pencil } from 'lucide-react';
+
+type MyCompaniesTableProps = {
+    items: ProfessionalCompanyData[];
+};
+
+export const MyCompaniesTable = ({ items }: MyCompaniesTableProps) => {
+    const headerTitles = ['Company Name', 'Actions'];
+    return (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    {headerTitles.map((header) => (
+                        <TableHead key={header}>{header}</TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {(items || [])
+                    .sort((a, b) => a.name.localeCompare(b.name))
+                    .map((company) => (
+                        <TableRow key={company.id}>
+                            <TableCell>{company.name}</TableCell>
+                            <TableCell className='py-0'>
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button variant='ghost' size='icon'>
+                                            <Ellipsis />
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent className='w-56'>
+                                        <DropdownMenuItem asChild>
+                                            <Link to={`/companydashboard/${company.id}`}>
+                                                <Pencil />
+                                                <span>Manage company</span>
+                                            </Link>
+                                        </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+            </TableBody>
+        </Table>
+    );
+};

--- a/TrashMob/client-app/src/pages/MyDashboard/index.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/index.tsx
@@ -22,6 +22,7 @@ import {
     Handshake,
     ClipboardList,
     Truck,
+    Briefcase,
 } from 'lucide-react';
 import { AxiosResponse } from 'axios';
 
@@ -37,6 +38,7 @@ import DisplayPartnerLocationEventData from '@/components/Models/DisplayPartnerL
 import LitterReportData from '@/components/Models/LitterReportData';
 import { LitterReportStatusEnum } from '@/components/Models/LitterReportStatus';
 import TeamData from '@/components/Models/TeamData';
+import ProfessionalCompanyData from '@/components/Models/ProfessionalCompanyData';
 
 import twofigure from '@/components/assets/card/twofigure.svg';
 import calendarclock from '@/components/assets/card/calendarclock.svg';
@@ -62,6 +64,7 @@ import { GetPartnerAdminInvitationsByUser } from '@/services/invitations';
 import { GetEventPickupLocationsByUser, GetPartnerLocationEventServicesByUserId } from '@/services/locations';
 import { GetUserLitterReports } from '@/services/litter-report';
 import { GetMyTeams, GetTeamsILead } from '@/services/teams';
+import { GetMyCompanies } from '@/services/professional-company-portal';
 
 import { useGetGoogleMapApiKey } from '@/hooks/useGetGoogleMapApiKey';
 import { useGetUserEvents } from '@/hooks/useGetUserEvents';
@@ -78,6 +81,7 @@ import { MyTeamsTable } from '@/pages/MyDashboard/MyTeamsTable';
 import { MyRoutesCard } from '@/pages/MyDashboard/MyRoutesCard';
 import { MyWaiversCard } from '@/pages/MyDashboard/MyWaiversCard';
 import { MyImpactCard } from '@/pages/MyDashboard/MyImpactCard';
+import { MyCompaniesTable } from '@/pages/MyDashboard/MyCompaniesTable';
 import { InviteFriendsCard } from '@/pages/MyDashboard/InviteFriendsCard';
 import { MyNewsletterPreferencesCard } from '@/pages/MyDashboard/MyNewsletterPreferencesCard';
 import { DashboardScrollNav, DashboardNavGroup } from './DashboardScrollNav';
@@ -108,6 +112,7 @@ const SECTION_IDS = [
     'partner-event-requests',
     'pickup-requests',
     'partner-admin-invitations',
+    'my-companies',
 ];
 
 const navGroups: DashboardNavGroup[] = [
@@ -155,6 +160,10 @@ const navGroups: DashboardNavGroup[] = [
             { id: 'pickup-requests', label: 'Pickup Requests', icon: Truck },
             { id: 'partner-admin-invitations', label: 'Admin Invitations', icon: UserPlus },
         ],
+    },
+    {
+        title: 'Professional Companies',
+        items: [{ id: 'my-companies', label: 'My Companies', icon: Briefcase }],
     },
 ];
 
@@ -254,6 +263,17 @@ const MyDashboard: FC<MyDashboardProps> = () => {
     const { data: teamsILead } = useQuery<AxiosResponse<TeamData[]>, unknown, TeamData[]>({
         queryKey: GetTeamsILead().key,
         queryFn: GetTeamsILead().service,
+        select: (res) => res.data,
+    });
+
+    // Professional companies user belongs to
+    const { data: myCompanies } = useQuery<
+        AxiosResponse<ProfessionalCompanyData[]>,
+        unknown,
+        ProfessionalCompanyData[]
+    >({
+        queryKey: GetMyCompanies().key,
+        queryFn: GetMyCompanies().service,
         select: (res) => res.data,
     });
 
@@ -680,6 +700,25 @@ const MyDashboard: FC<MyDashboardProps> = () => {
                                 </CardContent>
                             </Card>
                         </section>
+
+                        {/* Professional Companies */}
+                        {myCompanies && myCompanies.length > 0 ? (
+                            <section id='my-companies' className='scroll-mt-20'>
+                                <Card>
+                                    <CardHeader>
+                                        <CardTitle className='text-primary'>
+                                            <Briefcase className='inline-block h-5 w-5 mr-2' />
+                                            My Professional Companies ({myCompanies.length})
+                                        </CardTitle>
+                                    </CardHeader>
+                                    <CardContent>
+                                        <div className='overflow-auto'>
+                                            <MyCompaniesTable items={myCompanies} />
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            </section>
+                        ) : null}
                     </main>
                 </div>
             </div>

--- a/TrashMob/client-app/src/pages/companydashboard/$companyId/_layout.tsx
+++ b/TrashMob/client-app/src/pages/companydashboard/$companyId/_layout.tsx
@@ -1,0 +1,45 @@
+import { Outlet, useParams, Link } from 'react-router';
+import { LayoutDashboard, ClipboardPlus, History, ArrowLeft } from 'lucide-react';
+import { SidebarNav, NavGroup } from '@/components/ui/sidebar-nav';
+import { Button } from '@/components/ui/button';
+
+export const CompanyDashboardLayout = () => {
+    const { companyId } = useParams<{ companyId: string }>() as { companyId: string };
+
+    const pathPrefix = `/companydashboard/${companyId}`;
+
+    const navGroups: NavGroup[] = [
+        {
+            title: 'Company Portal',
+            items: [
+                { name: 'Dashboard', href: pathPrefix, icon: LayoutDashboard },
+                { name: 'Log Cleanup', href: `${pathPrefix}/log-cleanup`, icon: ClipboardPlus },
+                { name: 'Cleanup History', href: `${pathPrefix}/history`, icon: History },
+            ],
+        },
+    ];
+
+    return (
+        <div className='container mx-auto py-6'>
+            <div className='mb-4'>
+                <Button variant='ghost' size='sm' asChild>
+                    <Link to='/mydashboard#my-companies'>
+                        <ArrowLeft className='h-4 w-4 mr-2' />
+                        Back to My Dashboard
+                    </Link>
+                </Button>
+            </div>
+            <h1 className='scroll-m-20 pb-6 text-3xl font-light tracking-tight'>Company Dashboard</h1>
+            <div className='flex flex-col gap-6 lg:flex-row'>
+                <aside className='w-full shrink-0 lg:w-64'>
+                    <div className='sticky top-4 rounded-lg border bg-card p-4'>
+                        <SidebarNav groups={navGroups} />
+                    </div>
+                </aside>
+                <main className='min-w-0 flex-1'>
+                    <Outlet />
+                </main>
+            </div>
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/pages/companydashboard/$companyId/history.tsx
+++ b/TrashMob/client-app/src/pages/companydashboard/$companyId/history.tsx
@@ -1,0 +1,141 @@
+import { useMemo } from 'react';
+import { useParams, Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { Loader2, ArrowLeft, ClipboardList, Package, Scale } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import ProfessionalCleanupLogData from '@/components/Models/ProfessionalCleanupLogData';
+import { GetCompanyCleanupLogs } from '@/services/professional-company-portal';
+
+export const CompanyCleanupHistory = () => {
+    const { companyId } = useParams<{ companyId: string }>() as { companyId: string };
+
+    const { data: cleanupLogs, isLoading } = useQuery<
+        AxiosResponse<ProfessionalCleanupLogData[]>,
+        unknown,
+        ProfessionalCleanupLogData[]
+    >({
+        queryKey: GetCompanyCleanupLogs({ companyId }).key,
+        queryFn: GetCompanyCleanupLogs({ companyId }).service,
+        select: (res) => res.data,
+        enabled: !!companyId,
+    });
+
+    const stats = useMemo(() => {
+        const logs = cleanupLogs || [];
+        return {
+            totalCleanups: logs.length,
+            totalBags: logs.reduce((sum, l) => sum + l.bagsCollected, 0),
+            totalWeight: logs.reduce((sum, l) => sum + (l.weightInPounds ?? 0), 0),
+        };
+    }, [cleanupLogs]);
+
+    const formatDate = (dateStr: string | null | undefined) => {
+        if (!dateStr) return '-';
+        return new Date(dateStr).toLocaleDateString();
+    };
+
+    if (isLoading) {
+        return (
+            <div className='py-8 text-center'>
+                <Loader2 className='h-8 w-8 animate-spin mx-auto' />
+            </div>
+        );
+    }
+
+    return (
+        <div className='space-y-6'>
+            <div>
+                <Button variant='ghost' size='sm' asChild>
+                    <Link to={`/companydashboard/${companyId}`}>
+                        <ArrowLeft className='h-4 w-4 mr-2' />
+                        Back to Dashboard
+                    </Link>
+                </Button>
+            </div>
+
+            {/* Summary Stats */}
+            <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+                <Card>
+                    <CardHeader className='flex flex-row items-center justify-between pb-2'>
+                        <CardTitle className='text-sm font-medium'>Total Cleanups</CardTitle>
+                        <ClipboardList className='h-4 w-4 text-muted-foreground' />
+                    </CardHeader>
+                    <CardContent>
+                        <div className='text-2xl font-bold'>{stats.totalCleanups}</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader className='flex flex-row items-center justify-between pb-2'>
+                        <CardTitle className='text-sm font-medium'>Total Bags</CardTitle>
+                        <Package className='h-4 w-4 text-muted-foreground' />
+                    </CardHeader>
+                    <CardContent>
+                        <div className='text-2xl font-bold'>{stats.totalBags}</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader className='flex flex-row items-center justify-between pb-2'>
+                        <CardTitle className='text-sm font-medium'>Total Weight (lbs)</CardTitle>
+                        <Scale className='h-4 w-4 text-muted-foreground' />
+                    </CardHeader>
+                    <CardContent>
+                        <div className='text-2xl font-bold'>{stats.totalWeight.toFixed(1)}</div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            {/* Cleanup Logs Table */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                        <ClipboardList className='h-5 w-5' />
+                        Cleanup History
+                    </CardTitle>
+                    <CardDescription>Complete log of all professional cleanups.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {cleanupLogs && cleanupLogs.length > 0 ? (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Date</TableHead>
+                                    <TableHead>Area</TableHead>
+                                    <TableHead>Duration (min)</TableHead>
+                                    <TableHead>Bags</TableHead>
+                                    <TableHead>Weight (lbs)</TableHead>
+                                    <TableHead>Notes</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {cleanupLogs.map((log) => (
+                                    <TableRow key={log.id}>
+                                        <TableCell>{formatDate(log.cleanupDate)}</TableCell>
+                                        <TableCell>{log.sponsoredAdoption?.adoptableArea?.name || '-'}</TableCell>
+                                        <TableCell>{log.durationMinutes}</TableCell>
+                                        <TableCell>{log.bagsCollected}</TableCell>
+                                        <TableCell>
+                                            {log.weightInPounds != null ? log.weightInPounds.toFixed(1) : '-'}
+                                        </TableCell>
+                                        <TableCell className='max-w-xs truncate'>{log.notes || '-'}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    ) : (
+                        <div className='text-center py-8 text-muted-foreground'>
+                            <ClipboardList className='h-12 w-12 mx-auto mb-4 opacity-50' />
+                            <p className='font-medium'>No cleanup logs yet</p>
+                            <p className='text-sm'>Start logging cleanups to see your history here.</p>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
+
+export default CompanyCleanupHistory;

--- a/TrashMob/client-app/src/pages/companydashboard/$companyId/index.tsx
+++ b/TrashMob/client-app/src/pages/companydashboard/$companyId/index.tsx
@@ -1,0 +1,216 @@
+import { useMemo } from 'react';
+import { useParams, Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { Loader2, ClipboardPlus, MapPin, ClipboardList, AlertTriangle } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import SponsoredAdoptionData from '@/components/Models/SponsoredAdoptionData';
+import ProfessionalCleanupLogData from '@/components/Models/ProfessionalCleanupLogData';
+import { GetCompanyAssignments, GetCompanyCleanupLogs } from '@/services/professional-company-portal';
+
+export const CompanyDashboard = () => {
+    const { companyId } = useParams<{ companyId: string }>() as { companyId: string };
+
+    const { data: assignments, isLoading: assignmentsLoading } = useQuery<
+        AxiosResponse<SponsoredAdoptionData[]>,
+        unknown,
+        SponsoredAdoptionData[]
+    >({
+        queryKey: GetCompanyAssignments({ companyId }).key,
+        queryFn: GetCompanyAssignments({ companyId }).service,
+        select: (res) => res.data,
+        enabled: !!companyId,
+    });
+
+    const { data: cleanupLogs, isLoading: logsLoading } = useQuery<
+        AxiosResponse<ProfessionalCleanupLogData[]>,
+        unknown,
+        ProfessionalCleanupLogData[]
+    >({
+        queryKey: GetCompanyCleanupLogs({ companyId }).key,
+        queryFn: GetCompanyCleanupLogs({ companyId }).service,
+        select: (res) => res.data,
+        enabled: !!companyId,
+    });
+
+    // Compute schedule status for each assignment
+    const assignmentStatuses = useMemo(() => {
+        if (!assignments || !cleanupLogs) return [];
+        const now = new Date();
+
+        return assignments.map((adoption) => {
+            const logsForAdoption = cleanupLogs.filter((l) => l.sponsoredAdoptionId === adoption.id);
+            const lastLog = logsForAdoption.length > 0 ? logsForAdoption[0] : null; // logs are ordered desc
+            let nextDue: Date | null = null;
+            let isOverdue = false;
+
+            if (lastLog) {
+                nextDue = new Date(lastLog.cleanupDate);
+                nextDue.setDate(nextDue.getDate() + adoption.cleanupFrequencyDays);
+                isOverdue = nextDue < now;
+            } else {
+                // No cleanups yet — consider overdue from start date
+                nextDue = new Date(adoption.startDate);
+                nextDue.setDate(nextDue.getDate() + adoption.cleanupFrequencyDays);
+                isOverdue = nextDue < now;
+            }
+
+            return { adoption, lastLog, nextDue, isOverdue };
+        });
+    }, [assignments, cleanupLogs]);
+
+    const recentLogs = useMemo(() => (cleanupLogs || []).slice(0, 5), [cleanupLogs]);
+
+    const formatDate = (dateStr: string | Date | null | undefined) => {
+        if (!dateStr) return '-';
+        return new Date(dateStr).toLocaleDateString();
+    };
+
+    if (assignmentsLoading) {
+        return (
+            <div className='py-8 text-center'>
+                <Loader2 className='h-8 w-8 animate-spin mx-auto' />
+            </div>
+        );
+    }
+
+    return (
+        <div className='space-y-6'>
+            {/* Quick Actions */}
+            <Card>
+                <CardContent className='pt-6'>
+                    <div className='flex flex-col sm:flex-row gap-4'>
+                        <Button asChild size='lg' className='h-12'>
+                            <Link to={`/companydashboard/${companyId}/log-cleanup`}>
+                                <ClipboardPlus className='h-5 w-5 mr-2' />
+                                Log a Cleanup
+                            </Link>
+                        </Button>
+                        <Button variant='outline' asChild size='lg' className='h-12'>
+                            <Link to={`/companydashboard/${companyId}/history`}>
+                                <ClipboardList className='h-5 w-5 mr-2' />
+                                View Full History
+                            </Link>
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* Assigned Segments */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                        <MapPin className='h-5 w-5' />
+                        Assigned Segments
+                    </CardTitle>
+                    <CardDescription>Active sponsored adoptions assigned to your company.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {assignmentStatuses.length > 0 ? (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Area</TableHead>
+                                    <TableHead>Sponsor</TableHead>
+                                    <TableHead>Frequency</TableHead>
+                                    <TableHead>Next Due</TableHead>
+                                    <TableHead>Status</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {assignmentStatuses.map(({ adoption, nextDue, isOverdue }) => (
+                                    <TableRow key={adoption.id}>
+                                        <TableCell className='font-medium'>
+                                            {adoption.adoptableArea?.name || '-'}
+                                        </TableCell>
+                                        <TableCell>{adoption.sponsor?.name || '-'}</TableCell>
+                                        <TableCell>Every {adoption.cleanupFrequencyDays} days</TableCell>
+                                        <TableCell>{formatDate(nextDue)}</TableCell>
+                                        <TableCell>
+                                            {isOverdue ? (
+                                                <Badge className='bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'>
+                                                    <AlertTriangle className='h-3 w-3 mr-1' />
+                                                    Overdue
+                                                </Badge>
+                                            ) : (
+                                                <Badge className='bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'>
+                                                    On Schedule
+                                                </Badge>
+                                            )}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    ) : (
+                        <div className='text-center py-8 text-muted-foreground'>
+                            <MapPin className='h-12 w-12 mx-auto mb-4 opacity-50' />
+                            <p className='font-medium'>No active assignments</p>
+                            <p className='text-sm'>Your company has no active sponsored adoption assignments yet.</p>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            {/* Recent Activity */}
+            <Card>
+                <CardHeader>
+                    <div className='flex items-center justify-between'>
+                        <div>
+                            <CardTitle className='flex items-center gap-2'>
+                                <ClipboardList className='h-5 w-5' />
+                                Recent Activity
+                            </CardTitle>
+                            <CardDescription>Latest cleanup logs.</CardDescription>
+                        </div>
+                        {(cleanupLogs || []).length > 5 ? (
+                            <Button variant='outline' size='sm' asChild>
+                                <Link to={`/companydashboard/${companyId}/history`}>View All</Link>
+                            </Button>
+                        ) : null}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {logsLoading ? (
+                        <div className='py-4 text-center'>
+                            <Loader2 className='h-6 w-6 animate-spin mx-auto' />
+                        </div>
+                    ) : recentLogs.length > 0 ? (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Date</TableHead>
+                                    <TableHead>Area</TableHead>
+                                    <TableHead>Bags</TableHead>
+                                    <TableHead>Weight (lbs)</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {recentLogs.map((log) => (
+                                    <TableRow key={log.id}>
+                                        <TableCell>{formatDate(log.cleanupDate)}</TableCell>
+                                        <TableCell>{log.sponsoredAdoption?.adoptableArea?.name || '-'}</TableCell>
+                                        <TableCell>{log.bagsCollected}</TableCell>
+                                        <TableCell>
+                                            {log.weightInPounds != null ? log.weightInPounds.toFixed(1) : '-'}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    ) : (
+                        <div className='text-center py-8 text-muted-foreground'>
+                            <p>No cleanup logs recorded yet.</p>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
+
+export default CompanyDashboard;

--- a/TrashMob/client-app/src/pages/companydashboard/$companyId/log-cleanup.tsx
+++ b/TrashMob/client-app/src/pages/companydashboard/$companyId/log-cleanup.tsx
@@ -1,0 +1,280 @@
+import { useCallback } from 'react';
+import { useParams, useNavigate, Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2, ArrowLeft } from 'lucide-react';
+
+import { Form, FormControl, FormField, FormItem, FormMessage, FormDescription } from '@/components/ui/form';
+import { EnhancedFormLabel as FormLabel } from '@/components/ui/custom/form';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import ProfessionalCleanupLogData from '@/components/Models/ProfessionalCleanupLogData';
+import SponsoredAdoptionData from '@/components/Models/SponsoredAdoptionData';
+import { GetCompanyAssignments, GetCompanyCleanupLogs, LogCleanup } from '@/services/professional-company-portal';
+
+interface FormInputs {
+    sponsoredAdoptionId: string;
+    cleanupDate: string;
+    durationMinutes: number;
+    bagsCollected: number;
+    weightInPounds: string;
+    weightInKilograms: string;
+    notes: string;
+}
+
+const formSchema = z.object({
+    sponsoredAdoptionId: z.string().min(1, 'Please select an assignment'),
+    cleanupDate: z.string().min(1, 'Cleanup date is required'),
+    durationMinutes: z.coerce.number().min(1, 'Duration must be at least 1 minute'),
+    bagsCollected: z.coerce.number().min(0, 'Cannot be negative'),
+    weightInPounds: z.string(),
+    weightInKilograms: z.string(),
+    notes: z.string(),
+});
+
+const today = () => new Date().toISOString().split('T')[0];
+
+export const CompanyLogCleanup = () => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const { companyId } = useParams<{ companyId: string }>() as { companyId: string };
+    const { toast } = useToast();
+
+    const { data: assignments, isLoading } = useQuery<
+        AxiosResponse<SponsoredAdoptionData[]>,
+        unknown,
+        SponsoredAdoptionData[]
+    >({
+        queryKey: GetCompanyAssignments({ companyId }).key,
+        queryFn: GetCompanyAssignments({ companyId }).service,
+        select: (res) => res.data,
+        enabled: !!companyId,
+    });
+
+    const { mutate, isPending: isSubmitting } = useMutation({
+        mutationKey: LogCleanup().key,
+        mutationFn: (body: ProfessionalCleanupLogData) => LogCleanup().service({ companyId }, body),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: GetCompanyCleanupLogs({ companyId }).key });
+            queryClient.invalidateQueries({ queryKey: GetCompanyAssignments({ companyId }).key });
+            toast({
+                variant: 'primary',
+                title: 'Cleanup logged!',
+                description: 'Your cleanup has been recorded successfully.',
+            });
+            navigate(`/companydashboard/${companyId}`);
+        },
+        onError: () => {
+            toast({
+                variant: 'destructive',
+                title: 'Error',
+                description: 'Failed to log cleanup. Please try again.',
+            });
+        },
+    });
+
+    const form = useForm<FormInputs>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            sponsoredAdoptionId: '',
+            cleanupDate: today(),
+            durationMinutes: 60,
+            bagsCollected: 0,
+            weightInPounds: '',
+            weightInKilograms: '',
+            notes: '',
+        },
+    });
+
+    const onSubmit: SubmitHandler<FormInputs> = useCallback(
+        (formValues) => {
+            const log = new ProfessionalCleanupLogData();
+            log.sponsoredAdoptionId = formValues.sponsoredAdoptionId;
+            log.professionalCompanyId = companyId;
+            log.cleanupDate = formValues.cleanupDate;
+            log.durationMinutes = formValues.durationMinutes;
+            log.bagsCollected = formValues.bagsCollected;
+            log.weightInPounds = formValues.weightInPounds ? parseFloat(formValues.weightInPounds) : null;
+            log.weightInKilograms = formValues.weightInKilograms ? parseFloat(formValues.weightInKilograms) : null;
+            log.notes = formValues.notes;
+
+            mutate(log);
+        },
+        [companyId, mutate],
+    );
+
+    if (isLoading) {
+        return (
+            <div className='py-8 text-center'>
+                <Loader2 className='h-8 w-8 animate-spin mx-auto' />
+            </div>
+        );
+    }
+
+    return (
+        <div className='py-4'>
+            <div className='mb-6'>
+                <Button variant='ghost' size='sm' asChild>
+                    <Link to={`/companydashboard/${companyId}`}>
+                        <ArrowLeft className='h-4 w-4 mr-2' />
+                        Back to Dashboard
+                    </Link>
+                </Button>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-6'>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Log a Cleanup</CardTitle>
+                            <CardDescription>
+                                Record a professional cleanup for one of your assigned segments.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className='space-y-4'>
+                            <FormField
+                                control={form.control}
+                                name='sponsoredAdoptionId'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel required>Assignment</FormLabel>
+                                        <Select onValueChange={field.onChange} value={field.value}>
+                                            <FormControl>
+                                                <SelectTrigger className='h-12'>
+                                                    <SelectValue placeholder='Select an assignment' />
+                                                </SelectTrigger>
+                                            </FormControl>
+                                            <SelectContent>
+                                                {assignments?.map((adoption) => (
+                                                    <SelectItem key={adoption.id} value={adoption.id}>
+                                                        {adoption.adoptableArea?.name || 'Unknown Area'}
+                                                        {adoption.sponsor?.name ? ` — ${adoption.sponsor.name}` : ''}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+                                <FormField
+                                    control={form.control}
+                                    name='cleanupDate'
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel required>Cleanup Date</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} type='date' className='h-12' />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='durationMinutes'
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel required>Duration (minutes)</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} type='number' min={1} className='h-12' />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='bagsCollected'
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel required>Bags Collected</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} type='number' min={0} className='h-12' />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+
+                            <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+                                <FormField
+                                    control={form.control}
+                                    name='weightInPounds'
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Weight (lbs)</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} type='number' min={0} step='0.1' className='h-12' />
+                                            </FormControl>
+                                            <FormDescription>Optional.</FormDescription>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <FormField
+                                    control={form.control}
+                                    name='weightInKilograms'
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Weight (kg)</FormLabel>
+                                            <FormControl>
+                                                <Input {...field} type='number' min={0} step='0.1' className='h-12' />
+                                            </FormControl>
+                                            <FormDescription>Optional.</FormDescription>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+
+                            <FormField
+                                control={form.control}
+                                name='notes'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Notes</FormLabel>
+                                        <FormControl>
+                                            <Textarea
+                                                {...field}
+                                                className='h-24'
+                                                placeholder='Any notes about this cleanup...'
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </CardContent>
+                    </Card>
+
+                    <div className='flex justify-end gap-2'>
+                        <Button
+                            type='button'
+                            variant='outline'
+                            onClick={() => navigate(`/companydashboard/${companyId}`)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type='submit' disabled={isSubmitting} size='lg' className='h-12'>
+                            {isSubmitting ? <Loader2 className='h-4 w-4 animate-spin mr-2' /> : null}
+                            Submit Cleanup Log
+                        </Button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    );
+};
+
+export default CompanyLogCleanup;

--- a/TrashMob/client-app/src/services/professional-company-portal.ts
+++ b/TrashMob/client-app/src/services/professional-company-portal.ts
@@ -1,0 +1,63 @@
+// Professional Company Portal API service (user-facing)
+
+import { ApiService } from '.';
+import ProfessionalCompanyData from '../components/Models/ProfessionalCompanyData';
+import ProfessionalCleanupLogData from '../components/Models/ProfessionalCleanupLogData';
+import SponsoredAdoptionData from '../components/Models/SponsoredAdoptionData';
+
+// ============================================================================
+// My Companies (authenticated user)
+// ============================================================================
+
+export type GetMyCompanies_Response = ProfessionalCompanyData[];
+export const GetMyCompanies = () => ({
+    key: ['/professional-companies/mine'],
+    service: async () =>
+        ApiService('protected').fetchData<GetMyCompanies_Response>({
+            url: `/professional-companies/mine`,
+            method: 'get',
+        }),
+});
+
+// ============================================================================
+// Company Assignments
+// ============================================================================
+
+export type GetCompanyAssignments_Params = { companyId: string };
+export type GetCompanyAssignments_Response = SponsoredAdoptionData[];
+export const GetCompanyAssignments = (params: GetCompanyAssignments_Params) => ({
+    key: ['/professional-companies/', params.companyId, '/assignments'],
+    service: async () =>
+        ApiService('protected').fetchData<GetCompanyAssignments_Response>({
+            url: `/professional-companies/${params.companyId}/cleanup-logs/assignments`,
+            method: 'get',
+        }),
+});
+
+// ============================================================================
+// Company Cleanup Logs
+// ============================================================================
+
+export type GetCompanyCleanupLogs_Params = { companyId: string };
+export type GetCompanyCleanupLogs_Response = ProfessionalCleanupLogData[];
+export const GetCompanyCleanupLogs = (params: GetCompanyCleanupLogs_Params) => ({
+    key: ['/professional-companies/', params.companyId, '/cleanup-logs'],
+    service: async () =>
+        ApiService('protected').fetchData<GetCompanyCleanupLogs_Response>({
+            url: `/professional-companies/${params.companyId}/cleanup-logs`,
+            method: 'get',
+        }),
+});
+
+export type LogCleanup_Params = { companyId: string };
+export type LogCleanup_Body = ProfessionalCleanupLogData;
+export type LogCleanup_Response = ProfessionalCleanupLogData;
+export const LogCleanup = () => ({
+    key: ['/professional-companies/cleanup-logs', 'create'],
+    service: async (params: LogCleanup_Params, body: LogCleanup_Body) =>
+        ApiService('protected').fetchData<LogCleanup_Response, LogCleanup_Body>({
+            url: `/professional-companies/${params.companyId}/cleanup-logs`,
+            method: 'post',
+            data: body,
+        }),
+});


### PR DESCRIPTION
## Summary
- Adds new `GET /api/professional-companies/mine` backend endpoint so users can discover which companies they belong to
- Adds a dedicated company portal at `/companydashboard/:companyId` with dashboard (assigned segments + schedule status), mobile-friendly cleanup logging form, and full cleanup history with summary stats
- Integrates "My Professional Companies" section into MyDashboard with "Manage company" links

## Changes
**Backend (1 new file):**
- `ProfessionalCompanyPortalController` — single endpoint using existing `IProfessionalCompanyUserManager.GetCompaniesByUserIdAsync`

**Frontend (7 new files, 3 modified):**
- `professional-company-portal.ts` — 4 API service functions (GetMyCompanies, GetCompanyAssignments, GetCompanyCleanupLogs, LogCleanup)
- `companydashboard/$companyId/_layout.tsx` — sidebar layout with Dashboard, Log Cleanup, History nav
- `companydashboard/$companyId/index.tsx` — assignments table with on-schedule/overdue status, recent activity
- `companydashboard/$companyId/log-cleanup.tsx` — mobile-friendly form (h-12 touch targets, full-width layout)
- `companydashboard/$companyId/history.tsx` — complete history with summary stats cards
- `MyCompaniesTable.tsx` — table component for MyDashboard integration
- Modified `MyDashboard/index.tsx`, `App.tsx`, `ProfessionalCleanupLogData.tsx`

## Test plan
- [ ] Backend builds with 0 errors, 397 tests pass
- [ ] Frontend builds and lints with 0 errors
- [ ] MyDashboard shows "My Professional Companies" section for company users
- [ ] Company Dashboard loads assignments with schedule status indicators
- [ ] Log Cleanup form validates, submits, and invalidates cache
- [ ] History page shows all logs with area names and summary stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)