### PR TITLE
Add PageHelp component and convert SidebarLayout to full-width

### DIFF
--- a/TrashMob/client-app/src/components/ui/custom/PageHelp.tsx
+++ b/TrashMob/client-app/src/components/ui/custom/PageHelp.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { CircleHelp } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+
+interface PageHelpProps {
+    children: React.ReactNode;
+    side?: 'top' | 'right' | 'bottom' | 'left';
+}
+
+export const PageHelp: React.FC<PageHelpProps> = ({ children, side = 'bottom' }) => {
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button variant='ghost' size='icon' className='h-8 w-8' aria-label='Show page help'>
+                    <CircleHelp className='h-5 w-5 text-muted-foreground' />
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent side={side} align='end' className='w-80 max-w-sm text-sm'>
+                {children}
+            </PopoverContent>
+        </Popover>
+    );
+};

--- a/TrashMob/client-app/src/pages/layouts/_layout.sidebar.tsx
+++ b/TrashMob/client-app/src/pages/layouts/_layout.sidebar.tsx
@@ -1,9 +1,10 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
+import { PageHelp } from '@/components/ui/custom/PageHelp';
 import { ReactNode } from 'react';
 
 interface SidebarLayoutProps {
     title: string;
-    description: string;
+    description: ReactNode;
     children: ReactNode;
     useDefaultCard?: boolean;
 }
@@ -11,28 +12,18 @@ interface SidebarLayoutProps {
 export const SidebarLayout = (props: SidebarLayoutProps) => {
     const { title, description, children, useDefaultCard = true } = props;
     return (
-        <div className='container mx-auto'>
-            <div className='grid grid-cols-12 gap-8! my-8'>
-                <div className='col-span-12 lg:col-span-4'>
-                    <Card>
-                        <CardHeader>
-                            <CardTitle className='font-semibold tracking-tight text-primary text-2xl'>
-                                {title}
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>{description}</CardContent>
-                    </Card>
-                </div>
-                <div className='col-span-12 lg:col-span-8 space-y-8'>
-                    {useDefaultCard ? (
-                        <Card>
-                            <CardContent className='pt-6'>{children}</CardContent>
-                        </Card>
-                    ) : (
-                        children
-                    )}
-                </div>
+        <div className='container mx-auto my-8 space-y-4'>
+            <div className='flex items-center justify-between'>
+                <h2 className='font-semibold tracking-tight text-primary text-2xl'>{title}</h2>
+                <PageHelp>{description}</PageHelp>
             </div>
+            {useDefaultCard ? (
+                <Card>
+                    <CardContent className='pt-6'>{children}</CardContent>
+                </Card>
+            ) : (
+                children
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- Creates a reusable `PageHelp` component — a `CircleHelp` icon button that opens a Popover with help content
- Converts `SidebarLayout` from a 4/8 sidebar grid (help text always visible) to a full-width layout with help accessible via the icon
- All 8 partner admin pages automatically get the new behavior (no changes needed to individual pages)
- `PageHelp` is reusable across the entire site for future help/tutorial content

## Test plan
- [ ] Navigate to any partner admin page (e.g., Edit Partner)
- [ ] Verify content is full-width (no sidebar taking 33% of width)
- [ ] Verify page title and help icon are visible in the header
- [ ] Click the help icon — popover shows the help text
- [ ] Click outside the popover — it dismisses
- [ ] Check all 8 partner pages render correctly
- [ ] Verify responsive behavior on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)