### PR TITLE
Add mobile age gate and switch from B2C to Entra External ID

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -43,5 +43,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(ViewTeamPage), typeof(ViewTeamPage));
         Routing.RegisterRoute(nameof(WaiverPage), typeof(WaiverPage));
         Routing.RegisterRoute(nameof(WelcomePage), typeof(WelcomePage));
+        Routing.RegisterRoute(nameof(AgeGatePage), typeof(AgeGatePage));
     }
 }

--- a/TrashMobMobile/Authentication/AuthConstants.cs
+++ b/TrashMobMobile/Authentication/AuthConstants.cs
@@ -2,31 +2,28 @@ namespace TrashMobMobile.Authentication;
 
 public static class AuthConstants
 {
-    private const string SignInPolicy = "B2C_1A_TM_SIGNUP_SIGNIN";
-
 #if USETEST
-    public const string ClientId = "31cb1c9a-eaa6-4fd0-b59f-0bd0099845ee";
-    private const string TenantName = "TrashmobDev";
-    private const string TenantId = $"{TenantName}.onmicrosoft.com";
+    public const string ClientId = "33bfdd2c-80a4-4e6e-b211-337b0467226d";
+    private const string TenantName = "trashmobecodev";
+    private const string TenantDomain = "TrashMobEcoDev.onmicrosoft.com";
     public const string ApiBaseUri = "https://dev.trashmob.eco/api/";
 #else
-    public const string ClientId = "193638ed-30a1-4e29-ba95-fc39f0c0f242";
-    private const string TenantName = "Trashmob";
-    private const string TenantId = $"{TenantName}.onmicrosoft.com";
+    public const string ClientId = "33bfdd2c-80a4-4e6e-b211-337b0467226d"; // TODO: Register prod mobile app in Entra
+    private const string TenantName = "trashmobecodev"; // TODO: Update to prod tenant
+    private const string TenantDomain = "TrashMobEcoDev.onmicrosoft.com"; // TODO: Update to prod tenant
     public const string ApiBaseUri = "https://www.trashmob.eco/api/";
 #endif
 
     public static readonly string[] Scopes =
     [
-        $"https://{TenantId}/api/TrashMob.Writes",
-        $"https://{TenantId}/api/TrashMob.Read",
+        $"https://{TenantDomain}/api/TrashMob.Writes",
+        $"https://{TenantDomain}/api/TrashMob.Read",
         "email",
         "openid",
         "offline_access",
     ];
 
-    private const string AuthorityBase = $"https://{TenantName}.b2clogin.com/tfp/{TenantId}/";
-    public const string AuthoritySignIn = $"{AuthorityBase}{SignInPolicy}";
+    public const string Authority = $"https://{TenantName}.ciamlogin.com/";
 
     public const string IosKeychainSecurityGroup = "com.microsoft.adalcache";
     public const string RedirectUri = "eco.trashmob.trashmobmobile://auth";

--- a/TrashMobMobile/Authentication/AuthService.cs
+++ b/TrashMobMobile/Authentication/AuthService.cs
@@ -148,6 +148,11 @@ public class AuthService : IAuthService
         }
     }
 
