### PR TITLE
Polish mobile UI and fix register timeout

### DIFF
--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -86,8 +86,7 @@
         {
             return HttpPolicyExtensions
                 .HandleTransientHttpError()
-                .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
-                .WaitAndRetryAsync(6, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2,
+                .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2,
                     retryAttempt)));
         }
     }

--- a/TrashMobMobile/Pages/BrowseCommunitiesPage.xaml
+++ b/TrashMobMobile/Pages/BrowseCommunitiesPage.xaml
@@ -37,6 +37,14 @@
                                            MaxLines="2"
                                            TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                                     <HorizontalStackLayout Spacing="8">
+                                        <Image WidthRequest="14" HeightRequest="14">
+                                            <Image.Source>
+                                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                                 Glyph="{StaticResource IconMapMarkerOutline}"
+                                                                 Size="14"
+                                                                 Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            </Image.Source>
+                                        </Image>
                                         <Label Text="{Binding Location}"
                                                FontSize="Micro"
                                                TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />

--- a/TrashMobMobile/Pages/BrowseTeamsPage.xaml
+++ b/TrashMobMobile/Pages/BrowseTeamsPage.xaml
@@ -38,9 +38,25 @@
                                                MaxLines="2"
                                                TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                                         <HorizontalStackLayout Spacing="8">
+                                            <Image WidthRequest="14" HeightRequest="14">
+                                                <Image.Source>
+                                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                                     Glyph="{StaticResource IconMapMarkerOutline}"
+                                                                     Size="14"
+                                                                     Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                </Image.Source>
+                                            </Image>
                                             <Label Text="{Binding Location}"
                                                    FontSize="Micro"
                                                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Image WidthRequest="14" HeightRequest="14">
+                                                <Image.Source>
+                                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                                     Glyph="{StaticResource IconAccount}"
+                                                                     Size="14"
+                                                                     Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                </Image.Source>
+                                            </Image>
                                             <Label Text="{Binding MemberCountDisplay}"
                                                    FontSize="Micro"
                                                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />

--- a/TrashMobMobile/Pages/CreateEvent/Step3.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step3.xaml
@@ -16,8 +16,6 @@
                     VerticalOptions="Center"
                     Margin="5" />
 
-                <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
-
                 <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="3"
                       ColumnDefinitions="*, 2*">
                     <Label Grid.Row="0" Grid.Column="0" Text="{Binding SelectedEventType}" FontSize="Small"

--- a/TrashMobMobile/Pages/CreateEvent/Step4.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step4.xaml
@@ -8,8 +8,6 @@
     <ScrollView>
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
-
                 <Grid RowDefinitions="Auto, Auto, Auto">
                     <Label Grid.Row="0" Text="We're sorry. There are currently no partners available in your area." IsVisible="{Binding AreNoPartnersAvailable}" />
 

--- a/TrashMobMobile/Pages/EditEventPage.xaml
+++ b/TrashMobMobile/Pages/EditEventPage.xaml
@@ -15,8 +15,6 @@
     <Grid>
         <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
 
-            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
-
             <tabs:TabHostView Padding="10" 
                               Orientation="Horizontal" 
                               TabType="Fixed"

--- a/TrashMobMobile/Pages/ImpactPage.xaml
+++ b/TrashMobMobile/Pages/ImpactPage.xaml
@@ -12,8 +12,7 @@
 
             <!-- Your Impact -->
             <Label Text="Your Impact"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="5,10,5,0" />
 
             <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
@@ -74,8 +73,7 @@
 
             <!-- Community Impact -->
             <Label Text="Community Impact"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="5,15,5,0" />
 
             <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
@@ -149,8 +147,7 @@
 
             <!-- Explore More -->
             <Label Text="Explore More"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="5,15,5,5" />
 
             <VerticalStackLayout Spacing="8" Margin="5,0,5,20">

--- a/TrashMobMobile/Pages/ManageEventPartnersPage.xaml
+++ b/TrashMobMobile/Pages/ManageEventPartnersPage.xaml
@@ -9,8 +9,6 @@
     <ScrollView>
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
-
                 <Grid RowDefinitions="Auto, Auto">
                     <Label Grid.Row="0"
                            Text="Available Event Partners"

--- a/TrashMobMobile/Pages/ProfilePage.xaml
+++ b/TrashMobMobile/Pages/ProfilePage.xaml
@@ -45,8 +45,7 @@
 
             <!-- My Events Section -->
             <Label Text="My Events"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="5,15,5,5" />
 
             <HorizontalStackLayout Spacing="8" Margin="5,0">
@@ -124,8 +123,7 @@
 
             <!-- My Litter Reports Section -->
             <Label Text="My Litter Reports"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="5,15,5,5" />
 
             <Label Text="No litter reports"
@@ -162,6 +160,7 @@
                 <Label Text="My Teams"
                        FontFamily="LexendSemibold"
                        FontSize="Medium"
+                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                        Grid.Column="0" />
                 <Button Text="Browse Teams"
                         Command="{Binding BrowseTeamsCommand}"
