### PR TITLE
Update auth docs with Phase 0 lessons learned

### DIFF
--- a/Planning/Projects/Project_01_Auth_Revamp.md
+++ b/Planning/Projects/Project_01_Auth_Revamp.md
@@ -87,16 +87,31 @@ Custom CSS is **not available** — Entra External ID restricted custom CSS to t
 - [x] Add Entra guards in UserNav and DeleteMyData
 - [x] Document Phase 0 CLI commands in Auth_Migration.md
 
-#### Remaining (Manual — Azure Portal)
-- [ ] Create Entra External ID external tenant (dev) — see [Step-by-Step: Tenant Setup](#step-by-step-tenant-setup)
-- [ ] Register app registrations (web, mobile, backend) for dev — see [Step-by-Step: App Registrations](#step-by-step-app-registrations)
-- [ ] Configure social identity providers (Google, Microsoft, Apple, Facebook) — see [Step-by-Step: Social IDPs](#step-by-step-social-identity-providers)
-- [ ] Create sign-up/sign-in user flow with custom attributes — see [Step-by-Step: User Flow](#step-by-step-user-flow)
-- [ ] Configure built-in branding (logo, colors, background) — see [Step-by-Step: Branding](#step-by-step-branding)
+#### Completed (Manual — Azure Portal, Dev)
+- [x] Create Entra External ID external tenant (dev: `TrashMobEcoDev`, domain `trashmobecodev.ciamlogin.com`) — see [Step-by-Step: Tenant Setup](#step-by-step-tenant-setup)
+- [x] Register app registrations (web, mobile, backend) for dev — see [Step-by-Step: App Registrations](#step-by-step-app-registrations)
+- [x] Configure social identity providers: Google, Facebook — see [Step-by-Step: Social IDPs](#step-by-step-social-identity-providers)
+- [x] Create sign-up/sign-in user flow with custom attributes — see [Step-by-Step: User Flow](#step-by-step-user-flow)
+- [x] Configure built-in branding (logo, colors, background) — see [Step-by-Step: Branding](#step-by-step-branding)
+- [x] Fill in `AzureAdEntra` config values in appsettings.Development.json
+- [x] Test sign-in with `UseEntraExternalId: true` on dev — sign-in, sign-up, Google, and Facebook all working
+
+#### Remaining (Manual — Azure Portal, Dev)
+- [ ] Add custom attributes (givenName, surname, dateOfBirth) to user flow attribute collection — currently sign-up only collects email/password
+- [ ] Configure social identity provider: Microsoft account
+- [ ] Configure social identity provider: Apple (requires Apple Developer setup)
+- [ ] Improve banner logo for sign-in page — current logo is hard to read at the small display size (260x36px); consider a simplified/higher-contrast version
 - [ ] Request custom CSS exception from Microsoft (given Privo sponsorship)
-- [ ] Fill in `AzureAdEntra` config values in appsettings and Key Vault
-- [ ] Test sign-in with `UseEntraExternalId: true` on dev
+- [ ] Fill in `AzureAdEntra` config values in Key Vault (for deployed dev environment)
 - [ ] Document tenant setup process (Privo documentation deliverable)
+
+#### Remaining (Manual — Azure Portal, Prod)
+- [ ] Create Entra External ID external tenant (prod: `TrashMobEco`, domain `trashmobeco.ciamlogin.com`)
+- [ ] Register app registrations (web, mobile, backend) for prod
+- [ ] Configure social identity providers: Google, Facebook, Microsoft, Apple
+- [ ] Create sign-up/sign-in user flow with custom attributes
+- [ ] Configure built-in branding (logo, colors, background)
+- [ ] Fill in `AzureAdEntra` config values in Key Vault (for deployed prod environment)
 
 ### Phase 1 — Sign-Up/Sign-In + Profile Photos
 - [ ] Upgrade MSAL packages: `@azure/msal-browser` v2→v5 and `@azure/msal-react` v1→v5 (close Renovate PR #2036)

--- a/Planning/TechnicalDesigns/Auth_Migration.md
+++ b/Planning/TechnicalDesigns/Auth_Migration.md
@@ -484,7 +484,15 @@ Minor account upgraded from limited to full access
 
 ### Phase 0 Lessons
 
-- *(To be documented during implementation)*
+1. **App registrations must be added to the user flow.** After creating app registrations and a sign-up/sign-in user flow in the Entra External ID portal, you must explicitly add each app registration to the user flow. Without this step, the sign-in page will only show email/password sign-in — no sign-up option and no social identity providers will appear.
+
+2. **Tenant naming must avoid existing B2C namespaces.** Our B2C tenants use `trashmobdev` and `trashmob` domain prefixes. Since these are already claimed, the Entra External ID tenants need different names. We used `TrashMobEcoDev` (domain: `trashmobecodev.ciamlogin.com`) for development and `TrashMobEco` (domain: `trashmobeco.ciamlogin.com`) for production.
+
+3. **User flow attribute collection requires explicit configuration.** Custom attributes (e.g., `givenName`, `surname`, `dateOfBirth`) must be explicitly added to the user flow's attribute collection step in the portal. If attributes are not added, the sign-up form will only collect email and password — users won't be prompted for name or birthdate.
+
+4. **Config section is `AzureAdEntra`, not `AzureAd`.** The actual implementation uses a dedicated `AzureAdEntra` config section (see `appsettings.json`) to allow both B2C and Entra configs to coexist during the feature-flag transition period (`UseEntraExternalId`).
+
+5. **Built-in branding logo sizing.** The banner logo on the Entra External ID sign-in page displays at approximately 260x36 pixels. Standard logos may be hard to read at this size — consider creating a simplified or higher-contrast version specifically for the sign-in page.
 
 ### Known Limitations
 
@@ -525,7 +533,7 @@ Minor account upgraded from limited to full access
 | Instance | `https://{b2c}.b2clogin.com/` | `https://{tenant}.ciamlogin.com/` |
 | Domain | `{tenant}.onmicrosoft.com` | `{tenant}.onmicrosoft.com` |
 | Client ID | API app registration client ID | New API app registration client ID |
-| Config section | `AzureAdB2C` | `AzureAd` (or custom) |
+| Config section | `AzureAdB2C` | `AzureAdEntra` |
 
 ### Files That Need to Change
 
@@ -533,7 +541,7 @@ Minor account upgraded from limited to full access
 |------|-------------|
 | `TrashMob/appsettings.json` | Authority URL, client IDs, domain |
 | `TrashMob/appsettings.Development.json` | Dev tenant configuration |
-| `TrashMob/Program.cs` | Config section name (`AzureAdB2C` → `AzureAd`) |
+| `TrashMob/Program.cs` | Config section name (`AzureAdB2C` → `AzureAdEntra`) |
 | `TrashMob/Controllers/ConfigController.cs` | Config response format, remove policy references |
 | `TrashMob/client-app/src/store/AuthStore.tsx` | Authority format, remove policies, update fallback |
 | `TrashMobMobile/Authentication/AuthConstants.cs` | Tenant domain, authority format, client IDs |
@@ -608,4 +616,4 @@ Built-in branding (logo, colors, background image) is **portal-only**:
 
 **Last Updated:** February 9, 2026
 **Status:** Living document — updated as migration progresses
-**Next Update:** After Phase 0 completion
+**Next Update:** After Phase 1 implementation


### PR DESCRIPTION
## Summary
- Check off completed Phase 0 dev portal setup steps in Project 1 doc
- Add 5 Phase 0 lessons to Auth Migration guide (user flow app registration, tenant naming, attribute collection, config section naming, logo sizing)
- Add remaining dev tasks (attribute collection for name/birthdate, Microsoft/Apple IDPs, logo improvement, CSS exception, Key Vault config)
- Add production portal setup checklist (TrashMobEco tenant)
- Fix config section references from `AzureAd` to `AzureAdEntra` throughout migration guide

## Test plan
- [ ] Review doc accuracy against actual portal configuration
- [ ] Verify tenant names match (TrashMobEcoDev for dev, TrashMobEco for prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)