### PR TITLE
Add mobile community browse and detail pages (Project 10)

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -31,6 +31,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(SearchLitterReportsPage), typeof(SearchLitterReportsPage));
         Routing.RegisterRoute(nameof(SetUserLocationPreferencePage), typeof(SetUserLocationPreferencePage));
         Routing.RegisterRoute(nameof(AchievementsPage), typeof(AchievementsPage));
+        Routing.RegisterRoute(nameof(BrowseCommunitiesPage), typeof(BrowseCommunitiesPage));
         Routing.RegisterRoute(nameof(BrowseTeamsPage), typeof(BrowseTeamsPage));
         Routing.RegisterRoute(nameof(LeaderboardsPage), typeof(LeaderboardsPage));
         Routing.RegisterRoute(nameof(NewsletterPreferencesPage), typeof(NewsletterPreferencesPage));
@@ -38,6 +39,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(ViewEventSummaryPage), typeof(ViewEventSummaryPage));
         Routing.RegisterRoute(nameof(ViewLitterReportPage), typeof(ViewLitterReportPage));
         Routing.RegisterRoute(nameof(ViewPickupLocationPage), typeof(ViewPickupLocationPage));
+        Routing.RegisterRoute(nameof(ViewCommunityPage), typeof(ViewCommunityPage));
         Routing.RegisterRoute(nameof(ViewTeamPage), typeof(ViewTeamPage));
         Routing.RegisterRoute(nameof(WaiverPage), typeof(WaiverPage));
         Routing.RegisterRoute(nameof(WelcomePage), typeof(WelcomePage));

--- a/TrashMobMobile/Extensions/CommunityExtensions.cs
+++ b/TrashMobMobile/Extensions/CommunityExtensions.cs
@@ -1,0 +1,51 @@
+namespace TrashMobMobile.Extensions;
+
+using TrashMob.Models;
+using TrashMobMobile.ViewModels;
+
+public static class CommunityExtensions
+{
+    public static CommunityViewModel ToCommunityViewModel(this Partner partner)
+    {
+        var locationParts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(partner.City))
+        {
+            locationParts.Add(partner.City);
+        }
+
+        if (!string.IsNullOrWhiteSpace(partner.Region))
+        {
+            locationParts.Add(partner.Region);
+        }
+
+        if (!string.IsNullOrWhiteSpace(partner.Country))
+        {
+            locationParts.Add(partner.Country);
+        }
+
+        return new CommunityViewModel
+        {
+            Id = partner.Id,
+            Slug = partner.Slug ?? string.Empty,
+            Name = partner.Name ?? string.Empty,
+            Tagline = partner.Tagline ?? string.Empty,
+            Location = string.Join(", ", locationParts),
+            RegionTypeDisplay = GetRegionTypeLabel(partner.RegionType),
+            HasRegionType = partner.RegionType.HasValue,
+        };
+    }
+
+    private static string GetRegionTypeLabel(int? regionType)
+    {
+        return regionType switch
+        {
+            0 => "City",
+            1 => "County",
+            2 => "State",
+            3 => "Province",
+            4 => "Region",
+            5 => "Country",
+            _ => string.Empty,
+        };
+    }
+}

--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@
 
             services.AddSingleton<IAchievementManager, AchievementManager>();
             services.AddSingleton<IAchievementRestService, AchievementRestService>();
+            services.AddSingleton<ICommunityManager, CommunityManager>();
+            services.AddSingleton<ICommunityRestService, CommunityRestService>();
             services.AddSingleton<IContactRequestManager, ContactRequestManager>();
             services.AddSingleton<IContactRequestRestService, ContactRequestRestService>();
             services.AddSingleton<IEventAttendeeRestService, EventAttendeeRestService>();

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -83,6 +83,7 @@ public static class MauiProgram
         builder.Services.AddTransient<SearchLitterReportsPage>();
         builder.Services.AddTransient<SetUserLocationPreferencePage>();
         builder.Services.AddTransient<AchievementsPage>();