@@ -200,8 +199,7 @@
 
             <!-- Settings Section -->
             <Label Text="Settings"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="5,15,5,5" />
 
             <VerticalStackLayout Spacing="8" Margin="5,0">

--- a/TrashMobMobile/Pages/SearchEventsPage.xaml
+++ b/TrashMobMobile/Pages/SearchEventsPage.xaml
@@ -10,8 +10,6 @@
              Title="Search Events">
     <Grid>
         <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
-
             <Grid RowDefinitions="Auto, Auto, *">
                 <Grid RowDefinitions="Auto" ColumnDefinitions="*, *, *, *" Grid.Row="0">
                     <Button Margin="10"

--- a/TrashMobMobile/Pages/ViewCommunityPage.xaml
+++ b/TrashMobMobile/Pages/ViewCommunityPage.xaml
@@ -26,8 +26,7 @@
             <!-- About Section -->
             <VerticalStackLayout Padding="10,0" IsVisible="{Binding HasPublicNotes}">
                 <Label Text="About"
-                       FontFamily="LexendSemibold"
-                       FontSize="Medium"
+                       Style="{StaticResource SectionHeader}"
                        Margin="0,5,0,5" />
                 <Label Text="{Binding PublicNotes}"
                        FontSize="Small"
@@ -36,8 +35,7 @@
 
             <!-- Impact Stats -->
             <Label Text="Community Impact"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="10,15,10,5" />
 
             <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" Padding="10,0" ColumnSpacing="8" RowSpacing="8">
@@ -87,8 +85,7 @@
 
             <!-- Upcoming Events Section -->
             <Label Text="Upcoming Events"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="10,15,10,5" />
 
             <Label Text="No upcoming events"
@@ -126,8 +123,7 @@
 
             <!-- Nearby Teams Section -->
             <Label Text="Nearby Teams"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="10,15,10,5" />
 
             <Label Text="No nearby teams"
@@ -165,8 +161,7 @@
 
             <!-- Contact Info Section -->
             <Label Text="Contact"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="10,15,10,5" />
 
             <Border Style="{x:StaticResource RoundBorder}" Margin="5,3" Padding="10,10">

--- a/TrashMobMobile/Pages/ViewEventPage.xaml
+++ b/TrashMobMobile/Pages/ViewEventPage.xaml
@@ -13,24 +13,25 @@
     <Grid>
         <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Margin="10">
             <Label
-                    Text="{Binding EventViewModel.Name}" Style="{StaticResource Headline}"
+                    Text="{Binding EventViewModel.Name}"
+                    FontFamily="LexendSemibold"
+                    FontSize="Title"
+                    HorizontalOptions="Start"
                     VerticalOptions="Center"
                     Margin="4" />
 
-            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
-
-            <tabs:TabHostView Padding="10" 
-                              Orientation="Horizontal" 
+            <tabs:TabHostView Padding="0"
+                              Orientation="Horizontal"
                               TabType="Fixed"
-                              SelectedIndex="{Binding Source={x:Reference Switcher}, 
+                              SelectedIndex="{Binding Source={x:Reference Switcher},
                                           Path=SelectedIndex, Mode=TwoWay}">
                 <tabs:BottomTabItem Label="Details"  SelectedTabColor="{StaticResource Primary}" />
 
                 <tabs:BottomTabItem Label="Partners" SelectedTabColor="{StaticResource Primary}" />
 
-                <tabs:BottomTabItem Label="Attendees" SelectedTabColor="{StaticResource Primary}" />
+                <tabs:BottomTabItem Label="People" SelectedTabColor="{StaticResource Primary}" />
 
-                <tabs:BottomTabItem Label="Litter Reports" SelectedTabColor="{StaticResource Primary}" />
+                <tabs:BottomTabItem Label="Litter" SelectedTabColor="{StaticResource Primary}" />
 
                 <tabs:BottomTabItem Label="Photos" SelectedTabColor="{StaticResource Primary}" />
 

--- a/TrashMobMobile/Pages/ViewLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/ViewLitterReportPage.xaml
@@ -12,110 +12,81 @@
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
 
-                <Grid RowDefinitions="*, *, *, *">
-                    <Grid RowDefinitions="Auto" ColumnDefinitions="*, *, *, *"
-                      MaximumWidthRequest="400">
-                        <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="0" 
-                            Command="{Binding EditLitterReportCommand}" 
-                            Text="Edit"
+                <!-- Report Info Card -->
+                <Border Style="{x:StaticResource RoundBorder}" Margin="5,10,5,5">
+                    <VerticalStackLayout Spacing="4" Padding="10,10">
+                        <Label Text="{Binding LitterReportViewModel.Name}"
+                               FontFamily="LexendSemibold"
+                               FontSize="Large" />
+                        <Label Text="{Binding LitterReportStatus}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        <Label Text="{Binding LitterReportViewModel.Description}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Action Buttons -->
+                <VerticalStackLayout Spacing="8" Margin="5,5">
+                    <Button Command="{Binding EditLitterReportCommand}"
+                            Text="Edit Report"
                             IsEnabled="{Binding CanEditLitterReport}"
