### PR TITLE
Upgrade MSAL packages to v4 with async initialization

### DIFF
--- a/TrashMob/client-app/package-lock.json
+++ b/TrashMob/client-app/package-lock.json
@@ -8,8 +8,8 @@
             "name": "trashmob",
             "version": "0.1.0",
             "dependencies": {
-                "@azure/msal-browser": "^2.23.0",
-                "@azure/msal-react": "^1.3.2",
+                "@azure/msal-browser": "^4.28.1",
+                "@azure/msal-react": "^3.0.25",
                 "@hookform/resolvers": "^5.2.1",
                 "@radix-ui/react-alert-dialog": "^1.1.15",
                 "@radix-ui/react-checkbox": "^1.3.2",
@@ -156,37 +156,34 @@
             "license": "ISC"
         },
         "node_modules/@azure/msal-browser": {
-            "version": "2.39.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.39.0.tgz",
-            "integrity": "sha512-kks/n2AJzKUk+DBqZhiD+7zeQGBl+WpSOQYzWy6hff3bU0ZrYFqr4keFLlzB5VKuKZog0X59/FGHb1RPBDZLVg==",
-            "license": "MIT",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.28.1.tgz",
+            "integrity": "sha512-al2u2fTchbClq3L4C1NlqLm+vwKfhYCPtZN2LR/9xJVaQ4Mnrwf5vANvuyPSJHcGvw50UBmhuVmYUAhTEetTpA==",
             "dependencies": {
-                "@azure/msal-common": "13.3.3"
+                "@azure/msal-common": "15.14.1"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "13.3.3",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.3.tgz",
-            "integrity": "sha512-n278DdCXKeiWhLwhEL7/u9HRMyzhUXLefeajiknf6AmEedoiOiv2r5aRJ7LXdT3NGPyubkdIbthaJlVtmuEqvA==",
-            "license": "MIT",
+            "version": "15.14.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.14.1.tgz",
+            "integrity": "sha512-IkzF7Pywt6QKTS0kwdCv/XV8x8JXknZDvSjj/IccooxnP373T5jaadO3FnOrbWo3S0UqkfIDyZNTaQ/oAgRdXw==",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-react": {
-            "version": "1.5.13",
-            "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-1.5.13.tgz",
-            "integrity": "sha512-rv3q7hwZS5VQs5AXgdoXwrPnCc0/xs3YmWNxhyCFw7JWZ3Nq0hV1JJSvWXZgXQIINOV7hCky3lYaRgHYT9qyKw==",
-            "license": "MIT",
+            "version": "3.0.25",
+            "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-3.0.25.tgz",
+            "integrity": "sha512-BtcfBJQrtkfir4mDJ6X/55BT8WL59/QwfEgxGExY/gZLRfjGrqw/VwXiyQRFyLLaVbvKngF0a8rOcFZx1Jr9qQ==",
             "engines": {
                 "node": ">=10"
             },
             "peerDependencies": {
-                "@azure/msal-browser": "^2.38.4",
-                "react": "^16.8.0 || ^17 || ^18"
+                "@azure/msal-browser": "^4.28.1",
+                "react": "^16.8.0 || ^17 || ^18 || ^19.2.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -11889,22 +11886,22 @@
             }
         },
         "@azure/msal-browser": {
-            "version": "2.39.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.39.0.tgz",
-            "integrity": "sha512-kks/n2AJzKUk+DBqZhiD+7zeQGBl+WpSOQYzWy6hff3bU0ZrYFqr4keFLlzB5VKuKZog0X59/FGHb1RPBDZLVg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.28.1.tgz",
+            "integrity": "sha512-al2u2fTchbClq3L4C1NlqLm+vwKfhYCPtZN2LR/9xJVaQ4Mnrwf5vANvuyPSJHcGvw50UBmhuVmYUAhTEetTpA==",
             "requires": {
-                "@azure/msal-common": "13.3.3"
+                "@azure/msal-common": "15.14.1"
             }
         },
         "@azure/msal-common": {
-            "version": "13.3.3",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.3.tgz",
-            "integrity": "sha512-n278DdCXKeiWhLwhEL7/u9HRMyzhUXLefeajiknf6AmEedoiOiv2r5aRJ7LXdT3NGPyubkdIbthaJlVtmuEqvA=="
+            "version": "15.14.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.14.1.tgz",
+            "integrity": "sha512-IkzF7Pywt6QKTS0kwdCv/XV8x8JXknZDvSjj/IccooxnP373T5jaadO3FnOrbWo3S0UqkfIDyZNTaQ/oAgRdXw=="
         },
         "@azure/msal-react": {
-            "version": "1.5.13",
-            "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-1.5.13.tgz",
-            "integrity": "sha512-rv3q7hwZS5VQs5AXgdoXwrPnCc0/xs3YmWNxhyCFw7JWZ3Nq0hV1JJSvWXZgXQIINOV7hCky3lYaRgHYT9qyKw==",
+            "version": "3.0.25",
+            "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-3.0.25.tgz",
+            "integrity": "sha512-BtcfBJQrtkfir4mDJ6X/55BT8WL59/QwfEgxGExY/gZLRfjGrqw/VwXiyQRFyLLaVbvKngF0a8rOcFZx1Jr9qQ==",
             "requires": {}
         },
         "@babel/code-frame": {

--- a/TrashMob/client-app/package.json
+++ b/TrashMob/client-app/package.json
@@ -3,8 +3,8 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@azure/msal-browser": "^2.23.0",
-        "@azure/msal-react": "^1.3.2",
+        "@azure/msal-browser": "^4.28.1",
+        "@azure/msal-react": "^3.0.25",
         "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.2",


### PR DESCRIPTION
## Summary
- Upgrade `@azure/msal-browser` from ^2.23.0 to ^4.28.1 (3 major versions)
- Upgrade `@azure/msal-react` from ^1.3.2 to ^3.0.25 (2 major versions)
- Add required `await msalC.initialize()` call after `PublicClientApplication` construction (breaking change in v3+)
- Add safety guard in `getMsalClientInstance()` to throw if accessed before initialization

**Note:** v5 packages require React 19, so v4/v3 are the latest compatible with our React 18 stack. A future React 19 upgrade will unlock msal-browser v5 + msal-react v5.

Closes Renovate PR #2036 (which proposed v5, incompatible with React 18).

## What stays the same
All MSAL APIs used by the app (loginRedirect, acquireTokenSilent, addEventCallback, EventType, LogLevel, MsalProvider, MsalAuthenticationTemplate) are backward-compatible. Only `AuthStore.tsx` needed changes — `useLogin.ts`, `App.tsx`, and all other files are unchanged.

## Test plan
- [x] `npm run build` — compiles cleanly
- [x] `npm run lint` — passes
- [x] `npm test` — passes
- [ ] Manual: Sign in with Entra (dev) — login redirect, token acquisition, API calls
- [ ] Manual: Sign out and back in — session storage lifecycle
- [ ] Manual: Sign in with B2C (prod config) — verify backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)