### PR TITLE
Add sponsor portal (Project 41 Phase 4)

### DIFF
--- a/TrashMob.Shared/Managers/Interfaces/IProfessionalCleanupLogManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IProfessionalCleanupLogManager.cs
@@ -21,6 +21,14 @@ namespace TrashMob.Shared.Managers.Interfaces
         Task<IEnumerable<ProfessionalCleanupLog>> GetByCompanyIdAsync(Guid companyId, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Gets all cleanup logs across all adoptions for a specific sponsor.
+        /// </summary>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A collection of cleanup logs with navigation properties.</returns>
+        Task<IEnumerable<ProfessionalCleanupLog>> GetBySponsorIdAsync(Guid sponsorId, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Gets all cleanup logs for a specific sponsored adoption.
         /// </summary>
         /// <param name="sponsoredAdoptionId">The sponsored adoption ID.</param>

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCleanupLogManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCleanupLogManager.cs
@@ -48,6 +48,19 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
         }
 
         /// <inheritdoc />
+        public async Task<IEnumerable<ProfessionalCleanupLog>> GetBySponsorIdAsync(
+            Guid sponsorId,
+            CancellationToken cancellationToken = default)
+        {
+            return await Repo.Get()
+                .Include(l => l.SponsoredAdoption)
+                    .ThenInclude(sa => sa.AdoptableArea)
+                .Where(l => l.SponsoredAdoption.SponsorId == sponsorId)
+                .OrderByDescending(l => l.CleanupDate)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
         public async Task<IEnumerable<ProfessionalCleanupLog>> GetBySponsoredAdoptionIdAsync(
             Guid sponsoredAdoptionId,
             CancellationToken cancellationToken = default)

--- a/TrashMob/Controllers/SponsorPortalController.cs
+++ b/TrashMob/Controllers/SponsorPortalController.cs
@@ -1,0 +1,177 @@
+namespace TrashMob.Controllers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// Portal endpoints for sponsor users (read-only views of adoptions and cleanup logs).
+    /// </summary>
+    [Route("api/sponsors")]
+    [ApiController]
+    public class SponsorPortalController : SecureController
+    {
+        private readonly ISponsorManager sponsorManager;
+        private readonly IPartnerAdminManager partnerAdminManager;
+        private readonly IProfessionalCleanupLogManager logManager;
+        private readonly IKeyedManager<Partner> partnerManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SponsorPortalController"/> class.
+        /// </summary>
+        /// <param name="sponsorManager">The sponsor manager.</param>
+        /// <param name="partnerAdminManager">The partner admin manager.</param>
+        /// <param name="logManager">The cleanup log manager.</param>
+        /// <param name="partnerManager">The partner manager.</param>
+        public SponsorPortalController(
+            ISponsorManager sponsorManager,
+            IPartnerAdminManager partnerAdminManager,
+            IProfessionalCleanupLogManager logManager,
+            IKeyedManager<Partner> partnerManager)
+        {
+            this.sponsorManager = sponsorManager;
+            this.partnerAdminManager = partnerAdminManager;
+            this.logManager = logManager;
+            this.partnerManager = partnerManager;
+        }
+
+        /// <summary>
+        /// Gets all sponsors the authenticated user has access to via partner admin memberships.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("mine")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<Sponsor>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMySponsors(CancellationToken cancellationToken)
+        {
+            var partners = await partnerAdminManager.GetPartnersByUserIdAsync(UserId, cancellationToken);
+            var allSponsors = new List<Sponsor>();
+
+            foreach (var partner in partners)
+            {
+                var sponsors = await sponsorManager.GetByCommunityAsync(partner.Id, cancellationToken);
+                allSponsors.AddRange(sponsors);
+            }
+
+            return Ok(allSponsors);
+        }
+
+        /// <summary>
+        /// Gets all cleanup logs across all adoptions for a specific sponsor.
+        /// </summary>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("{sponsorId:guid}/cleanup-logs")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ProfessionalCleanupLog>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetSponsorCleanupLogs(Guid sponsorId, CancellationToken cancellationToken)
+        {
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor == null)
+            {
+                return NotFound();
+            }
+
+            var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
+            if (partner == null)
+            {
+                return NotFound();
+            }
+
+            var authResult = await AuthorizationService.AuthorizeAsync(
+                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
+            if (!authResult.Succeeded)
+            {
+                return Forbid();
+            }
+
+            var logs = await logManager.GetBySponsorIdAsync(sponsorId, cancellationToken);
+            return Ok(logs);
+        }
+
+        /// <summary>
+        /// Exports all cleanup logs for a sponsor as a CSV file.
+        /// </summary>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("{sponsorId:guid}/cleanup-logs/export")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ExportCleanupLogs(Guid sponsorId, CancellationToken cancellationToken)
+        {
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor == null)
+            {
+                return NotFound();
+            }
+
+            var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
+            if (partner == null)
+            {
+                return NotFound();
+            }
+
+            var authResult = await AuthorizationService.AuthorizeAsync(
+                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
+            if (!authResult.Succeeded)
+            {
+                return Forbid();
+            }
+
+            var logs = await logManager.GetBySponsorIdAsync(sponsorId, cancellationToken);
+
+            var csv = new StringBuilder();
+            csv.AppendLine("Date,Area,Duration (min),Bags,Weight (lbs),Notes");
+
+            foreach (var log in logs)
+            {
+                var date = log.CleanupDate;
+                var area = EscapeCsvField(log.SponsoredAdoption?.AdoptableArea?.Name ?? "");
+                var duration = log.DurationMinutes.ToString();
+                var bags = log.BagsCollected.ToString();
+                var weight = log.WeightInPounds?.ToString("F1") ?? "";
+                var notes = EscapeCsvField(log.Notes ?? "");
+
+                csv.AppendLine($"{date},{area},{duration},{bags},{weight},{notes}");
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(csv.ToString());
+            var fileName = $"{sponsor.Name.Replace(" ", "_")}_CleanupLogs_{DateTime.UtcNow:yyyyMMdd}.csv";
+
+            return File(bytes, "text/csv", fileName);
+        }
+
+        private static string EscapeCsvField(string field)
+        {
+            if (string.IsNullOrEmpty(field))
+            {
+                return "";
+            }
+
+            if (field.Contains(',') || field.Contains('"') || field.Contains('\n') || field.Contains('\r'))
+            {
+                return $"\"{field.Replace("\"", "\"\"")}\"";
+            }
+
+            return field;
+        }
+    }
+}

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -200,6 +200,20 @@ const CompanyCleanupHistory = lazy(() =>
     import('./pages/companydashboard/$companyId/history').then((m) => ({ default: m.CompanyCleanupHistory })),
 );
 