-                            IsVisible="{Binding CanEditLitterReport}" 
-                            Style="{StaticResource PrimarySmallButton}" >
-                        </Button>
-                        <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="1" 
-                            Command="{Binding MarkLitterReportCleanedCommand}" 
+                            IsVisible="{Binding CanEditLitterReport}"
+                            Style="{StaticResource PrimaryLargeButton}" />
+                    <Button Command="{Binding MarkLitterReportCleanedCommand}"
                             IsEnabled="{Binding CanMarkLitterReportCleaned}"
-                            IsVisible="{Binding CanMarkLitterReportCleaned}" 
-                            Style="{StaticResource SecondarySmallButton}" 
-                            Text="Mark Cleaned">
-                        </Button>
-                        <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="2" 
-                            Command="{Binding DeleteLitterReportCommand}" 
+                            IsVisible="{Binding CanMarkLitterReportCleaned}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            Text="Mark as Cleaned" />
+                    <Button Command="{Binding DeleteLitterReportCommand}"
                             IsEnabled="{Binding CanDeleteLitterReport}"
-                            IsVisible="{Binding CanDeleteLitterReport}" 
-                            Style="{StaticResource SecondarySmallButton}" 
-                            Text="Delete">
-                        </Button>
-                        <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="4" 
-                            Padding="5"
-                            Command="{Binding ViewEventCommand}" 
+                            IsVisible="{Binding CanDeleteLitterReport}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            Text="Delete Report" />
+                    <Button Command="{Binding ViewEventCommand}"
                             IsEnabled="{Binding IsAssignedToEvent}"
-                            IsVisible="{Binding IsAssignedToEvent}" 
-                            Style="{StaticResource SecondarySmallButton}" 
-                            Text="View Event">
-                        </Button>
-                        <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="4" 
-                            Padding="5"
-                            Command="{Binding CreateEventCommand}" 
+                            IsVisible="{Binding IsAssignedToEvent}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            Text="View Event" />
+                    <Button Command="{Binding CreateEventCommand}"
                             IsEnabled="{Binding IsNotAssignedToEvent}"
-                            IsVisible="{Binding IsNotAssignedToEvent}" 
-                            Style="{StaticResource SecondarySmallButton}" 
-                            Text="Create Event">
-                        </Button>
-                    </Grid>
+                            IsVisible="{Binding IsNotAssignedToEvent}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            Text="Create Event" />
+                </VerticalStackLayout>
 
-                    <VerticalStackLayout Grid.Row="1">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
-                        <Label
-                                Text="{Binding LitterReportViewModel.Name}"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Start"
-                                HorizontalTextAlignment="Center" />
-                    </VerticalStackLayout>
+                <!-- Map -->
+                <Label Text="Locations"
+                       Style="{StaticResource SectionHeader}"
+                       Margin="5,10,5,5" />
 
-                    <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Description" Style="{StaticResource FieldLabel}" />
-                        <Label
-                                Text="{Binding LitterReportViewModel.Description}"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Start"
-                                HorizontalTextAlignment="Center" />
-                    </VerticalStackLayout>
+                <Border Style="{x:StaticResource RoundBorder}" Margin="5,0">
+                    <controls:CustomMap x:Name="litterReportLocationMap" ItemsSource="{Binding LitterImageViewModels}">
+                        <maps:Map.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                <controls:CustomPin Location="{Binding Address.Location}"
+                                          Address="{Binding Address.StreetAddress}"
+                                          ImageSource="{Binding Address.IconFile}"
+                                          Label="Litter Image" />
+                            </DataTemplate>
+                        </maps:Map.ItemTemplate>
+                    </controls:CustomMap>
+                </Border>
 
-                    <VerticalStackLayout Grid.Row="3">
-                        <Label Text="Status" Style="{StaticResource FieldLabel}" />
-                        <Label
-                                Text="{Binding LitterReportStatus}"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Start"
-                                HorizontalTextAlignment="Center" />
-                    </VerticalStackLayout>
-                </Grid>
-
-                <controls:CustomMap x:Name="litterReportLocationMap" ItemsSource="{Binding LitterImageViewModels}">
-                    <maps:Map.ItemTemplate>
-                        <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                            <controls:CustomPin Location="{Binding Address.Location}"
-                                      Address="{Binding Address.StreetAddress}"
-                                      ImageSource="{Binding Address.IconFile}"
-                                      Label="Litter Image" />
-                        </DataTemplate>
-                    </maps:Map.ItemTemplate>
-                </controls:CustomMap>
-
+                <!-- Litter Images -->
                 <CollectionView x:Name="LitterImagesCollection"
                                 ItemsSource="{Binding LitterImageViewModels}"
