### PR TITLE
Fix mobile app async void crashes, static coupling, and code duplication

### DIFF
--- a/TrashMobMobile.Tests/ViewModels/ViewLitterReportViewModelTests.cs
+++ b/TrashMobMobile.Tests/ViewModels/ViewLitterReportViewModelTests.cs
@@ -13,6 +13,7 @@ public class ViewLitterReportViewModelTests
     private readonly Mock<ILitterReportManager> mockLitterReportManager;
     private readonly Mock<IEventLitterReportManager> mockEventLitterReportManager;
     private readonly Mock<INotificationService> mockNotificationService;
+    private readonly Mock<IUserManager> mockUserManager;
     private readonly ViewLitterReportViewModel sut;
 
     public ViewLitterReportViewModelTests()
@@ -20,13 +21,17 @@ public class ViewLitterReportViewModelTests
         mockLitterReportManager = new Mock<ILitterReportManager>();
         mockEventLitterReportManager = new Mock<IEventLitterReportManager>();
         mockNotificationService = new Mock<INotificationService>();
+        mockUserManager = new Mock<IUserManager>();
 
-        App.CurrentUser = TestHelpers.CreateTestUser();
+        var testUser = TestHelpers.CreateTestUser();
+        App.CurrentUser = testUser;
+        mockUserManager.Setup(m => m.CurrentUser).Returns(testUser);
 
         sut = new ViewLitterReportViewModel(
             mockLitterReportManager.Object,
             mockEventLitterReportManager.Object,
-            mockNotificationService.Object);
+            mockNotificationService.Object,
+            mockUserManager.Object);
     }
 
     [Fact]

