### PR TITLE
Add AI-assisted area definition (Project 44 Phase 3)

### DIFF
--- a/TrashMob.Models/AreaSuggestionRequest.cs
+++ b/TrashMob.Models/AreaSuggestionRequest.cs
@@ -1,0 +1,13 @@
+namespace TrashMob.Models
+{
+    public class AreaSuggestionRequest
+    {
+        public string Description { get; set; } = string.Empty;
+
+        public double? CenterLatitude { get; set; }
+
+        public double? CenterLongitude { get; set; }
+
+        public string? CommunityName { get; set; }
+    }
+}

--- a/TrashMob.Models/AreaSuggestionResult.cs
+++ b/TrashMob.Models/AreaSuggestionResult.cs
@@ -1,0 +1,15 @@
+namespace TrashMob.Models
+{
+    public class AreaSuggestionResult
+    {
+        public string? GeoJson { get; set; }
+
+        public string? SuggestedName { get; set; }
+
+        public string? SuggestedAreaType { get; set; }
+
+        public double Confidence { get; set; }
+
+        public string? Message { get; set; }
+    }
+}

--- a/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
@@ -1,0 +1,318 @@
+#nullable enable
+
+namespace TrashMob.Shared.Managers.Areas
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Anthropic;
+    using Anthropic.Models.Messages;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    public class AreaSuggestionService : IAreaSuggestionService
+    {
+        private readonly IConfiguration configuration;
+        private readonly ILogger<AreaSuggestionService> logger;
+        private readonly IMapManager mapManager;
+        private static readonly SemaphoreSlim RateLimiter = new(1, 1);
+        private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+        private const string SystemPrompt = """
+            You are a geographic area interpreter for TrashMob.eco, a community cleanup platform.
+            Users describe areas they want to adopt for cleanup. Your job is to convert their
+            natural language description into structured geocoding queries.
+
+            You must return ONLY a JSON object with these fields:
+            - "queries": array of objects, each with:
+              - "address": string — a specific address or intersection to geocode
+              - "type": string — either "point" (single location) or "street_segment" (a stretch of road)
+            - "suggestedName": string — a concise, descriptive name for this area (e.g. "200 Block of Main St")
+            - "suggestedAreaType": string — one of: "Highway", "Park", "Trail", "Waterway", "Street", "Spot"
+            - "geometryType": string — either "polygon" (for parks, lots, blocks) or "linestring" (for streets, trails, waterways)
+            - "confidence": number — your confidence in the interpretation, from 0.0 to 1.0
+
+            Guidelines:
+            - For street segments: provide start and end intersection addresses as two queries with type "street_segment"
+            - For parks or landmarks: provide the park/landmark name as a single query with type "point"
+            - For blocks: provide the two nearest cross-street intersections as queries
+            - Include the city/community name in each address for accurate geocoding
+            - If the description is ambiguous, use your best interpretation and lower the confidence
+
+            Return ONLY the JSON object, no markdown fences, no other text.
+            """;
+
+        public AreaSuggestionService(
+            IConfiguration configuration,
+            ILogger<AreaSuggestionService> logger,
+            IMapManager mapManager)
+        {
+            this.configuration = configuration;
+            this.logger = logger;
+            this.mapManager = mapManager;
+        }
+
+        public async Task<AreaSuggestionResult> SuggestAreaAsync(
+            AreaSuggestionRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(request.Description))
+            {
+                return new AreaSuggestionResult { Message = "Please provide a description of the area." };
+            }
+
+            var apiKey = configuration["AnthropicApiKey"];
+            if (string.IsNullOrWhiteSpace(apiKey) || apiKey == "x")
+            {
+                logger.LogWarning("Anthropic API key not configured. AI area suggestion unavailable.");
+                return new AreaSuggestionResult { Message = "AI area suggestion is not configured." };
+            }
+
+            await RateLimiter.WaitAsync(cancellationToken);
+            try
+            {
+                // Step 1: Ask Claude to interpret the description
+                var claudeResponse = await GetClaudeInterpretation(apiKey, request, cancellationToken);
+                if (claudeResponse == null)
+                {
+                    return new AreaSuggestionResult { Message = "Could not interpret the area description. Try being more specific." };
+                }
+
+                // Step 2: Geocode each query via Azure Maps
+                var coordinates = await GeocodeQueries(claudeResponse.Queries, cancellationToken);
+                if (coordinates.Count == 0)
+                {
+                    return new AreaSuggestionResult
+                    {
+                        Message = "Could not find coordinates for the described area. Try including a city name or more specific landmarks.",
+                        SuggestedName = claudeResponse.SuggestedName,
+                        SuggestedAreaType = claudeResponse.SuggestedAreaType,
+                        Confidence = claudeResponse.Confidence,
+                    };
+                }
+
+                // Step 3: Build GeoJSON from coordinates
+                var geoJson = BuildGeoJson(coordinates, claudeResponse.GeometryType);
+
+                return new AreaSuggestionResult
+                {
+                    GeoJson = geoJson,
+                    SuggestedName = claudeResponse.SuggestedName,
+                    SuggestedAreaType = claudeResponse.SuggestedAreaType,
+                    Confidence = claudeResponse.Confidence,
+                };
+            }
+            catch (JsonException ex)
+            {
+                logger.LogError(ex, "Failed to parse Claude response for area suggestion");
+                return new AreaSuggestionResult
+                {
+                    Message = "AI returned a response that could not be parsed. Try rephrasing your description.",
+                };
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error during AI area suggestion");
+                return new AreaSuggestionResult
+                {
+                    Message = $"Area suggestion failed: {ex.Message}",
+                };
+            }
+            finally
+            {
+                RateLimiter.Release();
+            }
+        }
+
+        private async Task<ClaudeAreaResponse?> GetClaudeInterpretation(
+            string apiKey,
+            AreaSuggestionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var userPrompt = BuildUserPrompt(request);
+
+            var client = new AnthropicClient { ApiKey = apiKey };
+            var maxTokens = int.TryParse(configuration["AnthropicMaxTokens"], out var mt) ? mt : 4096;
+
+            var response = await client.Messages.Create(new MessageCreateParams
+            {
+                Model = Model.ClaudeSonnet4_5_20250929,
+                MaxTokens = maxTokens,
+                System = SystemPrompt,
+                Messages = [new MessageParam { Role = "user", Content = userPrompt }],
+            }, cancellationToken: cancellationToken);
+
+            string responseText = "{}";
+            if (response.Content?.Count > 0 && response.Content[0].TryPickText(out var textBlock))
+            {
+                responseText = textBlock.Text;
+            }
+
+            var tokensUsed = (int)((response.Usage?.InputTokens ?? 0) + (response.Usage?.OutputTokens ?? 0));
+            logger.LogInformation("Claude area suggestion used {Tokens} tokens", tokensUsed);
+
+            // Strip markdown fences if present
+            responseText = responseText.Trim();
+            if (responseText.StartsWith("```"))
+            {
+                var firstNewline = responseText.IndexOf('\n');
+                if (firstNewline > 0)
+                {
+                    responseText = responseText[(firstNewline + 1)..];
+                }
+
+                if (responseText.EndsWith("```"))
+                {
+                    responseText = responseText[..^3].Trim();
+                }
+            }
+
+            return JsonSerializer.Deserialize<ClaudeAreaResponse>(responseText, JsonOptions);
+        }
+
+        private static string BuildUserPrompt(AreaSuggestionRequest request)
+        {
+            var parts = new List<string>
+            {
+                $"Area description: \"{request.Description}\"",
+            };
+
+            if (!string.IsNullOrWhiteSpace(request.CommunityName))
+            {
+                parts.Add($"Community: {request.CommunityName}");
+            }
+
+            if (request.CenterLatitude.HasValue && request.CenterLongitude.HasValue)
+            {
+                parts.Add($"Community center coordinates: {request.CenterLatitude.Value:F6}, {request.CenterLongitude.Value:F6}");
+            }
+
+            return string.Join("\n", parts);
+        }
+
+        private async Task<List<(double Lat, double Lon)>> GeocodeQueries(
+            List<GeocodingQuery>? queries,
+            CancellationToken cancellationToken)
+        {
+            var coordinates = new List<(double Lat, double Lon)>();
+
+            if (queries == null || queries.Count == 0)
+            {
+                return coordinates;
+            }
+
+            foreach (var query in queries)
+            {
+                try
+                {
+                    var rawJson = await mapManager.SearchAddressAsync(query.Address);
+                    var searchResult = JsonSerializer.Deserialize<AzureMapsSearchResponse>(rawJson, JsonOptions);
+
+                    if (searchResult?.Results != null && searchResult.Results.Count > 0)
+                    {
+                        var topResult = searchResult.Results[0];
+                        coordinates.Add((topResult.Position.Lat, topResult.Position.Lon));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to geocode query: {Address}", query.Address);
+                }
+            }
+
+            return coordinates;
+        }
+
+        private static string BuildGeoJson(List<(double Lat, double Lon)> coordinates, string? geometryType)
+        {
+            if (geometryType?.Equals("linestring", StringComparison.OrdinalIgnoreCase) == true
+                && coordinates.Count >= 2)
+            {
+                // Build a LineString
+                var coords = coordinates
+                    .Select(c => $"[{c.Lon.ToString(CultureInfo.InvariantCulture)},{c.Lat.ToString(CultureInfo.InvariantCulture)}]");
+                return $"{{\"type\":\"LineString\",\"coordinates\":[{string.Join(",", coords)}]}}";
+            }
+
+            // Build a Polygon
+            if (coordinates.Count == 1)
+            {
+                // Single point: create a small rectangular polygon around it (~100m)
+                var (lat, lon) = coordinates[0];
+                const double offset = 0.0005; // ~50m
+                return BuildRectangleGeoJson(lat - offset, lon - offset, lat + offset, lon + offset);
+            }
+
+            if (coordinates.Count == 2)
+            {
+                // Two points: create a rectangle from their bounding box with padding
+                var minLat = Math.Min(coordinates[0].Lat, coordinates[1].Lat);
+                var maxLat = Math.Max(coordinates[0].Lat, coordinates[1].Lat);
+                var minLon = Math.Min(coordinates[0].Lon, coordinates[1].Lon);
+                var maxLon = Math.Max(coordinates[0].Lon, coordinates[1].Lon);
+
+                // Add small padding
+                const double padding = 0.0002; // ~20m
+                return BuildRectangleGeoJson(minLat - padding, minLon - padding, maxLat + padding, maxLon + padding);
+            }
+
+            // 3+ points: close the polygon ring
+            var polyCoords = coordinates
+                .Select(c => $"[{c.Lon.ToString(CultureInfo.InvariantCulture)},{c.Lat.ToString(CultureInfo.InvariantCulture)}]")
+                .ToList();
+            // Close the ring by repeating the first point
+            polyCoords.Add(polyCoords[0]);
+            return $"{{\"type\":\"Polygon\",\"coordinates\":[[{string.Join(",", polyCoords)}]]}}";
+        }
+
+        private static string BuildRectangleGeoJson(double south, double west, double north, double east)
+        {
+            var sw = $"[{west.ToString(CultureInfo.InvariantCulture)},{south.ToString(CultureInfo.InvariantCulture)}]";
+            var nw = $"[{west.ToString(CultureInfo.InvariantCulture)},{north.ToString(CultureInfo.InvariantCulture)}]";
+            var ne = $"[{east.ToString(CultureInfo.InvariantCulture)},{north.ToString(CultureInfo.InvariantCulture)}]";
+            var se = $"[{east.ToString(CultureInfo.InvariantCulture)},{south.ToString(CultureInfo.InvariantCulture)}]";
+            return $"{{\"type\":\"Polygon\",\"coordinates\":[[{sw},{nw},{ne},{se},{sw}]]}}";
+        }
+
+        // Internal DTOs for Claude response parsing
+
+        private sealed class ClaudeAreaResponse
+        {
+            public List<GeocodingQuery>? Queries { get; set; }
+            public string? SuggestedName { get; set; }
+            public string? SuggestedAreaType { get; set; }
+            public string? GeometryType { get; set; }
+            public double Confidence { get; set; }
+        }
+
+        private sealed class GeocodingQuery
+        {
+            public string Address { get; set; } = string.Empty;
+            public string Type { get; set; } = "point";
+        }
+
+        // Internal DTOs for Azure Maps response parsing
+
+        private sealed class AzureMapsSearchResponse
+        {
+            public List<AzureMapsSearchResult>? Results { get; set; }
+        }
+
+        private sealed class AzureMapsSearchResult
+        {
+            public AzureMapsPosition Position { get; set; } = new();
+        }
+
+        private sealed class AzureMapsPosition
+        {
+            public double Lat { get; set; }
+            public double Lon { get; set; }
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Areas/IAreaSuggestionService.cs
+++ b/TrashMob.Shared/Managers/Areas/IAreaSuggestionService.cs
@@ -1,0 +1,12 @@
+namespace TrashMob.Shared.Managers.Areas
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models;
+
+    public interface IAreaSuggestionService
+    {
+        Task<AreaSuggestionResult> SuggestAreaAsync(
+            AreaSuggestionRequest request, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -11,6 +11,7 @@
     using TrashMob.Shared.Managers.Teams;
     using TrashMob.Shared.Managers.Communities;
     using TrashMob.Shared.Managers.Adoptions;
+    using TrashMob.Shared.Managers.Areas;
     using TrashMob.Shared.Managers.Gamification;
     using TrashMob.Shared.Managers.Prospects;
     using TrashMob.Shared.Managers.SponsoredAdoptions;
@@ -102,6 +103,7 @@
 
             // Adoption managers
             services.AddScoped<IAdoptableAreaManager, AdoptableAreaManager>();
+            services.AddScoped<IAreaSuggestionService, AreaSuggestionService>();
             services.AddScoped<ITeamAdoptionManager, TeamAdoptionManager>();
             services.AddScoped<ITeamAdoptionEventManager, TeamAdoptionEventManager>();
 

--- a/TrashMob/client-app/src/components/Map/AreaMapEditor/AiSuggestPanel.tsx
+++ b/TrashMob/client-app/src/components/Map/AreaMapEditor/AiSuggestPanel.tsx
@@ -1,0 +1,142 @@
+import { useState, useRef } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Sparkles, Check, Pencil, RotateCcw, Loader2, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { SuggestArea, SuggestArea_Response } from '@/services/adoptable-areas';
+
+interface AiSuggestPanelProps {
+    partnerId: string;
+    communityCenter?: { lat: number; lng: number } | null;
+    communityName?: string;
+    onSuggestionAccepted: (geoJson: string, suggestedName?: string, suggestedAreaType?: string) => void;
+    onSuggestionPreview: (geoJson: string | null) => void;
+    onRequestEditMode?: () => void;
+}
+
+export const AiSuggestPanel = ({
+    partnerId,
+    communityCenter,
+    communityName,
+    onSuggestionAccepted,
+    onSuggestionPreview,
+    onRequestEditMode,
+}: AiSuggestPanelProps) => {
+    const [description, setDescription] = useState('');
+    const [suggestion, setSuggestion] = useState<SuggestArea_Response | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const { mutate, isPending, error } = useMutation({
+        mutationKey: SuggestArea().key,
+        mutationFn: (desc: string) =>
+            SuggestArea().service(
+                { partnerId },
+                {
+                    description: desc,
+                    centerLatitude: communityCenter?.lat,
+                    centerLongitude: communityCenter?.lng,
+                    communityName,
+                },
+            ),
+        onSuccess: (response) => {
+            const data = response.data;
+            setSuggestion(data);
+            if (data.geoJson) {
+                onSuggestionPreview(data.geoJson);
+            }
+        },
+    });
+
+    const handleSuggest = () => {
+        if (!description.trim() || isPending) return;
+        setSuggestion(null);
+        mutate(description.trim());
+    };
+
+    const handleAccept = () => {
+        if (!suggestion?.geoJson) return;
+        onSuggestionPreview(null);
+        onSuggestionAccepted(
+            suggestion.geoJson,
+            suggestion.suggestedName ?? undefined,
+            suggestion.suggestedAreaType ?? undefined,
+        );
+        setSuggestion(null);
+        setDescription('');
+    };
+
+    const handleAdjust = () => {
+        if (!suggestion?.geoJson) return;
+        onSuggestionPreview(null);
+        onSuggestionAccepted(
+            suggestion.geoJson,
+            suggestion.suggestedName ?? undefined,
+            suggestion.suggestedAreaType ?? undefined,
+        );
+        onRequestEditMode?.();
+        setSuggestion(null);
+        setDescription('');
+    };
+
+    const handleTryAgain = () => {
+        onSuggestionPreview(null);
+        setSuggestion(null);
+        inputRef.current?.focus();
+    };
+
+    const errorMessage = suggestion?.message || (error ? 'An unexpected error occurred.' : null);
+    const hasSuggestion = suggestion?.geoJson != null;
+    const confidencePercent = suggestion ? Math.round(suggestion.confidence * 100) : 0;
+
+    return (
+        <div className='border rounded-t-lg bg-background'>
+            <div className='flex items-center gap-2 p-2'>
+                <Sparkles className='h-4 w-4 text-violet-500 shrink-0' />
+                <Input
+                    ref={inputRef}
+                    type='text'
+                    placeholder='Describe the area, e.g. "200 block of Main St from Oak to Elm"'
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleSuggest();
+                    }}
+                    disabled={isPending}
+                    className='h-8 text-sm'
+                />
+                <Button type='button' size='sm' onClick={handleSuggest} disabled={!description.trim() || isPending}>
+                    {isPending ? <Loader2 className='h-4 w-4 animate-spin' /> : 'Suggest'}
+                </Button>
+            </div>
+            {hasSuggestion ? (
+                <div className='flex items-center justify-between gap-2 px-2 pb-2'>
+                    <span className='text-sm text-muted-foreground truncate'>
+                        Suggested: <strong>{suggestion.suggestedName}</strong>
+                        {suggestion.suggestedAreaType ? ` (${suggestion.suggestedAreaType})` : ''}
+                        {confidencePercent > 0 ? ` \u2014 ${confidencePercent}% confidence` : ''}
+                    </span>
+                    <div className='flex gap-1 shrink-0'>
+                        <Button type='button' size='sm' variant='default' onClick={handleAccept}>
+                            <Check className='h-3.5 w-3.5 mr-1' />
+                            Accept
+                        </Button>
+                        <Button type='button' size='sm' variant='outline' onClick={handleAdjust}>
+                            <Pencil className='h-3.5 w-3.5 mr-1' />
+                            Adjust
+                        </Button>
+                        <Button type='button' size='sm' variant='ghost' onClick={handleTryAgain}>
+                            <RotateCcw className='h-3.5 w-3.5 mr-1' />
+                            Retry
+                        </Button>
+                    </div>
+                </div>
+            ) : null}
+            {errorMessage && !hasSuggestion ? (
+                <div className='flex items-center gap-2 px-2 pb-2 text-sm text-destructive'>
+                    <AlertCircle className='h-4 w-4 shrink-0' />
+                    <span>{errorMessage}</span>
+                </div>
+            ) : null}
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/$areaId.edit.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/$areaId.edit.tsx
@@ -453,6 +453,8 @@ export const PartnerCommunityAreaEdit = () => {
                                                 }
                                                 existingAreas={existingAreas}
                                                 currentAreaId={areaId}
+                                                partnerId={partnerId}
+                                                communityName={community?.name}
                                             />
                                         </FormControl>
                                         <FormMessage />

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/create.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/create.tsx
@@ -357,6 +357,8 @@ export const PartnerCommunityAreaCreate = () => {
                                                         : null
                                                 }
                                                 existingAreas={existingAreas}
+                                                partnerId={partnerId}
+                                                communityName={community?.name}
                                             />
                                         </FormControl>
                                         <FormMessage />

--- a/TrashMob/client-app/src/services/adoptable-areas.ts
+++ b/TrashMob/client-app/src/services/adoptable-areas.ts
@@ -90,3 +90,31 @@ export const DeleteAdoptableArea = () => ({
             method: 'delete',
         }),
 });
+
+// ============================================================================
+// AI Area Suggestion
+// ============================================================================
+
+export type SuggestArea_Params = { partnerId: string };
+export type SuggestArea_Body = {
+    description: string;
+    centerLatitude?: number;
+    centerLongitude?: number;
+    communityName?: string;
+};
+export type SuggestArea_Response = {
+    geoJson: string | null;
+    suggestedName: string | null;
+    suggestedAreaType: string | null;
+    confidence: number;
+    message: string | null;
+};
+export const SuggestArea = () => ({
+    key: ['/communities/areas', 'suggest'],
+    service: async (params: SuggestArea_Params, body: SuggestArea_Body) =>
+        ApiService('protected').fetchData<SuggestArea_Response>({
+            url: `/communities/${params.partnerId}/areas/suggest`,
+            method: 'post',
+            data: body,
+        }),
+});


### PR DESCRIPTION
## Summary
- Adds natural language area suggestion to the adoptable area map editor
- Community admins type a description (e.g. "200 block of Main St from Oak Ave to Elm Ave"), Claude interprets it into structured geocoding queries, Azure Maps resolves coordinates, and GeoJSON is constructed for preview on the map
- Accept/Adjust/Try Again workflow lets admins review, refine, or retry suggestions before saving

## Changes

**New backend files (4):**
- `TrashMob.Models/AreaSuggestionRequest.cs` — Request POCO
- `TrashMob.Models/AreaSuggestionResult.cs` — Response POCO with GeoJson, SuggestedName, SuggestedAreaType, Confidence, Message
- `TrashMob.Shared/Managers/Areas/IAreaSuggestionService.cs` — Service interface
- `TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs` — Claude API + Azure Maps geocoding implementation (follows ClaudeDiscoveryService pattern)

**New frontend file (1):**
- `AiSuggestPanel.tsx` — Inline panel with text input, Suggest button, and Accept/Adjust/Retry controls

**Modified files (7):**
- `ServiceBuilder.cs` — Register IAreaSuggestionService
- `AdoptableAreasController.cs` — Add `POST api/communities/{partnerId}/areas/suggest` endpoint
- `adoptable-areas.ts` — Add SuggestArea mutation service
- `DrawingLayer.tsx` — Add `injectGeoJson` prop for programmatic shape injection from AI suggestions
- `AreaMapEditor.tsx` — Integrate AiSuggestPanel, wire suggestion preview → DrawingLayer injection
- `create.tsx` / `$areaId.edit.tsx` — Pass `partnerId` and `communityName` props to AreaMapEditor

## Test plan
- [ ] Create area page shows AI Suggest panel above map toolbar
- [ ] Type a description and click Suggest → loading spinner → suggestion appears on map
- [ ] Accept → GeoJSON populates form field, shape stays on map
- [ ] Adjust → GeoJSON populates, map enters edit mode for vertex adjustment
- [ ] Try Again → clears suggestion, refocuses input
- [ ] If AnthropicApiKey is "x" → friendly "AI not configured" message
- [ ] If description can't be geocoded → friendly error message
- [ ] Overlap detection and measurement still work with AI-suggested shapes
- [ ] Edit area page also shows AI panel with same functionality
- [ ] `dotnet build` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)