### PR TITLE
Add comprehensive mobile ViewModel unit tests (170 new tests)

### DIFF
--- a/TrashMobMobile.Tests/Stubs/PageStubs.cs
+++ b/TrashMobMobile.Tests/Stubs/PageStubs.cs
@@ -38,3 +38,5 @@ internal class BrowseTeamsPage { }
 internal class LeaderboardsPage { }
 internal class NewsletterPreferencesPage { }
 internal class ViewTeamPage { }
+internal class BrowseCommunitiesPage { }
+internal class ViewCommunityPage { }

--- a/TrashMobMobile.Tests/TrashMobMobile.Tests.csproj
+++ b/TrashMobMobile.Tests/TrashMobMobile.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\TrashMobMobile\Extensions\DisplayUserExtensions.cs" Link="LinkedSource\Extensions\DisplayUserExtensions.cs" />
     <Compile Include="..\TrashMobMobile\Extensions\StringExtensions.cs" Link="LinkedSource\Extensions\StringExtensions.cs" />
     <Compile Include="..\TrashMobMobile\Extensions\TeamExtensions.cs" Link="LinkedSource\Extensions\TeamExtensions.cs" />
+    <Compile Include="..\TrashMobMobile\Extensions\CommunityExtensions.cs" Link="LinkedSource\Extensions\CommunityExtensions.cs" />
   </ItemGroup>
 
   <!-- Link authentication types -->

