### PR TITLE
Fix env var config override keeping dev site on B2C login

### DIFF
--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -49,12 +49,17 @@ public class Program
         var builder = WebApplication.CreateBuilder(args);
 
         builder.Configuration.AddJsonFile("appsettings.json", true, true)
-                             .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", true, true); // optional extra provider     
+                             .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", true, true); // optional extra provider
 
         if (builder.Environment.IsDevelopment())
         {
             builder.Configuration.AddJsonFile("appsettings.Development.json", true, true);
         }
+
+        // Re-add environment variables so they override JSON file values
+        // (CreateBuilder already adds them, but the AddJsonFile calls above
+        // were appended after, giving JSON files higher priority)
+        builder.Configuration.AddEnvironmentVariables();
 
         if (!builder.Environment.IsDevelopment())
         {


### PR DESCRIPTION
## Summary
- The dev site (dev.trashmob.eco) was still showing the old B2C login form despite `UseEntraExternalId=true` being set as an env var in the container app
- **Root cause:** `WebApplication.CreateBuilder()` adds env vars as a config source, but `Program.cs` then re-adds `appsettings.json` via `AddJsonFile()` *after* the env vars. In ASP.NET Core, last-added sources win — so `appsettings.json` (`UseEntraExternalId: false`) was overriding the env var (`true`)
- **Fix:** Add `builder.Configuration.AddEnvironmentVariables()` after the JSON file providers to restore expected env var precedence

## Test plan
- [x] `dotnet build` succeeds
- [ ] After merge + deploy, verify `https://dev.trashmob.eco/api/config` returns `"authProvider": "entra"` (currently returns `"b2c"`)
- [ ] Verify dev site shows Entra External ID login form instead of B2C

🤖 Generated with [Claude Code](https://claude.com/claude-code)