-                                SelectionMode="None">
+                                SelectionMode="None"
+                                Margin="0,5">
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                            <Border Style="{StaticResource RoundBorder}">
-                                <Grid WidthRequest="400"
-                                      ColumnDefinitions="*, *"
-                                      RowDefinitions="Auto"
-                                      x:Name="LitterImageItem">
-                                    <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="100" Grid.Column="0"
-                                           Grid.RowSpan="5" />
-                                    <Label Grid.Row="0" Grid.Column="2" Text="{Binding Address.DisplayAddress }" />
+                            <Border Style="{StaticResource RoundBorder}" Margin="5,3">
+                                <Grid ColumnDefinitions="Auto, *" Padding="8,6" ColumnSpacing="10">
+                                    <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="80" Aspect="AspectFill" Grid.Column="0" />
+                                    <Label Text="{Binding Address.DisplayAddress}" Grid.Column="1"
+                                           LineBreakMode="WordWrap" FontSize="Small" VerticalOptions="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                                 </Grid>
                             </Border>
                         </DataTemplate>

--- a/TrashMobMobile/Pages/ViewTeamPage.xaml
+++ b/TrashMobMobile/Pages/ViewTeamPage.xaml
@@ -30,20 +30,28 @@
             <Button Text="{Binding JoinButtonText}"
                     Command="{Binding JoinTeamCommand}"
                     IsVisible="{Binding CanJoin}"
-                    Style="{StaticResource PrimaryButton}"
+                    Style="{StaticResource PrimarySmallButton}"
                     Margin="10,5" />
 
-            <Label Text="You are a member of this team"
-                   IsVisible="{Binding IsUserMember}"
-                   FontSize="Small"
-                   FontAttributes="Bold"
-                   Margin="10,5"
-                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+            <HorizontalStackLayout IsVisible="{Binding IsUserMember}" Spacing="6" Margin="10,5">
+                <Image WidthRequest="18" HeightRequest="18">
+                    <Image.Source>
+                        <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                         Glyph="{StaticResource IconCheckCircle}"
+                                         Size="18"
+                                         Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                    </Image.Source>
+                </Image>
+                <Label Text="You are a member of this team"
+                       FontSize="Small"
+                       FontAttributes="Bold"
+                       VerticalOptions="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+            </HorizontalStackLayout>
 
             <!-- Members Section -->
             <Label Text="Members"
-                   FontFamily="LexendSemibold"
-                   FontSize="Medium"
+                   Style="{StaticResource SectionHeader}"
                    Margin="10,15,10,5" />
 
             <Label Text="No members found"
@@ -82,7 +90,8 @@
                 <Label Grid.Column="0"
                        Text="Upcoming Events"
                        FontFamily="LexendSemibold"
-                       FontSize="Medium" />
+                       FontSize="Medium"
+                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
                 <Button Grid.Column="1"
                         Text="Link Event"
                         Command="{Binding LinkEventCommand}"

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -769,7 +769,7 @@
     <!-- <x:String x:Key="IconImport">&#xf02fa;</x:String> -->
     <!-- <x:String x:Key="IconInboxArrowDown">&#xf02fb;</x:String> -->
     <!-- <x:String x:Key="IconInformation">&#xf02fc;</x:String> -->
-    <!-- <x:String x:Key="IconInformationOutline">&#xf02fd;</x:String> -->
+    <x:String x:Key="IconInformationOutline">&#xf02fd;</x:String>
     <!-- <x:String x:Key="IconInstagram">&#xf02fe;</x:String> -->
     <!-- <x:String x:Key="IconPotOutline">&#xf02ff;</x:String> -->
     <!-- <x:String x:Key="IconMicrosoftInternetExplorer">&#xf0300;</x:String> -->
@@ -1275,7 +1275,7 @@
     <!-- <x:String x:Key="IconTablet">&#xf04f6;</x:String> -->
     <!-- <x:String x:Key="IconReceiptOutline">&#xf04f7;</x:String> -->
     <!-- <x:String x:Key="IconTangram">&#xf04f8;</x:String> -->
-    <!-- <x:String x:Key="IconTag">&#xf04f9;</x:String> -->
+    <x:String x:Key="IconTag">&#xf04f9;</x:String>
     <!-- <x:String x:Key="IconTagFaces">&#xf04fa;</x:String> -->
     <!-- <x:String x:Key="IconTagMultiple">&#xf04fb;</x:String> -->
     <!-- <x:String x:Key="IconTagOutline">&#xf04fc;</x:String> -->
@@ -1308,7 +1308,7 @@
     <!-- <x:String x:Key="IconTicketConfirmation">&#xf0518;</x:String> -->
     <!-- <x:String x:Key="IconTie">&#xf0519;</x:String> -->
     <!-- <x:String x:Key="IconTimelapse">&#xf051a;</x:String> -->
-    <!-- <x:String x:Key="IconTimerOutline">&#xf051b;</x:String> -->
+    <x:String x:Key="IconTimerOutline">&#xf051b;</x:String>
     <!-- <x:String x:Key="IconTimer10">&#xf051c;</x:String> -->
     <!-- <x:String x:Key="IconTimer3">&#xf051d;</x:String> -->
     <!-- <x:String x:Key="IconTimerOffOutline">&#xf051e;</x:String> -->
