### PR TITLE
Add profile photo upload to MyProfile page

### DIFF
--- a/TrashMob.Models/Enums.cs
+++ b/TrashMob.Models/Enums.cs
@@ -242,6 +242,11 @@ namespace TrashMob.Models
         /// Image associated with a partner/community photo gallery.
         /// </summary>
         PartnerPhoto = 8,
+
+        /// <summary>
+        /// User profile photo (uploaded or replaced from social IDP).
+        /// </summary>
+        UserProfilePhoto = 9,
     }
 
     /// <summary>

--- a/TrashMob/client-app/src/services/users.ts
+++ b/TrashMob/client-app/src/services/users.ts
@@ -56,6 +56,23 @@ export const VerifyUniqueUserName = (params: VerifyUniqueUserName_Params) => ({
         }),
 });
 
+export type UploadProfilePhoto_Response = UserData;
+export const UploadProfilePhoto = () => ({
+    key: ['/users/photo', 'upload'],
+    service: async (file: File) => {
+        const formData = new FormData();
+        formData.append('formFile', file);
+        return ApiService('protected').fetchData<UploadProfilePhoto_Response>({
+            url: '/users/photo',
+            method: 'post',
+            data: formData,
+            headers: {
+                'Content-Type': 'multipart/form-data',
+            },
+        });
+    },
+});
+
 export type DeleteUserById_Params = { id: string };
 export type DeleteUserById_Response = UserData | null;
 export const DeleteUserById = () => ({


### PR DESCRIPTION
## Summary
- Adds `UserProfilePhoto = 9` to `ImageTypeEnum` for blob container routing
- Adds `POST /api/users/photo` endpoint to `UsersController` using the existing `IImageManager` infrastructure (creates Raw, Thumb 100x100, Reduced 400x400 versions in blob storage)
- Adds `UploadProfilePhoto` service in `users.ts` with FormData upload
- Replaces read-only profile photo display with clickable avatar (camera overlay on hover) and "Change Photo" button
- Client-side file validation: JPEG/PNG/WebP only, max 5MB
- Deletes existing blob before uploading replacement photo
- On success, calls `handleUserUpdated()` to refresh avatar across the app (UserNav, profile page)

This is **Phase 2 PR 3** of Project 1 (Auth Revamp). Previously, profile photos were only populated from social IDP JWT claims (Google/Facebook). Users who signed up via email or wanted a custom photo had no way to set one.

## Test plan
- [ ] Navigate to `/myprofile` — see current photo (from IDP) or placeholder icon
- [ ] Hover over avatar — camera overlay appears
- [ ] Click "Change Photo" or avatar — file picker opens
- [ ] Select valid image (JPEG/PNG/WebP, <5MB) — uploads, avatar updates on profile page and in header UserNav
- [ ] Select oversized file (>5MB) — validation toast shown, no upload
- [ ] Select non-image file — validation toast shown, no upload
- [ ] Upload a second photo — replaces the first (old blob deleted)
- [ ] Backend builds with 0 errors, 0 warnings
- [ ] Frontend builds, lints, and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)