+/** Sponsor Dashboard - Lazy loaded (sponsor portal) */
+const SponsorDashboardLayout = lazy(() =>
+    import('./pages/sponsordashboard/$sponsorId/_layout').then((m) => ({ default: m.SponsorDashboardLayout })),
+);
+const SponsorDashboard = lazy(() =>
+    import('./pages/sponsordashboard/$sponsorId').then((m) => ({ default: m.SponsorDashboard })),
+);
+const SponsorCleanupHistory = lazy(() =>
+    import('./pages/sponsordashboard/$sponsorId/history').then((m) => ({ default: m.SponsorCleanupHistory })),
+);
+const SponsorReports = lazy(() =>
+    import('./pages/sponsordashboard/$sponsorId/reports').then((m) => ({ default: m.SponsorReports })),
+);
+
 /** Partner Dashboard - Lazy loaded (partner admin pages) */
 const PartnerIndex = lazy(() =>
     import('./pages/partnerdashboard/$partnerId').then((m) => ({ default: m.PartnerIndex })),
@@ -535,6 +549,18 @@ const AppContent: FC = () => {
                                 <Route index element={<CompanyDashboard />} />
                                 <Route path='log-cleanup' element={<CompanyLogCleanup />} />
                                 <Route path='history' element={<CompanyCleanupHistory />} />
+                            </Route>
+                            <Route
+                                path='sponsordashboard/:sponsorId'
+                                element={
+                                    <Suspense fallback={<LazyLoadingFallback />}>
+                                        <SponsorDashboardLayout />
+                                    </Suspense>
+                                }
+                            >
+                                <Route index element={<SponsorDashboard />} />
+                                <Route path='history' element={<SponsorCleanupHistory />} />
+                                <Route path='reports' element={<SponsorReports />} />
                             </Route>
 
                             <Route path='/cancelevent/:eventId' element={<CancelEvent />} />

--- a/TrashMob/client-app/src/pages/MyDashboard/MySponsorsTable.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MySponsorsTable.tsx
@@ -1,0 +1,56 @@
+import { Link } from 'react-router';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import SponsorData from '@/components/Models/SponsorData';
+import { Ellipsis, Eye } from 'lucide-react';
+
+type MySponsorsTableProps = {
+    items: SponsorData[];
+};
+
+export const MySponsorsTable = ({ items }: MySponsorsTableProps) => {
+    const headerTitles = ['Sponsor Name', 'Actions'];
+    return (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    {headerTitles.map((header) => (
+                        <TableHead key={header}>{header}</TableHead>
+                    ))}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {(items || [])
+                    .sort((a, b) => a.name.localeCompare(b.name))
+                    .map((sponsor) => (
+                        <TableRow key={sponsor.id}>
+                            <TableCell>{sponsor.name}</TableCell>
+                            <TableCell className='py-0'>
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button variant='ghost' size='icon'>
+                                            <Ellipsis />
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent className='w-56'>
+                                        <DropdownMenuItem asChild>
+                                            <Link to={`/sponsordashboard/${sponsor.id}`}>
+                                                <Eye />
+                                                <span>View sponsor</span>
+                                            </Link>
+                                        </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+            </TableBody>
+        </Table>
+    );
+};

--- a/TrashMob/client-app/src/pages/MyDashboard/index.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/index.tsx
@@ -23,6 +23,7 @@ import {
     ClipboardList,
     Truck,
     Briefcase,
+    Heart,
 } from 'lucide-react';
 import { AxiosResponse } from 'axios';
 
@@ -39,6 +40,7 @@ import LitterReportData from '@/components/Models/LitterReportData';
 import { LitterReportStatusEnum } from '@/components/Models/LitterReportStatus';
 import TeamData from '@/components/Models/TeamData';
 import ProfessionalCompanyData from '@/components/Models/ProfessionalCompanyData';
+import SponsorData from '@/components/Models/SponsorData';
 
 import twofigure from '@/components/assets/card/twofigure.svg';
 import calendarclock from '@/components/assets/card/calendarclock.svg';
@@ -65,6 +67,7 @@ import { GetEventPickupLocationsByUser, GetPartnerLocationEventServicesByUserId 
 import { GetUserLitterReports } from '@/services/litter-report';
 import { GetMyTeams, GetTeamsILead } from '@/services/teams';
 import { GetMyCompanies } from '@/services/professional-company-portal';
+import { GetMySponsors } from '@/services/sponsor-portal';
 
 import { useGetGoogleMapApiKey } from '@/hooks/useGetGoogleMapApiKey';
 import { useGetUserEvents } from '@/hooks/useGetUserEvents';
@@ -82,6 +85,7 @@ import { MyRoutesCard } from '@/pages/MyDashboard/MyRoutesCard';
 import { MyWaiversCard } from '@/pages/MyDashboard/MyWaiversCard';
 import { MyImpactCard } from '@/pages/MyDashboard/MyImpactCard';
 import { MyCompaniesTable } from '@/pages/MyDashboard/MyCompaniesTable';
+import { MySponsorsTable } from '@/pages/MyDashboard/MySponsorsTable';
 import { InviteFriendsCard } from '@/pages/MyDashboard/InviteFriendsCard';
 import { MyNewsletterPreferencesCard } from '@/pages/MyDashboard/MyNewsletterPreferencesCard';
 import { DashboardScrollNav, DashboardNavGroup } from './DashboardScrollNav';
@@ -113,6 +117,7 @@ const SECTION_IDS = [
     'pickup-requests',
     'partner-admin-invitations',
     'my-companies',
+    'my-sponsors',
 ];
 
 const navGroups: DashboardNavGroup[] = [
@@ -164,6 +169,10 @@ const navGroups: DashboardNavGroup[] = [
     {
         title: 'Professional Companies',
         items: [{ id: 'my-companies', label: 'My Companies', icon: Briefcase }],
+    },
+    {
+        title: 'Sponsors',
+        items: [{ id: 'my-sponsors', label: 'My Sponsors', icon: Heart }],
     },
 ];
 
@@ -274,6 +283,13 @@ const MyDashboard: FC<MyDashboardProps> = () => {
     >({
         queryKey: GetMyCompanies().key,
         queryFn: GetMyCompanies().service,
+        select: (res) => res.data,
+    });
+
+    // Sponsors user has access to (via partner admin memberships)
+    const { data: mySponsors } = useQuery<AxiosResponse<SponsorData[]>, unknown, SponsorData[]>({
+        queryKey: GetMySponsors().key,
+        queryFn: GetMySponsors().service,
         select: (res) => res.data,
     });
 
@@ -714,6 +730,25 @@ const MyDashboard: FC<MyDashboardProps> = () => {
                                     <CardContent>
                                         <div className='overflow-auto'>
                                             <MyCompaniesTable items={myCompanies} />
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            </section>
+                        ) : null}
+
+                        {/* Sponsors */}
+                        {mySponsors && mySponsors.length > 0 ? (
+                            <section id='my-sponsors' className='scroll-mt-20'>
+                                <Card>
+                                    <CardHeader>
+                                        <CardTitle className='text-primary'>
+                                            <Heart className='inline-block h-5 w-5 mr-2' />
+                                            My Sponsors ({mySponsors.length})
+                                        </CardTitle>
+                                    </CardHeader>
+                                    <CardContent>
+                                        <div className='overflow-auto'>
+                                            <MySponsorsTable items={mySponsors} />
                                         </div>
                                     </CardContent>
                                 </Card>

--- a/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/_layout.tsx
+++ b/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/_layout.tsx
@@ -1,0 +1,45 @@
+import { Outlet, useParams, Link } from 'react-router';
+import { LayoutDashboard, History, Download, ArrowLeft } from 'lucide-react';
+import { SidebarNav, NavGroup } from '@/components/ui/sidebar-nav';
+import { Button } from '@/components/ui/button';
+
+export const SponsorDashboardLayout = () => {
+    const { sponsorId } = useParams<{ sponsorId: string }>() as { sponsorId: string };
+
+    const pathPrefix = `/sponsordashboard/${sponsorId}`;
+
+    const navGroups: NavGroup[] = [
+        {
+            title: 'Sponsor Portal',
+            items: [
+                { name: 'Dashboard', href: pathPrefix, icon: LayoutDashboard },
+                { name: 'Cleanup History', href: `${pathPrefix}/history`, icon: History },
+                { name: 'Reports', href: `${pathPrefix}/reports`, icon: Download },
+            ],
+        },
+    ];
+
+    return (
+        <div className='container mx-auto py-6'>
+            <div className='mb-4'>
+                <Button variant='ghost' size='sm' asChild>
+                    <Link to='/mydashboard#my-sponsors'>
+                        <ArrowLeft className='h-4 w-4 mr-2' />
+                        Back to My Dashboard
+                    </Link>
+                </Button>
+            </div>
+            <h1 className='scroll-m-20 pb-6 text-3xl font-light tracking-tight'>Sponsor Dashboard</h1>
+            <div className='flex flex-col gap-6 lg:flex-row'>
+                <aside className='w-full shrink-0 lg:w-64'>
+                    <div className='sticky top-4 rounded-lg border bg-card p-4'>
+                        <SidebarNav groups={navGroups} />
+                    </div>
+                </aside>
+                <main className='min-w-0 flex-1'>
+                    <Outlet />
+                </main>
+            </div>
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/history.tsx
+++ b/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/history.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+import { useParams, Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { Loader2, ArrowLeft, ClipboardList, Package, Scale } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import ProfessionalCleanupLogData from '@/components/Models/ProfessionalCleanupLogData';
+import { GetSponsorCleanupLogs } from '@/services/sponsor-portal';
+
+export const SponsorCleanupHistory = () => {
+    const { sponsorId } = useParams<{ sponsorId: string }>() as { sponsorId: string };
+
+    const { data: cleanupLogs, isLoading } = useQuery<
+        AxiosResponse<ProfessionalCleanupLogData[]>,
+        unknown,
+        ProfessionalCleanupLogData[]
+    >({
+        queryKey: GetSponsorCleanupLogs({ sponsorId }).key,
+        queryFn: GetSponsorCleanupLogs({ sponsorId }).service,
+        select: (res) => res.data,
+        enabled: !!sponsorId,
+    });
+
+    const stats = useMemo(() => {
+        const logs = cleanupLogs || [];
+        return {
+            totalCleanups: logs.length,
+            totalBags: logs.reduce((sum, l) => sum + l.bagsCollected, 0),
+            totalWeight: logs.reduce((sum, l) => sum + (l.weightInPounds ?? 0), 0),
+        };
+    }, [cleanupLogs]);
+
+    const formatDate = (dateStr: string | null | undefined) => {
+        if (!dateStr) return '-';
+        return new Date(dateStr).toLocaleDateString();
+    };
+
+    if (isLoading) {
+        return (
+            <div className='py-8 text-center'>
+                <Loader2 className='h-8 w-8 animate-spin mx-auto' />
+            </div>
+        );
+    }
+
+    return (
+        <div className='space-y-6'>
+            <div>
+                <Button variant='ghost' size='sm' asChild>
+                    <Link to={`/sponsordashboard/${sponsorId}`}>
+                        <ArrowLeft className='h-4 w-4 mr-2' />
+                        Back to Dashboard
+                    </Link>
+                </Button>
+            </div>
+
+            {/* Summary Stats */}
+            <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+                <Card>
+                    <CardHeader className='flex flex-row items-center justify-between pb-2'>
+                        <CardTitle className='text-sm font-medium'>Total Cleanups</CardTitle>
+                        <ClipboardList className='h-4 w-4 text-muted-foreground' />
+                    </CardHeader>
+                    <CardContent>
+                        <div className='text-2xl font-bold'>{stats.totalCleanups}</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader className='flex flex-row items-center justify-between pb-2'>
+                        <CardTitle className='text-sm font-medium'>Total Bags</CardTitle>
+                        <Package className='h-4 w-4 text-muted-foreground' />
+                    </CardHeader>
+                    <CardContent>
+                        <div className='text-2xl font-bold'>{stats.totalBags}</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader className='flex flex-row items-center justify-between pb-2'>
+                        <CardTitle className='text-sm font-medium'>Total Weight (lbs)</CardTitle>
+                        <Scale className='h-4 w-4 text-muted-foreground' />
+                    </CardHeader>
+                    <CardContent>
+                        <div className='text-2xl font-bold'>{stats.totalWeight.toFixed(1)}</div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            {/* Cleanup Logs Table */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                        <ClipboardList className='h-5 w-5' />
+                        Cleanup History
+                    </CardTitle>
+                    <CardDescription>
+                        Complete log of all professional cleanups for your sponsored segments.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {cleanupLogs && cleanupLogs.length > 0 ? (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Date</TableHead>
+                                    <TableHead>Area</TableHead>
+                                    <TableHead>Duration (min)</TableHead>
+                                    <TableHead>Bags</TableHead>
+                                    <TableHead>Weight (lbs)</TableHead>
+                                    <TableHead>Notes</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {cleanupLogs.map((log) => (
+                                    <TableRow key={log.id}>
+                                        <TableCell>{formatDate(log.cleanupDate)}</TableCell>
+                                        <TableCell>{log.sponsoredAdoption?.adoptableArea?.name || '-'}</TableCell>
+                                        <TableCell>{log.durationMinutes}</TableCell>
+                                        <TableCell>{log.bagsCollected}</TableCell>
+                                        <TableCell>
+                                            {log.weightInPounds != null ? log.weightInPounds.toFixed(1) : '-'}
+                                        </TableCell>
+                                        <TableCell className='max-w-xs truncate'>{log.notes || '-'}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    ) : (
+                        <div className='text-center py-8 text-muted-foreground'>
+                            <ClipboardList className='h-12 w-12 mx-auto mb-4 opacity-50' />
+                            <p className='font-medium'>No cleanup logs yet</p>
+                            <p className='text-sm'>
+                                Cleanup logs will appear here once professional companies log their work.
+                            </p>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
+
+export default SponsorCleanupHistory;

--- a/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/index.tsx
+++ b/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/index.tsx
@@ -1,0 +1,215 @@
+import { useMemo } from 'react';
+import { useParams, Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { Loader2, History, Download, MapPin, ClipboardList, AlertTriangle } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import SponsoredAdoptionData from '@/components/Models/SponsoredAdoptionData';
+import ProfessionalCleanupLogData from '@/components/Models/ProfessionalCleanupLogData';
+import { GetSponsorAdoptions, GetSponsorCleanupLogs } from '@/services/sponsor-portal';
+
+export const SponsorDashboard = () => {
+    const { sponsorId } = useParams<{ sponsorId: string }>() as { sponsorId: string };
+
+    const { data: adoptions, isLoading: adoptionsLoading } = useQuery<
+        AxiosResponse<SponsoredAdoptionData[]>,
+        unknown,
+        SponsoredAdoptionData[]
+    >({
+        queryKey: GetSponsorAdoptions({ sponsorId }).key,
+        queryFn: GetSponsorAdoptions({ sponsorId }).service,
+        select: (res) => res.data,
+        enabled: !!sponsorId,
+    });
+
+    const { data: cleanupLogs, isLoading: logsLoading } = useQuery<
+        AxiosResponse<ProfessionalCleanupLogData[]>,
+        unknown,
+        ProfessionalCleanupLogData[]
+    >({
+        queryKey: GetSponsorCleanupLogs({ sponsorId }).key,
+        queryFn: GetSponsorCleanupLogs({ sponsorId }).service,
+        select: (res) => res.data,
+        enabled: !!sponsorId,
+    });
+
+    // Compute compliance status for each adoption
+    const adoptionStatuses = useMemo(() => {
+        if (!adoptions || !cleanupLogs) return [];
+        const now = new Date();
+
+        return adoptions.map((adoption) => {
+            const logsForAdoption = cleanupLogs.filter((l) => l.sponsoredAdoptionId === adoption.id);
+            const lastLog = logsForAdoption.length > 0 ? logsForAdoption[0] : null;
+            let nextDue: Date | null = null;
+            let isOverdue = false;
+
+            if (lastLog) {
+                nextDue = new Date(lastLog.cleanupDate);
+                nextDue.setDate(nextDue.getDate() + adoption.cleanupFrequencyDays);
+                isOverdue = nextDue < now;
+            } else {
+                nextDue = new Date(adoption.startDate);
+                nextDue.setDate(nextDue.getDate() + adoption.cleanupFrequencyDays);
+                isOverdue = nextDue < now;
+            }
+
+            return { adoption, lastLog, nextDue, isOverdue };
+        });
+    }, [adoptions, cleanupLogs]);
+
+    const recentLogs = useMemo(() => (cleanupLogs || []).slice(0, 5), [cleanupLogs]);
+
+    const formatDate = (dateStr: string | Date | null | undefined) => {
+        if (!dateStr) return '-';
+        return new Date(dateStr).toLocaleDateString();
+    };
+
+    if (adoptionsLoading) {
+        return (
+            <div className='py-8 text-center'>
+                <Loader2 className='h-8 w-8 animate-spin mx-auto' />
+            </div>
+        );
+    }
+
+    return (
+        <div className='space-y-6'>
+            {/* Quick Actions */}
+            <Card>
+                <CardContent className='pt-6'>
+                    <div className='flex flex-col sm:flex-row gap-4'>
+                        <Button variant='outline' asChild size='lg' className='h-12'>
+                            <Link to={`/sponsordashboard/${sponsorId}/history`}>
+                                <History className='h-5 w-5 mr-2' />
+                                View Full History
+                            </Link>
+                        </Button>
+                        <Button variant='outline' asChild size='lg' className='h-12'>
+                            <Link to={`/sponsordashboard/${sponsorId}/reports`}>
+                                <Download className='h-5 w-5 mr-2' />
+                                Download Report
+                            </Link>
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* Adopted Segments */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                        <MapPin className='h-5 w-5' />
+                        Adopted Segments
+                    </CardTitle>
+                    <CardDescription>Segments sponsored by your organization.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {adoptionStatuses.length > 0 ? (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Area</TableHead>
+                                    <TableHead>Company</TableHead>
+                                    <TableHead>Frequency</TableHead>
+                                    <TableHead>Next Due</TableHead>
+                                    <TableHead>Status</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {adoptionStatuses.map(({ adoption, nextDue, isOverdue }) => (
+                                    <TableRow key={adoption.id}>
+                                        <TableCell className='font-medium'>
+                                            {adoption.adoptableArea?.name || '-'}
+                                        </TableCell>
+                                        <TableCell>{adoption.professionalCompany?.name || '-'}</TableCell>
+                                        <TableCell>Every {adoption.cleanupFrequencyDays} days</TableCell>
+                                        <TableCell>{formatDate(nextDue)}</TableCell>
+                                        <TableCell>
+                                            {isOverdue ? (
+                                                <Badge className='bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'>
+                                                    <AlertTriangle className='h-3 w-3 mr-1' />
+                                                    Overdue
+                                                </Badge>
+                                            ) : (
+                                                <Badge className='bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'>
+                                                    On Schedule
+                                                </Badge>
+                                            )}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    ) : (
+                        <div className='text-center py-8 text-muted-foreground'>
+                            <MapPin className='h-12 w-12 mx-auto mb-4 opacity-50' />
+                            <p className='font-medium'>No adopted segments</p>
+                            <p className='text-sm'>No sponsored adoptions found for this sponsor.</p>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            {/* Recent Activity */}
+            <Card>
+                <CardHeader>
+                    <div className='flex items-center justify-between'>
+                        <div>
+                            <CardTitle className='flex items-center gap-2'>
+                                <ClipboardList className='h-5 w-5' />
+                                Recent Activity
+                            </CardTitle>
+                            <CardDescription>Latest cleanup logs.</CardDescription>
+                        </div>
+                        {(cleanupLogs || []).length > 5 ? (
+                            <Button variant='outline' size='sm' asChild>
+                                <Link to={`/sponsordashboard/${sponsorId}/history`}>View All</Link>
+                            </Button>
+                        ) : null}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {logsLoading ? (
+                        <div className='py-4 text-center'>
+                            <Loader2 className='h-6 w-6 animate-spin mx-auto' />
+                        </div>
+                    ) : recentLogs.length > 0 ? (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Date</TableHead>
+                                    <TableHead>Area</TableHead>
+                                    <TableHead>Bags</TableHead>
+                                    <TableHead>Weight (lbs)</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {recentLogs.map((log) => (
+                                    <TableRow key={log.id}>
+                                        <TableCell>{formatDate(log.cleanupDate)}</TableCell>
+                                        <TableCell>{log.sponsoredAdoption?.adoptableArea?.name || '-'}</TableCell>
+                                        <TableCell>{log.bagsCollected}</TableCell>
+                                        <TableCell>
+                                            {log.weightInPounds != null ? log.weightInPounds.toFixed(1) : '-'}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    ) : (
+                        <div className='text-center py-8 text-muted-foreground'>
+                            <p>No cleanup logs recorded yet.</p>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
+
+export default SponsorDashboard;

--- a/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/reports.tsx
+++ b/TrashMob/client-app/src/pages/sponsordashboard/$sponsorId/reports.tsx
@@ -1,0 +1,85 @@
+import { useCallback } from 'react';
+import { useParams, Link } from 'react-router';
+import { ArrowLeft, Download, FileSpreadsheet } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { ExportSponsorCleanupLogs } from '@/services/sponsor-portal';
+
+export const SponsorReports = () => {
+    const { sponsorId } = useParams<{ sponsorId: string }>() as { sponsorId: string };
+    const { toast } = useToast();
+
+    const handleExport = useCallback(async () => {
+        if (!sponsorId) return;
+        try {
+            const response = await ExportSponsorCleanupLogs({ sponsorId }).service();
+            const blob = response.data;
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `CleanupLogs_${new Date().toISOString().split('T')[0]}.csv`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            window.URL.revokeObjectURL(url);
+            toast({
+                variant: 'primary',
+                title: 'Export successful',
+                description: 'Cleanup log data has been downloaded.',
+            });
+        } catch {
+            toast({
+                variant: 'destructive',
+                title: 'Export failed',
+                description: 'Failed to download cleanup log data. Please try again.',
+            });
+        }
+    }, [sponsorId, toast]);
+
+    return (
+        <div className='space-y-6'>
+            <div>
+                <Button variant='ghost' size='sm' asChild>
+                    <Link to={`/sponsordashboard/${sponsorId}`}>
+                        <ArrowLeft className='h-4 w-4 mr-2' />
+                        Back to Dashboard
+                    </Link>
+                </Button>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                        <FileSpreadsheet className='h-5 w-5' />
+                        Reports
+                    </CardTitle>
+                    <CardDescription>
+                        Download cleanup log data for your records or marketing materials.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className='space-y-4'>
+                        <div className='rounded-lg border p-4'>
+                            <div className='flex items-center justify-between'>
+                                <div>
+                                    <h3 className='font-medium'>Cleanup Logs (CSV)</h3>
+                                    <p className='text-sm text-muted-foreground'>
+                                        All cleanup dates, areas, bags collected, and weights.
+                                    </p>
+                                </div>
+                                <Button onClick={handleExport} size='lg' className='h-12'>
+                                    <Download className='h-4 w-4 mr-2' />
+                                    Download
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
+
+export default SponsorReports;

--- a/TrashMob/client-app/src/services/sponsor-portal.ts
+++ b/TrashMob/client-app/src/services/sponsor-portal.ts
@@ -1,0 +1,65 @@
+// Sponsor Portal API service (user-facing, read-only)
+
+import { ApiService } from '.';
+import SponsorData from '../components/Models/SponsorData';
+import SponsoredAdoptionData from '../components/Models/SponsoredAdoptionData';
+import ProfessionalCleanupLogData from '../components/Models/ProfessionalCleanupLogData';
+
+// ============================================================================
+// My Sponsors (authenticated user)
+// ============================================================================
+
+export type GetMySponsors_Response = SponsorData[];
+export const GetMySponsors = () => ({
+    key: ['/sponsors/mine'],
+    service: async () =>
+        ApiService('protected').fetchData<GetMySponsors_Response>({
+            url: `/sponsors/mine`,
+            method: 'get',
+        }),
+});
+
+// ============================================================================
+// Sponsor Adoptions
+// ============================================================================
+
+export type GetSponsorAdoptions_Params = { sponsorId: string };
+export type GetSponsorAdoptions_Response = SponsoredAdoptionData[];
+export const GetSponsorAdoptions = (params: GetSponsorAdoptions_Params) => ({
+    key: ['/sponsors/', params.sponsorId, '/adoptions'],
+    service: async () =>
+        ApiService('protected').fetchData<GetSponsorAdoptions_Response>({
+            url: `/sponsors/${params.sponsorId}/adoptions`,
+            method: 'get',
+        }),
+});
+
+// ============================================================================
+// Sponsor Cleanup Logs
+// ============================================================================
+
+export type GetSponsorCleanupLogs_Params = { sponsorId: string };
+export type GetSponsorCleanupLogs_Response = ProfessionalCleanupLogData[];
+export const GetSponsorCleanupLogs = (params: GetSponsorCleanupLogs_Params) => ({
+    key: ['/sponsors/', params.sponsorId, '/cleanup-logs'],
+    service: async () =>
+        ApiService('protected').fetchData<GetSponsorCleanupLogs_Response>({
+            url: `/sponsors/${params.sponsorId}/cleanup-logs`,
+            method: 'get',
+        }),
+});
+
+// ============================================================================
+// Export Cleanup Logs (CSV)
+// ============================================================================
+
+export type ExportSponsorCleanupLogs_Params = { sponsorId: string };
+export const ExportSponsorCleanupLogs = (params: ExportSponsorCleanupLogs_Params) => ({
+    key: ['/sponsors/', params.sponsorId, '/cleanup-logs/export'],
+    service: async () =>
+        ApiService('protected').fetchData<Blob>({
+            url: `/sponsors/${params.sponsorId}/cleanup-logs/export`,
+            method: 'get',
+            responseType: 'blob',
+        }),
+});


### PR DESCRIPTION
## Summary
- **New backend**: `SponsorPortalController` with 3 endpoints — `GET /sponsors/mine` (discover sponsors via partner admin chain), `GET /sponsors/{sponsorId}/cleanup-logs` (aggregated logs with nav props), `GET /sponsors/{sponsorId}/cleanup-logs/export` (CSV download)
- **New manager method**: `GetBySponsorIdAsync` on `IProfessionalCleanupLogManager` — single EF query joining through SponsoredAdoption with Include for AdoptableArea
- **New sponsor portal** at `/sponsordashboard/:sponsorId` with dashboard (compliance status + recent activity), cleanup history (stats cards + full table), and reports page (CSV export)
- **MyDashboard integration**: "My Sponsors" section shows sponsors accessible via partner admin memberships, with "View sponsor" action linking to the portal

## Test plan
- [ ] `dotnet build` — 0 errors
- [ ] `dotnet test TrashMob.Shared.Tests` — 397 tests pass
- [ ] `npm run build` — 0 errors
- [ ] `npm run lint` — clean
- [ ] MyDashboard shows "My Sponsors" section for users who are partner admins with sponsors
- [ ] Sponsor Dashboard loads adoptions with on-schedule/overdue badges
- [ ] Cleanup History shows stats cards and full log table
- [ ] Reports page downloads CSV file successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)