+        builder.Services.AddTransient<BrowseCommunitiesPage>();
         builder.Services.AddTransient<BrowseTeamsPage>();
         builder.Services.AddTransient<LeaderboardsPage>();
         builder.Services.AddTransient<NewsletterPreferencesPage>();
@@ -90,6 +91,7 @@ public static class MauiProgram
         builder.Services.AddTransient<ViewEventSummaryPage>();
         builder.Services.AddTransient<ViewLitterReportPage>();
         builder.Services.AddTransient<ViewPickupLocationPage>();
+        builder.Services.AddTransient<ViewCommunityPage>();
         builder.Services.AddTransient<ViewTeamPage>();
         builder.Services.AddTransient<WaiverPage>();
         builder.Services.AddTransient<WelcomePage>();
@@ -119,6 +121,7 @@ public static class MauiProgram
         builder.Services.AddTransient<SocialMediaShareViewModel>();
         builder.Services.AddTransient<UserLocationPreferenceViewModel>();
         builder.Services.AddTransient<AchievementsViewModel>();
+        builder.Services.AddTransient<BrowseCommunitiesViewModel>();
         builder.Services.AddTransient<BrowseTeamsViewModel>();
         builder.Services.AddTransient<LeaderboardsViewModel>();
         builder.Services.AddTransient<NewsletterPreferencesViewModel>();
@@ -126,6 +129,7 @@ public static class MauiProgram
         builder.Services.AddTransient<ViewEventSummaryViewModel>();
         builder.Services.AddTransient<ViewLitterReportViewModel>();
         builder.Services.AddTransient<ViewPickupLocationViewModel>();
+        builder.Services.AddTransient<ViewCommunityViewModel>();
         builder.Services.AddTransient<ViewTeamViewModel>();
         builder.Services.AddTransient<WaiverViewModel>();
         builder.Services.AddTransient<WelcomeViewModel>();

--- a/TrashMobMobile/Pages/BrowseCommunitiesPage.xaml
+++ b/TrashMobMobile/Pages/BrowseCommunitiesPage.xaml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:BrowseCommunitiesViewModel"
+             x:Class="TrashMobMobile.Pages.BrowseCommunitiesPage"
+             Title="Communities Near You">
+
+    <RefreshView Command="{Binding RefreshCommand}" IsRefreshing="{Binding IsBusy}">
+        <ScrollView>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+
+                <Label Text="Communities Near You"
+                       FontFamily="LexendSemibold"
+                       FontSize="Title"
+                       Margin="10,15,10,5" />
+
+                <Label Text="No communities found nearby"
+                       IsVisible="{Binding AreNoCommunitiesFound}"
+                       FontSize="Small"
+                       Margin="10,5"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                <CollectionView ItemsSource="{Binding Communities}"
+                                SelectionMode="None"
+                                IsVisible="{Binding AreCommunitiesFound}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:CommunityViewModel">
+                            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                <VerticalStackLayout Padding="10,10" Spacing="4">
+                                    <Label Text="{Binding Name}"
+                                           FontFamily="LexendSemibold"
+                                           FontSize="Small" />
+                                    <Label Text="{Binding Tagline}"
+                                           FontSize="Micro"
+                                           MaxLines="2"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    <HorizontalStackLayout Spacing="8">
+                                        <Label Text="{Binding Location}"
+                                               FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding RegionTypeDisplay}"
+                                               FontSize="Micro"
+                                               FontAttributes="Bold"
+                                               IsVisible="{Binding HasRegionType}"
+                                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                    </HorizontalStackLayout>
+                                </VerticalStackLayout>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:BrowseCommunitiesViewModel}}, Path=ViewCommunityCommand}"
+                                        CommandParameter="{Binding .}" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+</ContentPage>

--- a/TrashMobMobile/Pages/BrowseCommunitiesPage.xaml.cs
+++ b/TrashMobMobile/Pages/BrowseCommunitiesPage.xaml.cs
@@ -1,0 +1,19 @@
+namespace TrashMobMobile.Pages;
+
+public partial class BrowseCommunitiesPage : ContentPage
+{
+    private readonly BrowseCommunitiesViewModel viewModel;
+
+    public BrowseCommunitiesPage(BrowseCommunitiesViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        BindingContext = this.viewModel;
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init();
+    }
+}

