### PR TITLE
Add leaderboard, achievement, and route stats MCP tools (Project 17 Phase 2.5)

### DIFF
--- a/Planning/Projects/Project_17_MCP_Server.md
+++ b/Planning/Projects/Project_17_MCP_Server.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phase 2 Complete) |
+| **Status** | In Progress (Phase 2.5 Complete) |
 | **Priority** | Low |
 | **Risk** | Moderate |
 | **Size** | Medium |
@@ -46,6 +46,12 @@ Provide safe, privacy-aware AI access to events/metrics via Model Context Protoc
 - ✅ Litter report discovery - `SearchLitterReportsTool`
 - ✅ Partner/location search - `SearchPartnerLocationsTool`
 - ✅ Community search - `SearchCommunitiesTool`
+
+### Phase 2.5 - Feature Catch-Up Tools ✅
+- ✅ Leaderboard query (user & team rankings) - `GetLeaderboardTool`
+- ✅ Achievement types listing - `GetAchievementTypesTool`
+- ✅ Event route statistics - `GetEventRouteStatsTool`
+- ⬜ Adoptable areas search (deferred - requires authentication)
 
 ### Phase 3 - AI Features
 - ⬜ Event recommendations based on user location/history
@@ -108,15 +114,26 @@ None - can use existing API
 
 ```
 TrashMobMCP/
-├── Program.cs                 # MCP server entry point
+├── Program.cs                       # MCP server entry point
 ├── Tools/
-│   ├── EventSearchTool.cs    # Search events by criteria
-│   ├── StatsTool.cs          # Get platform/community stats
-│   ├── TeamSearchTool.cs     # Find teams
-│   ├── CommunityTool.cs      # Community information
-│   └── LitterReportTool.cs   # Litter report lookup
-├── Resources/
-│   └── EventResource.cs      # Event data resource
+│   ├── SearchEventsTool.cs          # Search events by criteria
+│   ├── GetStatsTool.cs              # Get platform/community stats
+│   ├── SearchTeamsTool.cs           # Find teams
+│   ├── SearchCommunitiesTool.cs     # Community information
+│   ├── SearchLitterReportsTool.cs   # Litter report lookup
+│   ├── SearchPartnerLocationsTool.cs # Partner location search
+│   ├── GetLeaderboardTool.cs        # Volunteer/team rankings
+│   ├── GetAchievementTypesTool.cs   # Available achievement badges
+│   └── GetEventRouteStatsTool.cs    # Event route tracking stats
+├── Dtos/
+│   ├── EventDto.cs
+│   ├── CommunityDto.cs
+│   ├── LitterReportDto.cs
+│   ├── PartnerLocationDto.cs
+│   ├── StatsDto.cs
+│   ├── TeamDto.cs
+│   ├── LeaderboardEntryDto.cs
+│   └── AchievementTypeDto.cs
 └── appsettings.json
 ```
 
@@ -406,7 +423,7 @@ The following GitHub issues are tracked as part of this project:
 
 ---
 
-**Last Updated:** January 31, 2026
+**Last Updated:** February 8, 2026
 **Owner:** Engineering Team
-**Status:** Not Started
+**Status:** In Progress (Phase 2.5 Complete — 9 tools)
 **Next Review:** When AI integration becomes priority

--- a/TrashMobMCP/Dtos/AchievementTypeDto.cs
+++ b/TrashMobMCP/Dtos/AchievementTypeDto.cs
@@ -1,0 +1,15 @@
+namespace TrashMobMCP.Dtos;
+
+/// <summary>
+/// Sanitized achievement type for MCP responses.
+/// Describes an available badge/achievement users can earn.
+/// </summary>
+public class AchievementTypeDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string? IconUrl { get; set; }
+    public int Points { get; set; }
+    public string? Criteria { get; set; }
+}

