### PR TITLE
Fix litter report detail page hanging in busy state on mobile

### DIFF
--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -369,14 +369,21 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetImage(Guid litterImageId, ImageSizeEnum imageSize,
             CancellationToken cancellationToken)
         {
-            var url = await imageManager.GetImageUrlAsync(litterImageId, ImageTypeEnum.LitterImage, imageSize, cancellationToken);
+            try
+            {
+                var url = await imageManager.GetImageUrlAsync(litterImageId, ImageTypeEnum.LitterImage, imageSize, cancellationToken);
 
-            if (string.IsNullOrEmpty(url))
+                if (string.IsNullOrEmpty(url))
+                {
+                    return NoContent();
+                }
+
+                return Ok(url);
+            }
+            catch (Exception)
             {
                 return NoContent();
             }
-
-            return Ok(url);
         }
     }
 }

--- a/TrashMobMobile/Services/LitterReportManager.cs
+++ b/TrashMobMobile/Services/LitterReportManager.cs
@@ -23,8 +23,15 @@
                 {
                     foreach (var litterImage in litterReport.LitterImages)
                     {
-                        litterImage.AzureBlobURL =
-                            await litterReportRestService.GetLitterImageUrlAsync(litterImage.Id, imageSize, cancellationToken);
+                        try
+                        {
+                            litterImage.AzureBlobURL =
+                                await litterReportRestService.GetLitterImageUrlAsync(litterImage.Id, imageSize, cancellationToken);
+                        }
+                        catch (Exception)
+                        {
+                            litterImage.AzureBlobURL = string.Empty;
+                        }
                     }
                 }
             }
@@ -45,8 +52,15 @@
 
             foreach (var litterImage in litterReport.LitterImages)
             {
-                litterImage.AzureBlobURL =
-                    await litterReportRestService.GetLitterImageUrlAsync(litterImage.Id, imageSize, cancellationToken);
+                try
+                {
+                    litterImage.AzureBlobURL =
+                        await litterReportRestService.GetLitterImageUrlAsync(litterImage.Id, imageSize, cancellationToken);
+                }
+                catch (Exception)
+                {
+                    litterImage.AzureBlobURL = string.Empty;
+                }
             }
 
             return litterReport;

--- a/TrashMobMobile/Services/LitterReportRestService.cs
+++ b/TrashMobMobile/Services/LitterReportRestService.cs
@@ -31,9 +31,19 @@
 
             using (var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken))
             {
-                response.EnsureSuccessStatusCode();
+                if (!response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+                {
+                    return string.Empty;
+                }
+
                 var result = await response.Content.ReadAsStringAsync(cancellationToken);
-                return JsonConvert.DeserializeObject<string>(result);
+
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    return string.Empty;
+                }
+
+                return JsonConvert.DeserializeObject<string>(result) ?? string.Empty;
             }
         }
 


### PR DESCRIPTION
## Summary

- Fix mobile app hanging when viewing a litter report detail page
- The `GET /api/litterreport/image/{id}/{size}` endpoint returns HTTP 500 when Azure blob storage has no matching image (e.g., images captured on device but never uploaded to blob storage)
- A single failing image URL fetch was aborting the entire report load, leaving the app stuck in busy state

## Changes

- **LitterReportRestService.cs**: `GetLitterImageUrlAsync` returns empty string on non-success/empty responses instead of throwing
- **LitterReportManager.cs**: Individual image URL fetches wrapped in try-catch so one failing image doesn't block the report
- **LitterReportController.cs**: Server-side `GetImage` endpoint catches blob storage exceptions and returns 204 NoContent

## Test plan

- [ ] Build mobile app and open a litter report with missing images — page loads with report data
- [ ] Verify litter reports with valid images still display correctly
- [ ] Verify backend returns 204 instead of 500 for missing images

🤖 Generated with [Claude Code](https://claude.com/claude-code)