--- a/TrashMobMobile/Pages/HomeFeedPage.xaml
+++ b/TrashMobMobile/Pages/HomeFeedPage.xaml
@@ -124,6 +124,29 @@
                     </Grid>
                 </Border>
 
+                <!-- Communities Discovery -->
+                <Label Text="Communities"
+                       FontFamily="LexendSemibold"
+                       FontSize="Medium"
+                       Margin="10,15,10,5" />
+
+                <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                    <Grid ColumnDefinitions="*, Auto" Padding="10,10">
+                        <VerticalStackLayout Grid.Column="0" Spacing="4">
+                            <Label Text="Explore Communities"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Small" />
+                            <Label Text="Discover local cleanup communities and see their impact."
+                                   FontSize="Micro"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                        <Button Grid.Column="1"
+                                Text="Browse"
+                                Command="{Binding BrowseCommunitiesCommand}"
+                                Style="{StaticResource SecondarySmallButton}" />
+                    </Grid>
+                </Border>
+
             </VerticalStackLayout>
         </ScrollView>
     </RefreshView>

--- a/TrashMobMobile/Pages/ViewCommunityPage.xaml
+++ b/TrashMobMobile/Pages/ViewCommunityPage.xaml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ViewCommunityViewModel"
+             x:Class="TrashMobMobile.Pages.ViewCommunityPage"
+             Title="Community Details">
+
+    <ScrollView>
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+
+            <!-- Community Header -->
+            <VerticalStackLayout Padding="10,15" Spacing="4">
+                <Label Text="{Binding CommunityName}"
+                       FontFamily="LexendSemibold"
+                       FontSize="Title" />
+                <Label Text="{Binding Tagline}"
+                       FontSize="Small"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                <Label Text="{Binding Location}"
+                       FontSize="Micro"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+            </VerticalStackLayout>
+
+            <!-- About Section -->
+            <VerticalStackLayout Padding="10,0" IsVisible="{Binding HasPublicNotes}">
+                <Label Text="About"
+                       FontFamily="LexendSemibold"
+                       FontSize="Medium"
+                       Margin="0,5,0,5" />
+                <Label Text="{Binding PublicNotes}"
+                       FontSize="Small"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+            </VerticalStackLayout>
+
+            <!-- Impact Stats -->
+            <Label Text="Community Impact"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="10,15,10,5" />
+
+            <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" Padding="10,0" ColumnSpacing="8" RowSpacing="8">
+                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="0" Padding="8">
+                    <VerticalStackLayout HorizontalOptions="Center">
+                        <Label Text="{Binding Stats.TotalEvents}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                        <Label Text="Events" FontSize="Micro" HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="1" Padding="8">
+                    <VerticalStackLayout HorizontalOptions="Center">
+                        <Label Text="{Binding Stats.TotalAttendees}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                        <Label Text="Volunteers" FontSize="Micro" HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="2" Padding="8">
+                    <VerticalStackLayout HorizontalOptions="Center">
+                        <Label Text="{Binding Stats.TotalBags}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                        <Label Text="Bags" FontSize="Micro" HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="0" Padding="8">
+                    <VerticalStackLayout HorizontalOptions="Center">
+                        <Label Text="{Binding Stats.TotalHours}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                        <Label Text="Hours" FontSize="Micro" HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="1" Padding="8">
+                    <VerticalStackLayout HorizontalOptions="Center">
+                        <Label Text="{Binding Stats.TotalLitterReportsSubmitted}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                        <Label Text="Reports" FontSize="Micro" HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="2" Padding="8">
+                    <VerticalStackLayout HorizontalOptions="Center">
+                        <Label Text="{Binding Stats.TotalLitterReportsClosed}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                        <Label Text="Resolved" FontSize="Micro" HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+            </Grid>
+
+            <!-- Upcoming Events Section -->
+            <Label Text="Upcoming Events"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="10,15,10,5" />
+
+            <Label Text="No upcoming events"
+                   IsVisible="{Binding AreNoEventsFound}"
+                   FontSize="Small"
+                   Margin="10,5"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <CollectionView ItemsSource="{Binding UpcomingEvents}"
+                            SelectionMode="None"
+                            IsVisible="{Binding AreEventsFound}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="viewModels:EventViewModel">
+                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                            <VerticalStackLayout Padding="10,10" Spacing="4">
+                                <Label Text="{Binding Name}"
+                                       FontFamily="LexendSemibold"
+                                       FontSize="Small" />
+                                <Label Text="{Binding DisplayDate}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding Address.DisplayAddress}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <Border.GestureRecognizers>
+                                <TapGestureRecognizer
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewCommunityViewModel}}, Path=ViewEventCommand}"
+                                    CommandParameter="{Binding .}" />
+                            </Border.GestureRecognizers>
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <!-- Nearby Teams Section -->
+            <Label Text="Nearby Teams"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="10,15,10,5" />
+
+            <Label Text="No nearby teams"
+                   IsVisible="{Binding AreNoTeamsFound}"
+                   FontSize="Small"
+                   Margin="10,5"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <CollectionView ItemsSource="{Binding NearbyTeams}"
+                            SelectionMode="None"
+                            IsVisible="{Binding AreTeamsFound}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="viewModels:TeamViewModel">
+                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                            <VerticalStackLayout Padding="10,10" Spacing="4">
+                                <Label Text="{Binding Name}"
+                                       FontFamily="LexendSemibold"
+                                       FontSize="Small" />
+                                <Label Text="{Binding Location}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding MemberCountDisplay}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <Border.GestureRecognizers>
+                                <TapGestureRecognizer
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewCommunityViewModel}}, Path=ViewTeamCommand}"
+                                    CommandParameter="{Binding .}" />
+                            </Border.GestureRecognizers>
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <!-- Contact Info Section -->
+            <Label Text="Contact"
+                   FontFamily="LexendSemibold"
+                   FontSize="Medium"
+                   Margin="10,15,10,5" />
+
+            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3" Padding="10,10">
+                <VerticalStackLayout Spacing="8">
+                    <VerticalStackLayout Spacing="2" IsVisible="{Binding HasWebsite}">
+                        <Label Text="Website" FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding Website}" FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                               TextDecorations="Underline">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding OpenWebsiteCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </VerticalStackLayout>
+                    <VerticalStackLayout Spacing="2" IsVisible="{Binding HasContactEmail}">
+                        <Label Text="Email" FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding ContactEmail}" FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                               TextDecorations="Underline">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding SendEmailCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </VerticalStackLayout>
+                    <VerticalStackLayout Spacing="2" IsVisible="{Binding HasContactPhone}">
+                        <Label Text="Phone" FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding ContactPhone}" FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                               TextDecorations="Underline">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding CallPhoneCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </Border>
+
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" Margin="0,20" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/TrashMobMobile/Pages/ViewCommunityPage.xaml.cs
+++ b/TrashMobMobile/Pages/ViewCommunityPage.xaml.cs
@@ -1,0 +1,22 @@
+namespace TrashMobMobile.Pages;
+
+[QueryProperty(nameof(Slug), nameof(Slug))]
+public partial class ViewCommunityPage : ContentPage
+{
+    private readonly ViewCommunityViewModel viewModel;
+
+    public ViewCommunityPage(ViewCommunityViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        BindingContext = this.viewModel;
+    }
+
+    public string Slug { get; set; } = string.Empty;
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init(Slug);
+    }
+}