+    public async Task<SignInResult> SignUpInteractiveAsync()
+    {
+        return await SignInInteractive();
+    }
+
     public string GetUserEmail()
     {
         if (string.IsNullOrWhiteSpace(userEmail))
@@ -162,7 +167,7 @@ public class AuthService : IAuthService
     {
         var pcaBuilder = PublicClientApplicationBuilder
             .Create(AuthConstants.ClientId)
-            .WithAuthority(AuthConstants.AuthoritySignIn)
+            .WithAuthority(AuthConstants.Authority)
 #if IOS
             .WithIosKeychainSecurityGroup(AuthConstants.IosKeychainSecurityGroup)
 #elif ANDROID

--- a/TrashMobMobile/Authentication/IAuthService.cs
+++ b/TrashMobMobile/Authentication/IAuthService.cs
@@ -10,7 +10,7 @@ public interface IAuthService
 
     Task<string> GetAccessTokenAsync();
 
-    string GetUserEmail();
+    Task<SignInResult> SignUpInteractiveAsync();
 
-    // TODO: Add other methods
+    string GetUserEmail();
 }

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -95,6 +95,7 @@ public static class MauiProgram
         builder.Services.AddTransient<ViewTeamPage>();
         builder.Services.AddTransient<WaiverPage>();
         builder.Services.AddTransient<WelcomePage>();
+        builder.Services.AddTransient<AgeGatePage>();
 
         // ViewModels
         builder.Services.AddTransient<CreatePickupLocationViewModel>();
@@ -133,6 +134,7 @@ public static class MauiProgram
         builder.Services.AddTransient<ViewTeamViewModel>();
         builder.Services.AddTransient<WaiverViewModel>();
         builder.Services.AddTransient<WelcomeViewModel>();
+        builder.Services.AddTransient<AgeGateViewModel>();
 
 #if USETEST
         builder.Logging.AddDebug();

--- a/TrashMobMobile/Pages/AgeGatePage.xaml
+++ b/TrashMobMobile/Pages/AgeGatePage.xaml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="vm:AgeGateViewModel"
+             x:Class="TrashMobMobile.Pages.AgeGatePage"
+             Shell.NavBarIsVisible="False">
+    <ScrollView>
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="16"
+                             VerticalOptions="Center">
+
+            <!-- Logo -->
+            <Image Source="{AppThemeBinding Light=bannerlogo_light.png, Dark=bannerlogo_dark.png}"
+                   MaximumHeightRequest="72"
+                   HorizontalOptions="Center"
+                   Margin="0,24,0,0" />
+
+            <!-- Blocked state -->
+            <VerticalStackLayout Spacing="16" IsVisible="{Binding IsBlocked}">
+                <Label Text="Unable to Create Account"
+                       FontFamily="LexendSemibold"
+                       FontSize="Large"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{StaticResource Destructive}" />
+
+                <Label Text="{Binding BlockMessage}"
+                       FontSize="Body"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0" />
+
+                <Button Text="Go Back"
+                        MaximumWidthRequest="200"
+                        Command="{Binding GoBackCommand}" />
+            </VerticalStackLayout>
+
+            <!-- Age verification form -->
+            <VerticalStackLayout Spacing="16" IsVisible="{Binding IsNotBlocked}">
+                <Label Text="Create Account"
+                       FontFamily="LexendSemibold"
+                       FontSize="Large"
+                       HorizontalTextAlignment="Center" />
+
+                <Label Text="Please enter your date of birth to continue. This is required for age verification."
+                       FontSize="Body"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0" />
+
+                <DatePicker Date="{Binding DateOfBirth}"
+                            MaximumDate="{Binding MaxDate}"
+                            MinimumDate="{Binding MinDate}"
+                            HorizontalOptions="Center"
+                            Format="d" />
+
+                <HorizontalStackLayout HorizontalOptions="Center" Spacing="12">
+                    <Button Text="Cancel"
+                            MaximumWidthRequest="140"
+                            BackgroundColor="Transparent"
+                            TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderWidth="1"
+                            Command="{Binding GoBackCommand}" />
+
+                    <Button Text="Continue"
+                            MaximumWidthRequest="140"
+                            Command="{Binding ContinueCommand}" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/TrashMobMobile/Pages/AgeGatePage.xaml.cs
+++ b/TrashMobMobile/Pages/AgeGatePage.xaml.cs
@@ -1,0 +1,49 @@
+namespace TrashMobMobile.Pages;
+
+using TrashMobMobile.Authentication;
+using TrashMobMobile.ViewModels;
+
+public partial class AgeGatePage : ContentPage
+{
+    private readonly AgeGateViewModel viewModel;
+    private readonly IAuthService authService;
+
+    public AgeGatePage(AgeGateViewModel viewModel, IAuthService authService)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        this.authService = authService;
+        BindingContext = viewModel;
+
+        viewModel.PropertyChanged += OnViewModelPropertyChanged;
+    }
+
+    private async void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(AgeGateViewModel.IsAgeVerified) && viewModel.IsAgeVerified)
+        {
+            viewModel.IsAgeVerified = false;
+
+            var result = await authService.SignUpInteractiveAsync();
+
+            if (result.Succeeded)
+            {
+                await Task.Delay(100);
+                await MainThread.InvokeOnMainThreadAsync(async () =>
+                {
+                    await Shell.Current.GoToAsync($"//{nameof(MainTabsPage)}");
+                });
+            }
+            else
+            {
+                await Shell.Current.GoToAsync("..");
+            }
+        }
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+    }
+}

--- a/TrashMobMobile/Pages/WelcomePage.xaml
+++ b/TrashMobMobile/Pages/WelcomePage.xaml
@@ -145,12 +145,22 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <!-- Login button -->
-                <Button Text="Get Started"
-                        AutomationId="GetStartedButton"
-                        MaximumWidthRequest="200"
-                        Margin="0,8,0,0"
-                        Command="{Binding SignInCommand}" />
+                <!-- Auth buttons -->
+                <HorizontalStackLayout HorizontalOptions="Center" Spacing="12" Margin="0,8,0,0">
+                    <Button Text="Sign In"
+                            AutomationId="SignInButton"
+                            MaximumWidthRequest="160"
+                            BackgroundColor="Transparent"
+                            TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderWidth="1"
+                            Command="{Binding SignInCommand}" />
+
+                    <Button Text="Create Account"
+                            AutomationId="CreateAccountButton"
+                            MaximumWidthRequest="160"
+                            Command="{Binding CreateAccountCommand}" />
+                </HorizontalStackLayout>
 
                 <Label Text="Something went wrong logging you in."
                        HorizontalOptions="Center"