@@ -2007,7 +2007,7 @@
     <!-- <x:String x:Key="IconLedStrip">&#xf07d6;</x:String> -->
     <!-- <x:String x:Key="IconLocker">&#xf07d7;</x:String> -->
     <!-- <x:String x:Key="IconLockerMultiple">&#xf07d8;</x:String> -->
-    <!-- <x:String x:Key="IconMapMarkerOutline">&#xf07d9;</x:String> -->
+    <x:String x:Key="IconMapMarkerOutline">&#xf07d9;</x:String>
     <!-- <x:String x:Key="IconMetronome">&#xf07da;</x:String> -->
     <!-- <x:String x:Key="IconMetronomeTick">&#xf07db;</x:String> -->
     <!-- <x:String x:Key="IconMicroSd">&#xf07dc;</x:String> -->

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -185,7 +185,7 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             EnableStopTrackEventRoute = false;
 
             WhatToExpect =
-                "What to Expect: \n\tCleanup supplies provided\n\tMeet fellow community members\n\tContribute to a cleaner environment.";
+                "What to Expect:\n\u2022 Cleanup supplies provided\n\u2022 Meet fellow community members\n\u2022 Contribute to a cleaner environment";
 
             await SetRegistrationOptions();
             await GetAttendeeCount();
@@ -438,6 +438,7 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             if (!await waiverManager.HasUserSignedTrashMobWaiverAsync())
             {
                 await Shell.Current.GoToAsync($"{nameof(WaiverPage)}");
+                return;
             }
 
             var eventAttendee = new EventAttendee

--- a/TrashMobMobile/Views/ViewEvent/TabAttendees.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabAttendees.xaml
@@ -15,34 +15,37 @@
                                     SelectionMode="None">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:EventAttendeeViewModel">
-                    <StackLayout Margin="5">
-                        <Border Style="{StaticResource RoundBorder}" Margin="5">
-                            <Grid ColumnDefinitions="*, *, Auto" RowDefinitions="*, *, *">
-                                <Label Text="User Name" Style="{StaticResource FieldLabel}" Grid.Row="0" />
-                                <Label Text="{Binding UserName}" Grid.Row="0" Grid.Column="1" />
-                                <Label Text="Member Since" Style="{StaticResource FieldLabel}" Grid.Row="1" />
-                                <Label Text="{Binding MemberSince}" Grid.Row="1" Grid.Column="1" />
-                                <Label Text="Event Role" Style="{StaticResource FieldLabel}" Grid.Row="2" />
-                                <Label Text="{Binding Role}" Grid.Row="2" Grid.Column="1"/>
-                                <StackLayout Grid.Row="0" Grid.RowSpan="3" Grid.Column="2" VerticalOptions="Center" Margin="10,0">
-                                    <Button Text="Promote"
-                                            Command="{Binding Source={x:Reference TabAttendeesView}, Path=BindingContext.PromoteToLeadCommand}"
-                                            CommandParameter="{Binding .}"
-                                            IsVisible="{Binding CanPromote}"
-                                            Style="{StaticResource PrimaryButton}"
-                                            Padding="10,5"
-                                            FontSize="12" />
-                                    <Button Text="Demote"
-                                            Command="{Binding Source={x:Reference TabAttendeesView}, Path=BindingContext.DemoteFromLeadCommand}"
-                                            CommandParameter="{Binding .}"
-                                            IsVisible="{Binding CanDemote}"
-                                            Style="{StaticResource SecondaryButton}"
-                                            Padding="10,5"
-                                            FontSize="12" />
-                                </StackLayout>
-                            </Grid>
-                        </Border>
-                    </StackLayout>
+                    <Border Style="{StaticResource RoundBorder}" Margin="5,3">
+                        <HorizontalStackLayout Padding="10,8" Spacing="10">
+                            <VerticalStackLayout Spacing="2" HorizontalOptions="FillAndExpand">
+                                <Label Text="{Binding UserName}"
+                                       FontFamily="LexendSemibold"
+                                       FontSize="Small" />
+                                <Label Text="{Binding MemberSince, StringFormat='Member since {0}'}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding Role}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </VerticalStackLayout>
+                            <StackLayout VerticalOptions="Center" Spacing="4">
+                                <Button Text="Promote"
+                                        Command="{Binding Source={x:Reference TabAttendeesView}, Path=BindingContext.PromoteToLeadCommand}"
+                                        CommandParameter="{Binding .}"
+                                        IsVisible="{Binding CanPromote}"
+                                        Style="{StaticResource PrimarySmallButton}"
+                                        Padding="10,5"
+                                        FontSize="12" />
+                                <Button Text="Demote"
+                                        Command="{Binding Source={x:Reference TabAttendeesView}, Path=BindingContext.DemoteFromLeadCommand}"
+                                        CommandParameter="{Binding .}"
+                                        IsVisible="{Binding CanDemote}"
+                                        Style="{StaticResource SecondarySmallButton}"
+                                        Padding="10,5"
+                                        FontSize="12" />
+                            </StackLayout>
+                        </HorizontalStackLayout>
+                    </Border>
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
@@ -5,85 +5,166 @@
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
              x:Class="TrashMobMobile.Views.ViewEvent.TabDetails">
