### PR TITLE
Add profile photo avatars to attendee lists and leaderboards

### DIFF
--- a/TrashMob.Models/Poco/DisplayUser.cs
+++ b/TrashMob.Models/Poco/DisplayUser.cs
@@ -41,5 +41,10 @@
         /// Gets or sets the date when the user became a member.
         /// </summary>
         public DateTimeOffset? MemberSince { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the user's profile photo.
+        /// </summary>
+        public string ProfilePhotoUrl { get; set; } = string.Empty;
     }
 }

--- a/TrashMob.Shared/Poco/LeaderboardEntry.cs
+++ b/TrashMob.Shared/Poco/LeaderboardEntry.cs
@@ -44,5 +44,10 @@ namespace TrashMob.Shared.Poco
         /// Gets or sets the city for location-based filtering.
         /// </summary>
         public string City { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profile photo URL for the entity.
+        /// </summary>
+        public string ProfilePhotoUrl { get; set; }
     }
 }

--- a/TrashMob.Shared/Poco/PocoExtensions.cs
+++ b/TrashMob.Shared/Poco/PocoExtensions.cs
@@ -24,6 +24,7 @@
                 Id = user.Id,
                 MemberSince = user.MemberSince,
                 Region = user.Region,
+                ProfilePhotoUrl = user.ProfilePhotoUrl,
             };
         }
 

--- a/TrashMob/client-app/src/components/Models/LeaderboardData.ts
+++ b/TrashMob/client-app/src/components/Models/LeaderboardData.ts
@@ -9,6 +9,7 @@ export interface LeaderboardEntry {
     formattedScore: string;
     region?: string;
     city?: string;
+    profilePhotoUrl?: string;
 }
 
 export interface LeaderboardResponse {

--- a/TrashMob/client-app/src/components/events/event-attendee-table.tsx
+++ b/TrashMob/client-app/src/components/events/event-attendee-table.tsx
@@ -17,7 +17,7 @@ import { GetEventAttendeeWaiverStatus } from '@/services/user-waivers';
 import { PaperWaiverUploadDialog } from '@/components/Waivers';
 import UserData from '../Models/UserData';
 import EventData from '../Models/EventData';
-import { ChevronUp, ChevronDown, MoreHorizontal, FileText, Upload } from 'lucide-react';
+import { ChevronUp, ChevronDown, MoreHorizontal, FileText, Upload, CircleUserRound } from 'lucide-react';
 
 interface EventAttendeeTableProps {
     users: UserData[];
@@ -143,6 +143,16 @@ export const EventAttendeeTable = (props: EventAttendeeTableProps) => {
                                 <TableRow key={user.id.toString()}>
                                     <TableCell>
                                         <span className='flex items-center gap-2'>
+                                            {user.profilePhotoUrl ? (
+                                                <img
+                                                    src={user.profilePhotoUrl}
+                                                    alt={user.userName}
+                                                    className='h-6 w-6 rounded-full object-cover'
+                                                    referrerPolicy='no-referrer'
+                                                />
+                                            ) : (
+                                                <CircleUserRound className='h-6 w-6 text-muted-foreground' />
+                                            )}
                                             {user.userName}
                                             {userIsLead ? (
                                                 <Badge variant='secondary' className='text-xs'>

--- a/TrashMob/client-app/src/components/leaderboards/LeaderboardTable.tsx
+++ b/TrashMob/client-app/src/components/leaderboards/LeaderboardTable.tsx
@@ -1,4 +1,4 @@
-import { Trophy, Medal, Award } from 'lucide-react';
+import { Trophy, Medal, Award, CircleUserRound } from 'lucide-react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { LeaderboardEntry } from '@/components/Models/LeaderboardData';
 
@@ -75,7 +75,21 @@ export const LeaderboardTable = ({ entries, isLoading, entityType = 'users' }: L
                                 </span>
                             </div>
                         </TableCell>
-                        <TableCell className='font-medium'>{entry.entityName}</TableCell>
+                        <TableCell className='font-medium'>
+                            <span className='flex items-center gap-2'>
+                                {entry.profilePhotoUrl ? (
+                                    <img
+                                        src={entry.profilePhotoUrl}
+                                        alt={entry.entityName}
+                                        className='h-6 w-6 rounded-full object-cover'
+                                        referrerPolicy='no-referrer'
+                                    />
+                                ) : (
+                                    <CircleUserRound className='h-6 w-6 text-muted-foreground' />
+                                )}
+                                {entry.entityName}
+                            </span>
+                        </TableCell>
                         <TableCell className='hidden sm:table-cell text-muted-foreground'>
                             {entry.city && entry.region
                                 ? `${entry.city}, ${entry.region}`


### PR DESCRIPTION
## Summary
- Display profile photo avatars next to user names in event attendee tables and leaderboard rankings
- Falls back to a generic CircleUserRound icon when no photo is available
- Leaderboard profile photos are fetched live from the Users table (not cached) to always show current photos without requiring a DB migration
- Added `ProfilePhotoUrl` to `DisplayUser` POCO and `LeaderboardEntry` for API responses

## Changes

### Backend
- `DisplayUser.cs` — added `ProfilePhotoUrl` property
- `PocoExtensions.cs` — map `ProfilePhotoUrl` in `ToDisplayUser()`
- `LeaderboardEntry.cs` — added `ProfilePhotoUrl` property
- `LeaderboardManager.cs` — added `EnrichWithProfilePhotosAsync()` that batch-fetches profile photos from Users table after cache query (both user and team leaderboard endpoints)

### Frontend
- `LeaderboardData.ts` — added `profilePhotoUrl` to `LeaderboardEntry` interface
- `event-attendee-table.tsx` — added avatar before username with fallback icon
- `LeaderboardTable.tsx` — added avatar before entity name with fallback icon

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 397 tests pass
- [x] `npm run build` — succeeds
- [x] `npm test` — passes
- [x] ESLint — clean on changed files
- [ ] Manual: verify avatars appear in event attendee list for users with profile photos
- [ ] Manual: verify fallback icon appears for users without profile photos
- [ ] Manual: verify leaderboard shows avatars for ranked users

🤖 Generated with [Claude Code](https://claude.com/claude-code)