--- a/TrashMobMobile/ViewModels/AgeGateViewModel.cs
+++ b/TrashMobMobile/ViewModels/AgeGateViewModel.cs
@@ -1,0 +1,59 @@
+namespace TrashMobMobile.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMobMobile.Services;
+
+public partial class AgeGateViewModel(INotificationService notificationService) : BaseViewModel(notificationService)
+{
+    [ObservableProperty]
+    private DateTime dateOfBirth = DateTime.Today.AddYears(-18);
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsNotBlocked))]
+    private bool isBlocked;
+
+    public bool IsNotBlocked => !IsBlocked;
+
+    [ObservableProperty]
+    private string blockMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool isAgeVerified;
+
+    public DateTime MaxDate => DateTime.Today;
+    public DateTime MinDate => DateTime.Today.AddYears(-120);
+
+    [RelayCommand]
+    private void Continue()
+    {
+        var age = CalculateAge(DateOfBirth);
+
+        if (age < 13)
+        {
+            IsBlocked = true;
+            BlockMessage = "You must be 13 or older to join TrashMob. Thank you for your interest in keeping our communities clean!";
+            return;
+        }
+
+        IsAgeVerified = true;
+    }
+
+    [RelayCommand]
+    private async Task GoBack()
+    {
+        await Shell.Current.GoToAsync("..");
+    }
+
+    private static int CalculateAge(DateTime dob)
+    {
+        var today = DateTime.Today;
+        var age = today.Year - dob.Year;
+        if (dob.Date > today.AddYears(-age))
+        {
+            age--;
+        }
+
+        return age;
+    }
+}

--- a/TrashMobMobile/ViewModels/WelcomeViewModel.cs
+++ b/TrashMobMobile/ViewModels/WelcomeViewModel.cs
@@ -3,6 +3,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TrashMobMobile.Authentication;
+using TrashMobMobile.Pages;
 using TrashMobMobile.Services;
 
 public partial class WelcomeViewModel(IAuthService authService, IStatsRestService statsRestService, INotificationService notificationService) : BaseViewModel(notificationService)
@@ -27,6 +28,12 @@ public partial class WelcomeViewModel(IAuthService authService, IStatsRestServic
             StatisticsViewModel.TotalLitterReportsClosed = stats.TotalLitterReportsClosed;
             StatisticsViewModel.TotalWeightInPounds = (int)stats.TotalWeightInPounds;
         }, "An error occurred while loading this page. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task CreateAccount()
+    {
+        await Shell.Current.GoToAsync(nameof(AgeGatePage));
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Switches MAUI mobile app authentication from Azure B2C to Entra External ID (CIAM)
- Adds COPPA-compliant age gate (Layer 1) that blocks under-13 users from creating accounts
- Splits WelcomePage into separate "Sign In" (no DOB check) and "Create Account" (DOB pre-screen) buttons

## Changes
- **AuthConstants.cs** — Entra CIAM authority, scopes, and mobile app registration (`33bfdd2c`)
- **AuthService.cs / IAuthService.cs** — `SignUpInteractiveAsync()` method for sign-up flow
- **AgeGatePage.xaml + AgeGateViewModel.cs** — New DOB entry page with under-13 blocking
- **WelcomePage.xaml + WelcomeViewModel.cs** — Two-button layout with AutomationIds
- **MauiProgram.cs + AppShell.xaml.cs** — DI registration and route for AgeGatePage

## Related PRs
- PR #2693 (Web age gate + backend DOB extraction — Layer 1 web side)
- PR #2692 (Switch default auth from B2C to Entra External ID — web config)

## Test plan
- [ ] "Sign In" button goes directly to Entra sign-in (no DOB check)
- [ ] "Create Account" button navigates to AgeGatePage
- [ ] Entering DOB making user under 13 shows friendly block message
- [ ] Entering DOB making user 13+ proceeds to Entra sign-up
- [ ] After successful Entra sign-up, app navigates to MainTabsPage
- [ ] Build succeeds on Android target

🤖 Generated with [Claude Code](https://claude.com/claude-code)