--- a/TrashMobMobile/Services/IUserManager.cs
+++ b/TrashMobMobile/Services/IUserManager.cs
@@ -5,7 +5,7 @@
 
     public interface IUserManager
     {
-        User CurrentUser { get; }
+        User CurrentUser { get; set; }
 
         Task<User> GetUserAsync(string userId, CancellationToken cancellationToken = default);
 

--- a/TrashMobMobile/Services/UserManager.cs
+++ b/TrashMobMobile/Services/UserManager.cs
@@ -14,10 +14,8 @@
 
         public User CurrentUser
         {
-            get
-            {
-                return App.CurrentUser!;
-            }
+            get => App.CurrentUser!;
+            set => App.CurrentUser = value;
         }
 
         public Task<User> GetUserAsync(string userId, CancellationToken cancellationToken = default)

--- a/TrashMobMobile/Services/WaiverManager.cs
+++ b/TrashMobMobile/Services/WaiverManager.cs
@@ -6,17 +6,19 @@ using TrashMobMobile.Extensions;
 public class WaiverManager : IWaiverManager
 {
     private const string TrashMobWaiverName = "trashmob";
- 
-    private readonly IWaiverRestService waiverRestService;
 
-    public WaiverManager(IWaiverRestService service)
+    private readonly IWaiverRestService waiverRestService;
+    private readonly IUserManager userManager;
+
+    public WaiverManager(IWaiverRestService service, IUserManager userManager)
     {
         waiverRestService = service;
+        this.userManager = userManager;
     }
 
     public async Task<bool> HasUserSignedTrashMobWaiverAsync(CancellationToken cancellationToken = default)
     {
         var waiver = await waiverRestService.GetWaiver(TrashMobWaiverName, cancellationToken);
-        return App.CurrentUser!.HasUserSignedWaiver(waiver, Settings.CurrentTrashMobWaiverVersion);
+        return userManager.CurrentUser.HasUserSignedWaiver(waiver, Settings.CurrentTrashMobWaiverVersion);
     }
 }

--- a/TrashMobMobile/ViewModels/CreateEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/CreateEventViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Color = Microsoft.Maui.Graphics.Color;
+using Sentry;
 using TrashMob.Models;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
@@ -401,8 +402,15 @@ public partial class CreateEventViewModel : BaseViewModel
 
     private async void PerformNavigation(EventPartnerLocationViewModel eventPartnerLocationViewModel)
     {
-        await Shell.Current.GoToAsync(
-            $"{nameof(EditEventPartnerLocationServicesPage)}?EventId={EventViewModel.Id}&PartnerLocationId={eventPartnerLocationViewModel.PartnerLocationId}");
+        try
+        {
+            await Shell.Current.GoToAsync(
+                $"{nameof(EditEventPartnerLocationServicesPage)}?EventId={EventViewModel.Id}&PartnerLocationId={eventPartnerLocationViewModel.PartnerLocationId}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     private Guid? initialLitterReport = null;

--- a/TrashMobMobile/ViewModels/EditEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/EditEventViewModel.cs
@@ -3,6 +3,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Sentry;
 using TrashMob.Models;
 using TrashMob.Models.Extensions;
 using TrashMobMobile.Extensions;
@@ -319,8 +320,15 @@ public partial class EditEventViewModel(IMobEventManager mobEventManager,
 
     private async void PerformNavigation(EventPartnerLocationViewModel eventPartnerLocationViewModel)
     {
-        await Shell.Current.GoToAsync(
-            $"{nameof(EditEventPartnerLocationServicesPage)}?EventId={EventViewModel.Id}&PartnerLocationId={eventPartnerLocationViewModel.PartnerLocationId}");
+        try
+        {
+            await Shell.Current.GoToAsync(
+                $"{nameof(EditEventPartnerLocationServicesPage)}?EventId={EventViewModel.Id}&PartnerLocationId={eventPartnerLocationViewModel.PartnerLocationId}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     [RelayCommand]

--- a/TrashMobMobile/ViewModels/LocationFilterViewModel.cs
+++ b/TrashMobMobile/ViewModels/LocationFilterViewModel.cs
@@ -1,0 +1,161 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMobMobile.Services;
+
+/// <summary>
+/// Base class for ViewModels that provide country/region/city filtering and map/list toggling.
+/// </summary>
+public abstract partial class LocationFilterViewModel(INotificationService notificationService)
+    : BaseViewModel(notificationService)
+{
+    protected IEnumerable<TrashMob.Models.Poco.Location> Locations { get; set; } = [];
+
+    private string? selectedCountry;
+    private string? selectedRegion;
+    private string? selectedCity;
+
+    [ObservableProperty]
+    private bool isMapSelected;
+
+    [ObservableProperty]
+    private bool isListSelected;
+
+    public ObservableCollection<string> CountryCollection { get; } = [];
+
+    public ObservableCollection<string> RegionCollection { get; } = [];
+
+    public ObservableCollection<string> CityCollection { get; } = [];
+
+    public string? SelectedCountry
+    {
+        get => selectedCountry;
+        set
+        {
+            selectedCountry = value;
+            OnPropertyChanged();
+            OnCountrySelected();
+        }
+    }
+
+    public string? SelectedRegion
+    {
+        get => selectedRegion;
+        set
+        {
+            selectedRegion = value;
+            OnPropertyChanged();
+            OnRegionSelected();
+        }
+    }
+
+    public string? SelectedCity
+    {
+        get => selectedCity;
+        set
+        {
+            selectedCity = value;
+            OnPropertyChanged();
+            OnCitySelected();
+        }
+    }
+
+    [RelayCommand]
+    private Task MapSelected()
+    {
+        IsMapSelected = true;
+        IsListSelected = false;
+        return Task.CompletedTask;
+    }
+
+    [RelayCommand]
+    private Task ListSelected()
+    {
+        IsMapSelected = false;
+        IsListSelected = true;
+        return Task.CompletedTask;
+    }
+
+    protected void PopulateCountries()
+    {
+        CountryCollection.Clear();
+        RegionCollection.Clear();
+        CityCollection.Clear();
+
+        if (Locations == null || !Locations.Any())
+        {
+            return;
+        }
+
+        foreach (var country in Locations.Select(l => l.Country).Distinct())
+        {
+            if (!string.IsNullOrEmpty(country))
+            {
+                CountryCollection.Add(country);
+            }
+        }
+    }
+
+    protected virtual void OnCountrySelected()
+    {
+        selectedRegion = null;
+        OnPropertyChanged(nameof(SelectedRegion));
+        selectedCity = null;
+        OnPropertyChanged(nameof(SelectedCity));
+
+        RegionCollection.Clear();
+
+        if (Locations != null && !string.IsNullOrEmpty(selectedCountry))
+        {
+            foreach (var region in Locations.Where(l => l.Country == selectedCountry).Select(l => l.Region).Distinct())
+            {
+                if (!string.IsNullOrEmpty(region))
+                {
+                    RegionCollection.Add(region);
+                }
+            }
+        }
+
+        ApplyFilters();
+    }
+
+    protected virtual void OnRegionSelected()
+    {
+        selectedCity = null;
+        OnPropertyChanged(nameof(SelectedCity));
+
+        CityCollection.Clear();
+
+        if (Locations != null && !string.IsNullOrEmpty(selectedCountry) && !string.IsNullOrEmpty(selectedRegion))
+        {
+            foreach (var city in Locations.Where(l => l.Country == selectedCountry && l.Region == selectedRegion).Select(l => l.City).Distinct())
+            {
+                if (!string.IsNullOrEmpty(city))
+                {
+                    CityCollection.Add(city);
+                }
+            }
+        }
+
+        ApplyFilters();
+    }
+
+    protected virtual void OnCitySelected()
+    {
+        ApplyFilters();
+    }
+
+    protected void ClearLocationSelections()
+    {
+        SelectedCountry = null;
+        SelectedRegion = null;
+        SelectedCity = null;
+    }
+
+    /// <summary>
+    /// Called when any location filter changes. Override to apply the filters to your data.
+    /// </summary>
+    protected abstract void ApplyFilters();
+}

--- a/TrashMobMobile/ViewModels/MainViewModel.cs
+++ b/TrashMobMobile/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using TrashMob.Models;
 using TrashMob.Models.Poco;
 using TrashMobMobile.Authentication;
+using Sentry;
 using TrashMobMobile.Config;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
@@ -79,7 +80,14 @@ public partial class MainViewModel(IAuthService authService,
 
     private async void PerformNavigation(EventViewModel eventViewModel)
     {
-        await Shell.Current.GoToAsync($"{nameof(ViewEventPage)}?EventId={eventViewModel.Id}");
+        try
+        {
+            await Shell.Current.GoToAsync($"{nameof(ViewEventPage)}?EventId={eventViewModel.Id}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     public async Task Init()

--- a/TrashMobMobile/ViewModels/ManageEventPartnersViewModel.cs
+++ b/TrashMobMobile/ViewModels/ManageEventPartnersViewModel.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Sentry;
 using TrashMob.Models;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
@@ -45,8 +46,15 @@ public partial class ManageEventPartnersViewModel(IMobEventManager mobEventManag
 
     private async void PerformNavigation(EventPartnerLocationViewModel eventPartnerLocationViewModel)
     {
-        await Shell.Current.GoToAsync(
-            $"{nameof(EditEventPartnerLocationServicesPage)}?EventId={MobEvent.Id}&PartnerLocationId={eventPartnerLocationViewModel.PartnerLocationId}");
+        try
+        {
+            await Shell.Current.GoToAsync(
+                $"{nameof(EditEventPartnerLocationServicesPage)}?EventId={MobEvent.Id}&PartnerLocationId={eventPartnerLocationViewModel.PartnerLocationId}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     public async Task Init(Guid eventId)

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TrashMob.Models.Poco;
+using Sentry;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
 
@@ -204,12 +205,26 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
 
     private async void PerformEventNavigation(EventViewModel eventViewModel)
     {
-        await Shell.Current.GoToAsync($"{nameof(ViewEventPage)}?EventId={eventViewModel.Id}");
+        try
+        {
+            await Shell.Current.GoToAsync($"{nameof(ViewEventPage)}?EventId={eventViewModel.Id}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     private async void PerformLitterReportNavigation(LitterReportViewModel litterReportViewModel)
     {
-        await Shell.Current.GoToAsync($"{nameof(ViewLitterReportPage)}?LitterReportId={litterReportViewModel.Id}");
+        try
+        {
+            await Shell.Current.GoToAsync($"{nameof(ViewLitterReportPage)}?LitterReportId={litterReportViewModel.Id}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     private async Task RefreshStatistics()
@@ -316,16 +331,37 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
 
     private async void HandleUpcomingDateRangeSelected()
     {
-        await ExecuteAsync(RefreshEvents, "Failed to refresh events. Please try again.");
+        try
+        {
+            await ExecuteAsync(RefreshEvents, "Failed to refresh events. Please try again.");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     private async void HandleCompletedDateRangeSelected()
     {
-        await ExecuteAsync(RefreshEvents, "Failed to refresh events. Please try again.");
+        try
+        {
+            await ExecuteAsync(RefreshEvents, "Failed to refresh events. Please try again.");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     private async void HandleCreatedDateRangeSelected()
     {
-        await ExecuteAsync(RefreshLitterReports, "Failed to refresh litter reports. Please try again.");
+        try
+        {
+            await ExecuteAsync(RefreshLitterReports, "Failed to refresh litter reports. Please try again.");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 }

--- a/TrashMobMobile/ViewModels/SearchLitterReportsViewModel.cs
+++ b/TrashMobMobile/ViewModels/SearchLitterReportsViewModel.cs
@@ -5,23 +5,20 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TrashMob.Models;
 using TrashMob.Models.Poco;
+using Sentry;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
 
-public partial class SearchLitterReportsViewModel(ILitterReportManager litterReportManager, INotificationService notificationService, IUserManager userManager) : BaseViewModel(notificationService)
+public partial class SearchLitterReportsViewModel(ILitterReportManager litterReportManager, INotificationService notificationService, IUserManager userManager) : LocationFilterViewModel(notificationService)
 {
     private readonly ILitterReportManager litterReportManager = litterReportManager;
     private readonly IUserManager userManager = userManager;
-    private IEnumerable<TrashMob.Models.Poco.Location> locations = [];
 
     [ObservableProperty]
     private string reportStatus = "New";
 
-    private string? selectedCity;
-    private string? selectedCountry;
     private LitterImageViewModel? selectedLitterImage;
     private LitterReportViewModel? selectedLitterReport;
-    private string? selectedRegion;
 
     [ObservableProperty]
     private AddressViewModel? userLocation;
@@ -31,17 +28,7 @@ public partial class SearchLitterReportsViewModel(ILitterReportManager litterRep
 
     public ObservableCollection<LitterImageViewModel> LitterImages { get; set; } = [];
 
-    public ObservableCollection<string> CountryCollection { get; set; } = [];
-    public ObservableCollection<string> RegionCollection { get; set; } = [];
-    public ObservableCollection<string> CityCollection { get; set; } = [];
-
     public ObservableCollection<string> CreatedDateRanges { get; set; } = [];
-
-    [ObservableProperty]
-    private bool isMapSelected;
-
-    [ObservableProperty]
-    private bool isListSelected;
 
     [ObservableProperty]
     private bool isNewSelected;
@@ -76,42 +63,6 @@ public partial class SearchLitterReportsViewModel(ILitterReportManager litterRep
                 OnPropertyChanged();
                 HandleCreatedDateRangeSelected();
             }
-        }
-    }
-
-    public string? SelectedCountry
-    {
-        get => selectedCountry;
-        set
-        {
-            selectedCountry = value;
-            OnPropertyChanged();
-
-            HandleCountrySelected(value);
-        }
-    }
-
-    public string? SelectedRegion
-    {
-        get => selectedRegion;
-        set
-        {
-            selectedRegion = value;
-            OnPropertyChanged();
-
-            HandleRegionSelected(value);
-        }
-    }
-
-    public string? SelectedCity
-    {
-        get => selectedCity;
-        set
-        {
-            selectedCity = value;
-            OnPropertyChanged();
-
-            HandleCitySelected(value);
         }
     }
 
@@ -184,7 +135,14 @@ public partial class SearchLitterReportsViewModel(ILitterReportManager litterRep
 
     private async void PerformNavigation(Guid litterReportId)
     {
-        await Shell.Current.GoToAsync($"{nameof(ViewLitterReportPage)}?LitterReportId={litterReportId}");
+        try
+        {
+            await Shell.Current.GoToAsync($"{nameof(ViewLitterReportPage)}?LitterReportId={litterReportId}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     private async Task RefreshLitterReports()
@@ -196,22 +154,10 @@ public partial class SearchLitterReportsViewModel(ILitterReportManager litterRep
 
         DateTimeOffset startDate = DateTimeOffset.Now.Date.AddDays(DateRanges.CreatedDateRangeDictionary[SelectedCreatedDateRange].Item1);
         DateTimeOffset endDate = DateTimeOffset.Now.Date.AddDays(DateRanges.CreatedDateRangeDictionary[SelectedCreatedDateRange].Item2);
-     
-        locations = await litterReportManager.GetLocationsByTimeRangeAsync(DateTimeOffset.Now.AddDays(-180),
+
+        Locations = await litterReportManager.GetLocationsByTimeRangeAsync(DateTimeOffset.Now.AddDays(-180),
             DateTimeOffset.Now);
-        CountryCollection.Clear();
-        RegionCollection.Clear();
-        CityCollection.Clear();
-
-        var countries = locations.Select(l => l.Country).Distinct();
-
-        foreach (var country in countries)
-        {
-            if (!string.IsNullOrEmpty(country))
-            {
-                CountryCollection.Add(country);
-            }
-        }
+        PopulateCountries();
 
         var litterReportFilter = new LitterReportFilter
         {
@@ -243,100 +189,39 @@ public partial class SearchLitterReportsViewModel(ILitterReportManager litterRep
 
     private async void HandleCreatedDateRangeSelected()
     {
-        IsBusy = true;
-
-        await RefreshLitterReports();
-
-        IsBusy = false;
-    }
-
-    private void HandleCountrySelected(string? selectedCountry)
-    {
-        IsBusy = true;
-
-        selectedRegion = null;
-        OnPropertyChanged(nameof(SelectedRegion));
-        selectedCity = null;
-        OnPropertyChanged(nameof(SelectedCity));
-
-        ApplyLocationFilters();
-
-        RefreshRegionList();
-
-        IsBusy = false;
-    }
-
-    private void RefreshRegionList()
-    {
-        RegionCollection.Clear();
-
-        var regions = locations.Where(l => l.Country == selectedCountry).Select(l => l.Region).Distinct();
-
-        foreach (var region in regions)
+        try
         {
-            if (!string.IsNullOrEmpty(region))
-            {
-                RegionCollection.Add(region);
-            }
+            IsBusy = true;
+
+            await RefreshLitterReports();
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
+        finally
+        {
+            IsBusy = false;
         }
     }
 
-    private void HandleRegionSelected(string? selectedRegion)
-    {
-        IsBusy = true;
-
-        selectedCity = null;
-        OnPropertyChanged(nameof(SelectedCity));
-
-        ApplyLocationFilters();
-
-        RefreshCityList();
-
-        IsBusy = false;
-    }
-
-    private void RefreshCityList()
-    {
-        CityCollection.Clear();
-
-        var cities = locations.Where(l => l.Country == selectedCountry && l.Region == selectedRegion)
-            .Select(l => l.City).Distinct();
-
-        foreach (var city in cities)
-        {
-            if (!string.IsNullOrEmpty(city))
-            {
-                CityCollection.Add(city);
-            }
-        }
-    }
-
-    private void HandleCitySelected(string? selectedCity)
-    {
-        IsBusy = true;
-
-        ApplyLocationFilters();
-
-        IsBusy = false;
-    }
-
-    private void ApplyLocationFilters()
+    protected override void ApplyFilters()
     {
         IEnumerable<LitterReport> filtered = AllLitterReports;
 
-        if (!string.IsNullOrEmpty(selectedCountry))
+        if (!string.IsNullOrEmpty(SelectedCountry))
         {
-            filtered = filtered.Where(l => l.LitterImages.Any(i => i.Country == selectedCountry));
+            filtered = filtered.Where(l => l.LitterImages.Any(i => i.Country == SelectedCountry));
         }
 
-        if (!string.IsNullOrEmpty(selectedRegion))
+        if (!string.IsNullOrEmpty(SelectedRegion))
         {
-            filtered = filtered.Where(l => l.LitterImages.Any(i => i.Region == selectedRegion));
+            filtered = filtered.Where(l => l.LitterImages.Any(i => i.Region == SelectedRegion));
         }
 
-        if (!string.IsNullOrEmpty(selectedCity))
+        if (!string.IsNullOrEmpty(SelectedCity))
         {
-            filtered = filtered.Where(l => l.LitterImages.Any(i => i.City == selectedCity));
+            filtered = filtered.Where(l => l.LitterImages.Any(i => i.City == SelectedCity));
         }
 
         RawLitterReports = filtered;
@@ -374,9 +259,7 @@ public partial class SearchLitterReportsViewModel(ILitterReportManager litterRep
     {
         IsBusy = true;
 
-        SelectedCountry = null;
-        SelectedRegion = null;
-        SelectedCity = null;
+        ClearLocationSelections();
 
         await RefreshLitterReports();
 
@@ -423,21 +306,5 @@ public partial class SearchLitterReportsViewModel(ILitterReportManager litterRep
         await RefreshLitterReports();
 
         IsBusy = false;
-    }
-
-    [RelayCommand]
-    private Task MapSelected()
-    {
-        IsMapSelected = true;
-        IsListSelected = false;
-        return Task.CompletedTask;
-    }
-
-    [RelayCommand]
-    private Task ListSelected()
-    {
-        IsMapSelected = false;
-        IsListSelected = true;
-        return Task.CompletedTask;
     }
 }

--- a/TrashMobMobile/ViewModels/ViewEventSummaryViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventSummaryViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TrashMob.Models;
 using TrashMob.Models.Poco;
+using Sentry;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
 
@@ -62,7 +63,14 @@ public partial class ViewEventSummaryViewModel(IMobEventManager mobEventManager,
 
     private async void PerformNavigation(Guid pickupLocationId)
     {
-        await Shell.Current.GoToAsync($"{nameof(ViewPickupLocationPage)}?PickupLocationId={pickupLocationId}");
+        try
+        {
+            await Shell.Current.GoToAsync($"{nameof(ViewPickupLocationPage)}?PickupLocationId={pickupLocationId}");
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     public async Task Init(Guid eventId, Action updRoutes)

--- a/TrashMobMobile/ViewModels/ViewLitterReportViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewLitterReportViewModel.cs
@@ -7,7 +7,7 @@ using TrashMob.Models;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
 
-public partial class ViewLitterReportViewModel(ILitterReportManager litterReportManager, IEventLitterReportManager eventLitterReportManager, INotificationService notificationService) : BaseViewModel(notificationService)
+public partial class ViewLitterReportViewModel(ILitterReportManager litterReportManager, IEventLitterReportManager eventLitterReportManager, INotificationService notificationService, IUserManager userManager) : BaseViewModel(notificationService)
 {
     private const int NewLitterReportStatus = 1;
     private const int AssignedLitterReportStatus = 2;
@@ -15,6 +15,7 @@ public partial class ViewLitterReportViewModel(ILitterReportManager litterReport
 
     private readonly ILitterReportManager litterReportManager = litterReportManager;
     private readonly IEventLitterReportManager eventLitterReportManager = eventLitterReportManager;
+    private readonly IUserManager userManager = userManager;
     [ObservableProperty]
     private bool canDeleteLitterReport;
 
@@ -68,7 +69,7 @@ public partial class ViewLitterReportViewModel(ILitterReportManager litterReport
                 }
             }
 
-            if (LitterReport.CreatedByUserId == App.CurrentUser!.Id &&
+            if (LitterReport.CreatedByUserId == userManager.CurrentUser.Id &&
                 LitterReport.LitterReportStatusId == NewLitterReportStatus)
             {
                 CanDeleteLitterReport = true;
@@ -78,7 +79,7 @@ public partial class ViewLitterReportViewModel(ILitterReportManager litterReport
                 CanDeleteLitterReport = false;
             }
 
-            if (LitterReport.CreatedByUserId == App.CurrentUser!.Id &&
+            if (LitterReport.CreatedByUserId == userManager.CurrentUser.Id &&
                 (LitterReport.LitterReportStatusId == NewLitterReportStatus ||
                  LitterReport.LitterReportStatusId == AssignedLitterReportStatus))
             {
@@ -89,7 +90,7 @@ public partial class ViewLitterReportViewModel(ILitterReportManager litterReport
                 CanEditLitterReport = false;
             }
 
-            if (LitterReport.CreatedByUserId == App.CurrentUser!.Id &&
+            if (LitterReport.CreatedByUserId == userManager.CurrentUser.Id &&
                 (LitterReport.LitterReportStatusId == NewLitterReportStatus ||
                  LitterReport.LitterReportStatusId == AssignedLitterReportStatus))
             {

--- a/TrashMobMobile/ViewModels/WaiverViewModel.cs
+++ b/TrashMobMobile/ViewModels/WaiverViewModel.cs
@@ -13,7 +13,7 @@ public partial class WaiverViewModel(INotificationService notificationService, I
     {
         await ExecuteAsync(async () =>
         {
-            var user = await userManager.GetUserAsync(App.CurrentUser!.Id.ToString());
+            var user = await userManager.GetUserAsync(userManager.CurrentUser.Id.ToString());
             if (user == null)
             {
                 throw new Exception("User not found.");
@@ -23,7 +23,7 @@ public partial class WaiverViewModel(INotificationService notificationService, I
             user.TrashMobWaiverVersion = Settings.CurrentTrashMobWaiverVersion.VersionId;
 
             await userManager.UpdateUserAsync(user);
-            App.CurrentUser = user;
+            userManager.CurrentUser = user;
             await Navigation.PopAsync();
         }, "An error occurred while signing the waiver. Please try again.");
     }


### PR DESCRIPTION
## Summary
- **Fix async void crash risk**: Add try-catch with Sentry logging to all 15 `async void` methods across 8 ViewModels. Previously, any exception in these fire-and-forget methods (navigation, date range changes) would crash the app as unhandled exceptions.
- **Remove App.CurrentUser static coupling**: Replace direct `App.CurrentUser` usage in ViewLitterReportViewModel, WaiverViewModel, and WaiverManager with injected `IUserManager.CurrentUser`, improving testability and removing hidden static state dependencies.
- **Extract duplicated location filtering**: Create `LocationFilterViewModel` base class consolidating ~200 lines of identical country/region/city cascading filter logic and map/list toggle behavior from SearchEventsViewModel, SearchLitterReportsViewModel, and ExploreViewModel.

Net effect: 364 insertions, 511 deletions (−147 lines).

## Test plan
- [x] Mobile build: 0 warnings, 0 errors
- [x] Mobile tests: 266 passed, 0 failed
- [x] Backend tests: 397 passed, 0 failed
- [ ] Verify location filtering works on Search Events page
- [ ] Verify location filtering works on Search Litter Reports page
- [ ] Verify location filtering works on Explore page
- [ ] Verify date range changes refresh data on Dashboard and Search pages
- [ ] Verify navigation from item selection still works (events, litter reports, teams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)