### PR TITLE
Convert MCP server from stdio to HTTP transport (Project 17)

### DIFF
--- a/Planning/Projects/Project_17_MCP_Server.md
+++ b/Planning/Projects/Project_17_MCP_Server.md
@@ -53,6 +53,14 @@ Provide safe, privacy-aware AI access to events/metrics via Model Context Protoc
 - ✅ Event route statistics - `GetEventRouteStatsTool`
 - ⬜ Adoptable areas search (deferred - requires authentication)
 
+### Phase 2.75 - HTTP Transport ✅
+- ✅ Convert from stdio to HTTP transport (SSE + Streamable HTTP)
+- ✅ Upgrade MCP SDK from 0.2.0-preview.1 to 0.8.0-preview.1
+- ✅ Add `ModelContextProtocol.AspNetCore` package
+- ✅ Convert from generic host to ASP.NET Core web host
+- ✅ Map MCP endpoints via `app.MapMcp()` (exposes `/sse` and `/messages`)
+- Container app deployment already configured (`containerAppMCP.bicep`)
+
 ### Phase 3 - AI Features
 - ⬜ Event recommendations based on user location/history
 - ⬜ Impact summaries (event, community, sitewide)
@@ -425,5 +433,5 @@ The following GitHub issues are tracked as part of this project:
 
 **Last Updated:** February 8, 2026
 **Owner:** Engineering Team
-**Status:** In Progress (Phase 2.5 Complete — 9 tools)
+**Status:** In Progress (Phase 2.75 Complete — 9 tools, HTTP transport)
 **Next Review:** When AI integration becomes priority

--- a/TrashMobMCP/Dockerfile
+++ b/TrashMobMCP/Dockerfile
@@ -20,5 +20,6 @@ RUN dotnet publish "TrashMobMCP.csproj" -c Release -o /app/publish /p:UseAppHost
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
+EXPOSE 8080
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "TrashMobMCP.dll"]

--- a/TrashMobMCP/Program.cs
+++ b/TrashMobMCP/Program.cs
@@ -3,8 +3,8 @@ namespace TrashMobMCP;
 using Azure.Identity;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol.AspNetCore;
 using ModelContextProtocol.Server;
 using TrashMob.Shared;
 using TrashMob.Shared.Managers;
@@ -13,23 +13,24 @@ using TrashMob.Shared.Persistence;
 
 public class Program
 {
-    public static async Task Main(string[] args)
+    public static void Main(string[] args)
     {
-        var builder = Host.CreateApplicationBuilder(args);
+        var builder = WebApplication.CreateBuilder(args);
 
         ConfigureServices(builder.Services);
 
-        // Add MCP server with stdio transport
+        // Add MCP server with HTTP transport (SSE + Streamable HTTP)
         builder.Services
             .AddMcpServer()
-            .WithStdioServerTransport()
+            .WithHttpTransport()
             .WithToolsFromAssembly();
 
         builder.Logging.AddConsole();
         builder.Logging.SetMinimumLevel(LogLevel.Information);
 
-        var host = builder.Build();
-        await host.RunAsync();
+        var app = builder.Build();
+        app.MapMcp();
+        app.Run();
     }
 
     private static void ConfigureServices(IServiceCollection services)

--- a/TrashMobMCP/TrashMobMCP.csproj
+++ b/TrashMobMCP/TrashMobMCP.csproj
@@ -1,7 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,8 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Converts the MCP server from stdio transport (local process only) to HTTP transport (publicly accessible)
- Upgrades `ModelContextProtocol` SDK from `0.2.0-preview.1` to `0.8.0-preview.1`
- Adds `ModelContextProtocol.AspNetCore` package for HTTP/SSE transport support
- Converts project from console app (`Microsoft.NET.Sdk`) to web app (`Microsoft.NET.Sdk.Web`)
- Changes `Host.CreateApplicationBuilder` to `WebApplication.CreateBuilder` with `app.MapMcp()` endpoint routing
- Exposes `/sse` and `/messages` endpoints for MCP client connections
- Adds `EXPOSE 8080` to Dockerfile (matching existing Bicep ingress config)
- **No changes needed** to any of the 9 tool classes or DTOs — SDK upgrade is fully backward compatible

This enables users to connect to the TrashMob MCP server from Claude Desktop, Claude Code, or any MCP-compatible AI client over HTTP, rather than requiring local process spawning with database credentials.

## Test plan
- [x] `dotnet build TrashMobMCP/TrashMobMCP.csproj -c Release` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 397/397 tests pass
- [ ] Verify container builds: `docker build -f TrashMobMCP/Dockerfile .`
- [ ] Verify MCP endpoints respond after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)