### PR TITLE
Extract IsAuthorizedAsync helper to reduce authorization boilerplate

### DIFF
--- a/TrashMob/Controllers/AdoptableAreasController.cs
+++ b/TrashMob/Controllers/AdoptableAreasController.cs
@@ -155,9 +155,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -196,9 +194,7 @@ namespace TrashMob.Controllers
             }
 
             // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -255,9 +251,7 @@ namespace TrashMob.Controllers
             }
 
             // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -325,9 +319,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -374,9 +366,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -419,9 +409,7 @@ namespace TrashMob.Controllers
             }
 
             // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/CommunitiesController.cs
+++ b/TrashMob/Controllers/CommunitiesController.cs
@@ -228,10 +228,7 @@ namespace TrashMob.Controllers
             }
 
             // Authorize: user must be partner admin or site admin
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -262,10 +259,7 @@ namespace TrashMob.Controllers
             }
 
             // Authorize: user must be partner admin or site admin
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -303,10 +297,7 @@ namespace TrashMob.Controllers
             }
 
             // Authorize: user must be partner admin or site admin
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, existing, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(existing, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -368,10 +359,7 @@ namespace TrashMob.Controllers
             }
 
             // Authorize: user must be partner admin or site admin
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -423,10 +411,7 @@ namespace TrashMob.Controllers
             }
 
             // Authorize: user must be partner admin or site admin
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -469,10 +454,7 @@ namespace TrashMob.Controllers
             }
 
             // Authorize: user must be partner admin or site admin
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/CommunityAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunityAdoptionsController.cs
@@ -56,10 +56,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            // Check authorization - must be partner admin
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -87,10 +84,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -123,10 +117,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -167,10 +158,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -208,10 +196,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -239,10 +224,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -270,10 +252,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            // Check authorization
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/CommunityInvitesController.cs
+++ b/TrashMob/Controllers/CommunityInvitesController.cs
@@ -51,10 +51,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetBatches(Guid communityId, CancellationToken cancellationToken = default)
         {
             var partner = await partnerManager.GetAsync(communityId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -80,10 +77,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetBatch(Guid communityId, Guid id, CancellationToken cancellationToken = default)
         {
             var partner = await partnerManager.GetAsync(communityId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -118,10 +112,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var partner = await partnerManager.GetAsync(communityId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
+++ b/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
@@ -59,9 +59,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -90,9 +88,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -130,9 +126,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -171,9 +165,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -218,9 +210,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -264,9 +254,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -301,9 +289,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
@@ -56,9 +56,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -87,9 +85,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -127,9 +123,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -167,9 +161,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -206,9 +198,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/CommunitySponsorsController.cs
+++ b/TrashMob/Controllers/CommunitySponsorsController.cs
@@ -55,9 +55,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -86,9 +84,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -123,9 +119,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -164,9 +158,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -205,9 +197,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/EventAttendeeMetricsController.cs
+++ b/TrashMob/Controllers/EventAttendeeMetricsController.cs
@@ -104,10 +104,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -135,10 +132,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -171,10 +165,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -215,10 +206,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -259,10 +247,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -309,10 +294,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -346,10 +328,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/EventAttendeeRoutesController.cs
+++ b/TrashMob/Controllers/EventAttendeeRoutesController.cs
@@ -110,10 +110,7 @@
         public async Task<IActionResult> UpdateEventAttendeeRoute(DisplayEventAttendeeRoute displayEventAttendeeRoute,
             CancellationToken cancellationToken)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, displayEventAttendeeRoute,
-                AuthorizationPolicyConstants.UserOwnsEntity);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(displayEventAttendeeRoute, AuthorizationPolicyConstants.UserOwnsEntity))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/EventAttendeesController.cs
+++ b/TrashMob/Controllers/EventAttendeesController.cs
@@ -62,11 +62,7 @@
         public async Task<IActionResult> UpdateEventAttendee(EventAttendee eventAttendee,
             CancellationToken cancellationToken)
         {
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, eventAttendee,
-                    AuthorizationPolicyConstants.UserOwnsEntity);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(eventAttendee, AuthorizationPolicyConstants.UserOwnsEntity))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/EventLitterReportController.cs
+++ b/TrashMob/Controllers/EventLitterReportController.cs
@@ -76,11 +76,7 @@
         public async Task<IActionResult> UpdateEventLitterReport(EventLitterReport eventLitterReport,
             CancellationToken cancellationToken)
         {
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, eventLitterReport,
-                    AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(eventLitterReport, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/EventPartnerLocationServicesController.cs
+++ b/TrashMob/Controllers/EventPartnerLocationServicesController.cs
@@ -108,10 +108,7 @@
                 return NotFound();
             }
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -157,10 +154,7 @@
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -211,10 +205,7 @@
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -254,10 +245,7 @@
                 return NotFound();
             }
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -294,10 +282,7 @@
                 return NotFound();
             }
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/EventSummariesController.cs
+++ b/TrashMob/Controllers/EventSummariesController.cs
@@ -115,11 +115,7 @@
         public async Task<IActionResult> UpdateEventSummary(EventSummary eventSummary,
             CancellationToken cancellationToken)
         {
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, eventSummary,
-                    AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(eventSummary, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -142,11 +138,7 @@
         [RequiredScope(Constants.TrashMobWriteScope)]
         public async Task<IActionResult> AddEventSummary(EventSummary eventSummary, CancellationToken cancellationToken)
         {
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, eventSummary,
-                    AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(eventSummary, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -172,10 +164,7 @@
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken).ConfigureAwait(false);
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/EventsController.cs
+++ b/TrashMob/Controllers/EventsController.cs
@@ -290,10 +290,7 @@
         [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
         public async Task<IActionResult> UpdateEvent(Event mobEvent, CancellationToken cancellationToken)
         {
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -351,10 +348,7 @@
             var mobEvent = await eventManager.GetAsync(eventCancellationRequest.EventId, cancellationToken)
                 .ConfigureAwait(false);
 
-            var authResult = await AuthorizationService.AuthorizeAsync(User, mobEvent,
-                AuthorizationPolicyConstants.UserIsEventLeadOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLeadOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/ImageController.cs
+++ b/TrashMob/Controllers/ImageController.cs
@@ -46,10 +46,8 @@
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(imageUpload.ParentId, cancellationToken).ConfigureAwait(false);
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -73,10 +71,8 @@
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(parentId, cancellationToken).ConfigureAwait(false);
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/JobOpportunityController.cs
+++ b/TrashMob/Controllers/JobOpportunityController.cs
@@ -49,10 +49,7 @@
         [RequiredScope(Constants.TrashMobWriteScope)]
         public async Task<IActionResult> Update(JobOpportunity jobOpportunity, CancellationToken cancellationToken)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, jobOpportunity,
-                AuthorizationPolicyConstants.UserIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(jobOpportunity, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -74,10 +71,7 @@
         [RequiredScope(Constants.TrashMobWriteScope)]
         public override async Task<IActionResult> Add(JobOpportunity jobOpportunity, CancellationToken cancellationToken)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, jobOpportunity,
-                AuthorizationPolicyConstants.UserIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(jobOpportunity, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -99,10 +93,7 @@
         [RequiredScope(Constants.TrashMobWriteScope)]
         public override async Task<IActionResult> Delete(Guid jobOpportunityId, CancellationToken cancellationToken)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, jobOpportunityId,
-                AuthorizationPolicyConstants.UserIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(jobOpportunityId, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/KeyedController.cs
+++ b/TrashMob/Controllers/KeyedController.cs
@@ -71,10 +71,7 @@
         {
             var entity = await Manager.GetAsync(id, cancellationToken).ConfigureAwait(false);
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, entity, AuthorizationPolicyConstants.UserOwnsEntity);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(entity, AuthorizationPolicyConstants.UserOwnsEntity))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -267,11 +267,8 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var litterImage = await litterImageManager.GetAsync(litterImageId, cancellationToken);
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, litterImage,
-                    AuthorizationPolicyConstants.UserOwnsEntity);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(litterImage, AuthorizationPolicyConstants.UserOwnsEntity))
             {
                 return Forbid();
             }
@@ -293,10 +290,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> UpdateLitterReport(LitterReport litterReport,
             CancellationToken cancellationToken)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, litterReport,
-                AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(litterReport, AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin))
             {
                 return Forbid();
             }
@@ -325,10 +319,7 @@ namespace TrashMob.Controllers
         {
             var litterReport = await litterReportManager.GetAsync(id, cancellationToken).ConfigureAwait(false);
 
-            var authResult = await AuthorizationService.AuthorizeAsync(User, litterReport,
-                AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(litterReport, AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/NewslettersController.cs
+++ b/TrashMob/Controllers/NewslettersController.cs
@@ -52,8 +52,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetNewsletters([FromQuery] string status = null, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -97,8 +96,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetNewsletter(Guid id, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -124,8 +122,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> CreateNewsletter([FromBody] CreateNewsletterRequest request, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -167,8 +164,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> UpdateNewsletter(Guid id, [FromBody] UpdateNewsletterRequest request, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -212,8 +208,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> ScheduleNewsletter(Guid id, [FromBody] ScheduleNewsletterRequest request, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -243,8 +238,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> SendNewsletter(Guid id, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -275,8 +269,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> SendTestEmail(Guid id, [FromBody] TestSendRequest request, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -311,8 +304,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> DeleteNewsletter(Guid id, CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }
@@ -344,8 +336,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetTemplates(CancellationToken cancellationToken = default)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, null, AuthorizationPolicyConstants.UserIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(null, AuthorizationPolicyConstants.UserIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerAdminInvitationsController.cs
+++ b/TrashMob/Controllers/PartnerAdminInvitationsController.cs
@@ -46,10 +46,7 @@
         public async Task<IActionResult> GetPartnerAdminInvitations(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -83,10 +80,7 @@
             CancellationToken cancellationToken = default)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -115,10 +109,7 @@
         {
             // Make sure the person adding the user is either an admin or already a user for the partner
             var partner = await partnerManager.GetAsync(partnerAdminInvitation.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -162,10 +153,7 @@
             var partner =
                 await partnerAdminInvitationManager.GetPartnerForInvitation(partnerAdminInvitationId,
                     cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -229,10 +217,7 @@
                     cancellationToken);
 
             // Make sure the person adding the user is either an admin or already a user for the partner
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerAdminsController.cs
+++ b/TrashMob/Controllers/PartnerAdminsController.cs
@@ -52,10 +52,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetPartnerAdmins(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -108,10 +105,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -145,10 +139,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetUsers(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -185,10 +176,7 @@ namespace TrashMob.Controllers
         {
             // Make sure the person adding the user is either an admin or already a user for the partner
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerContactsController.cs
+++ b/TrashMob/Controllers/PartnerContactsController.cs
@@ -78,10 +78,7 @@
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -104,10 +101,7 @@
         {
             // Make sure the person adding the user is either an admin or already a user for the partner
             var partner = await partnerManager.GetAsync(partnerContact.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -130,10 +124,7 @@
             CancellationToken cancellationToken)
         {
             var partner = await partnerContactManager.GetPartnerForContact(partnerContactId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerController.cs
+++ b/TrashMob/Controllers/PartnerController.cs
@@ -46,10 +46,7 @@
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         public async Task<IActionResult> Update(Partner partner, CancellationToken cancellationToken)
         {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerDocumentsController.cs
+++ b/TrashMob/Controllers/PartnerDocumentsController.cs
@@ -60,10 +60,8 @@
         public async Task<IActionResult> GetPartnerDocuments(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -97,10 +95,8 @@
         public async Task<IActionResult> Add(PartnerDocument partnerDocument, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerDocument.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -131,10 +127,8 @@
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -191,10 +185,8 @@
         public async Task<IActionResult> Download(Guid partnerDocumentId, CancellationToken cancellationToken)
         {
             var partner = await manager.GetPartnerForDocument(partnerDocumentId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -218,10 +210,8 @@
         public async Task<IActionResult> GetStorageUsage(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -240,10 +230,8 @@
         public async Task<IActionResult> Update(PartnerDocument partnerDocument, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerDocument.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -264,10 +252,8 @@
         public async Task<IActionResult> Delete(Guid partnerDocumentId, CancellationToken cancellationToken)
         {
             var partner = await manager.GetPartnerForDocument(partnerDocumentId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerLocationContactsController.cs
+++ b/TrashMob/Controllers/PartnerLocationContactsController.cs
@@ -83,10 +83,7 @@
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -112,10 +109,7 @@
             var partner =
                 await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationContact.PartnerLocationId,
                     cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -140,10 +134,7 @@
             var partner =
                 await partnerLocationContactManager.GetPartnerForLocationContact(partnerLocationContactId,
                     cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerLocationEventServicesController.cs
+++ b/TrashMob/Controllers/PartnerLocationEventServicesController.cs
@@ -41,10 +41,7 @@
             CancellationToken cancellationToken)
         {
             var partner = await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerLocationServicesController.cs
+++ b/TrashMob/Controllers/PartnerLocationServicesController.cs
@@ -82,10 +82,7 @@
             var partnerLocation =
                 await partnerLocationManager.GetAsync(partnerLocationService.PartnerLocationId, cancellationToken);
             var partner = await partnerManager.GetAsync(partnerLocation.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -115,10 +112,7 @@
             var partnerLocation =
                 await partnerLocationManager.GetAsync(partnerLocationService.PartnerLocationId, cancellationToken);
             var partner = await partnerManager.GetAsync(partnerLocation.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -144,10 +138,7 @@
         {
             var partnerLocation = await partnerLocationManager.GetAsync(partnerLocationId, cancellationToken);
             var partner = await partnerManager.GetAsync(partnerLocation.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerLocationsController.cs
+++ b/TrashMob/Controllers/PartnerLocationsController.cs
@@ -90,10 +90,7 @@
             }
 
             var partner = await partnerManager.GetAsync(partnerLocation.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -118,10 +115,7 @@
             // Make sure the person adding the user is either an admin or already a user for the partner
             var partner =
                 await partnerLocationManager.GetPartnerForLocationAsync(partnerLocation.Id, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -143,10 +137,7 @@
             CancellationToken cancellationToken)
         {
             var partner = await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PartnerSocialMediaAccountsController.cs
+++ b/TrashMob/Controllers/PartnerSocialMediaAccountsController.cs
@@ -42,10 +42,7 @@
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -80,10 +77,7 @@
             PartnerSocialMediaAccount partnerSocialMediaAccount, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerSocialMediaAccount.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -106,10 +100,7 @@
         {
             // Make sure the person adding the user is either an admin or already a user for the partner
             var partner = await partnerManager.GetAsync(partnerSocialMediaAccount.PartnerId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -132,10 +123,7 @@
             CancellationToken cancellationToken)
         {
             var partner = await manager.GetPartnerForSocialMediaAccount(partnerSocialMediaAccountId, cancellationToken);
-            var authResult = await AuthorizationService.AuthorizeAsync(User, partner,
-                AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/PickupLocationsController.cs
+++ b/TrashMob/Controllers/PickupLocationsController.cs
@@ -71,21 +71,12 @@
         {
             var localPickupLocation = await Manager.GetAsync(pickupLocation.Id, cancellationToken);
 
-            // Does the user own the pickup location?
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, localPickupLocation,
-                    AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            // Does the user own the pickup location or the event?
+            if (!await IsAuthorizedAsync(localPickupLocation, AuthorizationPolicyConstants.UserIsEventLead))
             {
-                // Does the user own the event?
                 var mobEvent = await eventManager.GetAsync(pickupLocation.EventId, cancellationToken);
 
-                authResult =
-                    await AuthorizationService.AuthorizeAsync(User, mobEvent,
-                        AuthorizationPolicyConstants.UserIsEventLead);
-
-                if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+                if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
                 {
                     return Forbid();
                 }
@@ -123,18 +114,12 @@
         {
             var pickupLocation = await Manager.GetAsync(pickupLocationId, cancellationToken).ConfigureAwait(false);
 
-            var authResult = await AuthorizationService.AuthorizeAsync(User, pickupLocation,
-                AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(pickupLocation, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 // Check if the user is the event lead
                 var mobEvent = await eventManager.GetAsync(pickupLocation.EventId, cancellationToken);
 
-                authResult = await AuthorizationService.AuthorizeAsync(User, mobEvent,
-                    AuthorizationPolicyConstants.UserIsEventLead);
-
-                if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+                if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
                 {
                     return Forbid();
                 }
@@ -160,10 +145,7 @@
         {
             var mobEvent = await eventManager.GetAsync(instance.EventId, cancellationToken);
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -188,10 +170,7 @@
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -217,10 +196,8 @@
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, mobEvent, AuthorizationPolicyConstants.UserIsEventLead);
 
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
@@ -282,19 +259,12 @@
             // Is the user the owner of the pickup location?
             var entity = await Manager.GetAsync(id, cancellationToken);
 
-            var authResult =
-                await AuthorizationService.AuthorizeAsync(User, entity, AuthorizationPolicyConstants.UserIsEventLead);
-
-            if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+            if (!await IsAuthorizedAsync(entity, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 // Does the user own the event?
                 var mobEvent = await eventManager.GetAsync(entity.EventId, cancellationToken);
 
-                authResult =
-                    await AuthorizationService.AuthorizeAsync(User, mobEvent,
-                        AuthorizationPolicyConstants.UserIsEventLead);
-
-                if (!User.Identity.IsAuthenticated || !authResult.Succeeded)
+                if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
                 {
                     return Forbid();
                 }

--- a/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
+++ b/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
@@ -59,9 +59,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -94,9 +92,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -134,9 +130,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/SecureController.cs
+++ b/TrashMob/Controllers/SecureController.cs
@@ -1,6 +1,7 @@
 namespace TrashMob.Controllers
 {
     using System;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.DependencyInjection;
@@ -37,5 +38,16 @@ namespace TrashMob.Controllers
         }
 
         protected Guid UserId => new(HttpContext.Items["UserId"].ToString());
+
+        protected async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (!User.Identity.IsAuthenticated)
+            {
+                return false;
+            }
+
+            var authResult = await AuthorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
     }
 }

--- a/TrashMob/Controllers/SponsorPortalController.cs
+++ b/TrashMob/Controllers/SponsorPortalController.cs
@@ -93,9 +93,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -129,9 +127,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }

--- a/TrashMob/Controllers/SponsorReportsController.cs
+++ b/TrashMob/Controllers/SponsorReportsController.cs
@@ -69,9 +69,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }
@@ -109,9 +107,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var authResult = await AuthorizationService.AuthorizeAsync(
-                User, partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin);
-            if (!authResult.Succeeded)
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
             {
                 return Forbid();
             }


### PR DESCRIPTION
## Summary
- Adds a reusable `IsAuthorizedAsync(resource, policy)` helper method to `SecureController` that combines the `User.Identity.IsAuthenticated` check and `AuthorizationService.AuthorizeAsync` call into a single method
- Replaces ~100 instances of duplicated 5-line authorization blocks across 33 controllers, removing ~320 lines of repetitive code
- Controllers that previously only checked `authResult.Succeeded` (without the `IsAuthenticated` check) now also get the authentication guard, which is a minor security improvement

## Test plan
- [x] Solution builds with 0 errors, 0 warnings
- [x] All 442 backend tests pass
- [x] Verified no remaining `AuthorizationService.AuthorizeAsync` calls in controllers (only in `SecureController` helper)
- [ ] Manual smoke test of admin, partner, and event endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)