--- a/TrashMobMCP/Dtos/LeaderboardEntryDto.cs
+++ b/TrashMobMCP/Dtos/LeaderboardEntryDto.cs
@@ -1,0 +1,16 @@
+namespace TrashMobMCP.Dtos;
+
+/// <summary>
+/// Sanitized leaderboard entry for MCP responses.
+/// Contains only public ranking information - no internal IDs.
+/// </summary>
+public class LeaderboardEntryDto
+{
+    public int Rank { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string EntityType { get; set; } = string.Empty;
+    public decimal Score { get; set; }
+    public string FormattedScore { get; set; } = string.Empty;
+    public string? Region { get; set; }
+    public string? City { get; set; }
+}

--- a/TrashMobMCP/Tools/GetAchievementTypesTool.cs
+++ b/TrashMobMCP/Tools/GetAchievementTypesTool.cs
@@ -1,0 +1,66 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Models;
+using TrashMob.Shared.Managers.Interfaces;
+using TrashMobMCP.Dtos;
+
+/// <summary>
+/// MCP tool for listing available TrashMob achievements.
+/// </summary>
+[McpServerToolType]
+public class GetAchievementTypesTool
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private readonly IAchievementManager _achievementManager;
+
+    public GetAchievementTypesTool(IAchievementManager achievementManager)
+    {
+        _achievementManager = achievementManager;
+    }
+
+    /// <summary>
+    /// Get all available achievement types that volunteers can earn.
+    /// </summary>
+    /// <param name="category">Filter by category: Participation, Impact, Special, or leave empty for all (optional)</param>
+    /// <returns>JSON array of achievement types with descriptions and point values</returns>
+    [McpServerTool]
+    [Description("Get available TrashMob achievement badges that volunteers can earn. Each achievement has criteria like attending events, collecting bags, or reaching milestones. Filter by category to see specific types.")]
+    public async Task<string> GetAchievementTypes(
+        string? category = null)
+    {
+        var achievementTypes = await _achievementManager.GetAchievementTypesAsync();
+
+        var sanitized = achievementTypes
+            .Where(a => a.IsActive != false)
+            .Where(a => string.IsNullOrWhiteSpace(category)
+                || string.Equals(a.Category, category, StringComparison.OrdinalIgnoreCase))
+            .Select(Sanitize)
+            .ToList();
+
+        return JsonSerializer.Serialize(new
+        {
+            achievement_types = sanitized,
+            total_count = sanitized.Count,
+            search_criteria = new
+            {
+                category
+            }
+        }, JsonOptions);
+    }
+
+    private static AchievementTypeDto Sanitize(AchievementType a)
+    {
+        return new AchievementTypeDto
+        {
+            Name = a.DisplayName ?? a.Name,
+            Description = a.Description,
+            Category = a.Category,
+            IconUrl = a.IconUrl,
+            Points = a.Points,
+            Criteria = a.Criteria
+        };
+    }
+}

--- a/TrashMobMCP/Tools/GetEventRouteStatsTool.cs
+++ b/TrashMobMCP/Tools/GetEventRouteStatsTool.cs
@@ -1,0 +1,57 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Shared.Managers.Interfaces;
+
+/// <summary>
+/// MCP tool for getting route tracking statistics for a TrashMob event.
+/// </summary>
+[McpServerToolType]
+public class GetEventRouteStatsTool
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private readonly IEventAttendeeRouteManager _routeManager;
+
+    public GetEventRouteStatsTool(IEventAttendeeRouteManager routeManager)
+    {
+        _routeManager = routeManager;
+    }
+
+    /// <summary>
+    /// Get route tracking statistics for a specific cleanup event.
+    /// </summary>
+    /// <param name="eventId">The event ID (GUID format)</param>
+    /// <returns>JSON with aggregated route statistics including distance, duration, coverage, and collection data</returns>
+    [McpServerTool]
+    [Description("Get route tracking statistics for a TrashMob cleanup event. Returns aggregated data including total distance walked, duration, area covered, number of contributors, and collection metrics (bags and weight).")]
+    public async Task<string> GetEventRouteStats(
+        string eventId)
+    {
+        if (!Guid.TryParse(eventId, out var parsedEventId))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "Invalid event ID format. Must be a valid GUID."
+            }, JsonOptions);
+        }
+
+        var stats = await _routeManager.GetEventRouteStatsAsync(parsedEventId);
+
+        return JsonSerializer.Serialize(new
+        {
+            route_stats = new
+            {
+                total_routes = stats.TotalRoutes,
+                total_distance_meters = stats.TotalDistanceMeters,
+                total_duration_minutes = stats.TotalDurationMinutes,
+                unique_contributors = stats.UniqueContributors,
+                total_bags_collected = stats.TotalBagsCollected,
+                total_weight_collected_lbs = stats.TotalWeightCollected,
+                coverage_area_square_meters = stats.CoverageAreaSquareMeters
+            },
+            event_url = $"https://trashmob.eco/eventdetails/{parsedEventId}"
+        }, JsonOptions);
+    }
+}