-    <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="3"
-                      ColumnDefinitions="*, 2*, *">
+    <ScrollView>
+        <VerticalStackLayout Spacing="12" Margin="0">
 
-        <controls:CustomMap x:Name="eventLocationMap" HeightRequest="200"
-                            HandlerProperties.DisconnectPolicy="Manual"
-                              ItemsSource="{Binding Addresses}" Grid.Row="0" Grid.ColumnSpan="3">
-            <maps:Map.ItemTemplate>
-                <DataTemplate x:DataType="viewModels:AddressViewModel">
-                    <controls:CustomPin Location="{Binding Location}"
-                                          Address="{Binding StreetAddress}"
-                                          ImageSource="{Binding IconFile}"                                          
-                                          Label="{Binding AddressType}" />
-                </DataTemplate>
-            </maps:Map.ItemTemplate>
-        </controls:CustomMap>
+            <!-- Map -->
+            <Border StrokeShape="RoundRectangle 10"
+                    StrokeThickness="0"
+                    Padding="0"
+                    Margin="5,0">
+                <controls:CustomMap x:Name="eventLocationMap" HeightRequest="200"
+                                    HandlerProperties.DisconnectPolicy="Manual"
+                                    ItemsSource="{Binding Addresses}">
+                    <maps:Map.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:AddressViewModel">
+                            <controls:CustomPin Location="{Binding Location}"
+                                                Address="{Binding StreetAddress}"
+                                                ImageSource="{Binding IconFile}"
+                                                Label="{Binding AddressType}" />
+                        </DataTemplate>
+                    </maps:Map.ItemTemplate>
+                </controls:CustomMap>
+            </Border>
 
-        <Label Grid.Row="1" Grid.Column="0" Text="{Binding EventViewModel.DisplayDate}"
-                           FontAttributes="Bold" Grid.ColumnSpan="2" />
-        <Label Grid.Row="1" Grid.Column="3" Text="{Binding EventViewModel.DisplayTime}" />
-        <Label Grid.Row="2" Grid.Column="0" Text="{Binding SelectedEventType}" Style="{StaticResource LongText}" Margin="20, 0, 0, 0"
-                           Grid.ColumnSpan="2" />
-        <Label Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding DisplayDuration}" Style="{StaticResource LongText}" Margin="20, 0, 0, 0" />
-        <Label Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
-                           Text="{Binding EventViewModel.Address.DisplayAddress }" Style="{StaticResource LongText}" Margin="20, 0, 0, 0" />
-        <Label Grid.Row="6" Grid.Column="0" Text="About this event" FontAttributes="Bold"
-                           Grid.ColumnSpan="2" />
-        <Label Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding EventViewModel.Description}" Style="{StaticResource LongText}" Margin="20, 0, 0, 0"
-                           FontSize="Micro" />
-        <Label Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding WhatToExpect}" Style="{StaticResource LongText}" Margin="20, 0, 0, 0"
-                           FontSize="Micro" />
-        <Label Grid.Row="9" Grid.Column="0" Text="Attendees" />
-        <Label Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding AttendeeCount}" Style="{StaticResource LongText}" Margin="20, 0, 0, 0" />
+            <!-- Event Info Card -->
+            <Border Style="{x:StaticResource RoundBorder}">
+                <VerticalStackLayout Spacing="10">
 