--- a/TrashMobMobile.Tests/ViewModels/BrowseCommunitiesViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/BrowseCommunitiesViewModelTests.cs
@@ -1,0 +1,153 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class BrowseCommunitiesViewModelTests
+{
+    private readonly Mock<ICommunityManager> mockCommunityManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly BrowseCommunitiesViewModel sut;
+
+    public BrowseCommunitiesViewModelTests()
+    {
+        mockCommunityManager = new Mock<ICommunityManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new BrowseCommunitiesViewModel(
+            mockCommunityManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_WithCommunities_SetsAreCommunitiesFound()
+    {
+        // Arrange
+        var partners = CreateTestPartners(2);
+        mockCommunityManager.Setup(m => m.GetCommunitiesAsync(
+                It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partners);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.AreCommunitiesFound);
+        Assert.False(sut.AreNoCommunitiesFound);
+    }
+
+    [Fact]
+    public async Task Init_WithNoCommunities_SetsAreNoCommunitiesFound()
+    {
+        // Arrange
+        mockCommunityManager.Setup(m => m.GetCommunitiesAsync(
+                It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Partner>());
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.False(sut.AreCommunitiesFound);
+        Assert.True(sut.AreNoCommunitiesFound);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesCommunitiesCollection()
+    {
+        // Arrange
+        var partners = CreateTestPartners(3);
+        mockCommunityManager.Setup(m => m.GetCommunitiesAsync(
+                It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partners);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(3, sut.Communities.Count);
+    }
+
+    [Fact]
+    public async Task Init_WithCommunities_MapsToViewModels()
+    {
+        // Arrange
+        var partners = new List<Partner>
+        {
+            new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = "Seattle Community",
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                Slug = "seattle",
+            },
+        };
+
+        mockCommunityManager.Setup(m => m.GetCommunitiesAsync(
+                It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partners);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Single(sut.Communities);
+        Assert.Equal("Seattle Community", sut.Communities[0].Name);
+    }
+
+    [Fact]
+    public async Task Init_ClearsExistingCommunitiesBeforeReloading()
+    {
+        // Arrange - first load
+        var partners1 = CreateTestPartners(2);
+        mockCommunityManager.Setup(m => m.GetCommunitiesAsync(
+                It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partners1);
+
+        await sut.Init();
+        Assert.Equal(2, sut.Communities.Count);
+
+        // Arrange - second load with different count
+        var partners2 = CreateTestPartners(1);
+        mockCommunityManager.Setup(m => m.GetCommunitiesAsync(
+                It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<double?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partners2);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Single(sut.Communities);
+    }
+
+    private static List<Partner> CreateTestPartners(int count)
+    {
+        var partners = new List<Partner>();
+        for (var i = 0; i < count; i++)
+        {
+            partners.Add(new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Community {i + 1}",
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                Slug = $"community-{i + 1}",
+            });
+        }
+
+        return partners;
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/CancelEventViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/CancelEventViewModelTests.cs
@@ -1,0 +1,175 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMobMobile.Models;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class CancelEventViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockMobEventManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly CancelEventViewModel sut;
+
+    private readonly User testUser;
+    private readonly Event testEvent;
+
+    public CancelEventViewModelTests()
+    {
+        mockMobEventManager = new Mock<IMobEventManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        testUser = TestHelpers.CreateTestUser();
+        testEvent = TestHelpers.CreateTestEvent(createdByUserId: testUser.Id);
+
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new CancelEventViewModel(
+            mockMobEventManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    private void SetupDefaultMocks(Event? mobEvent = null)
+    {
+        var evt = mobEvent ?? testEvent;
+        mockMobEventManager.Setup(m => m.GetEventAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(evt);
+    }
+
+    [Fact]
+    public async Task Init_LoadsEventViewModel()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.NotNull(sut.EventViewModel);
+        mockMobEventManager.Verify(m => m.GetEventAsync(testEvent.Id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_SetsEventViewModelProperties()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Equal(testEvent.Id, sut.EventViewModel.Id);
+        Assert.Equal(testEvent.Name, sut.EventViewModel.Name);
+        Assert.Equal(testEvent.Description, sut.EventViewModel.Description);
+        Assert.Equal(testEvent.EventDate, sut.EventViewModel.EventDate);
+        Assert.Equal(testEvent.IsEventPublic, sut.EventViewModel.IsEventPublic);
+    }
+
+    [Fact]
+    public async Task Init_SetsUserRoleForEvent()
+    {
+        // Arrange — testEvent.CreatedByUserId == testUser.Id, so user is the event lead
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Equal("Lead", sut.EventViewModel.UserRoleForEvent);
+    }
+
+    [Fact]
+    public async Task CancelEventCommand_CallsDeleteEventAsync()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(testEvent.Id);
+
+        sut.EventViewModel.CancellationReason = "Weather conditions";
+
+        var mockNavigation = new Mock<INavigation>();
+        sut.Navigation = mockNavigation.Object;
+
+        mockMobEventManager.Setup(m => m.DeleteEventAsync(It.IsAny<EventCancellationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await sut.CancelEventCommand.ExecuteAsync(null);
+
+        // Assert
+        mockMobEventManager.Verify(
+            m => m.DeleteEventAsync(
+                It.Is<EventCancellationRequest>(r =>
+                    r.EventId == testEvent.Id &&
+                    r.CancellationReason == "Weather conditions"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelEventCommand_NotifiesUser()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(testEvent.Id);
+
+        var mockNavigation = new Mock<INavigation>();
+        sut.Navigation = mockNavigation.Object;
+
+        mockMobEventManager.Setup(m => m.DeleteEventAsync(It.IsAny<EventCancellationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await sut.CancelEventCommand.ExecuteAsync(null);
+
+        // Assert
+        mockNotificationService.Verify(
+            m => m.Notify(It.Is<string>(s => s.Contains("cancelled")), It.IsAny<double>(), It.IsAny<CommunityToolkit.Maui.Core.ToastDuration>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelEventCommand_NavigatesBack()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(testEvent.Id);
+
+        var mockNavigation = new Mock<INavigation>();
+        sut.Navigation = mockNavigation.Object;
+
+        mockMobEventManager.Setup(m => m.DeleteEventAsync(It.IsAny<EventCancellationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await sut.CancelEventCommand.ExecuteAsync(null);
+
+        // Assert
+        mockNavigation.Verify(m => m.PopAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_SetsEventAddress()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Equal(testEvent.City, sut.EventViewModel.Address.City);
+        Assert.Equal(testEvent.Country, sut.EventViewModel.Address.Country);
+        Assert.Equal(testEvent.Region, sut.EventViewModel.Address.Region);
+        Assert.Equal(testEvent.StreetAddress, sut.EventViewModel.Address.StreetAddress);
+        Assert.Equal(testEvent.PostalCode, sut.EventViewModel.Address.PostalCode);
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ContactUsViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ContactUsViewModelTests.cs
@@ -1,0 +1,63 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMobMobile.Services;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class ContactUsViewModelTests
+{
+    private readonly Mock<IContactRequestManager> mockContactRequestManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly ContactUsViewModel sut;
+
+    public ContactUsViewModelTests()
+    {
+        mockContactRequestManager = new Mock<IContactRequestManager>();
+        mockNotificationService = new Mock<INotificationService>();
+
+        sut = new ContactUsViewModel(
+            mockContactRequestManager.Object,
+            mockNotificationService.Object);
+    }
+
+    [Fact]
+    public void Constructor_SetsDefaultValues()
+    {
+        // Assert
+        Assert.Equal(string.Empty, sut.Name);
+        Assert.Equal(string.Empty, sut.Email);
+        Assert.Equal(string.Empty, sut.Message);
+        Assert.Equal(string.Empty, sut.Confirmation);
+    }
+
+    [Fact]
+    public void Name_CanBeSet()
+    {
+        // Act
+        sut.Name = "John Doe";
+
+        // Assert
+        Assert.Equal("John Doe", sut.Name);
+    }
+
+    [Fact]
+    public void Email_CanBeSet()
+    {
+        // Act
+        sut.Email = "john@example.com";
+
+        // Assert
+        Assert.Equal("john@example.com", sut.Email);
+    }
+
+    [Fact]
+    public void Message_CanBeSet()
+    {
+        // Act
+        sut.Message = "I would like to volunteer.";
+
+        // Assert
+        Assert.Equal("I would like to volunteer.", sut.Message);
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/CreateEventViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/CreateEventViewModelTests.cs
@@ -1,0 +1,505 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class CreateEventViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockEventManager;
+    private readonly Mock<IEventTypeRestService> mockEventTypeRestService;
+    private readonly Mock<IMapRestService> mockMapRestService;
+    private readonly Mock<IWaiverManager> mockWaiverManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IEventPartnerLocationServiceRestService> mockEventPartnerLocationServiceRestService;
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<IEventLitterReportManager> mockEventLitterReportManager;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly CreateEventViewModel sut;
+
+    private readonly List<EventType> defaultEventTypes =
+    [
+        new EventType { Id = 1, Name = "Cleanup", DisplayOrder = 1 },
+        new EventType { Id = 2, Name = "Beautification", DisplayOrder = 2 },
+    ];
+
+    public CreateEventViewModelTests()
+    {
+        mockEventManager = new Mock<IMobEventManager>();
+        mockEventTypeRestService = new Mock<IEventTypeRestService>();
+        mockMapRestService = new Mock<IMapRestService>();
+        mockWaiverManager = new Mock<IWaiverManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockEventPartnerLocationServiceRestService = new Mock<IEventPartnerLocationServiceRestService>();
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockEventLitterReportManager = new Mock<IEventLitterReportManager>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new CreateEventViewModel(
+            mockEventManager.Object,
+            mockEventTypeRestService.Object,
+            mockMapRestService.Object,
+            mockWaiverManager.Object,
+            mockNotificationService.Object,
+            mockEventPartnerLocationServiceRestService.Object,
+            mockLitterReportManager.Object,
+            mockEventLitterReportManager.Object,
+            mockUserManager.Object);
+
+        // Set up Steps array with mock IContentView objects (5 steps in the wizard)
+        var mockSteps = new IContentView[5];
+        for (var i = 0; i < 5; i++)
+        {
+            mockSteps[i] = new Mock<IContentView>().Object;
+        }
+
+        sut.Steps = mockSteps;
+    }
+
+    private void SetupDefaultMocks()
+    {
+        mockWaiverManager.Setup(m => m.HasUserSignedTrashMobWaiverAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        mockEventTypeRestService.Setup(m => m.GetEventTypesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(defaultEventTypes);
+
+        mockEventPartnerLocationServiceRestService
+            .Setup(m => m.GetEventPartnerLocationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DisplayEventPartnerLocation>());
+    }
+
+    [Fact]
+    public async Task Init_WithNoLitterReport_SetsDefaultEventName()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.Equal("New Event", sut.EventViewModel.Name);
+    }
+
+    [Fact]
+    public async Task Init_WithNoLitterReport_SetsDefaultTimes()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.Equal(TimeSpan.FromHours(9), sut.StartTime);
+        Assert.Equal(TimeSpan.FromHours(11), sut.EndTime);
+    }
+
+    [Fact]
+    public async Task Init_LoadsEventTypes()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.Equal(2, sut.ETypes.Count);
+        Assert.Contains("Cleanup", sut.ETypes);
+        Assert.Contains("Beautification", sut.ETypes);
+    }
+
+    [Fact]
+    public async Task Init_ChecksWaiver()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        mockWaiverManager.Verify(m => m.HasUserSignedTrashMobWaiverAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_WhenWaiverNotSigned_DoesNotThrow()
+    {
+        // Arrange
+        mockWaiverManager.Setup(m => m.HasUserSignedTrashMobWaiverAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        mockEventTypeRestService.Setup(m => m.GetEventTypesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(defaultEventTypes);
+
+        mockEventPartnerLocationServiceRestService
+            .Setup(m => m.GetEventPartnerLocationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DisplayEventPartnerLocation>());
+
+        // Act & Assert - Shell.Current is null in tests, so ExecuteAsync catches the exception
+        // We just verify the waiver check was called; the Shell navigation will fail silently
+        // via the BaseViewModel error handler
+        var exception = await Record.ExceptionAsync(() => sut.Init(null));
+
+        mockWaiverManager.Verify(m => m.HasUserSignedTrashMobWaiverAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_WithLitterReportId_SetsAddressFromLitterReport()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        var litterReportId = Guid.NewGuid();
+        var litterReport = TestHelpers.CreateTestLitterReport(litterReportId);
+        litterReport.LitterImages =
+        [
+            new LitterImage
+            {
+                City = "Portland",
+                Country = "United States",
+                Region = "OR",
+                Latitude = 45.5155,
+                Longitude = -122.6789,
+                PostalCode = "97201",
+                StreetAddress = "456 Oak Ave",
+            },
+        ];
+
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportAsync(litterReportId, ImageSizeEnum.Thumb, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(litterReport);
+
+        // Act
+        await sut.Init(litterReportId);
+
+        // Assert
+        Assert.Equal("Portland", sut.EventViewModel.Address.City);
+        Assert.Equal("United States", sut.EventViewModel.Address.Country);
+        Assert.Equal(45.5155, sut.EventViewModel.Address.Latitude);
+        Assert.Equal(-122.6789, sut.EventViewModel.Address.Longitude);
+    }
+
+    [Fact]
+    public async Task SetCurrentStep_Forward_IncrementsStep()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        Assert.Equal(0, sut.CurrentStep);
+
+        // Act
+        await sut.SetCurrentStep(CreateEventViewModel.StepType.Forward);
+
+        // Assert
+        Assert.Equal(1, sut.CurrentStep);
+    }
+
+    [Fact]
+    public async Task SetCurrentStep_Backward_DecrementsStep()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Move to step 1 first
+        await sut.SetCurrentStep(CreateEventViewModel.StepType.Forward);
+        Assert.Equal(1, sut.CurrentStep);
+
+        // Act
+        await sut.SetCurrentStep(CreateEventViewModel.StepType.Backward);
+
+        // Assert
+        Assert.Equal(0, sut.CurrentStep);
+    }
+
+    [Fact]
+    public async Task SetCurrentStep_Backward_AtStepZero_DoesNotDecrement()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        Assert.Equal(0, sut.CurrentStep);
+
+        // Act
+        await sut.SetCurrentStep(CreateEventViewModel.StepType.Backward);
+
+        // Assert
+        Assert.Equal(0, sut.CurrentStep);
+    }
+
+    [Fact]
+    public async Task CanGoBack_AtStepZero_IsFalse()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Assert
+        Assert.False(sut.CanGoBack);
+    }
+
+    [Fact]
+    public async Task CanGoBack_AtStepOne_IsTrue()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Act
+        await sut.SetCurrentStep(CreateEventViewModel.StepType.Forward);
+
+        // Assert
+        Assert.Equal(1, sut.CurrentStep);
+        Assert.True(sut.CanGoBack);
+    }
+
+    [Fact]
+    public async Task ValidateCurrentStep_Step0_ValidInput_SetsIsStepValidTrue()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Act - Init sets defaults that should make step 0 valid:
+        // Name = "New Event", EventDate = tomorrow, SelectedEventType = "Cleanup",
+        // Duration = 2 hours, but Description is empty by default
+        sut.EventViewModel.Description = "A test event description";
+
+        // Assert
+        Assert.True(sut.IsStepValid);
+    }
+
+    [Fact]
+    public async Task ValidateCurrentStep_Step0_MissingName_SetsIsStepValidFalse()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        sut.EventViewModel.Description = "A test event description";
+
+        // Act
+        sut.EventViewModel.Name = string.Empty;
+
+        // Assert
+        Assert.False(sut.IsStepValid);
+    }
+
+    [Fact]
+    public async Task ValidateCurrentStep_Step0_MissingDescription_SetsIsStepValidFalse()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // EventViewModel.Description defaults to empty string
+        // Trigger validation by setting it explicitly
+        sut.EventViewModel.Description = string.Empty;
+
+        // Assert
+        Assert.False(sut.IsStepValid);
+    }
+
+    [Fact]
+    public async Task StartTime_EndTime_UpdatesDuration()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Act
+        sut.StartTime = TimeSpan.FromHours(8);
+        sut.EndTime = TimeSpan.FromHours(12);
+
+        // Assert
+        Assert.Equal(4, sut.EventViewModel.DurationHours);
+        Assert.Equal(0, sut.EventViewModel.DurationMinutes);
+    }
+
+    [Fact]
+    public async Task FormattedEventDuration_ReturnsFormattedString()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Act
+        sut.StartTime = TimeSpan.FromHours(9);
+        sut.EndTime = new TimeSpan(11, 30, 0);
+
+        // Assert
+        Assert.Equal("2 Hours and 30 Minutes", sut.FormattedEventDuration);
+    }
+
+    [Fact]
+    public async Task EventDuration_Over10Hours_SetsError()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Act - set duration to 11 hours
+        sut.StartTime = TimeSpan.FromHours(0);
+        sut.EndTime = TimeSpan.FromHours(11);
+
+        // Assert
+        Assert.Equal("Event maximum duration can only be 10 hours", sut.EventDurationError);
+    }
+
+    [Fact]
+    public async Task EventDuration_Under1Hour_SetsError()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        // Act - set duration to 30 minutes
+        sut.StartTime = TimeSpan.FromHours(9);
+        sut.EndTime = new TimeSpan(9, 30, 0);
+
+        // Assert
+        Assert.Equal("Event minimum duration must be at least 1 hour", sut.EventDurationError);
+    }
+
+    [Fact]
+    public async Task MapSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsLitterReportMapSelected);
+        Assert.False(sut.IsLitterReportListSelected);
+    }
+
+    [Fact]
+    public async Task ListSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsLitterReportMapSelected);
+        Assert.True(sut.IsLitterReportListSelected);
+    }
+
+    [Fact]
+    public async Task ChangeLocation_UpdatesEventAddress()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(null);
+
+        var newLocation = new Microsoft.Maui.Devices.Sensors.Location(45.5155, -122.6789);
+        var returnedAddress = new Address
+        {
+            City = "Portland",
+            Country = "United States",
+            Region = "OR",
+            PostalCode = "97201",
+            StreetAddress = "456 Oak Ave",
+        };
+
+        mockMapRestService.Setup(m => m.GetAddressAsync(45.5155, -122.6789, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(returnedAddress);
+
+        // Act
+        await sut.ChangeLocation(newLocation);
+
+        // Assert
+        Assert.Equal("Portland", sut.EventViewModel.Address.City);
+        Assert.Equal("United States", sut.EventViewModel.Address.Country);
+        Assert.Equal("OR", sut.EventViewModel.Address.Region);
+        Assert.Equal("97201", sut.EventViewModel.Address.PostalCode);
+        Assert.Equal("456 Oak Ave", sut.EventViewModel.Address.StreetAddress);
+        Assert.Equal(45.5155, sut.EventViewModel.Address.Latitude);
+        Assert.Equal(-122.6789, sut.EventViewModel.Address.Longitude);
+    }
+
+    [Fact]
+    public async Task Init_SetsDefaultEventProperties()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.True(sut.EventViewModel.IsEventPublic);
+        Assert.Equal(0, sut.EventViewModel.MaxNumberOfParticipants);
+        Assert.Equal(2, sut.EventViewModel.DurationHours);
+        Assert.Equal(0, sut.EventViewModel.DurationMinutes);
+        Assert.Equal(1, sut.EventViewModel.EventTypeId);
+    }
+
+    [Fact]
+    public async Task Init_SetsSelectedEventTypeToFirstByDisplayOrder()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.Equal("Cleanup", sut.SelectedEventType);
+    }
+
+    [Fact]
+    public async Task Init_SetsUserLocation()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.NotNull(sut.UserLocation);
+        Assert.Equal("Seattle", sut.UserLocation.City);
+        Assert.Equal("WA", sut.UserLocation.Region);
+        Assert.Equal("United States", sut.UserLocation.Country);
+    }
+
+    [Fact]
+    public async Task Init_WithNoLitterReport_SetsAddressFromUserLocation()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.Equal("Seattle", sut.EventViewModel.Address.City);
+        Assert.Equal("WA", sut.EventViewModel.Address.Region);
+        Assert.Equal("United States", sut.EventViewModel.Address.Country);
+    }
+
+    [Fact]
+    public async Task Init_AddsEventToEventsCollection()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(null);
+
+        // Assert
+        Assert.Single(sut.Events);
+        Assert.Same(sut.EventViewModel, sut.Events[0]);
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/CreateLitterReportViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/CreateLitterReportViewModelTests.cs
@@ -1,0 +1,157 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class CreateLitterReportViewModelTests
+{
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<IMapRestService> mockMapRestService;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly CreateLitterReportViewModel sut;
+
+    public CreateLitterReportViewModelTests()
+    {
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockMapRestService = new Mock<IMapRestService>();
+        mockNotificationService = new Mock<INotificationService>();
+
+        sut = new CreateLitterReportViewModel(
+            mockLitterReportManager.Object,
+            mockMapRestService.Object,
+            mockNotificationService.Object);
+    }
+
+    [Fact]
+    public void Constructor_SetsDefaultName()
+    {
+        // Assert
+        Assert.Equal("New Litter Report", sut.Name);
+    }
+
+    [Fact]
+    public void Constructor_SetsNewLitterReportStatus()
+    {
+        // Assert
+        Assert.NotNull(sut.LitterReportViewModel);
+        Assert.Equal(1, sut.LitterReportViewModel.LitterReportStatusId);
+    }
+
+    [Fact]
+    public void ValidateReport_NoImages_ReportIsNotValid()
+    {
+        // Arrange
+        sut.Name = "Valid Name Here";
+        sut.Description = "Valid Description Here";
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.False(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_WithImages_ValidNameAndDescription_ReportIsValid()
+    {
+        // Arrange
+        sut.Name = "Valid Name Here";
+        sut.Description = "Valid Description Here";
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.True(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_ShortName_ReportIsNotValid()
+    {
+        // Arrange
+        sut.Name = "Short";
+        sut.Description = "Valid Description Here";
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.False(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_MaxImages_SetsHasMaxImages()
+    {
+        // Arrange
+        for (var i = 0; i < CreateLitterReportViewModel.MaxImages; i++)
+        {
+            sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+        }
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.True(sut.HasMaxImages);
+        Assert.False(sut.CanAddImages);
+    }
+
+    [Fact]
+    public void ValidateReport_LessThanMax_SetsCanAddImages()
+    {
+        // Arrange
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.False(sut.HasMaxImages);
+        Assert.True(sut.CanAddImages);
+    }
+
+    [Fact]
+    public void Name_PropertyChanged_TriggersValidation()
+    {
+        // Arrange
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+        sut.Description = "Valid Description Here";
+
+        // Act - setting Name triggers ValidateReport internally
+        sut.Name = "Valid Name Here";
+
+        // Assert
+        Assert.True(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void Description_PropertyChanged_TriggersValidation()
+    {
+        // Arrange
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+        sut.Name = "Valid Name Here";
+
+        // Act - setting Description triggers ValidateReport internally
+        sut.Description = "Valid Description Here";
+
+        // Assert
+        Assert.True(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_NoImages_HasNoImagesIsTrue()
+    {
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.True(sut.HasNoImages);
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/EditEventViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/EditEventViewModelTests.cs
@@ -1,0 +1,306 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class EditEventViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockMobEventManager;
+    private readonly Mock<IEventTypeRestService> mockEventTypeRestService;
+    private readonly Mock<IMapRestService> mockMapRestService;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly Mock<IEventPartnerLocationServiceRestService> mockEventPartnerLocationServiceRestService;
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<IEventLitterReportManager> mockEventLitterReportManager;
+    private readonly EditEventViewModel sut;
+
+    private readonly User testUser;
+    private readonly Event testEvent;
+
+    public EditEventViewModelTests()
+    {
+        mockMobEventManager = new Mock<IMobEventManager>();
+        mockEventTypeRestService = new Mock<IEventTypeRestService>();
+        mockMapRestService = new Mock<IMapRestService>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+        mockEventPartnerLocationServiceRestService = new Mock<IEventPartnerLocationServiceRestService>();
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockEventLitterReportManager = new Mock<IEventLitterReportManager>();
+
+        testUser = TestHelpers.CreateTestUser();
+        testEvent = TestHelpers.CreateTestEvent(createdByUserId: testUser.Id);
+
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new EditEventViewModel(
+            mockMobEventManager.Object,
+            mockEventTypeRestService.Object,
+            mockMapRestService.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object,
+            mockEventPartnerLocationServiceRestService.Object,
+            mockLitterReportManager.Object,
+            mockEventLitterReportManager.Object);
+    }
+
+    private void SetupDefaultMocks(Event? mobEvent = null)
+    {
+        var evt = mobEvent ?? testEvent;
+
+        mockMobEventManager.Setup(m => m.GetEventAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(evt);
+        mockEventTypeRestService.Setup(m => m.GetEventTypesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<EventType>
+            {
+                new() { Id = 1, Name = "Cleanup" },
+                new() { Id = 2, Name = "Beautification" },
+            });
+        mockEventPartnerLocationServiceRestService
+            .Setup(m => m.GetEventPartnerLocationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DisplayEventPartnerLocation>());
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+        mockEventLitterReportManager
+            .Setup(m => m.GetEventLitterReportsAsync(It.IsAny<Guid>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<FullEventLitterReport>());
+    }
+
+    [Fact]
+    public async Task Init_LoadsEvent()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.NotNull(sut.EventViewModel);
+        Assert.Equal(testEvent.Id, sut.EventViewModel.Id);
+        mockMobEventManager.Verify(m => m.GetEventAsync(testEvent.Id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_SetsSelectedEventType()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Equal("Cleanup", sut.SelectedEventType);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesETypes()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Equal(2, sut.ETypes.Count);
+        Assert.Contains("Cleanup", sut.ETypes);
+        Assert.Contains("Beautification", sut.ETypes);
+    }
+
+    [Fact]
+    public async Task Init_LoadsPartners_WhenAvailable()
+    {
+        // Arrange
+        var partners = new List<DisplayEventPartnerLocation>
+        {
+            new()
+            {
+                EventId = testEvent.Id,
+                PartnerId = Guid.NewGuid(),
+                PartnerLocationId = Guid.NewGuid(),
+                PartnerLocationName = "Test Partner Location",
+                PartnerLocationNotes = "Some notes",
+                PartnerServicesEngaged = "Hauling",
+            },
+        };
+
+        SetupDefaultMocks();
+        mockEventPartnerLocationServiceRestService
+            .Setup(m => m.GetEventPartnerLocationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partners);
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Single(sut.AvailablePartners);
+        Assert.True(sut.ArePartnersAvailable);
+        Assert.False(sut.AreNoPartnersAvailable);
+    }
+
+    [Fact]
+    public async Task Init_LoadsPartners_WhenNone_SetsAreNoPartnersAvailable()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Empty(sut.AvailablePartners);
+        Assert.False(sut.ArePartnersAvailable);
+        Assert.True(sut.AreNoPartnersAvailable);
+    }
+
+    [Fact]
+    public async Task Init_LoadsLitterReports()
+    {
+        // Arrange
+        var litterReport = TestHelpers.CreateTestLitterReport();
+        var litterReports = new PaginatedList<LitterReport>();
+        litterReports.Add(litterReport);
+
+        SetupDefaultMocks();
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(litterReports);
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        mockLitterReportManager.Verify(
+            m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        mockEventLitterReportManager.Verify(
+            m => m.GetEventLitterReportsAsync(It.IsAny<Guid>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangeLocation_UpdatesEventAddress()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init(testEvent.Id);
+
+        var newLocation = new Microsoft.Maui.Devices.Sensors.Location(48.8566, 2.3522);
+        var newAddress = new Address
+        {
+            City = "Paris",
+            Country = "France",
+            PostalCode = "75001",
+            Region = "Ile-de-France",
+            StreetAddress = "1 Rue de Rivoli",
+        };
+
+        mockMapRestService.Setup(m => m.GetAddressAsync(48.8566, 2.3522, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newAddress);
+
+        // Act
+        await sut.ChangeLocation(newLocation);
+
+        // Assert
+        Assert.Equal("Paris", sut.EventViewModel.Address.City);
+        Assert.Equal("France", sut.EventViewModel.Address.Country);
+        Assert.Equal("75001", sut.EventViewModel.Address.PostalCode);
+        Assert.Equal("Ile-de-France", sut.EventViewModel.Address.Region);
+        Assert.Equal("1 Rue de Rivoli", sut.EventViewModel.Address.StreetAddress);
+        Assert.Equal(48.8566, sut.EventViewModel.Address.Latitude);
+        Assert.Equal(2.3522, sut.EventViewModel.Address.Longitude);
+    }
+
+    [Fact]
+    public async Task MapSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsLitterReportMapSelected);
+        Assert.False(sut.IsLitterReportListSelected);
+    }
+
+    [Fact]
+    public async Task ListSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsLitterReportMapSelected);
+        Assert.True(sut.IsLitterReportListSelected);
+    }
+
+    [Fact]
+    public async Task Init_SetsEventsCollection()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Single(sut.Events);
+        Assert.Equal(testEvent.Id, sut.Events[0].Id);
+    }
+
+    [Fact]
+    public async Task Init_SetsUserLocation()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.NotNull(sut.UserLocation);
+        Assert.Equal(testUser.City, sut.UserLocation.City);
+        Assert.Equal(testUser.Country, sut.UserLocation.Country);
+        Assert.Equal(testUser.Region, sut.UserLocation.Region);
+    }
+
+    [Fact]
+    public async Task Init_SetsEventViewModelProperties()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert
+        Assert.Equal(testEvent.Name, sut.EventViewModel.Name);
+        Assert.Equal(testEvent.Description, sut.EventViewModel.Description);
+        Assert.Equal(testEvent.EventDate, sut.EventViewModel.EventDate);
+        Assert.Equal(testEvent.EventTypeId, sut.EventViewModel.EventTypeId);
+        Assert.Equal(testEvent.IsEventPublic, sut.EventViewModel.IsEventPublic);
+        Assert.Equal(testEvent.MaxNumberOfParticipants, sut.EventViewModel.MaxNumberOfParticipants);
+    }
+
+    [Fact]
+    public async Task Init_SetsLitterReportDefaultViewState()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(testEvent.Id);
+
+        // Assert — LoadLitterReports sets map selected by default
+        Assert.True(sut.IsLitterReportMapSelected);
+        Assert.False(sut.IsLitterReportListSelected);
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/EditLitterReportViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/EditLitterReportViewModelTests.cs
@@ -1,0 +1,231 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class EditLitterReportViewModelTests
+{
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<IMapRestService> mockMapRestService;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly EditLitterReportViewModel sut;
+
+    public EditLitterReportViewModelTests()
+    {
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockMapRestService = new Mock<IMapRestService>();
+        mockNotificationService = new Mock<INotificationService>();
+
+        sut = new EditLitterReportViewModel(
+            mockLitterReportManager.Object,
+            mockMapRestService.Object,
+            mockNotificationService.Object);
+    }
+
+    [Fact]
+    public async Task Init_LoadsLitterReport()
+    {
+        // Arrange
+        var litterReportId = Guid.NewGuid();
+        var testLitterReport = CreateTestLitterReportWithImages();
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(litterReportId);
+
+        // Assert
+        mockLitterReportManager.Verify(
+            m => m.GetLitterReportAsync(litterReportId, ImageSizeEnum.Thumb, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_SetsNameAndDescription()
+    {
+        // Arrange
+        var testLitterReport = CreateTestLitterReportWithImages();
+        testLitterReport.Name = "Litter at Park";
+        testLitterReport.Description = "Large pile of trash near playground";
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.Equal("Litter at Park", sut.Name);
+        Assert.Equal("Large pile of trash near playground", sut.Description);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesLitterImageViewModels()
+    {
+        // Arrange
+        var testLitterReport = CreateTestLitterReportWithImages(imageCount: 3);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.Equal(3, sut.LitterImageViewModels.Count);
+    }
+
+    [Fact]
+    public void ValidateReport_NoImages_ReportIsNotValid()
+    {
+        // Arrange
+        sut.Name = "Valid Name Here";
+        sut.Description = "Valid Description Here";
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.False(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_WithImages_ValidNameAndDescription_ReportIsValid()
+    {
+        // Arrange
+        sut.Name = "Valid Name Here";
+        sut.Description = "Valid Description Here";
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.True(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_ShortName_ReportIsNotValid()
+    {
+        // Arrange
+        sut.Name = "Short";
+        sut.Description = "Valid Description Here";
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.False(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_ShortDescription_ReportIsNotValid()
+    {
+        // Arrange
+        sut.Name = "Valid Name Here";
+        sut.Description = "Short";
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.False(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void ValidateReport_MaxImages_SetsHasMaxImages()
+    {
+        // Arrange
+        for (var i = 0; i < EditLitterReportViewModel.MaxImages; i++)
+        {
+            sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+        }
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.True(sut.HasMaxImages);
+        Assert.False(sut.CanAddImages);
+    }
+
+    [Fact]
+    public void ValidateReport_LessThanMax_CanAddImages()
+    {
+        // Arrange
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+
+        // Act
+        sut.ValidateReport();
+
+        // Assert
+        Assert.False(sut.HasMaxImages);
+        Assert.True(sut.CanAddImages);
+    }
+
+    [Fact]
+    public void Name_PropertyChanged_TriggersValidation()
+    {
+        // Arrange
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+        sut.Description = "Valid Description Here";
+
+        // Act - setting Name triggers ValidateReport internally
+        sut.Name = "Valid Name Here";
+
+        // Assert
+        Assert.True(sut.ReportIsValid);
+    }
+
+    [Fact]
+    public void Description_PropertyChanged_TriggersValidation()
+    {
+        // Arrange
+        sut.LitterImageViewModels.Add(new LitterImageViewModel(mockNotificationService.Object));
+        sut.Name = "Valid Name Here";
+
+        // Act - setting Description triggers ValidateReport internally
+        sut.Description = "Valid Description Here";
+
+        // Assert
+        Assert.True(sut.ReportIsValid);
+    }
+
+    private void SetupGetLitterReport(LitterReport litterReport)
+    {
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportAsync(It.IsAny<Guid>(), It.IsAny<ImageSizeEnum>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(litterReport);
+    }
+
+    private static LitterReport CreateTestLitterReportWithImages(int imageCount = 2)
+    {
+        var testLitterReport = TestHelpers.CreateTestLitterReport();
+        testLitterReport.LitterImages = new List<LitterImage>();
+
+        for (var i = 0; i < imageCount; i++)
+        {
+            testLitterReport.LitterImages.Add(new LitterImage
+            {
+                Id = Guid.NewGuid(),
+                LitterReportId = testLitterReport.Id,
+                Latitude = 47.6062 + i * 0.001,
+                Longitude = -122.3321 + i * 0.001,
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                PostalCode = "98101",
+                StreetAddress = $"{100 + i} Main St",
+                AzureBlobURL = $"https://example.blob.core.windows.net/image{i}.jpg",
+                CreatedByUserId = Guid.NewGuid(),
+                LastUpdatedByUserId = Guid.NewGuid(),
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedDate = DateTimeOffset.UtcNow,
+            });
+        }
+
+        return testLitterReport;
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ExploreViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ExploreViewModelTests.cs
@@ -1,0 +1,284 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class ExploreViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockMobEventManager;
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly ExploreViewModel sut;
+
+    public ExploreViewModelTests()
+    {
+        mockMobEventManager = new Mock<IMobEventManager>();
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new ExploreViewModel(
+            mockMobEventManager.Object,
+            mockLitterReportManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_SetsMapSelected()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task Init_LoadsEvents()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockMobEventManager
+            .Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(3, sut.Events.Count);
+        mockMobEventManager.Verify(
+            m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_LoadsLitterReports()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        var reports = new PaginatedList<LitterReport>();
+        reports.Add(TestHelpers.CreateTestLitterReport());
+        reports.Add(TestHelpers.CreateTestLitterReport());
+
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reports);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(2, sut.LitterReports.Count);
+    }
+
+    [Fact]
+    public async Task Init_WithData_SetsAreItemsFound()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(2);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockMobEventManager
+            .Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.AreItemsFound);
+        Assert.False(sut.AreNoItemsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithNoData_SetsAreNoItemsFound()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.False(sut.AreItemsFound);
+        Assert.True(sut.AreNoItemsFound);
+    }
+
+    [Fact]
+    public async Task MapSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task ListSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsMapSelected);
+        Assert.True(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task ToggleEventsCommand_TogglesShowEvents()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init();
+        var initialValue = sut.ShowEvents;
+
+        // Act
+        sut.ToggleEventsCommand.Execute(null);
+
+        // Assert
+        Assert.NotEqual(initialValue, sut.ShowEvents);
+    }
+
+    [Fact]
+    public async Task ToggleLitterReportsCommand_TogglesShowLitterReports()
+    {
+        // Arrange
+        SetupDefaultMocks();
+        await sut.Init();
+        var initialValue = sut.ShowLitterReports;
+
+        // Act
+        sut.ToggleLitterReportsCommand.Execute(null);
+
+        // Assert
+        Assert.NotEqual(initialValue, sut.ShowLitterReports);
+    }
+
+    [Fact]
+    public async Task CountryFilter_FiltersEvents()
+    {
+        // Arrange
+        var usEvents = TestHelpers.CreateTestEvents(3, country: "United States");
+        var canadaEvents = TestHelpers.CreateTestEvents(2, country: "Canada", region: "BC", city: "Vancouver");
+        var allEvents = usEvents.Concat(canadaEvents).ToList();
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(allEvents.ToPaginatedList());
+        mockMobEventManager
+            .Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+        SetupDefaultLitterReportMock();
+
+        await sut.Init();
+
+        // Act
+        sut.SelectedCountry = "United States";
+
+        // Assert
+        Assert.Equal(3, sut.Events.Count);
+        Assert.All(sut.Events, e => Assert.Equal("United States", e.Address.Country));
+    }
+
+    [Fact]
+    public async Task Init_PopulatesCountryCollection()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(1);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockMobEventManager
+            .Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.CountryCollection.Count > 0);
+        Assert.Contains("United States", sut.CountryCollection);
+        Assert.Contains("Canada", sut.CountryCollection);
+    }
+
+    [Fact]
+    public async Task ClearSelectionsCommand_ResetsFilters()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        var locations = TestHelpers.CreateTestLocations();
+
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        mockMobEventManager
+            .Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+        SetupDefaultLitterReportMock();
+
+        await sut.Init();
+        sut.SelectedCountry = "United States";
+
+        // Act
+        await sut.ClearSelectionsCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.Null(sut.SelectedCountry);
+        Assert.Null(sut.SelectedRegion);
+        Assert.Null(sut.SelectedCity);
+    }
+
+    private void SetupDefaultMocks()
+    {
+        SetupDefaultEventMock();
+        SetupDefaultLitterReportMock();
+    }
+
+    private void SetupDefaultEventMock()
+    {
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<Event>());
+        mockMobEventManager
+            .Setup(m => m.GetLocationsByTimeRangeAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Location>());
+    }
+
+    private void SetupDefaultLitterReportMock()
+    {
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/HomeFeedViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/HomeFeedViewModelTests.cs
@@ -1,0 +1,246 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class HomeFeedViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockMobEventManager;
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly HomeFeedViewModel sut;
+
+    public HomeFeedViewModelTests()
+    {
+        mockMobEventManager = new Mock<IMobEventManager>();
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new HomeFeedViewModel(
+            mockMobEventManager.Object,
+            mockLitterReportManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_SetsWelcomeMessage()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal("Welcome, TestUser!", sut.WelcomeMessage);
+    }
+
+    [Fact]
+    public async Task Init_LoadsUpcomingEvents()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(3, sut.UpcomingEvents.Count);
+        mockMobEventManager.Verify(
+            m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_WithNoEvents_SetsAreNoEventsFound()
+    {
+        // Arrange
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<Event>());
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Empty(sut.UpcomingEvents);
+        Assert.False(sut.AreEventsFound);
+        Assert.True(sut.AreNoEventsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithEvents_SetsAreEventsFound()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.AreEventsFound);
+        Assert.False(sut.AreNoEventsFound);
+    }
+
+    [Fact]
+    public async Task Init_LoadsNearbyLitterReports()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        var reports = new PaginatedList<LitterReport>();
+        reports.Add(TestHelpers.CreateTestLitterReport());
+        reports.Add(TestHelpers.CreateTestLitterReport());
+
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reports);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(2, sut.NearbyLitterReports.Count);
+        mockLitterReportManager.Verify(
+            m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_WithNoLitterReports_SetsAreNoLitterReportsFound()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Empty(sut.NearbyLitterReports);
+        Assert.False(sut.AreLitterReportsFound);
+        Assert.True(sut.AreNoLitterReportsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithLitterReports_SetsAreLitterReportsFound()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        var reports = new PaginatedList<LitterReport>();
+        reports.Add(TestHelpers.CreateTestLitterReport());
+
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reports);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.AreLitterReportsFound);
+        Assert.False(sut.AreNoLitterReportsFound);
+    }
+
+    [Fact]
+    public async Task Init_LimitsEventsTo10()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(15);
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(10, sut.UpcomingEvents.Count);
+    }
+
+    [Fact]
+    public async Task Init_LimitsLitterReportsTo5()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        var reports = new PaginatedList<LitterReport>();
+        for (var i = 0; i < 10; i++)
+        {
+            reports.Add(TestHelpers.CreateTestLitterReport());
+        }
+
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reports);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(5, sut.NearbyLitterReports.Count);
+    }
+
+    [Fact]
+    public async Task Init_ExcludesCompletedEvents()
+    {
+        // Arrange
+        var futureEvents = TestHelpers.CreateTestEvents(2);
+        var pastEvent = TestHelpers.CreateTestEvent(
+            name: "Past Event",
+            eventDate: DateTimeOffset.UtcNow.AddDays(-7));
+        var allEvents = futureEvents.Concat(new[] { pastEvent }).ToList();
+
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(allEvents.ToPaginatedList());
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(2, sut.UpcomingEvents.Count);
+    }
+
+    private void SetupDefaultMocks()
+    {
+        SetupDefaultEventMock();
+        SetupDefaultLitterReportMock();
+    }
+
+    private void SetupDefaultEventMock()
+    {
+        mockMobEventManager
+            .Setup(m => m.GetFilteredEventsAsync(It.IsAny<EventFilter>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<Event>());
+    }
+
+    private void SetupDefaultLitterReportMock()
+    {
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ImpactViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ImpactViewModelTests.cs
@@ -1,0 +1,200 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class ImpactViewModelTests
+{
+    private readonly Mock<IStatsRestService> mockStatsRestService;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly ImpactViewModel sut;
+
+    public ImpactViewModelTests()
+    {
+        mockStatsRestService = new Mock<IStatsRestService>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new ImpactViewModel(
+            mockStatsRestService.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_LoadsPersonalStats()
+    {
+        // Arrange
+        var personalStats = TestHelpers.CreateTestStats();
+        SetupMocks(personalStats: personalStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        mockStatsRestService.Verify(
+            m => m.GetUserStatsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_LoadsCommunityStats()
+    {
+        // Arrange
+        var communityStats = TestHelpers.CreateTestStats();
+        SetupMocks(communityStats: communityStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        mockStatsRestService.Verify(
+            m => m.GetStatsAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_PersonalStats_MapsTotalEvents()
+    {
+        // Arrange
+        var personalStats = new Stats
+        {
+            TotalEvents = 42,
+            TotalBags = 100,
+            TotalHours = 80,
+            TotalParticipants = 10,
+            TotalLitterReportsSubmitted = 25,
+        };
+        SetupMocks(personalStats: personalStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(42, sut.PersonalStats.TotalEvents);
+    }
+
+    [Fact]
+    public async Task Init_CommunityStats_MapsTotalAttendees()
+    {
+        // Arrange
+        var communityStats = new Stats
+        {
+            TotalParticipants = 5000,
+            TotalEvents = 300,
+            TotalBags = 10000,
+            TotalHours = 6000,
+            TotalLitterReportsSubmitted = 800,
+        };
+        SetupMocks(communityStats: communityStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(5000, sut.CommunityStats.TotalAttendees);
+    }
+
+    [Fact]
+    public async Task Init_PersonalStats_MapsTotalBags()
+    {
+        // Arrange
+        var personalStats = new Stats
+        {
+            TotalEvents = 10,
+            TotalBags = 250,
+            TotalHours = 40,
+            TotalParticipants = 5,
+            TotalLitterReportsSubmitted = 15,
+        };
+        SetupMocks(personalStats: personalStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(250, sut.PersonalStats.TotalBags);
+    }
+
+    [Fact]
+    public async Task Init_CommunityStats_MapsTotalEvents()
+    {
+        // Arrange
+        var communityStats = new Stats
+        {
+            TotalParticipants = 2000,
+            TotalEvents = 150,
+            TotalBags = 8000,
+            TotalHours = 4000,
+            TotalLitterReportsSubmitted = 600,
+        };
+        SetupMocks(communityStats: communityStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(150, sut.CommunityStats.TotalEvents);
+    }
+
+    [Fact]
+    public async Task Init_PersonalStats_MapsTotalHours()
+    {
+        // Arrange
+        var personalStats = new Stats
+        {
+            TotalEvents = 20,
+            TotalBags = 100,
+            TotalHours = 55,
+            TotalParticipants = 8,
+            TotalLitterReportsSubmitted = 30,
+        };
+        SetupMocks(personalStats: personalStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(55, sut.PersonalStats.TotalHours);
+    }
+
+    [Fact]
+    public async Task Init_PersonalStats_MapsLitterReportsSubmitted()
+    {
+        // Arrange
+        var personalStats = new Stats
+        {
+            TotalEvents = 10,
+            TotalBags = 50,
+            TotalHours = 20,
+            TotalParticipants = 3,
+            TotalLitterReportsSubmitted = 17,
+        };
+        SetupMocks(personalStats: personalStats);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(17, sut.PersonalStats.TotalLitterReportsSubmitted);
+    }
+
+    private void SetupMocks(Stats? personalStats = null, Stats? communityStats = null)
+    {
+        mockStatsRestService
+            .Setup(m => m.GetUserStatsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(personalStats ?? TestHelpers.CreateTestStats());
+
+        mockStatsRestService
+            .Setup(m => m.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(communityStats ?? TestHelpers.CreateTestStats());
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/MyDashboardViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/MyDashboardViewModelTests.cs
@@ -1,0 +1,285 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class MyDashboardViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockMobEventManager;
+    private readonly Mock<IStatsRestService> mockStatsRestService;
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly MyDashboardViewModel sut;
+
+    public MyDashboardViewModelTests()
+    {
+        mockMobEventManager = new Mock<IMobEventManager>();
+        mockStatsRestService = new Mock<IStatsRestService>();
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new MyDashboardViewModel(
+            mockMobEventManager.Object,
+            mockStatsRestService.Object,
+            mockLitterReportManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesUpcomingDateRanges()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.UpcomingDateRanges.Count > 0);
+        Assert.Contains(DateRanges.ThisMonth, sut.UpcomingDateRanges);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesCompletedDateRanges()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.CompletedDateRanges.Count > 0);
+        Assert.Contains(DateRanges.LastMonth, sut.CompletedDateRanges);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesCreatedDateRanges()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.CreatedDateRanges.Count > 0);
+        Assert.Contains(DateRanges.LastMonth, sut.CreatedDateRanges);
+    }
+
+    [Fact]
+    public async Task Init_RefreshesStatistics()
+    {
+        // Arrange
+        var stats = TestHelpers.CreateTestStats();
+        mockStatsRestService
+            .Setup(m => m.GetUserStatsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        SetupDefaultEventMock();
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(stats.TotalBags, sut.StatisticsViewModel.TotalBags);
+        Assert.Equal(stats.TotalEvents, sut.StatisticsViewModel.TotalEvents);
+        Assert.Equal(stats.TotalHours, sut.StatisticsViewModel.TotalHours);
+        mockStatsRestService.Verify(
+            m => m.GetUserStatsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_WithUpcomingEvents_SetsAreUpcomingEventsFound()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        mockMobEventManager
+            .Setup(m => m.GetUserEventsAsync(It.IsAny<EventFilter>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        SetupDefaultStatsMock();
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.AreUpcomingEventsFound);
+        Assert.False(sut.AreNoUpcomingEventsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithNoUpcomingEvents_SetsAreNoUpcomingEventsFound()
+    {
+        // Arrange
+        mockMobEventManager
+            .Setup(m => m.GetUserEventsAsync(It.IsAny<EventFilter>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<Event>());
+        SetupDefaultStatsMock();
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Empty(sut.UpcomingEvents);
+        Assert.False(sut.AreUpcomingEventsFound);
+        Assert.True(sut.AreNoUpcomingEventsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithCompletedEvents_SetsAreCompletedEventsFound()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(2);
+        mockMobEventManager
+            .Setup(m => m.GetUserEventsAsync(It.IsAny<EventFilter>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events.ToPaginatedList());
+        SetupDefaultStatsMock();
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.AreCompletedEventsFound);
+        Assert.False(sut.AreNoCompletedEventsFound);
+    }
+
+    [Fact]
+    public async Task Init_RefreshesLitterReports()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        SetupDefaultStatsMock();
+        var reports = new PaginatedList<LitterReport>();
+        reports.Add(TestHelpers.CreateTestLitterReport());
+        reports.Add(TestHelpers.CreateTestLitterReport());
+
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reports);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(2, sut.LitterReports.Count);
+        mockLitterReportManager.Verify(
+            m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task Init_WithLitterReports_SetsAreLitterReportsFound()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        SetupDefaultStatsMock();
+        var reports = new PaginatedList<LitterReport>();
+        reports.Add(TestHelpers.CreateTestLitterReport());
+
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reports);
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.AreLitterReportsFound);
+        Assert.False(sut.AreNoLitterReportsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithNoLitterReports_SetsAreNoLitterReportsFound()
+    {
+        // Arrange
+        SetupDefaultEventMock();
+        SetupDefaultStatsMock();
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Empty(sut.LitterReports);
+        Assert.False(sut.AreLitterReportsFound);
+        Assert.True(sut.AreNoLitterReportsFound);
+    }
+
+    [Fact]
+    public async Task Init_SetsDefaultSelectedDateRanges()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(DateRanges.ThisMonth, sut.SelectedUpcomingDateRange);
+        Assert.Equal(DateRanges.LastMonth, sut.SelectedCompletedDateRange);
+        Assert.Equal(DateRanges.LastMonth, sut.SelectedCreatedDateRange);
+    }
+
+    [Fact]
+    public async Task Init_StatisticsIncludeLitterReportMetrics()
+    {
+        // Arrange
+        var stats = TestHelpers.CreateTestStats();
+        mockStatsRestService
+            .Setup(m => m.GetUserStatsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        SetupDefaultEventMock();
+        SetupDefaultLitterReportMock();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.Equal(stats.TotalLitterReportsSubmitted, sut.StatisticsViewModel.TotalLitterReportsSubmitted);
+    }
+
+    private void SetupDefaultMocks()
+    {
+        SetupDefaultEventMock();
+        SetupDefaultStatsMock();
+        SetupDefaultLitterReportMock();
+    }
+
+    private void SetupDefaultEventMock()
+    {
+        mockMobEventManager
+            .Setup(m => m.GetUserEventsAsync(It.IsAny<EventFilter>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<Event>());
+    }
+
+    private void SetupDefaultStatsMock()
+    {
+        mockStatsRestService
+            .Setup(m => m.GetUserStatsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestHelpers.CreateTestStats());
+    }
+
+    private void SetupDefaultLitterReportMock()
+    {
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportsAsync(It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/SearchLitterReportsViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/SearchLitterReportsViewModelTests.cs
@@ -1,0 +1,165 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class SearchLitterReportsViewModelTests
+{
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly SearchLitterReportsViewModel sut;
+
+    public SearchLitterReportsViewModelTests()
+    {
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new SearchLitterReportsViewModel(
+            mockLitterReportManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_SetsMapSelected()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task Init_SetsNewSelected()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.IsNewSelected);
+        Assert.False(sut.IsAssignedSelected);
+        Assert.False(sut.IsCleanedSelected);
+    }
+
+    [Fact]
+    public async Task Init_SetsUserLocation()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.NotNull(sut.UserLocation);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesCreatedDateRanges()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init();
+
+        // Assert
+        Assert.True(sut.CreatedDateRanges.Count > 0);
+    }
+
+    [Fact]
+    public async Task MapSelectedCommand_SetsMapState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task ListSelectedCommand_SetsListState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsMapSelected);
+        Assert.True(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task ViewNewCommand_SetsNewState()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.ViewNewCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsNewSelected);
+        Assert.False(sut.IsAssignedSelected);
+        Assert.False(sut.IsCleanedSelected);
+    }
+
+    [Fact]
+    public async Task ViewAssignedCommand_SetsAssignedState()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.ViewAssignedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsNewSelected);
+        Assert.True(sut.IsAssignedSelected);
+        Assert.False(sut.IsCleanedSelected);
+    }
+
+    [Fact]
+    public async Task ViewCleanedCommand_SetsCleanedState()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.ViewCleanedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsNewSelected);
+        Assert.False(sut.IsAssignedSelected);
+        Assert.True(sut.IsCleanedSelected);
+    }
+
+    private void SetupDefaultMocks()
+    {
+        mockLitterReportManager.Setup(m => m.GetLocationsByTimeRangeAsync(
+                It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Location>());
+
+        mockLitterReportManager.Setup(m => m.GetLitterReportsAsync(
+                It.IsAny<LitterReportFilter>(), It.IsAny<ImageSizeEnum>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaginatedList<LitterReport>());
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ViewCommunityViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ViewCommunityViewModelTests.cs
@@ -1,0 +1,242 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class ViewCommunityViewModelTests
+{
+    private readonly Mock<ICommunityManager> mockCommunityManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly ViewCommunityViewModel sut;
+    private const string TestSlug = "test-community";
+
+    public ViewCommunityViewModelTests()
+    {
+        mockCommunityManager = new Mock<ICommunityManager>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new ViewCommunityViewModel(
+            mockCommunityManager.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_SetsCommunityName()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.Equal("Test Community", sut.CommunityName);
+    }
+
+    [Fact]
+    public async Task Init_SetsTagline()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.Equal("A great community", sut.Tagline);
+    }
+
+    [Fact]
+    public async Task Init_SetsLocation()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.Contains("Seattle", sut.Location);
+        Assert.Contains("WA", sut.Location);
+        Assert.Contains("United States", sut.Location);
+    }
+
+    [Fact]
+    public async Task Init_SetsWebsite()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.Equal("https://example.com", sut.Website);
+    }
+
+    [Fact]
+    public async Task Init_HasWebsite_WhenWebsiteNotEmpty()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.True(sut.HasWebsite);
+    }
+
+    [Fact]
+    public async Task Init_SetsContactEmail()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.Equal("info@example.com", sut.ContactEmail);
+        Assert.True(sut.HasContactEmail);
+    }
+
+    [Fact]
+    public async Task Init_LoadsStats()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.Equal(1000, sut.Stats.TotalAttendees);
+        Assert.Equal(200, sut.Stats.TotalEvents);
+        Assert.Equal(5000, sut.Stats.TotalBags);
+        Assert.Equal(3000, sut.Stats.TotalHours);
+    }
+
+    [Fact]
+    public async Task Init_WithEvents_SetsAreEventsFound()
+    {
+        // Arrange
+        var events = TestHelpers.CreateTestEvents(3);
+        SetupDefaultMocks(events: events);
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.True(sut.AreEventsFound);
+        Assert.False(sut.AreNoEventsFound);
+        Assert.Equal(3, sut.UpcomingEvents.Count);
+    }
+
+    [Fact]
+    public async Task Init_WithNoEvents_SetsAreNoEventsFound()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.False(sut.AreEventsFound);
+        Assert.True(sut.AreNoEventsFound);
+    }
+
+    [Fact]
+    public async Task Init_WithActiveTeams_SetsAreTeamsFound()
+    {
+        // Arrange
+        var teams = CreateTestTeams(2, allActive: true);
+        SetupDefaultMocks(teams: teams);
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.True(sut.AreTeamsFound);
+        Assert.False(sut.AreNoTeamsFound);
+        Assert.Equal(2, sut.NearbyTeams.Count);
+    }
+
+    [Fact]
+    public async Task Init_WithNoTeams_SetsAreNoTeamsFound()
+    {
+        // Arrange
+        SetupDefaultMocks();
+
+        // Act
+        await sut.Init(TestSlug);
+
+        // Assert
+        Assert.False(sut.AreTeamsFound);
+        Assert.True(sut.AreNoTeamsFound);
+    }
+
+    private void SetupDefaultMocks(
+        List<Event>? events = null,
+        List<Team>? teams = null)
+    {
+        var testPartner = new Partner
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Community",
+            City = "Seattle",
+            Region = "WA",
+            Country = "United States",
+            Slug = TestSlug,
+            Tagline = "A great community",
+            Website = "https://example.com",
+            ContactEmail = "info@example.com",
+        };
+
+        mockCommunityManager.Setup(m => m.GetCommunityBySlugAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testPartner);
+
+        mockCommunityManager.Setup(m => m.GetCommunityStatsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestHelpers.CreateTestStats());
+
+        mockCommunityManager.Setup(m => m.GetCommunityEventsAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events ?? new List<Event>());
+
+        mockCommunityManager.Setup(m => m.GetCommunityTeamsAsync(It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(teams ?? new List<Team>());
+    }
+
+    private static List<Team> CreateTestTeams(int count, bool allActive = true)
+    {
+        var teams = new List<Team>();
+        for (var i = 0; i < count; i++)
+        {
+            teams.Add(new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Team {i + 1}",
+                Description = $"Description for team {i + 1}",
+                City = "Seattle",
+                Region = "WA",
+                Country = "United States",
+                IsPublic = true,
+                IsActive = allActive,
+                Members = [],
+            });
+        }
+
+        return teams;
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ViewEventSummaryViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ViewEventSummaryViewModelTests.cs
@@ -1,0 +1,149 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class ViewEventSummaryViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockMobEventManager;
+    private readonly Mock<IPickupLocationManager> mockPickupLocationManager;
+    private readonly Mock<IEventAttendeeRouteRestService> mockEventAttendeeRouteRestService;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly ViewEventSummaryViewModel sut;
+    private readonly Guid testUserId;
+
+    public ViewEventSummaryViewModelTests()
+    {
+        mockMobEventManager = new Mock<IMobEventManager>();
+        mockPickupLocationManager = new Mock<IPickupLocationManager>();
+        mockEventAttendeeRouteRestService = new Mock<IEventAttendeeRouteRestService>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        var testUser = TestHelpers.CreateTestUser();
+        testUserId = testUser.Id;
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new ViewEventSummaryViewModel(
+            mockMobEventManager.Object,
+            mockPickupLocationManager.Object,
+            mockEventAttendeeRouteRestService.Object,
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public async Task Init_LoadsEventViewModel()
+    {
+        // Arrange
+        var testEvent = TestHelpers.CreateTestEvent(createdByUserId: testUserId);
+        SetupDefaultMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal(testEvent.Name, sut.EventViewModel.Name);
+    }
+
+    [Fact]
+    public async Task Init_WhenUserIsLead_EnablesEditEventSummary()
+    {
+        // Arrange
+        var testEvent = TestHelpers.CreateTestEvent(createdByUserId: testUserId);
+        SetupDefaultMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.EnableEditEventSummary);
+    }
+
+    [Fact]
+    public async Task Init_WhenUserIsNotLead_DisablesEditEventSummary()
+    {
+        // Arrange
+        var otherUserId = Guid.NewGuid();
+        var testEvent = TestHelpers.CreateTestEvent(createdByUserId: otherUserId);
+        SetupDefaultMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.False(sut.EnableEditEventSummary);
+    }
+
+    [Fact]
+    public async Task Init_WithNoPickupLocations_CollectionIsEmpty()
+    {
+        // Arrange
+        var testEvent = TestHelpers.CreateTestEvent(createdByUserId: testUserId);
+        SetupDefaultMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Empty(sut.PickupLocations);
+    }
+
+    [Fact]
+    public async Task Init_SetsMapSelected()
+    {
+        // Arrange
+        var testEvent = TestHelpers.CreateTestEvent(createdByUserId: testUserId);
+        SetupDefaultMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task MapSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsMapSelected);
+        Assert.False(sut.IsListSelected);
+    }
+
+    [Fact]
+    public async Task ListSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsMapSelected);
+        Assert.True(sut.IsListSelected);
+    }
+
+    private void SetupDefaultMocks(Event testEvent)
+    {
+        mockMobEventManager.Setup(m => m.GetEventAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testEvent);
+
+        mockMobEventManager.Setup(m => m.GetEventSummaryAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EventSummary)null!);
+
+        mockPickupLocationManager.Setup(m => m.GetPickupLocationsAsync(It.IsAny<Guid>(), It.IsAny<ImageSizeEnum>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PickupLocationImage>());
+
+        mockEventAttendeeRouteRestService.Setup(m => m.GetEventAttendeeRoutesForEventAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DisplayEventAttendeeRoute>());
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ViewEventViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ViewEventViewModelTests.cs
@@ -1,0 +1,455 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class ViewEventViewModelTests
+{
+    private readonly Mock<IMobEventManager> mockMobEventManager;
+    private readonly Mock<IEventTypeRestService> mockEventTypeRestService;
+    private readonly Mock<IWaiverManager> mockWaiverManager;
+    private readonly Mock<IEventAttendeeRestService> mockEventAttendeeRestService;
+    private readonly Mock<IEventAttendeeRouteRestService> mockEventAttendeeRouteRestService;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IEventLitterReportManager> mockEventLitterReportManager;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly Mock<IEventPartnerLocationServiceRestService> mockEventPartnerLocationServiceRestService;
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<IEventPhotoManager> mockEventPhotoManager;
+    private readonly User testUser;
+    private readonly ViewEventViewModel sut;
+
+    public ViewEventViewModelTests()
+    {
+        mockMobEventManager = new Mock<IMobEventManager>();
+        mockEventTypeRestService = new Mock<IEventTypeRestService>();
+        mockWaiverManager = new Mock<IWaiverManager>();
+        mockEventAttendeeRestService = new Mock<IEventAttendeeRestService>();
+        mockEventAttendeeRouteRestService = new Mock<IEventAttendeeRouteRestService>();
+        mockNotificationService = new Mock<INotificationService>();
+        mockEventLitterReportManager = new Mock<IEventLitterReportManager>();
+        mockUserManager = new Mock<IUserManager>();
+        mockEventPartnerLocationServiceRestService = new Mock<IEventPartnerLocationServiceRestService>();
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockEventPhotoManager = new Mock<IEventPhotoManager>();
+
+        testUser = TestHelpers.CreateTestUser();
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
+
+        sut = new ViewEventViewModel(
+            mockMobEventManager.Object,
+            mockEventTypeRestService.Object,
+            mockWaiverManager.Object,
+            mockEventAttendeeRestService.Object,
+            mockEventAttendeeRouteRestService.Object,
+            mockNotificationService.Object,
+            mockEventLitterReportManager.Object,
+            mockUserManager.Object,
+            mockEventPartnerLocationServiceRestService.Object,
+            mockLitterReportManager.Object,
+            mockEventPhotoManager.Object);
+    }
+
+    private Event CreateFutureEvent(Guid? createdByUserId = null, int maxParticipants = 50)
+    {
+        return TestHelpers.CreateTestEvent(
+            createdByUserId: createdByUserId ?? testUser.Id,
+            eventDate: DateTimeOffset.UtcNow.AddDays(7));
+    }
+
+    private Event CreatePastEvent(Guid? createdByUserId = null)
+    {
+        return TestHelpers.CreateTestEvent(
+            createdByUserId: createdByUserId ?? testUser.Id,
+            eventDate: DateTimeOffset.UtcNow.AddDays(-7));
+    }
+
+    private void SetupMocks(Event testEvent, List<DisplayUser>? attendees = null, List<DisplayUser>? leads = null,
+        bool isUserAttending = false)
+    {
+        attendees ??= new List<DisplayUser>();
+        leads ??= new List<DisplayUser>();
+
+        mockMobEventManager.Setup(m => m.GetEventAsync(It.IsAny<Guid>())).ReturnsAsync(testEvent);
+        mockEventTypeRestService.Setup(m => m.GetEventTypesAsync())
+            .ReturnsAsync(new List<EventType> { new() { Id = 1, Name = "Cleanup" } });
+        mockEventAttendeeRestService.Setup(m => m.GetEventAttendeesAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(attendees);
+        mockEventAttendeeRestService.Setup(m => m.GetEventLeadsAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(leads);
+        mockMobEventManager.Setup(m => m.IsUserAttendingAsync(It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(isUserAttending);
+        mockEventPartnerLocationServiceRestService
+            .Setup(m => m.GetEventPartnerLocationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DisplayEventPartnerLocation>());
+        mockEventLitterReportManager
+            .Setup(m => m.GetEventLitterReportsAsync(It.IsAny<Guid>(), It.IsAny<ImageSizeEnum>()))
+            .ReturnsAsync(new List<FullEventLitterReport>());
+        mockEventPhotoManager.Setup(m => m.GetEventPhotosAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<EventPhoto>());
+        mockEventAttendeeRouteRestService
+            .Setup(m => m.GetEventAttendeeRoutesForEventAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DisplayEventAttendeeRoute>());
+    }
+
+    // 1. Init_LoadsEventDetails
+    [Fact]
+    public async Task Init_LoadsEventDetails()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        SetupMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal(testEvent.Id, sut.EventViewModel.Id);
+        Assert.Equal(testEvent.Name, sut.EventViewModel.Name);
+        Assert.Equal(testEvent.Description, sut.EventViewModel.Description);
+        Assert.Single(sut.Events);
+        Assert.Single(sut.Addresses);
+    }
+
+    // 2. Init_SetsSelectedEventType
+    [Fact]
+    public async Task Init_SetsSelectedEventType()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        SetupMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal("Cleanup", sut.SelectedEventType);
+    }
+
+    // 3. Init_WhenUserIsLead_EnablesEditEvent
+    [Fact]
+    public async Task Init_WhenUserIsLead_EnablesEditEvent()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent(createdByUserId: testUser.Id);
+        SetupMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.EnableEditEvent);
+    }
+
+    // 4. Init_WhenUserIsNotLead_DisablesEditEvent
+    [Fact]
+    public async Task Init_WhenUserIsNotLead_DisablesEditEvent()
+    {
+        // Arrange
+        var otherUserId = Guid.NewGuid();
+        var testEvent = CreateFutureEvent(createdByUserId: otherUserId);
+        SetupMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.False(sut.EnableEditEvent);
+    }
+
+    // 5. Init_WhenEventCompleted_EnablesViewEventSummary
+    [Fact]
+    public async Task Init_WhenEventCompleted_EnablesViewEventSummary()
+    {
+        // Arrange - past event is completed (EventDate in the past)
+        var testEvent = CreatePastEvent(createdByUserId: testUser.Id);
+        SetupMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.EnableViewEventSummary);
+    }
+
+    // 6. Init_WhenEventNotCompleted_DisablesViewEventSummary
+    [Fact]
+    public async Task Init_WhenEventNotCompleted_DisablesViewEventSummary()
+    {
+        // Arrange - future event is not completed
+        var testEvent = CreateFutureEvent(createdByUserId: testUser.Id);
+        SetupMocks(testEvent);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.False(sut.EnableViewEventSummary);
+    }
+
+    // 7. Init_SetsAttendeeCount_SinglePerson
+    [Fact]
+    public async Task Init_SetsAttendeeCount_SinglePerson()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        var attendees = new List<DisplayUser>
+        {
+            new() { Id = Guid.NewGuid(), UserName = "User1", MemberSince = DateTimeOffset.UtcNow.AddYears(-1) },
+        };
+        SetupMocks(testEvent, attendees: attendees);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal("1 person is going!", sut.AttendeeCount);
+    }
+
+    // 8. Init_SetsAttendeeCount_MultiplePeople
+    [Fact]
+    public async Task Init_SetsAttendeeCount_MultiplePeople()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        var attendees = new List<DisplayUser>
+        {
+            new() { Id = Guid.NewGuid(), UserName = "User1", MemberSince = DateTimeOffset.UtcNow.AddYears(-1) },
+            new() { Id = Guid.NewGuid(), UserName = "User2", MemberSince = DateTimeOffset.UtcNow.AddMonths(-6) },
+            new() { Id = Guid.NewGuid(), UserName = "User3", MemberSince = DateTimeOffset.UtcNow.AddMonths(-3) },
+        };
+        SetupMocks(testEvent, attendees: attendees);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal("3 people are going!", sut.AttendeeCount);
+    }
+
+    // 9. Init_WithMaxParticipants_ShowsSpotsLeft
+    [Fact]
+    public async Task Init_WithMaxParticipants_ShowsSpotsLeft()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        testEvent.MaxNumberOfParticipants = 10;
+        var attendees = new List<DisplayUser>
+        {
+            new() { Id = Guid.NewGuid(), UserName = "User1", MemberSince = DateTimeOffset.UtcNow },
+            new() { Id = Guid.NewGuid(), UserName = "User2", MemberSince = DateTimeOffset.UtcNow },
+        };
+        SetupMocks(testEvent, attendees: attendees);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal("8 spot left!", sut.SpotsLeft);
+    }
+
+    // 10. Init_WithMaxParticipantsReached_ShowsFullMessage
+    [Fact]
+    public async Task Init_WithMaxParticipantsReached_ShowsFullMessage()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        testEvent.MaxNumberOfParticipants = 2;
+        var attendees = new List<DisplayUser>
+        {
+            new() { Id = Guid.NewGuid(), UserName = "User1", MemberSince = DateTimeOffset.UtcNow },
+            new() { Id = Guid.NewGuid(), UserName = "User2", MemberSince = DateTimeOffset.UtcNow },
+        };
+        SetupMocks(testEvent, attendees: attendees);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal("We're sorry. This event is currently full.", sut.SpotsLeft);
+    }
+
+    // 11. Init_WithNoMaxParticipants_HidesSpotsLeft
+    [Fact]
+    public async Task Init_WithNoMaxParticipants_HidesSpotsLeft()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        testEvent.MaxNumberOfParticipants = 0;
+        var attendees = new List<DisplayUser>
+        {
+            new() { Id = Guid.NewGuid(), UserName = "User1", MemberSince = DateTimeOffset.UtcNow },
+        };
+        SetupMocks(testEvent, attendees: attendees);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.Equal("", sut.SpotsLeft);
+    }
+
+    // 12. Init_LoadsPartners_WhenAvailable
+    [Fact]
+    public async Task Init_LoadsPartners_WhenAvailable()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent();
+        SetupMocks(testEvent);
+
+        var partners = new List<DisplayEventPartnerLocation>
+        {
+            new()
+            {
+                EventId = testEvent.Id,
+                PartnerId = Guid.NewGuid(),
+                PartnerLocationId = Guid.NewGuid(),
+                PartnerLocationName = "Partner Location 1",
+                PartnerLocationNotes = "Some notes",
+                PartnerServicesEngaged = "Hauling, Supplies",
+            },
+        };
+
+        mockEventPartnerLocationServiceRestService
+            .Setup(m => m.GetEventPartnerLocationsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(partners);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.ArePartnersAvailable);
+        Assert.False(sut.AreNoPartnersAvailable);
+        Assert.Single(sut.AvailablePartners);
+        Assert.Equal("Partner Location 1", sut.AvailablePartners[0].PartnerLocationName);
+    }
+
+    // 13. Init_LoadsPhotos
+    [Fact]
+    public async Task Init_LoadsPhotos()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent(createdByUserId: testUser.Id);
+        SetupMocks(testEvent);
+
+        var photos = new List<EventPhoto>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                EventId = testEvent.Id,
+                ImageUrl = "https://example.com/photo1.jpg",
+                ThumbnailUrl = "https://example.com/thumb1.jpg",
+                PhotoType = EventPhotoType.Before,
+                Caption = "Before cleanup",
+                UploadedDate = DateTimeOffset.UtcNow,
+                UploadedByUserId = testUser.Id,
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                EventId = testEvent.Id,
+                ImageUrl = "https://example.com/photo2.jpg",
+                ThumbnailUrl = "https://example.com/thumb2.jpg",
+                PhotoType = EventPhotoType.After,
+                Caption = "After cleanup",
+                UploadedDate = DateTimeOffset.UtcNow.AddMinutes(30),
+                UploadedByUserId = testUser.Id,
+            },
+        };
+
+        mockEventPhotoManager.Setup(m => m.GetEventPhotosAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(photos);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.ArePhotosFound);
+        Assert.False(sut.AreNoPhotosFound);
+        Assert.Equal(2, sut.EventPhotos.Count);
+        Assert.Equal("2 photos", sut.PhotoCountDisplay);
+    }
+
+    // 14. MapSelectedCommand_SetsCorrectState
+    [Fact]
+    public async Task MapSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.MapSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.True(sut.IsLitterReportMapSelected);
+        Assert.False(sut.IsLitterReportListSelected);
+    }
+
+    // 15. ListSelectedCommand_SetsCorrectState
+    [Fact]
+    public async Task ListSelectedCommand_SetsCorrectState()
+    {
+        // Act
+        await sut.ListSelectedCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.False(sut.IsLitterReportMapSelected);
+        Assert.True(sut.IsLitterReportListSelected);
+    }
+
+    // 16. Init_SetsCanManageCoLeads_WhenUserIsLead
+    [Fact]
+    public async Task Init_SetsCanManageCoLeads_WhenUserIsLead()
+    {
+        // Arrange
+        var testEvent = CreateFutureEvent(createdByUserId: testUser.Id);
+        var leads = new List<DisplayUser>
+        {
+            new() { Id = testUser.Id, UserName = testUser.UserName, MemberSince = DateTimeOffset.UtcNow },
+        };
+        SetupMocks(testEvent, leads: leads);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.CanManageCoLeads);
+        Assert.Equal(1, sut.CoLeadCount);
+        Assert.Equal("Co-leads: 1/5", sut.CoLeadCountDisplay);
+    }
+
+    // 17. Init_WhenUserAttending_DisablesRegister
+    [Fact]
+    public async Task Init_WhenUserAttending_DisablesRegister()
+    {
+        // Arrange - user is attending but not the lead
+        var otherUserId = Guid.NewGuid();
+        var testEvent = CreateFutureEvent(createdByUserId: otherUserId);
+        SetupMocks(testEvent, isUserAttending: true);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.False(sut.EnableRegister);
+    }
+
+    // 18. Init_WhenUserNotAttending_EnablesRegister
+    [Fact]
+    public async Task Init_WhenUserNotAttending_EnablesRegister()
+    {
+        // Arrange - user is not attending and not the lead, future event
+        var otherUserId = Guid.NewGuid();
+        var testEvent = CreateFutureEvent(createdByUserId: otherUserId);
+        SetupMocks(testEvent, isUserAttending: false);
+
+        // Act
+        await sut.Init(testEvent.Id, () => { });
+
+        // Assert
+        Assert.True(sut.EnableRegister);
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ViewLitterReportViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ViewLitterReportViewModelTests.cs
@@ -1,0 +1,274 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMob.Models;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+using TrashMobMobile.Tests.Helpers;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class ViewLitterReportViewModelTests
+{
+    private readonly Mock<ILitterReportManager> mockLitterReportManager;
+    private readonly Mock<IEventLitterReportManager> mockEventLitterReportManager;
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly ViewLitterReportViewModel sut;
+
+    public ViewLitterReportViewModelTests()
+    {
+        mockLitterReportManager = new Mock<ILitterReportManager>();
+        mockEventLitterReportManager = new Mock<IEventLitterReportManager>();
+        mockNotificationService = new Mock<INotificationService>();
+
+        App.CurrentUser = TestHelpers.CreateTestUser();
+
+        sut = new ViewLitterReportViewModel(
+            mockLitterReportManager.Object,
+            mockEventLitterReportManager.Object,
+            mockNotificationService.Object);
+    }
+
+    [Fact]
+    public async Task Init_LoadsLitterReport()
+    {
+        // Arrange
+        var litterReportId = Guid.NewGuid();
+        var testLitterReport = CreateLitterReportForCurrentUser();
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(litterReportId);
+
+        // Assert
+        mockLitterReportManager.Verify(
+            m => m.GetLitterReportAsync(litterReportId, ImageSizeEnum.Reduced, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Init_SetsLitterReportViewModel()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser();
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.NotNull(sut.LitterReportViewModel);
+        Assert.Equal(testLitterReport.Id, sut.LitterReportViewModel!.Id);
+        Assert.Equal(testLitterReport.Name, sut.LitterReportViewModel.Name);
+    }
+
+    [Fact]
+    public async Task Init_WhenUserIsCreator_AndStatusNew_CanDeleteIsTrue()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.New);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.True(sut.CanDeleteLitterReport);
+    }
+
+    [Fact]
+    public async Task Init_WhenUserIsNotCreator_CanDeleteIsFalse()
+    {
+        // Arrange
+        var testLitterReport = TestHelpers.CreateTestLitterReport();
+        testLitterReport.CreatedByUserId = Guid.NewGuid(); // Different user
+        testLitterReport.LitterReportStatusId = (int)LitterReportStatusEnum.New;
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.False(sut.CanDeleteLitterReport);
+    }
+
+    [Fact]
+    public async Task Init_WhenUserIsCreator_AndStatusNew_CanEditIsTrue()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.New);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.True(sut.CanEditLitterReport);
+    }
+
+    [Fact]
+    public async Task Init_WhenUserIsCreator_AndStatusAssigned_CanEditIsTrue()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.Assigned);
+        SetupEventLitterReportMock(testLitterReport.Id);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.True(sut.CanEditLitterReport);
+    }
+
+    [Fact]
+    public async Task Init_WhenStatusCleaned_CanEditIsFalse()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.Cleaned);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.False(sut.CanEditLitterReport);
+    }
+
+    [Fact]
+    public async Task Init_WhenStatusAssigned_IsAssignedToEventIsTrue()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.Assigned);
+        var eventId = Guid.NewGuid();
+        SetupEventLitterReportMock(testLitterReport.Id, eventId);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.True(sut.IsAssignedToEvent);
+        Assert.False(sut.IsNotAssignedToEvent);
+        Assert.Equal(eventId, sut.EventIdAssignedTo);
+    }
+
+    [Fact]
+    public async Task Init_WhenStatusNew_IsNotAssignedToEvent()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.New);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.False(sut.IsAssignedToEvent);
+        Assert.True(sut.IsNotAssignedToEvent);
+    }
+
+    [Fact]
+    public async Task Init_PopulatesLitterImageViewModels()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser();
+        testLitterReport.LitterImages = new List<LitterImage>
+        {
+            CreateTestLitterImage(testLitterReport.Id),
+            CreateTestLitterImage(testLitterReport.Id),
+        };
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.Equal(2, sut.LitterImageViewModels.Count);
+    }
+
+    [Fact]
+    public async Task Init_WhenStatusNew_CanMarkCleanedIsTrue()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.New);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.True(sut.CanMarkLitterReportCleaned);
+    }
+
+    [Fact]
+    public async Task Init_WhenStatusCleaned_CanMarkCleanedIsFalse()
+    {
+        // Arrange
+        var testLitterReport = CreateLitterReportForCurrentUser(statusId: (int)LitterReportStatusEnum.Cleaned);
+        SetupGetLitterReport(testLitterReport);
+
+        // Act
+        await sut.Init(testLitterReport.Id);
+
+        // Assert
+        Assert.False(sut.CanMarkLitterReportCleaned);
+    }
+
+    private LitterReport CreateLitterReportForCurrentUser(int statusId = (int)LitterReportStatusEnum.New)
+    {
+        var testLitterReport = TestHelpers.CreateTestLitterReport();
+        testLitterReport.CreatedByUserId = App.CurrentUser!.Id;
+        testLitterReport.LitterReportStatusId = statusId;
+        return testLitterReport;
+    }
+
+    private void SetupGetLitterReport(LitterReport litterReport)
+    {
+        mockLitterReportManager
+            .Setup(m => m.GetLitterReportAsync(It.IsAny<Guid>(), It.IsAny<ImageSizeEnum>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(litterReport);
+    }
+
+    private void SetupEventLitterReportMock(Guid litterReportId, Guid? eventId = null)
+    {
+        var fullEventLitterReport = new FullEventLitterReport
+        {
+            EventId = eventId ?? Guid.NewGuid(),
+            LitterReportId = litterReportId,
+            LitterReport = new FullLitterReport
+            {
+                Id = litterReportId,
+                Name = "Test",
+                Description = "Test",
+                LitterReportStatusId = (int)LitterReportStatusEnum.Assigned,
+                LitterImages = [],
+            },
+        };
+
+        mockEventLitterReportManager
+            .Setup(m => m.GetEventLitterReportByLitterReportIdAsync(litterReportId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fullEventLitterReport);
+    }
+
+    private static LitterImage CreateTestLitterImage(Guid litterReportId)
+    {
+        return new LitterImage
+        {
+            Id = Guid.NewGuid(),
+            LitterReportId = litterReportId,
+            Latitude = 47.6062,
+            Longitude = -122.3321,
+            City = "Seattle",
+            Region = "WA",
+            Country = "United States",
+            PostalCode = "98101",
+            StreetAddress = "123 Main St",
+            AzureBlobURL = "https://example.blob.core.windows.net/image.jpg",
+            CreatedByUserId = Guid.NewGuid(),
+            LastUpdatedByUserId = Guid.NewGuid(),
+            CreatedDate = DateTimeOffset.UtcNow,
+            LastUpdatedDate = DateTimeOffset.UtcNow,
+        };
+    }
+}

--- a/TrashMobMobile.Tests/ViewModels/ViewTeamViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ViewTeamViewModelTests.cs
@@ -206,6 +206,20 @@ public class ViewTeamViewModelTests
         }
 
         var members = CreateTestMembers(memberCount);
+
+        // If user is a member, add them to the members list returned by GetTeamMembersAsync
+        // so UpdateMembershipState() finds them in the Members collection
+        if (isUserMember)
+        {
+            members.Add(new TeamMember
+            {
+                UserId = testUserId,
+                IsTeamLead = false,
+                JoinedDate = DateTimeOffset.UtcNow,
+                User = new User { UserName = "TestUser" },
+            });
+        }
+
         var events = TestHelpers.CreateTestEvents(upcomingEventCount);
 
         mockTeamManager.Setup(m => m.GetTeamAsync(testTeamId, It.IsAny<CancellationToken>())).ReturnsAsync(team);

--- a/TrashMobMobile.Tests/ViewModels/WaiverViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/WaiverViewModelTests.cs
@@ -1,0 +1,37 @@
+namespace TrashMobMobile.Tests.ViewModels;
+
+using Moq;
+using TrashMobMobile.Services;
+using TrashMobMobile.ViewModels;
+using Xunit;
+
+public class WaiverViewModelTests
+{
+    private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
+    private readonly WaiverViewModel sut;
+
+    public WaiverViewModelTests()
+    {
+        mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
+
+        sut = new WaiverViewModel(
+            mockNotificationService.Object,
+            mockUserManager.Object);
+    }
+
+    [Fact]
+    public void Constructor_CreatesViewModel()
+    {
+        // Assert
+        Assert.NotNull(sut);
+    }
+
+    [Fact]
+    public void SignWaiverCommand_Exists()
+    {
+        // Assert
+        Assert.NotNull(sut.SignWaiverCommand);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **170 new unit tests** across **17 new test files** covering all major mobile ViewModels
- Increases mobile test count from **96 to 266** (177% increase)
- Fixes pre-existing bug in `ViewTeamViewModelTests` where `Init_WhenUserIsMember_SetsIsUserMember` was failing
- Adds `CommunityExtensions.cs` link to test project for community ViewModel testing

## ViewModels Covered

| Test File | Tests | Coverage Area |
|-----------|-------|---------------|
| CreateEventViewModelTests | 22 | Multi-step wizard, validation, duration, litter report linking |
| ViewEventViewModelTests | 18 | Event loading, registration, attendees, photos, partners |
| EditEventViewModelTests | 12 | Event editing, location changes, partner/litter report loading |
| CancelEventViewModelTests | 7 | Cancellation flow |
| ViewLitterReportViewModelTests | 12 | Permissions, status-based actions |
| EditLitterReportViewModelTests | 10 | Validation, image management |
| CreateLitterReportViewModelTests | 9 | Defaults, validation |
| HomeFeedViewModelTests | 10 | Feed loading, event/report limits |
| MyDashboardViewModelTests | 12 | Date ranges, stats, events, litter reports |
| ExploreViewModelTests | 12 | Map/list toggle, country/region/city filters |
| ImpactViewModelTests | 8 | Personal and community stats |
| SearchLitterReportsViewModelTests | 9 | Status filters, view mode toggles |
| BrowseCommunitiesViewModelTests | 5 | Community listing |
| ViewCommunityViewModelTests | 11 | Community details, events, teams |
| ContactUsViewModelTests | 4 | Form fields |
| WaiverViewModelTests | 2 | Command existence |
| ViewEventSummaryViewModelTests | 7 | Summary loading, permissions |

## Bug Fix
Fixed `ViewTeamViewModelTests.Init_WhenUserIsMember_SetsIsUserMember` — the test was setting the user on `team.Members` but `UpdateMembershipState()` checks the `Members` ObservableCollection populated from `GetTeamMembersAsync`. Added the test user to the mocked members list.

## Test plan
- [x] All 266 tests pass (`dotnet test TrashMobMobile.Tests`)
- [x] Build succeeds with 0 warnings, 0 errors
- [ ] Verify no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)