### PR TITLE
Fix Project 45 status in Planning README overview table

### DIFF
--- a/Planning/README.md
+++ b/Planning/README.md
@@ -146,10 +146,10 @@
 | Status | Count | Projects |
 |--------|-------|----------|
 | ✅ **Complete** | 24 | Projects 3, 7, 9, 10, 11, 13, 14, 16, 17, 18, 19, 20, 21, 26, 27, 28, 29, 32, 34, 35, 37, 39, 40, 42 |
-| **In Progress** | 11 | Projects 1 (Phase 0 — code complete, portal remaining), 4 (Phases 1-2 Complete), 6, 8 (Phase 1-4 Complete), 15 (Backend & Website Complete), 22 (Phase 1-3 Complete), 25 (Phase 1 Complete), 30, 38 (Phases 1-4, 6-7 Complete), 41 (Phases 1-4 Complete), 44 (Phases 1-4 Complete) |
+| **In Progress** | 12 | Projects 1 (Phase 0 — code complete, portal remaining), 4 (Phases 1-2 Complete), 6, 8 (Phase 1-4 Complete), 15 (Backend & Website Complete), 22 (Phase 1-3 Complete), 25 (Phase 1 Complete), 30, 38 (Phases 1-4, 6-7 Complete), 41 (Phases 1-4 Complete), 44 (Phases 1-4 Complete), 45 (Phases 1+4 Complete) |
 | **Ready for Review** | 2 | Projects 2, 5 |
 | **Planning** | 1 | Project 23 (combined with Project 1) |
-| **Not Started** | 6 | Projects 12, 24, 31, 36, 43, 45 |
+| **Not Started** | 5 | Projects 12, 24, 31, 36, 43 |
 | **Deprioritized** | 1 | Project 33 |
 
 **Total:** 45 project specifications documented


### PR DESCRIPTION
## Summary
- Fixed Project 45 (Community Showcase) status inconsistency in the Planning README status overview table
- Project 45 was listed as "Not Started" in the overview but was already "In Progress (Phases 1+4 Complete)" in the project table
- Corrected counts: In Progress 11→12, Not Started 6→5

## Test plan
- [ ] Verify status overview table counts add up to 45

🤖 Generated with [Claude Code](https://claude.com/claude-code)