-        <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *, *"
-                      MaximumWidthRequest="400" Grid.Row="11" Grid.ColumnSpan="2">
-            <Button Margin="5"
-                            Grid.Row="0" 
-                            Grid.Column="0" 
-                            Text="Register" 
-                            Command="{Binding RegisterCommand}"
-                            IsVisible="{Binding EnableRegister}"
-                            Style="{StaticResource PrimarySmallButton}" />
-            <Button Margin="5"
-                            Grid.Row="0" 
-                            Grid.Column="0" 
-                            Text="Unregister" 
-                            Command="{Binding UnregisterCommand}"
-                            IsVisible="{Binding EnableUnregister}"
-                            Style="{StaticResource PrimarySmallButton}" />
-            <Button Margin="5"
-                            Grid.Row="0" 
-                            Grid.Column="0" 
-                            Text="Edit Event" 
-                            Command="{Binding EditEventCommand}"
-                            IsVisible="{Binding EnableEditEvent}"
-                            Style="{StaticResource PrimarySmallButton}" />
-            <Button Margin="5"
-                            Grid.Row="0" 
-                            Grid.Column="1" 
-                            Command="{Binding ViewEventSummaryCommand}" 
-                            Text="View Event Summary"
-                            IsVisible="{Binding EnableViewEventSummary}"
-                            Style="{StaticResource SecondarySmallButton}" />
-            <!--<Button Margin="5"
-                            Grid.Row="0"
-                            Grid.Column="2"
-                            Command="{Binding RealTimeLocationTrackerCommand}"
-                            IsVisible="{Binding EnableStartTrackEventRoute}"
-                            IsEnabled="{Binding EnableStartTrackEventRoute}"
-                            Text="Start Tracking"
-                            Style="{StaticResource SecondarySmallButton}" />
-            <Button Margin="5"
-                            Grid.Row="0"
-                            Grid.Column="2"
-                            Command="{Binding RealTimeLocationTrackerCancelCommand}"
-                            IsEnabled="{Binding EnableStopTrackEventRoute}"
-                            IsVisible="{Binding EnableStopTrackEventRoute}"
-                            Text="Stop Tracking"
-                            Style="{StaticResource SecondarySmallButton}" />-->
-        </Grid>
-    </Grid>
+                    <!-- Date & Time -->
+                    <HorizontalStackLayout Spacing="10">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Start">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconCalendarCheck}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <VerticalStackLayout Spacing="2">
+                            <Label Text="{Binding EventViewModel.DisplayDate}"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Small" />
+                            <Label Text="{Binding EventViewModel.DisplayTime}"
+                                   FontSize="Micro"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                    </HorizontalStackLayout>
+
+                    <!-- Duration -->
+                    <HorizontalStackLayout Spacing="10">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconTimerOutline}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="{Binding DisplayDuration}"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+
+                    <!-- Address -->
+                    <HorizontalStackLayout Spacing="10">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Start">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconMapMarkerOutline}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="{Binding EventViewModel.Address.DisplayAddress}"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+
+                    <!-- Event Type -->
+                    <HorizontalStackLayout Spacing="10">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconTag}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="{Binding SelectedEventType}"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- About This Event Card -->
+            <Border Style="{x:StaticResource RoundBorder}">
+                <VerticalStackLayout Spacing="8">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconInformationOutline}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="About this event"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small" />
+                    </HorizontalStackLayout>
+                    <Label Text="{Binding EventViewModel.Description}"
+                           FontSize="Micro"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <Label Text="{Binding WhatToExpect}"
+                           FontSize="Micro"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Attendees -->
+            <HorizontalStackLayout Spacing="8" Margin="5,4">
+                <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                    <Image.Source>
+                        <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                         Glyph="{StaticResource IconAccount}"
+                                         Size="20"
+                                         Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                    </Image.Source>
+                </Image>
+                <Label Text="{Binding AttendeeCount}"
+                       FontSize="Small"
+                       VerticalOptions="Center" />
+            </HorizontalStackLayout>
+
+            <!-- Primary Actions -->
+            <Button Text="Register"
+                    Command="{Binding RegisterCommand}"
+                    IsVisible="{Binding EnableRegister}"
+                    HorizontalOptions="Fill"
+                    Margin="5,4" />
+            <Button Text="Unregister"
+                    Command="{Binding UnregisterCommand}"
+                    IsVisible="{Binding EnableUnregister}"
+                    Style="{StaticResource SecondarySmallButton}"
+                    HorizontalOptions="Fill"
+                    Margin="5,4" />
+            <Button Text="Edit Event"
+                    Command="{Binding EditEventCommand}"
+                    IsVisible="{Binding EnableEditEvent}"
+                    Style="{StaticResource SecondarySmallButton}"
+                    HorizontalOptions="Fill"
+                    Margin="5,4" />
+
+            <!-- Secondary Actions -->
+            <Button Text="View Event Summary"
+                    Command="{Binding ViewEventSummaryCommand}"
+                    IsVisible="{Binding EnableViewEventSummary}"
+                    Style="{StaticResource SecondarySmallButton}"
+                    Margin="5,4" />
+
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentView>

