### PR TITLE
Auto-populate profile photo and name from social provider claims

### DIFF
--- a/TrashMob/Security/UserIsValidUserAuthHandler.cs
+++ b/TrashMob/Security/UserIsValidUserAuthHandler.cs
@@ -44,6 +44,46 @@
                     return;
                 }
 
+                // Auto-populate profile fields from social provider claims (one-time fill)
+                var needsUpdate = false;
+
+                if (string.IsNullOrEmpty(user.ProfilePhotoUrl))
+                {
+                    var pictureClaim = context.User.FindFirst("picture");
+                    if (pictureClaim != null)
+                    {
+                        user.ProfilePhotoUrl = pictureClaim.Value;
+                        needsUpdate = true;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(user.GivenName))
+                {
+                    var givenNameClaim = context.User.FindFirst(ClaimTypes.GivenName)
+                                      ?? context.User.FindFirst("given_name");
+                    if (givenNameClaim != null)
+                    {
+                        user.GivenName = givenNameClaim.Value;
+                        needsUpdate = true;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(user.Surname))
+                {
+                    var surnameClaim = context.User.FindFirst(ClaimTypes.Surname)
+                                    ?? context.User.FindFirst("family_name");
+                    if (surnameClaim != null)
+                    {
+                        user.Surname = surnameClaim.Value;
+                        needsUpdate = true;
+                    }
+                }
+
+                if (needsUpdate)
+                {
+                    await userManager.UpdateAsync(user, CancellationToken.None);
+                }
+
                 if (!httpContext.HttpContext.Items.ContainsKey("UserId"))
                 {
                     httpContext.HttpContext.Items.Add("UserId", user.Id);


### PR DESCRIPTION
## Summary
- Extract `picture`, `given_name`, `family_name` claims from JWT tokens during authentication
- Auto-populate `ProfilePhotoUrl`, `GivenName`, and `Surname` on the user record when empty
- One-time fill: only writes when the field is null/empty, never overwrites user-set values
- Safe no-op when claims aren't present (depends on Entra user flow configuration)

This enables profile photos from Google, Facebook, and Microsoft to automatically appear in the app after a user signs in via a social provider — no manual upload needed.

## How it works
The `UserIsValidUserAuthHandler` runs on every authenticated request. After the existing user lookup, it checks for social provider claims in the JWT. If found and the user's corresponding field is empty, it updates the record. The check is cheap (3 string comparisons) and the DB write only happens once per field.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 397 tests passed
- [ ] Manual: Sign in with Google via Entra on dev, verify `ProfilePhotoUrl` populated
- [ ] Manual: Sign in again, verify values NOT overwritten
- [ ] Manual: Check UserNav displays profile photo (existing Phase 0 display code)

**Note:** Claims availability depends on Entra External ID user flow configuration. The user flow must be configured to pass social provider claims through to the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)