--- a/TrashMobMCP/Tools/GetLeaderboardTool.cs
+++ b/TrashMobMCP/Tools/GetLeaderboardTool.cs
@@ -1,0 +1,103 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Shared.Managers.Interfaces;
+using TrashMob.Shared.Poco;
+using TrashMobMCP.Dtos;
+
+/// <summary>
+/// MCP tool for querying TrashMob leaderboards.
+/// </summary>
+[McpServerToolType]
+public class GetLeaderboardTool
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private readonly ILeaderboardManager _leaderboardManager;
+
+    public GetLeaderboardTool(ILeaderboardManager leaderboardManager)
+    {
+        _leaderboardManager = leaderboardManager;
+    }
+
+    /// <summary>
+    /// Get volunteer or team leaderboard rankings.
+    /// </summary>
+    /// <param name="type">Leaderboard type: Events, Bags, Weight, or Hours (default: Events)</param>
+    /// <param name="timeRange">Time range: Week, Month, Year, or AllTime (default: Month)</param>
+    /// <param name="scope">Location scope: Global, Region, or City (default: Global)</param>
+    /// <param name="location">Location value (region or city name). Required if scope is not Global.</param>
+    /// <param name="entity">Entity type: User or Team (default: User)</param>
+    /// <param name="maxResults">Maximum number of entries to return (default: 20, max: 50)</param>
+    /// <returns>JSON leaderboard with ranked entries</returns>
+    [McpServerTool]
+    [Description("Get TrashMob volunteer or team leaderboard rankings. Shows top contributors by events attended, bags collected, weight collected, or hours volunteered. Filter by time range and location.")]
+    public async Task<string> GetLeaderboard(
+        string type = "Events",
+        string timeRange = "Month",
+        string scope = "Global",
+        string? location = null,
+        string entity = "User",
+        int maxResults = 20)
+    {
+        var limit = Math.Min(maxResults, 50);
+
+        var isTeam = string.Equals(entity, "Team", StringComparison.OrdinalIgnoreCase);
+
+        LeaderboardResponse response;
+
+        if (isTeam)
+        {
+            response = await _leaderboardManager.GetTeamLeaderboardAsync(
+                type, timeRange, scope, location, limit);
+        }
+        else
+        {
+            response = await _leaderboardManager.GetLeaderboardAsync(
+                type, timeRange, scope, location, limit);
+        }
+
+        var entries = response.Entries
+            .Select(Sanitize)
+            .ToList();
+
+        return JsonSerializer.Serialize(new
+        {
+            leaderboard = new
+            {
+                type = response.LeaderboardType,
+                time_range = response.TimeRange,
+                scope = response.LocationScope,
+                location = response.LocationValue,
+                entity = isTeam ? "Team" : "User",
+                computed_date = response.ComputedDate.ToString("O"),
+                total_entries = response.TotalEntries
+            },
+            entries,
+            search_criteria = new
+            {
+                type,
+                time_range = timeRange,
+                scope,
+                location,
+                entity,
+                max_results = limit
+            }
+        }, JsonOptions);
+    }
+
+    private static LeaderboardEntryDto Sanitize(LeaderboardEntry e)
+    {
+        return new LeaderboardEntryDto
+        {
+            Rank = e.Rank,
+            Name = e.EntityName,
+            EntityType = e.EntityType,
+            Score = e.Score,
+            FormattedScore = e.FormattedScore,
+            Region = e.Region,
+            City = e.City
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 3 new MCP server tools to expose recently completed features to AI assistants
- **GetLeaderboardTool** — Query volunteer or team leaderboard rankings by type (Events/Bags/Weight/Hours), time range, and location scope
- **GetAchievementTypesTool** — List available achievement badges with descriptions, criteria, and point values
- **GetEventRouteStatsTool** — Get aggregated route tracking statistics for a cleanup event (distance, duration, coverage area, collection metrics)
- Adds corresponding DTOs (`LeaderboardEntryDto`, `AchievementTypeDto`) for sanitized MCP responses
- Updates Project 17 planning doc with Phase 2.5 scope and current file structure

## Test plan
- [x] `dotnet build TrashMobMCP/TrashMobMCP.csproj -c Release` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 397/397 tests pass
- [ ] Verify tools are auto-discovered via `[McpServerToolType]` + `WithToolsFromAssembly()`
- [ ] Manual test: connect MCP client and verify all 9 tools are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)