--- a/TrashMobMobile/Views/ViewEvent/TabLitterReports.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabLitterReports.xaml
@@ -43,36 +43,36 @@
                                     SelectionMode="None">
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="viewModels:EventLitterReportViewModel">
-                        <StackLayout Margin="5">
-                            <Border Style="{StaticResource RoundBorder}" Margin="5">
-                                <Grid ColumnDefinitions="*, *"
-                                              RowDefinitions="*, *, *, *, *, *, *"
-                                              x:Name="LitterReportItem">
-                                    <Label Text="Name" Style="{StaticResource FieldLabel}" Grid.Row="0" />
-                                    <Label Text="{Binding Name}" Grid.Row="0" Grid.Column="1" />
-                                    <Label Text="Date Created" Style="{StaticResource FieldLabel}" Grid.Row="1" />
-                                    <Label Text="{Binding CreatedDate}" Grid.Row="1" Grid.Column="1" />
-                                    <Label Text="Status" Style="{StaticResource FieldLabel}" Grid.Row="2" />
-                                    <Label Text="{Binding Status}" Grid.Row="2" Grid.Column="1"/>
-                                    <Label Text="Description" Style="{StaticResource FieldLabel}" Grid.Row="3" />
-                                    <Label Text="{Binding Description}" Grid.Row="3" Grid.Column="1" />
-                                    <Label Text="Locations" Grid.Row="5" Style="{StaticResource FieldLabel}" />
-                                    <CollectionView ItemsSource="{Binding LitterImageViewModels}" Grid.Row="6"
-                                                            Grid.Column="0" Grid.ColumnSpan="2">
-                                        <CollectionView.ItemTemplate>
-                                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                                <Border Style="{StaticResource RoundBorder}" Margin="0, 3">
-                                                    <Grid ColumnDefinitions="*, *">
-                                                        <Label Text="{Binding Address.DisplayAddress}" Grid.Column="0" LineBreakMode="WordWrap" FontSize="Micro" />
-                                                        <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="60" Grid.Column="1" />
-                                                    </Grid>
-                                                </Border>
-                                            </DataTemplate>
-                                        </CollectionView.ItemTemplate>
-                                    </CollectionView>
-                                </Grid>
-                            </Border>
-                        </StackLayout>
+                        <Border Style="{StaticResource RoundBorder}" Margin="5,3">
+                            <VerticalStackLayout Spacing="4" Padding="10,8">
+                                <Label Text="{Binding Name}"
+                                       FontFamily="LexendSemibold"
+                                       FontSize="Small" />
+                                <Label Text="{Binding CreatedDate}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding Status}"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding Description}"
+                                       FontSize="Micro"
+                                       MaxLines="2"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <CollectionView ItemsSource="{Binding LitterImageViewModels}">
+                                    <CollectionView.ItemTemplate>
+                                        <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                            <Border Style="{StaticResource RoundBorder}" Margin="0,3">
+                                                <Grid ColumnDefinitions="*, Auto" Padding="8,6">
+                                                    <Label Text="{Binding Address.DisplayAddress}" Grid.Column="0" LineBreakMode="WordWrap" FontSize="Micro"
+                                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                    <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="60" Grid.Column="1" />
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </CollectionView.ItemTemplate>
+                                </CollectionView>
+                            </VerticalStackLayout>
+                        </Border>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>

--- a/TrashMobMobile/Views/ViewEvent/TabPartners.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabPartners.xaml
@@ -11,18 +11,23 @@
                                     SelectionMode="None" 
                                     IsVisible="{Binding ArePartnersAvailable}">
             <CollectionView.ItemTemplate>
-                <DataTemplate 
-                                x:DataType="viewModels:EventPartnerLocationViewModel">
-                    <Border Style="{StaticResource RoundBorder}" Margin="5">
-                        <Grid RowDefinitions="1*, 2*, 1*" ColumnDefinitions="*, *"
-                                          x:Name="PartnerLocationItem">
-                            <Label Text="Partner Name" Style="{StaticResource FieldLabel}" Grid.Row="0" />
-                            <Label Text="{Binding PartnerLocationName}" Grid.Column="1" Grid.Row="0" />
-                            <Label Text="Info" Style="{StaticResource FieldLabel}" Grid.Row="1" />
-                            <Label Text="{Binding PartnerLocationNotes}" Grid.Row="1" Grid.Column="1" />
-                            <Label Text="Services Requested" Style="{StaticResource FieldLabel}" Grid.Row="2" />
-                            <Label Text="{Binding PartnerServicesEngaged}" Grid.Row="2" Grid.Column="1" />
-                        </Grid>
+                <DataTemplate x:DataType="viewModels:EventPartnerLocationViewModel">
+                    <Border Style="{StaticResource RoundBorder}" Margin="5,3">
+                        <VerticalStackLayout Spacing="4" Padding="10,8">
+                            <Label Text="{Binding PartnerLocationName}"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Small" />
+                            <Label Text="{Binding PartnerLocationNotes}"
+                                   FontSize="Micro"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <HorizontalStackLayout Spacing="4">
+                                <Label Text="Services:"
+                                       FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding PartnerServicesEngaged}"
+                                       FontSize="Micro" />
+                            </HorizontalStackLayout>
+                        </VerticalStackLayout>
                     </Border>
                 </DataTemplate>
             </CollectionView.ItemTemplate>


### PR DESCRIPTION
## Summary

- Apply consistent visual polish (teal section headers, Material icons, card layouts) across all remaining mobile pages
- Fix register button timeout caused by aggressive retry policy (126s → 14s) and 404 retries
- Fix duplicate activity spinners appearing on 6 pages
- Fix missing `return` after waiver navigation in Register flow

## Test plan

- [ ] Verify teal SectionHeader style on Profile, Impact, ViewCommunity, ViewTeam pages
- [ ] Verify clean card layouts on Event → People, Partners, Litter tabs
- [ ] Verify full-width buttons and card info on ViewLitterReport page
- [ ] Verify map/member icons on BrowseTeams and BrowseCommunities pages
- [ ] Verify Register button responds within ~15 seconds (success or error)
- [ ] Verify only one spinner shows during loading on all pages
- [ ] Verify dark mode adapts correctly on all modified pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)