--- a/TrashMobMobile/Services/CommunityManager.cs
+++ b/TrashMobMobile/Services/CommunityManager.cs
@@ -1,0 +1,34 @@
+namespace TrashMobMobile.Services;
+
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+
+public class CommunityManager(ICommunityRestService service) : ICommunityManager
+{
+    private readonly ICommunityRestService communityRestService = service;
+
+    public Task<IEnumerable<Partner>> GetCommunitiesAsync(double? latitude = null, double? longitude = null, double? radiusMiles = null, CancellationToken cancellationToken = default)
+    {
+        return communityRestService.GetCommunitiesAsync(latitude, longitude, radiusMiles, cancellationToken);
+    }
+
+    public Task<Partner> GetCommunityBySlugAsync(string slug, CancellationToken cancellationToken = default)
+    {
+        return communityRestService.GetCommunityBySlugAsync(slug, cancellationToken);
+    }
+
+    public Task<IEnumerable<Event>> GetCommunityEventsAsync(string slug, bool upcomingOnly = true, CancellationToken cancellationToken = default)
+    {
+        return communityRestService.GetCommunityEventsAsync(slug, upcomingOnly, cancellationToken);
+    }
+
+    public Task<IEnumerable<Team>> GetCommunityTeamsAsync(string slug, double radiusMiles = 50, CancellationToken cancellationToken = default)
+    {
+        return communityRestService.GetCommunityTeamsAsync(slug, radiusMiles, cancellationToken);
+    }
+
+    public Task<Stats> GetCommunityStatsAsync(string slug, CancellationToken cancellationToken = default)
+    {
+        return communityRestService.GetCommunityStatsAsync(slug, cancellationToken);
+    }
+}

