### PR TITLE
Add 21-day stability policy to Renovate config

### DIFF
--- a/Planning/Projects/Project_01_Auth_Revamp.md
+++ b/Planning/Projects/Project_01_Auth_Revamp.md
@@ -99,6 +99,7 @@ Custom CSS is **not available** — Entra External ID restricted custom CSS to t
 - [ ] Document tenant setup process (Privo documentation deliverable)
 
 ### Phase 1 — Sign-Up/Sign-In + Profile Photos
+- [ ] Upgrade MSAL packages: `@azure/msal-browser` v2→v5 and `@azure/msal-react` v1→v5 (close Renovate PR #2036)
 - [ ] Configure MSAL on web (React) to point to new tenant
 - [ ] Update backend JWT validation (authority URL, audience)
 - [ ] Auto-populate `ProfilePhotoUrl` from social provider `picture` claim on sign-up

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,15 @@
   "labels": ["dependencies"],
   "automergeStrategy": "merge-commit",
   "prHourlyLimit": 2,
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "minimumReleaseAge": "21 days",
+  "internalChecksFilter": "strict",
+  "packageRules": [
+    {
+      "description": "Allow critical security fixes immediately regardless of age",
+      "matchUpdateTypes": ["patch", "minor", "major"],
+      "matchCategories": ["security"],
+      "minimumReleaseAge": "0 days"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Require dependency versions to be at least 21 days old before Renovate creates PRs, reducing risk from early-release bugs
- Critical security fixes bypass the waiting period immediately
- Add MSAL v2→v5 upgrade task to Project 1 Phase 1 checklist

## Test plan
- [ ] Verify Renovate dashboard reflects the new `minimumReleaseAge` setting on next run
- [ ] Confirm existing open PRs for versions older than 21 days are unaffected
- [ ] Verify security-tagged updates still come through immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)