--- a/TrashMobMobile/Services/CommunityRestService.cs
+++ b/TrashMobMobile/Services/CommunityRestService.cs
@@ -1,0 +1,78 @@
+namespace TrashMobMobile.Services;
+
+using System.Globalization;
+using Newtonsoft.Json;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+
+public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), ICommunityRestService
+{
+    protected override string Controller => "communities";
+
+    public async Task<IEnumerable<Partner>> GetCommunitiesAsync(double? latitude = null, double? longitude = null, double? radiusMiles = null, CancellationToken cancellationToken = default)
+    {
+        var requestUri = Controller;
+        var queryParams = new List<string>();
+
+        if (latitude.HasValue)
+        {
+            queryParams.Add($"latitude={latitude.Value.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        if (longitude.HasValue)
+        {
+            queryParams.Add($"longitude={longitude.Value.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        if (radiusMiles.HasValue)
+        {
+            queryParams.Add($"radiusMiles={radiusMiles.Value.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        if (queryParams.Count > 0)
+        {
+            requestUri += "?" + string.Join("&", queryParams);
+        }
+
+        using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<List<Partner>>(content) ?? [];
+    }
+
+    public async Task<Partner> GetCommunityBySlugAsync(string slug, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{Controller}/{slug}";
+        using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<Partner>(content);
+    }
+
+    public async Task<IEnumerable<Event>> GetCommunityEventsAsync(string slug, bool upcomingOnly = true, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{Controller}/{slug}/events?upcomingOnly={upcomingOnly}";
+        using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<List<Event>>(content) ?? [];
+    }
+
+    public async Task<IEnumerable<Team>> GetCommunityTeamsAsync(string slug, double radiusMiles = 50, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{Controller}/{slug}/teams?radiusMiles={radiusMiles.ToString(CultureInfo.InvariantCulture)}";
+        using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<List<Team>>(content) ?? [];
+    }
+
+    public async Task<Stats> GetCommunityStatsAsync(string slug, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{Controller}/{slug}/stats";
+        using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<Stats>(content) ?? new Stats();
+    }
+}

--- a/TrashMobMobile/Services/ICommunityManager.cs
+++ b/TrashMobMobile/Services/ICommunityManager.cs
@@ -1,0 +1,17 @@
+namespace TrashMobMobile.Services;
+
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+
+public interface ICommunityManager
+{
+    Task<IEnumerable<Partner>> GetCommunitiesAsync(double? latitude = null, double? longitude = null, double? radiusMiles = null, CancellationToken cancellationToken = default);
+
+    Task<Partner> GetCommunityBySlugAsync(string slug, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<Event>> GetCommunityEventsAsync(string slug, bool upcomingOnly = true, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<Team>> GetCommunityTeamsAsync(string slug, double radiusMiles = 50, CancellationToken cancellationToken = default);
+
+    Task<Stats> GetCommunityStatsAsync(string slug, CancellationToken cancellationToken = default);
+}

--- a/TrashMobMobile/Services/ICommunityRestService.cs
+++ b/TrashMobMobile/Services/ICommunityRestService.cs
@@ -1,0 +1,17 @@
+namespace TrashMobMobile.Services;
+
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+
+public interface ICommunityRestService
+{
+    Task<IEnumerable<Partner>> GetCommunitiesAsync(double? latitude = null, double? longitude = null, double? radiusMiles = null, CancellationToken cancellationToken = default);
+
+    Task<Partner> GetCommunityBySlugAsync(string slug, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<Event>> GetCommunityEventsAsync(string slug, bool upcomingOnly = true, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<Team>> GetCommunityTeamsAsync(string slug, double radiusMiles = 50, CancellationToken cancellationToken = default);
+
+    Task<Stats> GetCommunityStatsAsync(string slug, CancellationToken cancellationToken = default);
+}

--- a/TrashMobMobile/ViewModels/BrowseCommunitiesViewModel.cs
+++ b/TrashMobMobile/ViewModels/BrowseCommunitiesViewModel.cs
@@ -1,0 +1,63 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMobMobile.Extensions;
+using TrashMobMobile.Services;
+
+public partial class BrowseCommunitiesViewModel(
+    ICommunityManager communityManager,
+    INotificationService notificationService,
+    IUserManager userManager) : BaseViewModel(notificationService)
+{
+    private readonly ICommunityManager communityManager = communityManager;
+    private readonly IUserManager userManager = userManager;
+
+    [ObservableProperty]
+    private bool areCommunitiesFound;
+
+    [ObservableProperty]
+    private bool areNoCommunitiesFound = true;
+
+    public ObservableCollection<CommunityViewModel> Communities { get; } = [];
+
+    public async Task Init()
+    {
+        await ExecuteAsync(async () =>
+        {
+            var user = userManager.CurrentUser;
+            var address = user.GetAddress();
+
+            var communities = await communityManager.GetCommunitiesAsync(
+                address.Latitude, address.Longitude, 100);
+
+            Communities.Clear();
+            foreach (var community in communities)
+            {
+                Communities.Add(community.ToCommunityViewModel());
+            }
+
+            AreCommunitiesFound = Communities.Count > 0;
+            AreNoCommunitiesFound = !AreCommunitiesFound;
+        }, "Failed to load communities. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task Refresh()
+    {
+        await Init();
+    }
+
+    [RelayCommand]
+    private async Task ViewCommunity(CommunityViewModel? communityVm)
+    {
+        if (communityVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewCommunityPage)}?Slug={communityVm.Slug}");
+    }
+}

--- a/TrashMobMobile/ViewModels/CommunityViewModel.cs
+++ b/TrashMobMobile/ViewModels/CommunityViewModel.cs
@@ -1,0 +1,27 @@
+namespace TrashMobMobile.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+public partial class CommunityViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private Guid id;
+
+    [ObservableProperty]
+    private string slug = string.Empty;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private string tagline = string.Empty;
+
+    [ObservableProperty]
+    private string location = string.Empty;
+
+    [ObservableProperty]
+    private string regionTypeDisplay = string.Empty;
+
+    [ObservableProperty]
+    private bool hasRegionType;
+}

--- a/TrashMobMobile/ViewModels/HomeFeedViewModel.cs
+++ b/TrashMobMobile/ViewModels/HomeFeedViewModel.cs
@@ -75,6 +75,12 @@ public partial class HomeFeedViewModel(
     }
 
     [RelayCommand]
+    private async Task BrowseCommunities()
+    {
+        await Shell.Current.GoToAsync(nameof(BrowseCommunitiesPage));
+    }
+
+    [RelayCommand]
     private async Task ViewLitterReport(LitterReportViewModel? reportVm)
     {
         if (reportVm == null)

--- a/TrashMobMobile/ViewModels/ViewCommunityViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewCommunityViewModel.cs
@@ -1,0 +1,214 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMobMobile.Extensions;
+using TrashMobMobile.Services;
+
+public partial class ViewCommunityViewModel(
+    ICommunityManager communityManager,
+    INotificationService notificationService,
+    IUserManager userManager) : BaseViewModel(notificationService)
+{
+    private readonly ICommunityManager communityManager = communityManager;
+    private readonly IUserManager userManager = userManager;
+
+    private string slug = string.Empty;
+
+    [ObservableProperty]
+    private string communityName = string.Empty;
+
+    [ObservableProperty]
+    private string tagline = string.Empty;
+
+    [ObservableProperty]
+    private string publicNotes = string.Empty;
+
+    [ObservableProperty]
+    private bool hasPublicNotes;
+
+    [ObservableProperty]
+    private string location = string.Empty;
+
+    [ObservableProperty]
+    private string website = string.Empty;
+
+    [ObservableProperty]
+    private bool hasWebsite;
+
+    [ObservableProperty]
+    private string contactEmail = string.Empty;
+
+    [ObservableProperty]
+    private bool hasContactEmail;
+
+    [ObservableProperty]
+    private string contactPhone = string.Empty;
+
+    [ObservableProperty]
+    private bool hasContactPhone;
+
+    [ObservableProperty]
+    private StatisticsViewModel stats = new();
+
+    [ObservableProperty]
+    private bool areEventsFound;
+
+    [ObservableProperty]
+    private bool areNoEventsFound = true;
+
+    [ObservableProperty]
+    private bool areTeamsFound;
+
+    [ObservableProperty]
+    private bool areNoTeamsFound = true;
+
+    public ObservableCollection<EventViewModel> UpcomingEvents { get; } = [];
+
+    public ObservableCollection<TeamViewModel> NearbyTeams { get; } = [];
+
+    public async Task Init(string slug)
+    {
+        this.slug = slug;
+
+        await ExecuteAsync(async () =>
+        {
+            await Task.WhenAll(
+                RefreshCommunity(),
+                RefreshStats(),
+                RefreshUpcomingEvents(),
+                RefreshNearbyTeams());
+        }, "Failed to load community details. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task ViewEvent(EventViewModel? eventVm)
+    {
+        if (eventVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewEventPage)}?EventId={eventVm.Id}");
+    }
+
+    [RelayCommand]
+    private async Task ViewTeam(TeamViewModel? teamVm)
+    {
+        if (teamVm == null)
+        {
+            return;
+        }
+
+        await Shell.Current.GoToAsync(
+            $"{nameof(ViewTeamPage)}?TeamId={teamVm.Id}");
+    }
+
+    [RelayCommand]
+    private async Task OpenWebsite()
+    {
+        if (!string.IsNullOrEmpty(website))
+        {
+            await Browser.Default.OpenAsync(website, BrowserLaunchMode.SystemPreferred);
+        }
+    }
+
+    [RelayCommand]
+    private async Task SendEmail()
+    {
+        if (!string.IsNullOrEmpty(contactEmail))
+        {
+            await Browser.Default.OpenAsync($"mailto:{contactEmail}", BrowserLaunchMode.SystemPreferred);
+        }
+    }
+
+    [RelayCommand]
+    private async Task CallPhone()
+    {
+        if (!string.IsNullOrEmpty(contactPhone))
+        {
+            await Browser.Default.OpenAsync($"tel:{contactPhone}", BrowserLaunchMode.SystemPreferred);
+        }
+    }
+
+    private async Task RefreshCommunity()
+    {
+        var community = await communityManager.GetCommunityBySlugAsync(slug);
+
+        CommunityName = community.Name ?? string.Empty;
+        Tagline = community.Tagline ?? string.Empty;
+        PublicNotes = community.PublicNotes ?? string.Empty;
+        HasPublicNotes = !string.IsNullOrWhiteSpace(PublicNotes);
+
+        var locationParts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(community.City))
+        {
+            locationParts.Add(community.City);
+        }
+
+        if (!string.IsNullOrWhiteSpace(community.Region))
+        {
+            locationParts.Add(community.Region);
+        }
+
+        if (!string.IsNullOrWhiteSpace(community.Country))
+        {
+            locationParts.Add(community.Country);
+        }
+
+        Location = string.Join(", ", locationParts);
+
+        Website = community.Website ?? string.Empty;
+        HasWebsite = !string.IsNullOrWhiteSpace(Website);
+        ContactEmail = community.ContactEmail ?? string.Empty;
+        HasContactEmail = !string.IsNullOrWhiteSpace(ContactEmail);
+        ContactPhone = community.ContactPhone ?? string.Empty;
+        HasContactPhone = !string.IsNullOrWhiteSpace(ContactPhone);
+    }
+
+    private async Task RefreshStats()
+    {
+        var statsData = await communityManager.GetCommunityStatsAsync(slug);
+
+        Stats = new StatisticsViewModel
+        {
+            TotalAttendees = statsData.TotalParticipants,
+            TotalEvents = statsData.TotalEvents,
+            TotalBags = statsData.TotalBags,
+            TotalHours = statsData.TotalHours,
+            TotalLitterReportsSubmitted = statsData.TotalLitterReportsSubmitted,
+            TotalLitterReportsClosed = statsData.TotalLitterReportsClosed,
+        };
+    }
+
+    private async Task RefreshUpcomingEvents()
+    {
+        var events = await communityManager.GetCommunityEventsAsync(slug, true);
+        var userId = userManager.CurrentUser.Id;
+
+        UpcomingEvents.Clear();
+        foreach (var mobEvent in events.OrderBy(e => e.EventDate).Take(10))
+        {
+            UpcomingEvents.Add(mobEvent.ToEventViewModel(userId));
+        }
+
+        AreEventsFound = UpcomingEvents.Count > 0;
+        AreNoEventsFound = !AreEventsFound;
+    }
+
+    private async Task RefreshNearbyTeams()
+    {
+        var teams = await communityManager.GetCommunityTeamsAsync(slug);
+
+        NearbyTeams.Clear();
+        foreach (var team in teams.Where(t => t.IsActive).Take(10))
+        {
+            NearbyTeams.Add(team.ToTeamViewModel());
+        }
+
+        AreTeamsFound = NearbyTeams.Count > 0;
+        AreNoTeamsFound = !AreTeamsFound;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds browse communities page with location-based search (100mi radius) and pull-to-refresh
- Adds community detail page with info, impact stats (6-tile grid), upcoming events, nearby teams, and contact info
- Adds "Communities" discovery card to the Home Feed page
- Follows the existing Teams feature architecture exactly (service → manager → VM → page)

## New Files (12)
- `Services/ICommunityRestService.cs`, `CommunityRestService.cs` — REST client for 5 public community endpoints (anonymous HTTP)
- `Services/ICommunityManager.cs`, `CommunityManager.cs` — Manager layer pass-through
- `Extensions/CommunityExtensions.cs` — Partner → CommunityViewModel mapping
- `ViewModels/CommunityViewModel.cs` — Browse list display model
- `ViewModels/BrowseCommunitiesViewModel.cs` — Browse page VM with location search
- `ViewModels/ViewCommunityViewModel.cs` — Detail page VM with parallel data loading
- `Pages/BrowseCommunitiesPage.xaml` + `.xaml.cs` — Browse page
- `Pages/ViewCommunityPage.xaml` + `.xaml.cs` — Detail page with stats, events, teams, contact

## Modified Files (5)
- `Extensions/ServiceCollectionExtensions.cs` — Register ICommunityManager + ICommunityRestService singletons
- `MauiProgram.cs` — Register 4 transient services (2 pages + 2 VMs)
- `AppShell.xaml.cs` — Register 2 routes
- `ViewModels/HomeFeedViewModel.cs` — Add BrowseCommunitiesCommand
- `Pages/HomeFeedPage.xaml` — Add Communities discovery card

## Test plan
- [ ] Build succeeds for Android target (verified: 0 errors, 0 warnings)
- [ ] Home Feed shows "Communities" card with Browse button
- [ ] Tapping Browse navigates to BrowseCommunitiesPage
- [ ] Communities load based on user location
- [ ] Tapping a community navigates to ViewCommunityPage with slug
- [ ] Detail page shows community info, stats grid, upcoming events, nearby teams, contact
- [ ] Tapping an event navigates to event detail
- [ ] Tapping a team navigates to team detail
- [ ] Contact links (website, email, phone) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)