### PR TITLE
Remove ConfigureAwait(false) and standardize string validation

### DIFF
--- a/TrashMob.Shared/Managers/ActiveDirectoryManager.cs
+++ b/TrashMob.Shared/Managers/ActiveDirectoryManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Threading;
@@ -52,7 +52,7 @@
             }
 
             var response = await DoesUserExist(activeDirectoryNewUserRequest.userName,
-                activeDirectoryNewUserRequest.email, cancellationToken).ConfigureAwait(false);
+                activeDirectoryNewUserRequest.email, cancellationToken);
 
             if (response != null)
             {
@@ -66,7 +66,7 @@
                 UserName = activeDirectoryNewUserRequest.userName,
             };
 
-            await userManager.AddAsync(user, cancellationToken).ConfigureAwait(false);
+            await userManager.AddAsync(user, cancellationToken);
 
             var newUserResponse = new ActiveDirectoryContinuationResponse();
 
@@ -91,7 +91,7 @@
                 return response;
             }
 
-            await userManager.DeleteAsync(user.Id, cancellationToken).ConfigureAwait(false);
+            await userManager.DeleteAsync(user.Id, cancellationToken);
 
             var deleteUserResponse = new ActiveDirectoryContinuationResponse
             {
@@ -132,7 +132,7 @@
             }
 
             var response = await DoesUserExist(activeDirectoryValidateNewUserRequest.userName,
-                activeDirectoryValidateNewUserRequest.email, cancellationToken).ConfigureAwait(false);
+                activeDirectoryValidateNewUserRequest.email, cancellationToken);
 
             if (response != null)
             {
@@ -166,8 +166,7 @@
             }
 
             var originalUser = await userManager
-                .GetUserByObjectIdAsync(activeDirectoryUpdateUserProfileRequest.objectId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetUserByObjectIdAsync(activeDirectoryUpdateUserProfileRequest.objectId, cancellationToken);
 
             if (originalUser == null)
             {
@@ -182,8 +181,7 @@
             }
 
             var checkUser = await userManager
-                .GetUserByUserNameAsync(activeDirectoryUpdateUserProfileRequest.userName, CancellationToken.None)
-                .ConfigureAwait(false);
+                .GetUserByUserNameAsync(activeDirectoryUpdateUserProfileRequest.userName, CancellationToken.None);
 
             if (checkUser != null && checkUser.ObjectId != activeDirectoryUpdateUserProfileRequest.objectId)
             {
@@ -224,8 +222,7 @@
             }
 
             var originalUser = await userManager
-                .GetUserByObjectIdAsync(activeDirectoryUpdateUserProfileRequest.objectId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetUserByObjectIdAsync(activeDirectoryUpdateUserProfileRequest.objectId, cancellationToken);
 
             if (originalUser == null)
             {
@@ -241,7 +238,7 @@
 
             originalUser.UserName = activeDirectoryUpdateUserProfileRequest.userName;
 
-            await userManager.UpdateAsync(originalUser, cancellationToken).ConfigureAwait(false);
+            await userManager.UpdateAsync(originalUser, cancellationToken);
 
             var newUserResponse = new ActiveDirectoryContinuationResponse
             {
@@ -255,7 +252,7 @@
         private async Task<ActiveDirectoryResponseBase> DoesUserExist(string userName, string email,
             CancellationToken cancellationToken = default)
         {
-            var originalUser = await userManager.GetUserByEmailAsync(email, cancellationToken).ConfigureAwait(false);
+            var originalUser = await userManager.GetUserByEmailAsync(email, cancellationToken);
 
             if (originalUser != null)
             {
@@ -269,8 +266,7 @@
                 return response;
             }
 
-            var checkUser = await userManager.GetUserByUserNameAsync(userName, CancellationToken.None)
-                .ConfigureAwait(false);
+            var checkUser = await userManager.GetUserByUserNameAsync(userName, CancellationToken.None);
 
             if (checkUser != null)
             {

--- a/TrashMob.Shared/Managers/Adoptions/TeamAdoptionEventManager.cs
+++ b/TrashMob.Shared/Managers/Adoptions/TeamAdoptionEventManager.cs
@@ -44,7 +44,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             CancellationToken cancellationToken = default)
         {
             // Validate adoption exists and is approved
-            var adoption = await adoptionManager.GetAsync(teamAdoptionId, cancellationToken).ConfigureAwait(false);
+            var adoption = await adoptionManager.GetAsync(teamAdoptionId, cancellationToken);
             if (adoption == null)
             {
                 return ServiceResult<TeamAdoptionEvent>.Failure("Adoption not found.");
@@ -56,14 +56,14 @@ namespace TrashMob.Shared.Managers.Adoptions
             }
 
             // Validate event exists
-            var evt = await eventManager.GetAsync(eventId, cancellationToken).ConfigureAwait(false);
+            var evt = await eventManager.GetAsync(eventId, cancellationToken);
             if (evt == null)
             {
                 return ServiceResult<TeamAdoptionEvent>.Failure("Event not found.");
             }
 
             // Check if already linked
-            if (await IsEventLinkedAsync(teamAdoptionId, eventId, cancellationToken).ConfigureAwait(false))
+            if (await IsEventLinkedAsync(teamAdoptionId, eventId, cancellationToken))
             {
                 return ServiceResult<TeamAdoptionEvent>.Failure("Event is already linked to this adoption.");
             }
@@ -81,10 +81,10 @@ namespace TrashMob.Shared.Managers.Adoptions
                 LastUpdatedDate = DateTimeOffset.UtcNow,
             };
 
-            var created = await AddAsync(adoptionEvent, userId, cancellationToken).ConfigureAwait(false);
+            var created = await AddAsync(adoptionEvent, userId, cancellationToken);
 
             // Update compliance tracking on the adoption
-            await UpdateComplianceAsync(teamAdoptionId, userId, cancellationToken).ConfigureAwait(false);
+            await UpdateComplianceAsync(teamAdoptionId, userId, cancellationToken);
 
             return ServiceResult<TeamAdoptionEvent>.Success(created);
         }
@@ -95,7 +95,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             Guid userId,
             CancellationToken cancellationToken = default)
         {
-            var adoptionEvent = await GetAsync(teamAdoptionEventId, cancellationToken).ConfigureAwait(false);
+            var adoptionEvent = await GetAsync(teamAdoptionEventId, cancellationToken);
             if (adoptionEvent == null)
             {
                 return ServiceResult<bool>.Failure("Adoption event link not found.");
@@ -103,10 +103,10 @@ namespace TrashMob.Shared.Managers.Adoptions
 
             var teamAdoptionId = adoptionEvent.TeamAdoptionId;
 
-            await DeleteAsync(teamAdoptionEventId, cancellationToken).ConfigureAwait(false);
+            await DeleteAsync(teamAdoptionEventId, cancellationToken);
 
             // Update compliance tracking on the adoption
-            await UpdateComplianceAsync(teamAdoptionId, userId, cancellationToken).ConfigureAwait(false);
+            await UpdateComplianceAsync(teamAdoptionId, userId, cancellationToken);
 
             return ServiceResult<bool>.Success(true);
         }
@@ -119,8 +119,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             return await Repo.Get(ae => ae.TeamAdoptionId == teamAdoptionId)
                 .Include(ae => ae.Event)
                 .OrderByDescending(ae => ae.Event.EventDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -131,8 +130,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             return await Repo.Get(ae => ae.EventId == eventId)
                 .Include(ae => ae.TeamAdoption)
                     .ThenInclude(a => a.AdoptableArea)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -142,8 +140,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             CancellationToken cancellationToken = default)
         {
             return await Repo.Get(ae => ae.TeamAdoptionId == teamAdoptionId && ae.EventId == eventId)
-                .AnyAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .AnyAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -158,8 +155,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                     && a.Status == "Approved"
                     && (a.AdoptionEndDate == null || a.AdoptionEndDate >= today))
                 .Include(a => a.AdoptableArea)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -168,14 +164,14 @@ namespace TrashMob.Shared.Managers.Adoptions
             Guid userId,
             CancellationToken cancellationToken = default)
         {
-            var adoption = await adoptionManager.GetAsync(teamAdoptionId, cancellationToken).ConfigureAwait(false);
+            var adoption = await adoptionManager.GetAsync(teamAdoptionId, cancellationToken);
             if (adoption == null)
             {
                 return;
             }
 
             // Get all linked events
-            var linkedEvents = await GetByAdoptionIdAsync(teamAdoptionId, cancellationToken).ConfigureAwait(false);
+            var linkedEvents = await GetByAdoptionIdAsync(teamAdoptionId, cancellationToken);
             var eventsList = linkedEvents.ToList();
 
             // Update tracking fields
@@ -193,7 +189,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             adoption.LastUpdatedByUserId = userId;
             adoption.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            await adoptionManager.UpdateAsync(adoption, userId, cancellationToken).ConfigureAwait(false);
+            await adoptionManager.UpdateAsync(adoption, userId, cancellationToken);
         }
 
         private static bool CalculateCompliance(TeamAdoption adoption)

--- a/TrashMob.Shared/Managers/Adoptions/TeamAdoptionManager.cs
+++ b/TrashMob.Shared/Managers/Adoptions/TeamAdoptionManager.cs
@@ -54,14 +54,14 @@ namespace TrashMob.Shared.Managers.Adoptions
             CancellationToken cancellationToken = default)
         {
             // Validate team exists and is active
-            var team = await teamManager.GetAsync(teamId, cancellationToken).ConfigureAwait(false);
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
             if (team == null || !team.IsActive)
             {
                 return ServiceResult<TeamAdoption>.Failure("Team not found or is inactive.");
             }
 
             // Validate area exists, is active, and is available
-            var area = await adoptableAreaManager.GetAsync(adoptableAreaId, cancellationToken).ConfigureAwait(false);
+            var area = await adoptableAreaManager.GetAsync(adoptableAreaId, cancellationToken);
             if (area == null || !area.IsActive)
             {
                 return ServiceResult<TeamAdoption>.Failure("Adoptable area not found or is inactive.");
@@ -73,7 +73,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             }
 
             // Check for existing application
-            if (await HasExistingApplicationAsync(teamId, adoptableAreaId, cancellationToken).ConfigureAwait(false))
+            if (await HasExistingApplicationAsync(teamId, adoptableAreaId, cancellationToken))
             {
                 return ServiceResult<TeamAdoption>.Failure("This team already has a pending or approved adoption for this area.");
             }
@@ -93,10 +93,10 @@ namespace TrashMob.Shared.Managers.Adoptions
                 LastUpdatedDate = DateTimeOffset.UtcNow
             };
 
-            var result = await base.AddAsync(adoption, submittedByUserId, cancellationToken).ConfigureAwait(false);
+            var result = await base.AddAsync(adoption, submittedByUserId, cancellationToken);
 
             // Send notification to community admins
-            await SendApplicationSubmittedNotificationAsync(result, team, area, cancellationToken).ConfigureAwait(false);
+            await SendApplicationSubmittedNotificationAsync(result, team, area, cancellationToken);
 
             return ServiceResult<TeamAdoption>.Success(result);
         }
@@ -107,7 +107,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             Guid reviewedByUserId,
             CancellationToken cancellationToken = default)
         {
-            var adoption = await Repo.GetAsync(adoptionId, cancellationToken).ConfigureAwait(false);
+            var adoption = await Repo.GetAsync(adoptionId, cancellationToken);
             if (adoption == null)
             {
                 return ServiceResult<TeamAdoption>.Failure("Adoption application not found.");
@@ -124,21 +124,21 @@ namespace TrashMob.Shared.Managers.Adoptions
             adoption.LastUpdatedByUserId = reviewedByUserId;
             adoption.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            var result = await base.UpdateAsync(adoption, reviewedByUserId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(adoption, reviewedByUserId, cancellationToken);
 
             // Update area status if not allowing co-adoption
-            var area = await adoptableAreaManager.GetAsync(adoption.AdoptableAreaId, cancellationToken).ConfigureAwait(false);
+            var area = await adoptableAreaManager.GetAsync(adoption.AdoptableAreaId, cancellationToken);
             if (area != null && !area.AllowCoAdoption)
             {
                 area.Status = "Adopted";
                 area.LastUpdatedByUserId = reviewedByUserId;
                 area.LastUpdatedDate = DateTimeOffset.UtcNow;
-                await adoptableAreaManager.UpdateAsync(area, reviewedByUserId, cancellationToken).ConfigureAwait(false);
+                await adoptableAreaManager.UpdateAsync(area, reviewedByUserId, cancellationToken);
             }
 
             // Send approval notification to team leads
-            var team = await teamManager.GetAsync(adoption.TeamId, cancellationToken).ConfigureAwait(false);
-            await SendApplicationApprovedNotificationAsync(result, team, area, cancellationToken).ConfigureAwait(false);
+            var team = await teamManager.GetAsync(adoption.TeamId, cancellationToken);
+            await SendApplicationApprovedNotificationAsync(result, team, area, cancellationToken);
 
             return ServiceResult<TeamAdoption>.Success(result);
         }
@@ -150,7 +150,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             Guid reviewedByUserId,
             CancellationToken cancellationToken = default)
         {
-            var adoption = await Repo.GetAsync(adoptionId, cancellationToken).ConfigureAwait(false);
+            var adoption = await Repo.GetAsync(adoptionId, cancellationToken);
             if (adoption == null)
             {
                 return ServiceResult<TeamAdoption>.Failure("Adoption application not found.");
@@ -168,12 +168,12 @@ namespace TrashMob.Shared.Managers.Adoptions
             adoption.LastUpdatedByUserId = reviewedByUserId;
             adoption.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            var result = await base.UpdateAsync(adoption, reviewedByUserId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(adoption, reviewedByUserId, cancellationToken);
 
             // Send rejection notification to team leads
-            var team = await teamManager.GetAsync(adoption.TeamId, cancellationToken).ConfigureAwait(false);
-            var area = await adoptableAreaManager.GetAsync(adoption.AdoptableAreaId, cancellationToken).ConfigureAwait(false);
-            await SendApplicationRejectedNotificationAsync(result, team, area, cancellationToken).ConfigureAwait(false);
+            var team = await teamManager.GetAsync(adoption.TeamId, cancellationToken);
+            var area = await adoptableAreaManager.GetAsync(adoption.AdoptableAreaId, cancellationToken);
+            await SendApplicationRejectedNotificationAsync(result, team, area, cancellationToken);
 
             return ServiceResult<TeamAdoption>.Success(result);
         }
@@ -188,8 +188,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                 .Include(a => a.AdoptableArea)
                     .ThenInclude(aa => aa.Partner)
                 .OrderByDescending(a => a.ApplicationDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -201,8 +200,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                 .Where(a => a.AdoptableAreaId == adoptableAreaId)
                 .Include(a => a.Team)
                 .OrderByDescending(a => a.ApplicationDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -215,8 +213,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                 .Include(a => a.Team)
                 .Include(a => a.AdoptableArea)
                 .OrderBy(a => a.ApplicationDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -229,8 +226,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                 .Include(a => a.Team)
                 .Include(a => a.AdoptableArea)
                 .OrderByDescending(a => a.ReviewedDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -243,8 +239,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                 .AnyAsync(a => a.TeamId == teamId
                     && a.AdoptableAreaId == adoptableAreaId
                     && (a.Status == "Pending" || a.Status == "Approved"),
-                    cancellationToken)
-                .ConfigureAwait(false);
+                    cancellationToken);
         }
 
         /// <inheritdoc />
@@ -262,8 +257,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                 .Include(a => a.Team)
                 .Include(a => a.AdoptableArea)
                 .OrderBy(a => a.LastEventDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -278,11 +272,9 @@ namespace TrashMob.Shared.Managers.Adoptions
                     && a.Status == "Approved"
                     && (a.AdoptionEndDate == null || a.AdoptionEndDate >= today))
                 .Include(a => a.AdoptableArea)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
-            var areas = await adoptableAreaManager.GetByCommunityAsync(partnerId, cancellationToken)
-                .ConfigureAwait(false);
+            var areas = await adoptableAreaManager.GetByCommunityAsync(partnerId, cancellationToken);
 
             var activeAreas = areas.Where(a => a.IsActive).ToList();
             var adoptedAreaIds = adoptions.Select(a => a.AdoptableAreaId).Distinct().ToList();
@@ -313,8 +305,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                 .Include(a => a.AdoptableArea)
                 .OrderBy(a => a.AdoptableArea.Name)
                 .ThenBy(a => a.Team.Name)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <summary>
@@ -351,8 +342,8 @@ namespace TrashMob.Shared.Managers.Adoptions
             AdoptableArea area,
             CancellationToken cancellationToken)
         {
-            var partner = await partnerManager.GetAsync(area.PartnerId, cancellationToken).ConfigureAwait(false);
-            var admins = await partnerAdminManager.GetAdminsForPartnerAsync(area.PartnerId, cancellationToken).ConfigureAwait(false);
+            var partner = await partnerManager.GetAsync(area.PartnerId, cancellationToken);
+            var admins = await partnerAdminManager.GetAdminsForPartnerAsync(area.PartnerId, cancellationToken);
 
             var adminList = admins.ToList();
             if (adminList.Count == 0)
@@ -369,7 +360,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             var subject = $"New Adoption Application: {team.Name} for {area.Name}";
 
             var recipients = adminList
-                .Where(a => !string.IsNullOrEmpty(a.Email))
+                .Where(a => !string.IsNullOrWhiteSpace(a.Email))
                 .Select(a => new EmailAddress { Name = a.UserName ?? a.Email, Email = a.Email })
                 .ToList();
 
@@ -388,8 +379,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                     SendGridEmailGroupId.General,
                     dynamicTemplateData,
                     recipients,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken);
             }
         }
 
@@ -402,8 +392,8 @@ namespace TrashMob.Shared.Managers.Adoptions
             AdoptableArea area,
             CancellationToken cancellationToken)
         {
-            var partner = await partnerManager.GetAsync(area.PartnerId, cancellationToken).ConfigureAwait(false);
-            var teamLeads = await teamMemberManager.GetTeamLeadsAsync(adoption.TeamId, cancellationToken).ConfigureAwait(false);
+            var partner = await partnerManager.GetAsync(area.PartnerId, cancellationToken);
+            var teamLeads = await teamMemberManager.GetTeamLeadsAsync(adoption.TeamId, cancellationToken);
 
             var leadList = teamLeads.ToList();
             if (leadList.Count == 0)
@@ -422,7 +412,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             var subject = $"Adoption Approved: {area.Name}";
 
             var recipients = leadList
-                .Where(l => l.User != null && !string.IsNullOrEmpty(l.User.Email))
+                .Where(l => l.User != null && !string.IsNullOrWhiteSpace(l.User.Email))
                 .Select(l => new EmailAddress { Name = l.User.UserName ?? l.User.Email, Email = l.User.Email })
                 .ToList();
 
@@ -441,8 +431,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                     SendGridEmailGroupId.General,
                     dynamicTemplateData,
                     recipients,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken);
             }
         }
 
@@ -455,8 +444,8 @@ namespace TrashMob.Shared.Managers.Adoptions
             AdoptableArea area,
             CancellationToken cancellationToken)
         {
-            var partner = await partnerManager.GetAsync(area.PartnerId, cancellationToken).ConfigureAwait(false);
-            var teamLeads = await teamMemberManager.GetTeamLeadsAsync(adoption.TeamId, cancellationToken).ConfigureAwait(false);
+            var partner = await partnerManager.GetAsync(area.PartnerId, cancellationToken);
+            var teamLeads = await teamMemberManager.GetTeamLeadsAsync(adoption.TeamId, cancellationToken);
 
             var leadList = teamLeads.ToList();
             if (leadList.Count == 0)
@@ -473,7 +462,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             var subject = $"Adoption Application Update: {area.Name}";
 
             var recipients = leadList
-                .Where(l => l.User != null && !string.IsNullOrEmpty(l.User.Email))
+                .Where(l => l.User != null && !string.IsNullOrWhiteSpace(l.User.Email))
                 .Select(l => new EmailAddress { Name = l.User.UserName ?? l.User.Email, Email = l.User.Email })
                 .ToList();
 
@@ -492,8 +481,7 @@ namespace TrashMob.Shared.Managers.Adoptions
                     SendGridEmailGroupId.General,
                     dynamicTemplateData,
                     recipients,
-                    cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken);
             }
         }
     }

--- a/TrashMob.Shared/Managers/ContactRequestManager.cs
+++ b/TrashMob.Shared/Managers/ContactRequestManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Collections.Generic;
@@ -61,8 +61,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None);
 
             return outputContactRequest;
         }

--- a/TrashMob.Shared/Managers/EmailInviteManager.cs
+++ b/TrashMob.Shared/Managers/EmailInviteManager.cs
@@ -229,14 +229,14 @@ namespace TrashMob.Shared.Managers
             string emailCopy;
             string subject;
 
-            if (!string.IsNullOrEmpty(teamName))
+            if (!string.IsNullOrWhiteSpace(teamName))
             {
                 // Use team-specific template
                 emailCopy = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.InviteToJoinTeam.ToString());
                 emailCopy = emailCopy.Replace("{teamName}", teamName);
                 subject = $"You're Invited to Join {teamName} on TrashMob.eco!";
             }
-            else if (!string.IsNullOrEmpty(communityName))
+            else if (!string.IsNullOrWhiteSpace(communityName))
             {
                 // Use community-specific template
                 emailCopy = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.InviteToJoinCommunity.ToString());

--- a/TrashMob.Shared/Managers/EmailManager.cs
+++ b/TrashMob.Shared/Managers/EmailManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Collections.Generic;
@@ -65,7 +65,7 @@
 
             email.Addresses.AddRange(recipients);
 
-            await emailSender.SendTemplatedEmailAsync(email, cancellationToken).ConfigureAwait(false);
+            await emailSender.SendTemplatedEmailAsync(email, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/EmailSender.cs
+++ b/TrashMob.Shared/Managers/EmailSender.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Collections.Generic;
@@ -42,7 +42,7 @@
                 var client = new SendGridClient(ApiKey);
                 var message = MailHelper.CreateSingleEmailToMultipleRecipients(from, tos, email.Subject, email.Message,
                     email.HtmlMessage);
-                var response = await client.SendEmailAsync(message, cancellationToken).ConfigureAwait(false);
+                var response = await client.SendEmailAsync(message, cancellationToken);
                 logger.LogInformation("SendGrid response: {StatusCode}", response.StatusCode);
             }
             catch (Exception ex)
@@ -85,7 +85,7 @@
                     },
                 };
 
-                var response = await client.SendEmailAsync(message, cancellationToken).ConfigureAwait(false);
+                var response = await client.SendEmailAsync(message, cancellationToken);
                 logger.LogInformation("SendGrid templated email response: {StatusCode}", response.StatusCode);
             }
             catch (Exception ex)

--- a/TrashMob.Shared/Managers/EventPhotoManager.cs
+++ b/TrashMob.Shared/Managers/EventPhotoManager.cs
@@ -96,7 +96,7 @@ namespace TrashMob.Shared.Managers
             };
 
             // Upload image to blob storage
-            if (!string.IsNullOrEmpty(imageData))
+            if (!string.IsNullOrWhiteSpace(imageData))
             {
                 // Convert base64 to IFormFile-like stream
                 var bytes = Convert.FromBase64String(imageData);

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Events
+namespace TrashMob.Shared.Managers.Events
 {
     using System;
     using System.Collections.Generic;
@@ -208,7 +208,7 @@
 
         private async Task SendCoLeadNotificationAsync(Guid eventId, User user, NotificationTypeEnum notificationType, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(user?.Email))
+            if (string.IsNullOrWhiteSpace(user?.Email))
             {
                 return;
             }

--- a/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
@@ -44,7 +44,7 @@ namespace TrashMob.Shared.Managers.Events
             CancellationToken cancellationToken = default)
         {
             // Validate event exists
-            var eventEntity = await eventManager.GetAsync(eventId, cancellationToken).ConfigureAwait(false);
+            var eventEntity = await eventManager.GetAsync(eventId, cancellationToken);
             if (eventEntity == null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Event not found.");
@@ -52,8 +52,7 @@ namespace TrashMob.Shared.Managers.Events
 
             // Check if user is a registered attendee for this event
             var attendingEvents = await eventAttendeeManager
-                .GetEventsUserIsAttendingAsync(userId, false, cancellationToken)
-                .ConfigureAwait(false);
+                .GetEventsUserIsAttendingAsync(userId, false, cancellationToken);
 
             if (!attendingEvents.Any(e => e.Id == eventId))
             {
@@ -61,7 +60,7 @@ namespace TrashMob.Shared.Managers.Events
             }
 
             // Check for existing submission
-            var existingMetrics = await GetMyMetricsAsync(eventId, userId, cancellationToken).ConfigureAwait(false);
+            var existingMetrics = await GetMyMetricsAsync(eventId, userId, cancellationToken);
 
             if (existingMetrics != null)
             {
@@ -79,7 +78,7 @@ namespace TrashMob.Shared.Managers.Events
                 existingMetrics.LastUpdatedByUserId = userId;
                 existingMetrics.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-                var updatedResult = await base.UpdateAsync(existingMetrics, userId, cancellationToken).ConfigureAwait(false);
+                var updatedResult = await base.UpdateAsync(existingMetrics, userId, cancellationToken);
                 return ServiceResult<EventAttendeeMetrics>.Success(updatedResult);
             }
 
@@ -101,7 +100,7 @@ namespace TrashMob.Shared.Managers.Events
                 LastUpdatedDate = DateTimeOffset.UtcNow
             };
 
-            var result = await base.AddAsync(newMetrics, userId, cancellationToken).ConfigureAwait(false);
+            var result = await base.AddAsync(newMetrics, userId, cancellationToken);
             return ServiceResult<EventAttendeeMetrics>.Success(result);
         }
 
@@ -114,8 +113,7 @@ namespace TrashMob.Shared.Managers.Events
             return await Repo.Get()
                 .Include(m => m.PickedWeightUnit)
                 .Include(m => m.AdjustedPickedWeightUnit)
-                .FirstOrDefaultAsync(m => m.EventId == eventId && m.UserId == userId, cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(m => m.EventId == eventId && m.UserId == userId, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -129,8 +127,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Include(m => m.PickedWeightUnit)
                 .Include(m => m.AdjustedPickedWeightUnit)
                 .OrderBy(m => m.User.UserName)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -143,8 +140,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Include(m => m.User)
                 .Include(m => m.PickedWeightUnit)
                 .OrderBy(m => m.CreatedDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -153,7 +149,7 @@ namespace TrashMob.Shared.Managers.Events
             Guid reviewerId,
             CancellationToken cancellationToken = default)
         {
-            var metrics = await Repo.GetAsync(metricsId, cancellationToken).ConfigureAwait(false);
+            var metrics = await Repo.GetAsync(metricsId, cancellationToken);
             if (metrics == null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Metrics submission not found.");
@@ -170,7 +166,7 @@ namespace TrashMob.Shared.Managers.Events
             metrics.LastUpdatedByUserId = reviewerId;
             metrics.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            var result = await base.UpdateAsync(metrics, reviewerId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(metrics, reviewerId, cancellationToken);
             return ServiceResult<EventAttendeeMetrics>.Success(result);
         }
 
@@ -181,7 +177,7 @@ namespace TrashMob.Shared.Managers.Events
             Guid reviewerId,
             CancellationToken cancellationToken = default)
         {
-            var metrics = await Repo.GetAsync(metricsId, cancellationToken).ConfigureAwait(false);
+            var metrics = await Repo.GetAsync(metricsId, cancellationToken);
             if (metrics == null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Metrics submission not found.");
@@ -199,7 +195,7 @@ namespace TrashMob.Shared.Managers.Events
             metrics.LastUpdatedByUserId = reviewerId;
             metrics.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            var result = await base.UpdateAsync(metrics, reviewerId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(metrics, reviewerId, cancellationToken);
             return ServiceResult<EventAttendeeMetrics>.Success(result);
         }
 
@@ -211,7 +207,7 @@ namespace TrashMob.Shared.Managers.Events
             Guid reviewerId,
             CancellationToken cancellationToken = default)
         {
-            var metrics = await Repo.GetAsync(metricsId, cancellationToken).ConfigureAwait(false);
+            var metrics = await Repo.GetAsync(metricsId, cancellationToken);
             if (metrics == null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Metrics submission not found.");
@@ -233,7 +229,7 @@ namespace TrashMob.Shared.Managers.Events
             metrics.LastUpdatedByUserId = reviewerId;
             metrics.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            var result = await base.UpdateAsync(metrics, reviewerId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(metrics, reviewerId, cancellationToken);
             return ServiceResult<EventAttendeeMetrics>.Success(result);
         }
 
@@ -245,8 +241,7 @@ namespace TrashMob.Shared.Managers.Events
         {
             var pendingMetrics = await Repo.Get()
                 .Where(m => m.EventId == eventId && m.Status == "Pending")
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             if (pendingMetrics.Count == 0)
             {
@@ -261,7 +256,7 @@ namespace TrashMob.Shared.Managers.Events
                 metrics.LastUpdatedByUserId = reviewerId;
                 metrics.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-                await base.UpdateAsync(metrics, reviewerId, cancellationToken).ConfigureAwait(false);
+                await base.UpdateAsync(metrics, reviewerId, cancellationToken);
             }
 
             return ServiceResult<int>.Success(pendingMetrics.Count);
@@ -276,8 +271,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Where(m => m.EventId == eventId)
                 .Include(m => m.PickedWeightUnit)
                 .Include(m => m.AdjustedPickedWeightUnit)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             var approvedMetrics = allMetrics.Where(m => m.Status == "Approved" || m.Status == "Adjusted").ToList();
 
@@ -344,8 +338,7 @@ namespace TrashMob.Shared.Managers.Events
             CancellationToken cancellationToken = default)
         {
             return await Repo.Get()
-                .AnyAsync(m => m.EventId == eventId && m.UserId == userId, cancellationToken)
-                .ConfigureAwait(false);
+                .AnyAsync(m => m.EventId == eventId && m.UserId == userId, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -358,8 +351,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Include(m => m.User)
                 .Include(m => m.PickedWeightUnit)
                 .Include(m => m.AdjustedPickedWeightUnit)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             var summary = new EventMetricsPublicSummary
             {
@@ -444,8 +436,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Include(m => m.PickedWeightUnit)
                 .Include(m => m.AdjustedPickedWeightUnit)
                 .OrderByDescending(m => m.Event.EventDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             var stats = new UserImpactStats
             {

--- a/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Events
+namespace TrashMob.Shared.Managers.Events
 {
     using System;
     using System.Collections.Generic;
@@ -147,12 +147,12 @@
             }
 
             var validPrivacyLevels = new[] { "Private", "EventOnly", "Public" };
-            if (!string.IsNullOrEmpty(request.PrivacyLevel) && !validPrivacyLevels.Contains(request.PrivacyLevel))
+            if (!string.IsNullOrWhiteSpace(request.PrivacyLevel) && !validPrivacyLevels.Contains(request.PrivacyLevel))
             {
                 return ServiceResult<EventAttendeeRoute>.Failure("Invalid privacy level. Must be Private, EventOnly, or Public.");
             }
 
-            if (!string.IsNullOrEmpty(request.PrivacyLevel))
+            if (!string.IsNullOrWhiteSpace(request.PrivacyLevel))
             {
                 route.PrivacyLevel = request.PrivacyLevel;
             }

--- a/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Events
+namespace TrashMob.Shared.Managers.Events
 {
     using System;
     using System.Collections.Generic;
@@ -85,8 +85,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.EventRelated, adminDynamicTemplateData, recipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.EventRelated, adminDynamicTemplateData, recipients, CancellationToken.None);
 
             var partnerMessage = pls.IsAutoApproved
                 ? emailManager.GetHtmlEmailCopy(NotificationTypeEnum.EventPartnerRequest.ToString())
@@ -111,13 +110,12 @@
             }
 
             await emailManager.SendTemplatedEmailAsync(partnerSubject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.EventRelated, dynamicTemplateData, partnerRecipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.EventRelated, dynamicTemplateData, partnerRecipients, CancellationToken.None);
 
             if (pls.IsAutoApproved)
             {
                 instance.EventPartnerLocationServiceStatusId = (int)EventPartnerLocationServiceStatusEnum.Accepted;
-                await UpdateAsync(instance, userId, cancellationToken).ConfigureAwait(false);
+                await UpdateAsync(instance, userId, cancellationToken);
             }
 
             return existingService;
@@ -138,8 +136,7 @@
                 .Include(ep => ep.PartnerLocation.Partner)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            var user = await userRepository.GetAsync(existingService.CreatedByUserId, cancellationToken)
-                .ConfigureAwait(false);
+            var user = await userRepository.GetAsync(existingService.CreatedByUserId, cancellationToken);
 
             // Notify Admins that a partner request has been responded to
             var subject = "A partner request for an event has been responded to!";
@@ -159,8 +156,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.EventRelated, adminDynamicTemplateData, recipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.EventRelated, adminDynamicTemplateData, recipients, CancellationToken.None);
 
             var partnerMessage = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.EventPartnerResponse.ToString());
             var partnerSubject = "A TrashMob.eco Partner has responded to your request!";
@@ -184,8 +180,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(partnerSubject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.EventRelated, dynamicTemplateData, partnerRecipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.EventRelated, dynamicTemplateData, partnerRecipients, CancellationToken.None);
 
             return existingService;
         }
@@ -351,7 +346,7 @@
                 .Include(p => p.PartnerLocation)
                 .Include(p => p.PartnerLocation.PartnerLocationContacts)
                 .Select(p => p.PartnerLocation)
-                .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
             return partnerLocation;
         }
 
@@ -361,10 +356,10 @@
         {
             var displayEventPartners = new List<DisplayEventPartnerLocation>();
             var currentPartners =
-                (await GetCurrentPartnersAsync(eventId, cancellationToken).ConfigureAwait(false)).DistinctBy(p =>
+                (await GetCurrentPartnersAsync(eventId, cancellationToken)).DistinctBy(p =>
                     new { p.EventId, p.PartnerLocationId });
             var possiblePartners =
-                await GetPotentialPartnerLocationsAsync(eventId, cancellationToken).ConfigureAwait(false);
+                await GetPotentialPartnerLocationsAsync(eventId, cancellationToken);
 
             // Convert the current list of partners for the event to a display partner (reduces round trips)
             foreach (var cp in currentPartners.ToList())
@@ -438,7 +433,7 @@
             var eventPartners = await Repository.Get(ea => ea.EventId == eventId)
                 .Include(p => p.PartnerLocation)
                 .Include(p => p.PartnerLocation.Partner)
-                .ToListAsync(cancellationToken).ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             return eventPartners;
         }

--- a/TrashMob.Shared/Managers/Events/EventSummaryManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventSummaryManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Events
+namespace TrashMob.Shared.Managers.Events
 {
     using System;
     using System.Collections.Generic;
@@ -85,8 +85,7 @@
         {
             var stats = new Stats();
             var result1 = await eventManager.GetUserEventsAsync(userId, false, cancellationToken);
-            var result2 = await eventAttendeeManager.GetEventsUserIsAttendingAsync(userId, false, cancellationToken)
-                .ConfigureAwait(false);
+            var result2 = await eventAttendeeManager.GetEventsUserIsAttendingAsync(userId, false, cancellationToken);
 
             var allResults = result1.Union(result2, new EventComparer());
 
@@ -185,10 +184,10 @@
         public override async Task<EventSummary> AddAsync(EventSummary eventSummary, Guid userId, CancellationToken cancellationToken = default)
         {
             // Add the event summary first
-            var result = await base.AddAsync(eventSummary, userId, cancellationToken).ConfigureAwait(false);
+            var result = await base.AddAsync(eventSummary, userId, cancellationToken);
 
             // Mark all associated litter reports as Cleaned
-            await MarkAssociatedLitterReportsAsCleanedAsync(eventSummary.EventId, userId, cancellationToken).ConfigureAwait(false);
+            await MarkAssociatedLitterReportsAsCleanedAsync(eventSummary.EventId, userId, cancellationToken);
 
             return result;
         }
@@ -197,10 +196,10 @@
         public override async Task<EventSummary> UpdateAsync(EventSummary eventSummary, Guid userId, CancellationToken cancellationToken = default)
         {
             // Update the event summary
-            var result = await base.UpdateAsync(eventSummary, userId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(eventSummary, userId, cancellationToken);
 
             // Mark all associated litter reports as Cleaned (in case new associations were added)
-            await MarkAssociatedLitterReportsAsCleanedAsync(eventSummary.EventId, userId, cancellationToken).ConfigureAwait(false);
+            await MarkAssociatedLitterReportsAsCleanedAsync(eventSummary.EventId, userId, cancellationToken);
 
             return result;
         }
@@ -208,7 +207,7 @@
         private async Task MarkAssociatedLitterReportsAsCleanedAsync(Guid eventId, Guid userId, CancellationToken cancellationToken)
         {
             // Get all litter reports associated with this event
-            var eventLitterReports = await eventLitterReportManager.GetByParentIdAsync(eventId, cancellationToken).ConfigureAwait(false);
+            var eventLitterReports = await eventLitterReportManager.GetByParentIdAsync(eventId, cancellationToken);
 
             foreach (var eventLitterReport in eventLitterReports)
             {
@@ -217,7 +216,7 @@
                 {
                     // Update the litter report status to Cleaned
                     eventLitterReport.LitterReport.LitterReportStatusId = (int)LitterReportStatusEnum.Cleaned;
-                    await litterReportManager.UpdateAsync(eventLitterReport.LitterReport, userId, cancellationToken).ConfigureAwait(false);
+                    await litterReportManager.UpdateAsync(eventLitterReport.LitterReport, userId, cancellationToken);
                 }
             }
         }

--- a/TrashMob.Shared/Managers/Gamification/AchievementManager.cs
+++ b/TrashMob.Shared/Managers/Gamification/AchievementManager.cs
@@ -37,15 +37,13 @@ namespace TrashMob.Shared.Managers.Gamification
                 .AsNoTracking()
                 .Where(a => a.IsActive == true)
                 .OrderBy(a => a.DisplayOrder)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             // Get user's earned achievements
             var earnedAchievements = await dbContext.UserAchievements
                 .AsNoTracking()
                 .Where(ua => ua.UserId == userId)
-                .ToDictionaryAsync(ua => ua.AchievementTypeId, ua => ua.EarnedDate, cancellationToken)
-                .ConfigureAwait(false);
+                .ToDictionaryAsync(ua => ua.AchievementTypeId, ua => ua.EarnedDate, cancellationToken);
 
             var achievements = achievementTypes.Select(at => new AchievementDto
             {
@@ -81,8 +79,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .AsNoTracking()
                 .Where(a => a.IsActive == true)
                 .OrderBy(a => a.DisplayOrder)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -95,8 +92,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .Include(ua => ua.AchievementType)
                 .Where(ua => ua.UserId == userId && !ua.NotificationSent)
                 .OrderByDescending(ua => ua.EarnedDate)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             return unreadAchievements.Select(ua => new NewAchievementNotification
             {
@@ -124,8 +120,7 @@ namespace TrashMob.Shared.Managers.Gamification
         {
             var achievements = await dbContext.UserAchievements
                 .Where(ua => ua.UserId == userId && achievementTypeIds.Contains(ua.AchievementTypeId))
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             foreach (var achievement in achievements)
             {
@@ -134,7 +129,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 achievement.LastUpdatedDate = DateTimeOffset.UtcNow;
             }
 
-            await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await dbContext.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -147,8 +142,7 @@ namespace TrashMob.Shared.Managers.Gamification
             var existingAchievement = await dbContext.UserAchievements
                 .AsNoTracking()
                 .Where(ua => ua.UserId == userId && ua.AchievementTypeId == achievementTypeId)
-                .FirstOrDefaultAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
 
             if (existingAchievement != null)
             {
@@ -169,7 +163,7 @@ namespace TrashMob.Shared.Managers.Gamification
             };
 
             dbContext.UserAchievements.Add(userAchievement);
-            await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await dbContext.SaveChangesAsync(cancellationToken);
 
             return true;
         }

--- a/TrashMob.Shared/Managers/Gamification/LeaderboardManager.cs
+++ b/TrashMob.Shared/Managers/Gamification/LeaderboardManager.cs
@@ -69,7 +69,7 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.TimeRange == timeRange
                     && l.LocationScope == locationScope);
 
-            if (locationScope != "Global" && !string.IsNullOrEmpty(locationValue))
+            if (locationScope != "Global" && !string.IsNullOrWhiteSpace(locationValue))
             {
                 query = query.Where(l => l.LocationValue == locationValue);
             }
@@ -78,7 +78,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 query = query.Where(l => l.LocationValue == null || l.LocationValue == "");
             }
 
-            var totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+            var totalCount = await query.CountAsync(cancellationToken);
 
             var entries = await query
                 .OrderBy(l => l.Rank)
@@ -92,15 +92,13 @@ namespace TrashMob.Shared.Managers.Gamification
                     Score = l.Score,
                     FormattedScore = FormatScore(l.Score, leaderboardType)
                 })
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
-            await EnrichWithProfilePhotosAsync(entries, cancellationToken).ConfigureAwait(false);
+            await EnrichWithProfilePhotosAsync(entries, cancellationToken);
 
             var computedDate = await query
                 .Select(l => l.ComputedDate)
-                .FirstOrDefaultAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
 
             return new LeaderboardResponse
             {
@@ -137,8 +135,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .AsNoTracking()
                 .Where(u => u.Id == userId)
                 .Select(u => new { u.ShowOnLeaderboards })
-                .FirstOrDefaultAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
 
             if (user == null)
             {
@@ -169,8 +166,7 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.LeaderboardType == leaderboardType
                     && l.TimeRange == timeRange
                     && l.LocationScope == "Global")
-                .CountAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .CountAsync(cancellationToken);
 
             // Get user's entry
             var userEntry = await dbContext.LeaderboardCaches
@@ -180,13 +176,12 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.LeaderboardType == leaderboardType
                     && l.TimeRange == timeRange
                     && l.LocationScope == "Global")
-                .FirstOrDefaultAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
 
             if (userEntry == null)
             {
                 // User not ranked - check why
-                var eventCount = await GetUserEventCountAsync(userId, timeRange, cancellationToken).ConfigureAwait(false);
+                var eventCount = await GetUserEventCountAsync(userId, timeRange, cancellationToken);
                 var ineligibleReason = eventCount < 3
                     ? $"You need to attend at least 3 events to appear on leaderboards. You have attended {eventCount} event(s)."
                     : "You are not yet ranked on this leaderboard.";
@@ -249,8 +244,7 @@ namespace TrashMob.Shared.Managers.Gamification
             return await query
                 .Select(ea => ea.EventId)
                 .Distinct()
-                .CountAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .CountAsync(cancellationToken);
         }
 
         private static DateTimeOffset GetStartDateForTimeRange(string timeRange)
@@ -303,7 +297,7 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.TimeRange == timeRange
                     && l.LocationScope == locationScope);
 
-            if (locationScope != "Global" && !string.IsNullOrEmpty(locationValue))
+            if (locationScope != "Global" && !string.IsNullOrWhiteSpace(locationValue))
             {
                 query = query.Where(l => l.LocationValue == locationValue);
             }
@@ -312,7 +306,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 query = query.Where(l => l.LocationValue == null || l.LocationValue == "");
             }
 
-            var totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+            var totalCount = await query.CountAsync(cancellationToken);
 
             var entries = await query
                 .OrderBy(l => l.Rank)
@@ -326,15 +320,13 @@ namespace TrashMob.Shared.Managers.Gamification
                     Score = l.Score,
                     FormattedScore = FormatScore(l.Score, leaderboardType)
                 })
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
-            await EnrichWithProfilePhotosAsync(entries, cancellationToken).ConfigureAwait(false);
+            await EnrichWithProfilePhotosAsync(entries, cancellationToken);
 
             var computedDate = await query
                 .Select(l => l.ComputedDate)
-                .FirstOrDefaultAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
 
             return new LeaderboardResponse
             {
@@ -371,8 +363,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .AsNoTracking()
                 .Where(t => t.Id == teamId)
                 .Select(t => new { t.Name, t.IsActive })
-                .FirstOrDefaultAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
 
             if (team == null)
             {
@@ -406,8 +397,7 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.LeaderboardType == leaderboardType
                     && l.TimeRange == timeRange
                     && l.LocationScope == "Global")
-                .CountAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .CountAsync(cancellationToken);
 
             // Get team's entry
             var teamEntry = await dbContext.LeaderboardCaches
@@ -417,13 +407,12 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.LeaderboardType == leaderboardType
                     && l.TimeRange == timeRange
                     && l.LocationScope == "Global")
-                .FirstOrDefaultAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .FirstOrDefaultAsync(cancellationToken);
 
             if (teamEntry == null)
             {
                 // Team not ranked - check why
-                var eventCount = await GetTeamEventCountAsync(teamId, timeRange, cancellationToken).ConfigureAwait(false);
+                var eventCount = await GetTeamEventCountAsync(teamId, timeRange, cancellationToken);
                 var ineligibleReason = eventCount < 3
                     ? $"Teams need at least 3 events with member participation to appear on leaderboards. This team has {eventCount} event(s)."
                     : "This team is not yet ranked on this leaderboard.";
@@ -467,8 +456,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .AsNoTracking()
                 .Where(u => userIds.Contains(u.Id))
                 .Select(u => new { u.Id, u.ProfilePhotoUrl })
-                .ToDictionaryAsync(u => u.Id, u => u.ProfilePhotoUrl, cancellationToken)
-                .ConfigureAwait(false);
+                .ToDictionaryAsync(u => u.Id, u => u.ProfilePhotoUrl, cancellationToken);
 
             foreach (var entry in userEntries)
             {
@@ -497,8 +485,7 @@ namespace TrashMob.Shared.Managers.Gamification
             return await query
                 .Select(x => x.EventId)
                 .Distinct()
-                .CountAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .CountAsync(cancellationToken);
         }
     }
 }

--- a/TrashMob.Shared/Managers/KeyVaultManager.cs
+++ b/TrashMob.Shared/Managers/KeyVaultManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Security.Cryptography.X509Certificates;
@@ -25,7 +25,7 @@
         /// <inheritdoc />
         public async Task<X509Certificate2> GetCertificateAsync(string certificateSecretName)
         {
-            var secret = await secretClient.GetSecretAsync(certificateSecretName).ConfigureAwait(false)
+            var secret = await secretClient.GetSecretAsync(certificateSecretName)
                 ?? throw new InvalidOperationException($"Unable to find certificate with secret name {certificateSecretName}");
 
             var pfxBytes = Convert.FromBase64String(secret.Value.Value);

--- a/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
@@ -75,7 +75,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         /// <inheritdoc />
         public async Task<int> HardDeleteAsync(Guid id, CancellationToken cancellationToken = default)
         {
-            await base.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            await base.DeleteAsync(id, cancellationToken);
             await imageManager.DeleteImage(id, ImageTypeEnum.LitterImage);
 
             return 1;

--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -129,7 +129,7 @@ namespace TrashMob.Shared.Managers.LitterReport
             try
             {
                 var creator = await userManager.GetUserByInternalIdAsync(litterReport.CreatedByUserId, cancellationToken);
-                if (creator == null || string.IsNullOrEmpty(creator.Email))
+                if (creator == null || string.IsNullOrWhiteSpace(creator.Email))
                 {
                     logger.LogWarning("Could not find creator for litter report {LitterReportId} to send cleaned notification", litterReport.Id);
                     return;
@@ -160,8 +160,7 @@ namespace TrashMob.Shared.Managers.LitterReport
 
                 await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.LitterReportRelated, dynamicTemplateData, recipients,
-                        cancellationToken)
-                    .ConfigureAwait(false);
+                        cancellationToken);
 
                 logger.LogInformation("Sent litter report cleaned notification to user {UserId} for report {LitterReportId}", creator.Id, litterReport.Id);
             }
@@ -227,8 +226,7 @@ namespace TrashMob.Shared.Managers.LitterReport
 
                 await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.LitterReportEmail,
                         SendGridEmailGroupId.LitterReportRelated, dynamicTemplateData, recipients,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+                        CancellationToken.None);
 
                 return newLitterReport;
             }
@@ -247,14 +245,14 @@ namespace TrashMob.Shared.Managers.LitterReport
             {
                 await dbTransaction.BeginTransactionAsync();
 
-                var instance = await Repo.GetAsync(id, cancellationToken).ConfigureAwait(false);
+                var instance = await Repo.GetAsync(id, cancellationToken);
                 if (instance == null)
                 {
                     return -1;
                 }
 
                 instance.LitterReportStatusId = (int)LitterReportStatusEnum.Cancelled;
-                await base.UpdateAsync(instance, userId, cancellationToken).ConfigureAwait(false);
+                await base.UpdateAsync(instance, userId, cancellationToken);
 
                 var ExistinglitterImages = await litterImageManager.GetByParentIdAsync(id, cancellationToken);
                 foreach (var image in ExistinglitterImages)
@@ -279,8 +277,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             return await Repo.Get(lr => lr.LitterReportStatusId == (int)LitterReportStatusEnum.New)
                 .Include(lr => lr.LitterImages)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -289,8 +286,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             return await Repo.Get(lr => lr.LitterReportStatusId == (int)LitterReportStatusEnum.Assigned)
                 .Include(lr => lr.LitterImages)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -299,8 +295,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             return await Repo.Get(lr => lr.LitterReportStatusId == (int)LitterReportStatusEnum.Cleaned)
                 .Include(lr => lr.LitterImages)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -309,8 +304,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             return await Repo.Get(lr => lr.LitterReportStatusId != (int)LitterReportStatusEnum.Cancelled)
                 .Include(lr => lr.LitterImages)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -319,8 +313,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             return await Repo.Get(lr => lr.LitterReportStatusId == (int)LitterReportStatusEnum.Cancelled)
                 .Include(lr => lr.LitterImages)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -329,8 +322,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             return await Repo.Get(lr => lr.CreatedByUserId == userId)
                 .Include(lr => lr.LitterImages)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -359,8 +351,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                 .GroupBy(li => new { li.Country, li.Region, li.City })
                 .Select(group => new Location
                     { Country = group.Key.Country, Region = group.Key.Region, City = group.Key.City })
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
 
             return locations;
         }
@@ -381,7 +372,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                                          lr.LitterImages.Any(li => li.Region == filter.Region)) &&
                                         (filter.City == null || lr.LitterImages.Any(li => li.City == filter.City)))
                 .Include(lr => lr.LitterImages.Where(f => filter.IncludeLitterImages))
-                .ToListAsync(cancellationToken).ConfigureAwait(false);
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -389,7 +380,7 @@ namespace TrashMob.Shared.Managers.LitterReport
             CancellationToken cancellationToken)
         {
             var existingInstance =
-                await Repo.GetWithNoTrackingAsync(instance.Id, cancellationToken).ConfigureAwait(false);
+                await Repo.GetWithNoTrackingAsync(instance.Id, cancellationToken);
 
             if (existingInstance == null)
             {
@@ -489,8 +480,7 @@ namespace TrashMob.Shared.Managers.LitterReport
 
                     await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.LitterReportEmail,
                             SendGridEmailGroupId.LitterReportRelated, dynamicTemplateData, recipients,
-                            CancellationToken.None)
-                        .ConfigureAwait(false);
+                            CancellationToken.None);
                 }
                 catch (Exception emailEx)
                 {

--- a/TrashMob.Shared/Managers/MapManager.cs
+++ b/TrashMob.Shared/Managers/MapManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Net;
@@ -58,7 +58,7 @@
         /// Determines if managed identity authentication should be used.
         /// Managed identity is used when AzureMapsClientId is configured.
         /// </summary>
-        private bool UseManagedIdentity => !string.IsNullOrEmpty(GetAzureMapsClientId());
+        private bool UseManagedIdentity => !string.IsNullOrWhiteSpace(GetAzureMapsClientId());
 
         /// <summary>
         /// Gets a bearer token for Azure Maps API authentication using managed identity.
@@ -66,7 +66,7 @@
         private async Task<string> GetBearerTokenAsync(CancellationToken cancellationToken = default)
         {
             var tokenRequestContext = new TokenRequestContext(new[] { AzureMapsScope });
-            var token = await tokenCredential.GetTokenAsync(tokenRequestContext, cancellationToken).ConfigureAwait(false);
+            var token = await tokenCredential.GetTokenAsync(tokenRequestContext, cancellationToken);
             return token.Token;
         }
 
@@ -97,7 +97,7 @@
             logger.LogInformation("Getting distance between two points: {0}",
                 JsonSerializer.Serialize(distanceRequest));
 
-            var response = await azureMaps.GetGreatCircleDistance(distanceRequest).ConfigureAwait(false);
+            var response = await azureMaps.GetGreatCircleDistance(distanceRequest);
 
             logger.LogInformation("Response from getting distance between two points: {0}",
                 JsonSerializer.Serialize(response));
@@ -152,7 +152,7 @@
 
             logger.LogInformation("Getting time for timezoneRequest: {0}", JsonSerializer.Serialize(timezoneRequest));
 
-            var response = await azureMaps.GetTimezoneByCoordinates(timezoneRequest).ConfigureAwait(false);
+            var response = await azureMaps.GetTimezoneByCoordinates(timezoneRequest);
 
             logger.LogInformation("Response from getting time for timezoneRequest: {0}",
                 JsonSerializer.Serialize(response));
@@ -182,7 +182,7 @@
             logger.LogInformation("Getting address for searchAddressReverseRequest: {0}",
                 JsonSerializer.Serialize(searchAddressReverseRequest));
 
-            var response = await azureMaps.GetSearchAddressReverse(searchAddressReverseRequest).ConfigureAwait(false);
+            var response = await azureMaps.GetSearchAddressReverse(searchAddressReverseRequest);
 
             logger.LogInformation("Response from getting address for searcAddressReverseRequest: {0}",
                 JsonSerializer.Serialize(response));
@@ -218,7 +218,7 @@
                 // Use managed identity with bearer token authentication
                 url = $"https://atlas.microsoft.com/search/address/json?typeahead=true&api-version=1.0&query={Uri.EscapeDataString(query)}";
 
-                var token = await GetBearerTokenAsync().ConfigureAwait(false);
+                var token = await GetBearerTokenAsync();
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 httpClient.DefaultRequestHeaders.Add("x-ms-client-id", GetAzureMapsClientId());
             }
@@ -229,12 +229,12 @@
                 url = $"https://atlas.microsoft.com/search/address/json?typeahead=true&subscription-key={subscriptionKey}&api-version=1.0&query={Uri.EscapeDataString(query)}";
             }
 
-            if (!string.IsNullOrEmpty(entityType))
+            if (!string.IsNullOrWhiteSpace(entityType))
             {
                 url += $"&entityType={Uri.EscapeDataString(entityType)}";
             }
 
-            var response = await httpClient.GetAsync(url).ConfigureAwait(false);
+            var response = await httpClient.GetAsync(url);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -242,7 +242,7 @@
                 throw new Exception($"Azure Maps search failed: {response.StatusCode}");
             }
 
-            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync();
             logger.LogInformation("Address search completed with {Length} bytes", content.Length);
 
             return content;
@@ -261,7 +261,7 @@
                 // Use managed identity with bearer token authentication
                 url = $"https://atlas.microsoft.com/search/address/reverse/json?api-version=1.0&query={latitude},{longitude}";
 
-                var token = await GetBearerTokenAsync().ConfigureAwait(false);
+                var token = await GetBearerTokenAsync();
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 httpClient.DefaultRequestHeaders.Add("x-ms-client-id", GetAzureMapsClientId());
             }
@@ -272,7 +272,7 @@
                 url = $"https://atlas.microsoft.com/search/address/reverse/json?subscription-key={subscriptionKey}&api-version=1.0&query={latitude},{longitude}";
             }
 
-            var response = await httpClient.GetAsync(url).ConfigureAwait(false);
+            var response = await httpClient.GetAsync(url);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -280,7 +280,7 @@
                 throw new Exception($"Azure Maps reverse geocode failed: {response.StatusCode}");
             }
 
-            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync();
             logger.LogInformation("Reverse geocode completed with {Length} bytes", content.Length);
 
             return content;

--- a/TrashMob.Shared/Managers/NewsletterManager.cs
+++ b/TrashMob.Shared/Managers/NewsletterManager.cs
@@ -58,7 +58,7 @@ namespace TrashMob.Shared.Managers
                 .Include(n => n.Category)
                 .AsQueryable();
 
-            if (!string.IsNullOrEmpty(status))
+            if (!string.IsNullOrWhiteSpace(status))
             {
                 query = query.Where(n => n.Status == status);
             }
@@ -176,7 +176,7 @@ namespace TrashMob.Shared.Managers
             var subscribedSet = subscribedUserIds.ToHashSet();
 
             var users = await query.ToListAsync(cancellationToken);
-            return users.Where(u => subscribedSet.Contains(u.Id) && !string.IsNullOrEmpty(u.Email));
+            return users.Where(u => subscribedSet.Contains(u.Id) && !string.IsNullOrWhiteSpace(u.Email));
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -123,8 +123,7 @@
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+                        CancellationToken.None);
 
                 instance.InvitationStatusId = (int)InvitationStatusEnum.Sent;
             }
@@ -151,13 +150,13 @@
 
                     await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
-                        CancellationToken.None).ConfigureAwait(false);
+                        CancellationToken.None);
 
                     instance.InvitationStatusId = (int)InvitationStatusEnum.Sent;
                 }
             }
 
-            var newInvitation = await base.UpdateAsync(instance, userId, cancellationToken).ConfigureAwait(false);
+            var newInvitation = await base.UpdateAsync(instance, userId, cancellationToken);
             return newInvitation;
         }
 
@@ -229,8 +228,7 @@
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+                        CancellationToken.None);
             }
             else
             {
@@ -252,8 +250,7 @@
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+                        CancellationToken.None);
             }
 
             instance.InvitationStatusId = (int)InvitationStatusEnum.Sent;

--- a/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
@@ -53,7 +53,7 @@ namespace TrashMob.Shared.Managers.Partners
         public async Task<int> HardDeleteAsync(Guid id, CancellationToken cancellationToken = default)
         {
             // Delete from database first
-            await base.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            await base.DeleteAsync(id, cancellationToken);
 
             // Then delete from blob storage
             await imageManager.DeleteImage(id, ImageTypeEnum.PartnerPhoto);

--- a/TrashMob.Shared/Managers/Partners/PartnerRequestManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerRequestManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -71,8 +71,7 @@
                 };
 
                 await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
-                        SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None)
-                    .ConfigureAwait(false);
+                        SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None);
             }
             else
             {
@@ -106,8 +105,7 @@
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+                        CancellationToken.None);
 
                 // Also gets sent to the TrashMob Admin for informational purposes
                 var message =
@@ -127,8 +125,7 @@
                 };
 
                 await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
-                        SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None)
-                    .ConfigureAwait(false);
+                        SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None);
             }
 
             return result;
@@ -138,12 +135,12 @@
         public async Task<PartnerRequest> ApproveBecomeAPartnerAsync(Guid partnerRequestId, Guid userId,
             CancellationToken cancellationToken)
         {
-            var partnerRequest = await Repo.GetAsync(partnerRequestId, cancellationToken).ConfigureAwait(false);
+            var partnerRequest = await Repo.GetAsync(partnerRequestId, cancellationToken);
             partnerRequest.PartnerRequestStatusId = (int)PartnerRequestStatusEnum.Approved;
 
-            var result = await base.UpdateAsync(partnerRequest, userId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(partnerRequest, userId, cancellationToken);
 
-            await CreatePartnerAsync(partnerRequest, cancellationToken).ConfigureAwait(false);
+            await CreatePartnerAsync(partnerRequest, cancellationToken);
 
             var partnerMessage = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.PartnerRequestAccepted.ToString());
             partnerMessage = partnerMessage.Replace("{PartnerName}", partnerRequest.Name);
@@ -162,8 +159,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(partnerSubject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.General, dynamicTemplateData, partnerRecipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.General, dynamicTemplateData, partnerRecipients, CancellationToken.None);
 
             return result;
         }
@@ -172,10 +168,10 @@
         public async Task<PartnerRequest> DenyBecomeAPartnerAsync(Guid partnerRequestId, Guid userId,
             CancellationToken cancellationToken)
         {
-            var partnerRequest = await Repo.GetAsync(partnerRequestId, cancellationToken).ConfigureAwait(false);
+            var partnerRequest = await Repo.GetAsync(partnerRequestId, cancellationToken);
             partnerRequest.PartnerRequestStatusId = (int)PartnerRequestStatusEnum.Denied;
 
-            var result = await base.UpdateAsync(partnerRequest, userId, cancellationToken).ConfigureAwait(false);
+            var result = await base.UpdateAsync(partnerRequest, userId, cancellationToken);
 
             var partnerMessage = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.PartnerRequestDeclined.ToString());
             partnerMessage = partnerMessage.Replace("{PartnerName}", partnerRequest.Name);
@@ -194,8 +190,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(partnerSubject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.General, dynamicTemplateData, partnerRecipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.General, dynamicTemplateData, partnerRecipients, CancellationToken.None);
 
             return result;
         }
@@ -212,8 +207,7 @@
             var partner = partnerRequest.ToPartner();
 
             // Add the partner record
-            var newPartner = await partnerManager.AddAsync(partner, partnerRequest.CreatedByUserId, cancellationToken)
-                .ConfigureAwait(false);
+            var newPartner = await partnerManager.AddAsync(partner, partnerRequest.CreatedByUserId, cancellationToken);
 
             // Make the creator of the partner request a registered user for the partner
             var partnerUser = new PartnerAdmin
@@ -222,8 +216,7 @@
                 UserId = partnerRequest.CreatedByUserId,
             };
 
-            await partnerUserManager.AddAsync(partnerUser, partnerRequest.CreatedByUserId, cancellationToken)
-                .ConfigureAwait(false);
+            await partnerUserManager.AddAsync(partnerUser, partnerRequest.CreatedByUserId, cancellationToken);
         }
     }
 }

--- a/TrashMob.Shared/Managers/PhotoModerationManager.cs
+++ b/TrashMob.Shared/Managers/PhotoModerationManager.cs
@@ -533,7 +533,7 @@ namespace TrashMob.Shared.Managers
 
         private async Task SendPhotoRemovedNotificationAsync(PhotoModerationItem photo, string reason, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(photo.UploaderEmail))
+            if (string.IsNullOrWhiteSpace(photo.UploaderEmail))
             {
                 return;
             }

--- a/TrashMob.Shared/Managers/PickupLocationManager.cs
+++ b/TrashMob.Shared/Managers/PickupLocationManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Collections.Generic;
@@ -144,8 +144,7 @@
             }
 
             await emailManager.SendTemplatedEmailAsync(emailSubject, SendGridEmailTemplateId.PickupEmail,
-                    SendGridEmailGroupId.EventRelated, dynamicTemplateData, recipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.EventRelated, dynamicTemplateData, recipients, CancellationToken.None);
 
             // Update the submitted status
             foreach (var pickupLocation in pickupLocations)

--- a/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
@@ -289,7 +289,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 .Get(p => p.NextFollowUpDate != null
                     && p.NextFollowUpDate <= now
                     && p.PipelineStage == 1  // Contacted
-                    && !string.IsNullOrEmpty(p.ContactEmail))
+                    && !string.IsNullOrWhiteSpace(p.ContactEmail))
                 .Take(settings.MaxFollowUpsPerRun)
                 .ToListAsync(cancellationToken);
 

--- a/TrashMob.Shared/Managers/Teams/TeamPhotoManager.cs
+++ b/TrashMob.Shared/Managers/Teams/TeamPhotoManager.cs
@@ -53,7 +53,7 @@ namespace TrashMob.Shared.Managers.Teams
         /// <inheritdoc />
         public async Task<int> HardDeleteAsync(Guid id, CancellationToken cancellationToken = default)
         {
-            await base.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            await base.DeleteAsync(id, cancellationToken);
             await imageManager.DeleteImage(id, ImageTypeEnum.TeamPhoto);
 
             return 1;

--- a/TrashMob.Shared/Managers/UserFeedbackManager.cs
+++ b/TrashMob.Shared/Managers/UserFeedbackManager.cs
@@ -54,7 +54,7 @@ namespace TrashMob.Shared.Managers
         {
             var query = Repository.Get();
 
-            if (!string.IsNullOrEmpty(status))
+            if (!string.IsNullOrWhiteSpace(status))
             {
                 query = query.Where(f => f.Status == status);
             }
@@ -107,7 +107,7 @@ namespace TrashMob.Shared.Managers
             message = message.Replace("{Description}", feedback.Description);
 
             // Add screenshot section if available
-            var screenshotSection = string.IsNullOrEmpty(feedback.ScreenshotUrl)
+            var screenshotSection = string.IsNullOrWhiteSpace(feedback.ScreenshotUrl)
                 ? string.Empty
                 : $"<p><strong>Screenshot:</strong> <a href=\"{feedback.ScreenshotUrl}\">View Screenshot</a></p>";
             message = message.Replace("{ScreenshotSection}", screenshotSection);

--- a/TrashMob.Shared/Managers/UserManager.cs
+++ b/TrashMob.Shared/Managers/UserManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Collections.Generic;
@@ -93,7 +93,7 @@
         public override async Task<User> UpdateAsync(User user, CancellationToken cancellationToken = default)
         {
             // The IsSiteAdmin flag can only be changed directly in the database, so once set, we need to preserve that, no matter what the user passes in
-            var matchedUser = await GetUserByInternalIdAsync(user.Id, cancellationToken).ConfigureAwait(false);
+            var matchedUser = await GetUserByInternalIdAsync(user.Id, cancellationToken);
             user.IsSiteAdmin = matchedUser.IsSiteAdmin;
 
             return await base.UpdateAsync(user, cancellationToken);
@@ -266,7 +266,7 @@
             }
 
             // Remove the user's profile
-            var user = await Repo.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            var user = await Repo.GetAsync(id, cancellationToken);
             var result = await Repo.DeleteAsync(user);
 
             return result;
@@ -300,8 +300,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None);
 
             // Send welcome email to new User
             var welcomeMessage = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.WelcomeToTrashMob.ToString());
@@ -320,8 +319,7 @@
             };
 
             await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
-                    SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients, CancellationToken.None)
-                .ConfigureAwait(false);
+                    SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients, CancellationToken.None);
 
             return addedUser;
         }

--- a/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
+++ b/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
@@ -211,7 +211,7 @@ namespace TrashMob.Shared.Managers
         /// </summary>
         private static string MaskEmail(string email)
         {
-            if (string.IsNullOrEmpty(email) || !email.Contains('@'))
+            if (string.IsNullOrWhiteSpace(email) || !email.Contains('@'))
             {
                 return "***";
             }

--- a/TrashMob.Shared/Managers/WaiverDocumentManager.cs
+++ b/TrashMob.Shared/Managers/WaiverDocumentManager.cs
@@ -443,7 +443,7 @@ namespace TrashMob.Shared.Managers
                     default:
                         // Try to get text content
                         var content = inline.ToString();
-                        if (!string.IsNullOrEmpty(content))
+                        if (!string.IsNullOrWhiteSpace(content))
                         {
                             text.Span(content);
                         }
@@ -477,7 +477,7 @@ namespace TrashMob.Shared.Managers
 
         private static string TruncateUserAgent(string userAgent)
         {
-            if (string.IsNullOrEmpty(userAgent))
+            if (string.IsNullOrWhiteSpace(userAgent))
             {
                 return "Not recorded";
             }

--- a/TrashMob/Controllers/AdminController.cs
+++ b/TrashMob/Controllers/AdminController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -40,8 +40,7 @@
         public async Task<IActionResult> UpdatePartnerRequest(Guid userId, PartnerRequest partnerRequest,
             CancellationToken cancellationToken)
         {
-            var result = await partnerRequestManager.UpdateAsync(partnerRequest, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await partnerRequestManager.UpdateAsync(partnerRequest, UserId, cancellationToken);
             TrackEvent(nameof(UpdatePartnerRequest));
 
             return Ok(result);
@@ -56,7 +55,7 @@
         [ProducesResponseType(typeof(IEnumerable<EmailTemplate>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEmails(CancellationToken cancellationToken)
         {
-            var result = await emailManager.GetEmailTemplatesAsync(cancellationToken).ConfigureAwait(false);
+            var result = await emailManager.GetEmailTemplatesAsync(cancellationToken);
             TrackEvent(nameof(GetEmails));
 
             return Ok(result);

--- a/TrashMob/Controllers/CmsController.cs
+++ b/TrashMob/Controllers/CmsController.cs
@@ -43,7 +43,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         public async Task<IActionResult> GetHeroSection(CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(strapiBaseUrl))
+            if (string.IsNullOrWhiteSpace(strapiBaseUrl))
             {
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured");
             }
@@ -72,7 +72,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         public async Task<IActionResult> GetWhatIsTrashmob(CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(strapiBaseUrl))
+            if (string.IsNullOrWhiteSpace(strapiBaseUrl))
             {
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured");
             }
@@ -101,7 +101,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         public async Task<IActionResult> GetGettingStarted(CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(strapiBaseUrl))
+            if (string.IsNullOrWhiteSpace(strapiBaseUrl))
             {
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured");
             }
@@ -130,7 +130,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         public IActionResult GetAdminUrl()
         {
-            if (string.IsNullOrEmpty(strapiBaseUrl))
+            if (string.IsNullOrWhiteSpace(strapiBaseUrl))
             {
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured");
             }

--- a/TrashMob/Controllers/CommunityAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunityAdoptionsController.cs
@@ -287,7 +287,7 @@ namespace TrashMob.Controllers
 
         private static string EscapeCsvField(string field)
         {
-            if (string.IsNullOrEmpty(field))
+            if (string.IsNullOrWhiteSpace(field))
             {
                 return "";
             }

--- a/TrashMob/Controllers/CommunityInvitesController.cs
+++ b/TrashMob/Controllers/CommunityInvitesController.cs
@@ -56,7 +56,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            var result = await emailInviteManager.GetCommunityBatchesAsync(communityId, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetCommunityBatchesAsync(communityId, cancellationToken);
             TrackEvent(nameof(GetBatches));
 
             return Ok(result);
@@ -82,7 +82,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
             if (result == null || result.CommunityId != communityId)
             {
@@ -129,10 +129,10 @@ namespace TrashMob.Controllers
                 "Community",
                 communityId,
                 null,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
 
             // Process the batch (send emails)
-            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken);
 
             TrackEvent(nameof(CreateBatch));
 

--- a/TrashMob/Controllers/ConfigController.cs
+++ b/TrashMob/Controllers/ConfigController.cs
@@ -24,7 +24,7 @@ namespace TrashMob.Controllers
             // Extract instrumentation key from connection string
             // Format: InstrumentationKey=xxx;IngestionEndpoint=xxx;LiveEndpoint=xxx
             string instrumentationKey = null;
-            if (!string.IsNullOrEmpty(connectionString))
+            if (!string.IsNullOrWhiteSpace(connectionString))
             {
                 foreach (var part in connectionString.Split(';'))
                 {
@@ -58,7 +58,7 @@ namespace TrashMob.Controllers
             string profileEditAuthority = null;
             string authorityDomain = null;
 
-            if (!string.IsNullOrEmpty(b2cInstance) && !string.IsNullOrEmpty(b2cDomain))
+            if (!string.IsNullOrWhiteSpace(b2cInstance) && !string.IsNullOrWhiteSpace(b2cDomain))
             {
                 var baseAuthority = $"{b2cInstance}/{b2cDomain}";
                 signUpSignInAuthority = $"{baseAuthority}/{b2cSignUpSignInPolicyId}";
@@ -113,7 +113,7 @@ namespace TrashMob.Controllers
             string authority = null;
             string authorityDomain = null;
 
-            if (!string.IsNullOrEmpty(entraInstance) && !string.IsNullOrEmpty(entraTenantId))
+            if (!string.IsNullOrWhiteSpace(entraInstance) && !string.IsNullOrWhiteSpace(entraTenantId))
             {
                 // Entra External ID authority: https://{tenant}.ciamlogin.com/{tenantId}
                 authority = $"{entraInstance}/{entraTenantId}";

--- a/TrashMob/Controllers/ContactRequestController.cs
+++ b/TrashMob/Controllers/ContactRequestController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -20,7 +20,7 @@
         [ProducesResponseType(typeof(void), 400)]
         public virtual async Task<IActionResult> Add([FromBody] ContactRequest instance, CancellationToken cancellationToken)
         {
-            await manager.AddAsync(instance, cancellationToken).ConfigureAwait(false);
+            await manager.AddAsync(instance, cancellationToken);
 
             TrackEvent("AddContactRequest");
 

--- a/TrashMob/Controllers/EmailInvitesController.cs
+++ b/TrashMob/Controllers/EmailInvitesController.cs
@@ -43,7 +43,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(typeof(IEnumerable<EmailInviteBatch>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetBatches(CancellationToken cancellationToken = default)
         {
-            var result = await emailInviteManager.GetAdminBatchesAsync(cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetAdminBatchesAsync(cancellationToken);
             TrackEvent(nameof(GetBatches));
 
             return Ok(result);
@@ -62,7 +62,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetBatch(Guid id, CancellationToken cancellationToken = default)
         {
-            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
             if (result == null)
             {
@@ -101,10 +101,10 @@ namespace TrashMob.Controllers
                 "Admin",
                 null,
                 null,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
 
             // Process the batch (send emails)
-            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken);
 
             TrackEvent(nameof(CreateBatch));
 

--- a/TrashMob/Controllers/EventAttendeeRoutesController.cs
+++ b/TrashMob/Controllers/EventAttendeeRoutesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -31,7 +31,7 @@
         [ProducesResponseType(typeof(IEnumerable<EventAttendeeRoute>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEventAttendeeRoutes(Guid eventId, Guid userId, CancellationToken cancellationToken)
         {
-            var result = (await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken).ConfigureAwait(false)).Where(e => e.CreatedByUserId == userId);
+            var result = (await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken)).Where(e => e.CreatedByUserId == userId);
 
             TrackEvent(nameof(GetEventAttendeeRoutes));
             return Ok(result);
@@ -46,7 +46,7 @@
         [ProducesResponseType(typeof(IEnumerable<DisplayEventAttendeeRoute>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEventAttendeeRoutesByEventId(Guid eventId, CancellationToken cancellationToken)
         {
-            var result = await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken).ConfigureAwait(false);
+            var result = await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken);
 
             var currentUserId = User.Identity?.IsAuthenticated == true ? UserId : Guid.Empty;
 
@@ -68,7 +68,7 @@
         [ProducesResponseType(typeof(IEnumerable<EventAttendeeRoute>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEventAttendeeRoutesByUserId(Guid userId, CancellationToken cancellationToken)
         {
-            var result = await eventAttendeeRouteManager.GetByCreatedUserIdAsync(userId, cancellationToken).ConfigureAwait(false);
+            var result = await eventAttendeeRouteManager.GetByCreatedUserIdAsync(userId, cancellationToken);
 
             TrackEvent(nameof(GetEventAttendeeRoutes));
             return Ok(result);
@@ -85,7 +85,7 @@
         [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetEventAttendeeRoute(Guid id, CancellationToken cancellationToken)
         {
-            var result = await eventAttendeeRouteManager.GetAsync(x => x.Id == id, cancellationToken).ConfigureAwait(false);
+            var result = await eventAttendeeRouteManager.GetAsync(x => x.Id == id, cancellationToken);
 
             if (result == null || result.Count() == 0)
             {
@@ -118,7 +118,7 @@
             var eventAttendeeRoute = displayEventAttendeeRoute.ToEventAttendeeRoute();
 
             var updatedEventAttendeeRoute = await eventAttendeeRouteManager
-                .UpdateAsync(eventAttendeeRoute, UserId, cancellationToken).ConfigureAwait(false);
+                .UpdateAsync(eventAttendeeRoute, UserId, cancellationToken);
             TrackEvent(nameof(UpdateEventAttendeeRoute));
 
             return Ok(updatedEventAttendeeRoute);
@@ -138,8 +138,7 @@
         {
             var eventAttendeeRoute = displayEventAttendeeRoute.ToEventAttendeeRoute();
 
-            await eventAttendeeRouteManager.AddAsync(eventAttendeeRoute, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            await eventAttendeeRouteManager.AddAsync(eventAttendeeRoute, UserId, cancellationToken);
             TrackEvent(nameof(AddEventAttendeeRoute));
             return Ok();
         }
@@ -157,7 +156,7 @@
         public async Task<IActionResult> DeleteEventAttendeeRoute(Guid routeId,
             CancellationToken cancellationToken)
         {
-            await eventAttendeeRouteManager.DeleteAsync(routeId, cancellationToken).ConfigureAwait(false);
+            await eventAttendeeRouteManager.DeleteAsync(routeId, cancellationToken);
             TrackEvent(nameof(DeleteEventAttendeeRoute));
 
             return new NoContentResult();

--- a/TrashMob/Controllers/EventAttendeesController.cs
+++ b/TrashMob/Controllers/EventAttendeesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -41,7 +41,7 @@
         public async Task<IActionResult> GetEventAttendees(Guid eventId, CancellationToken cancellationToken)
         {
             var result =
-                (await eventAttendeeManager.GetByParentIdAsync(eventId, cancellationToken).ConfigureAwait(false))
+                (await eventAttendeeManager.GetByParentIdAsync(eventId, cancellationToken))
                 .Select(u => u.User.ToDisplayUser());
             TrackEvent(nameof(GetEventAttendees));
             return Ok(result);
@@ -70,15 +70,14 @@
             try
             {
                 var updatedEventAttendee = await eventAttendeeManager
-                    .UpdateAsync(eventAttendee, UserId, cancellationToken).ConfigureAwait(false);
+                    .UpdateAsync(eventAttendee, UserId, cancellationToken);
                 TrackEvent(nameof(UpdateEventAttendee));
 
                 return Ok(updatedEventAttendee);
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!await EventAttendeeExists(eventAttendee.EventId, eventAttendee.UserId, cancellationToken)
-                        .ConfigureAwait(false))
+                if (!await EventAttendeeExists(eventAttendee.EventId, eventAttendee.UserId, cancellationToken))
                 {
                     return NotFound();
                 }
@@ -103,14 +102,12 @@
         {
             // Validate waiver compliance before registration
             var hasValidWaiver = await userWaiverManager
-                .HasValidWaiverForEventAsync(eventAttendee.UserId, eventAttendee.EventId, cancellationToken)
-                .ConfigureAwait(false);
+                .HasValidWaiverForEventAsync(eventAttendee.UserId, eventAttendee.EventId, cancellationToken);
 
             if (!hasValidWaiver)
             {
                 var requiredWaivers = await userWaiverManager
-                    .GetRequiredWaiversForEventAsync(eventAttendee.UserId, eventAttendee.EventId, cancellationToken)
-                    .ConfigureAwait(false);
+                    .GetRequiredWaiversForEventAsync(eventAttendee.UserId, eventAttendee.EventId, cancellationToken);
 
                 return BadRequest(new WaiverRequiredResponse
                 {
@@ -120,7 +117,7 @@
                 });
             }
 
-            await eventAttendeeManager.AddAsync(eventAttendee, UserId, cancellationToken).ConfigureAwait(false);
+            await eventAttendeeManager.AddAsync(eventAttendee, UserId, cancellationToken);
             TrackEvent(nameof(AddEventAttendee));
             return Ok();
         }
@@ -139,7 +136,7 @@
         public async Task<IActionResult> DeleteEventAttendee(Guid eventId, Guid userId,
             CancellationToken cancellationToken)
         {
-            await eventAttendeeManager.Delete(eventId, userId, cancellationToken).ConfigureAwait(false);
+            await eventAttendeeManager.Delete(eventId, userId, cancellationToken);
             TrackEvent(nameof(DeleteEventAttendee));
 
             return new NoContentResult();
@@ -155,7 +152,7 @@
         public async Task<IActionResult> GetEventLeads(Guid eventId, CancellationToken cancellationToken)
         {
             var result =
-                (await eventAttendeeManager.GetEventLeadsAsync(eventId, cancellationToken).ConfigureAwait(false))
+                (await eventAttendeeManager.GetEventLeadsAsync(eventId, cancellationToken))
                 .Select(ea => ea.User.ToDisplayUser());
             TrackEvent(nameof(GetEventLeads));
             return Ok(result);
@@ -252,8 +249,7 @@
             // Check if caller is event lead or admin
             var isAdmin = User.IsInRole("Admin");
             var isEventLead = await eventAttendeeManager
-                .IsEventLeadAsync(eventId, UserId, cancellationToken)
-                .ConfigureAwait(false);
+                .IsEventLeadAsync(eventId, UserId, cancellationToken);
 
             if (!isAdmin && !isEventLead)
             {
@@ -261,8 +257,7 @@
             }
 
             var hasValidWaiver = await userWaiverManager
-                .HasValidWaiverForEventAsync(userId, eventId, cancellationToken)
-                .ConfigureAwait(false);
+                .HasValidWaiverForEventAsync(userId, eventId, cancellationToken);
 
             TrackEvent(nameof(VerifyAttendeeWaiverStatus));
 
@@ -272,7 +267,7 @@
         private async Task<bool> EventAttendeeExists(Guid eventId, Guid userId, CancellationToken cancellationToken)
         {
             var attendee = await eventAttendeeManager
-                .GetAsync(ea => ea.EventId == eventId && ea.UserId == userId, cancellationToken).ConfigureAwait(false);
+                .GetAsync(ea => ea.EventId == eventId && ea.UserId == userId, cancellationToken);
 
             return attendee?.FirstOrDefault() != null;
         }

--- a/TrashMob/Controllers/EventLitterReportController.cs
+++ b/TrashMob/Controllers/EventLitterReportController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -32,8 +32,7 @@
         [ProducesResponseType(typeof(IEnumerable<EventLitterReport>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEventLitterReports(Guid eventId, CancellationToken cancellationToken)
         {
-            var result = await eventLitterReportManager.GetByParentIdAsync(eventId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await eventLitterReportManager.GetByParentIdAsync(eventId, cancellationToken);
 
             var fullEventLitterReports = await ToFullEventLitterReports(result, cancellationToken);
 
@@ -50,8 +49,7 @@
         [ProducesResponseType(typeof(FullEventLitterReport), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEventLitterReportByLitterReportId(Guid litterReportId, CancellationToken cancellationToken)
         {
-            var result = await eventLitterReportManager.GetAsync(l => l.LitterReportId == litterReportId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await eventLitterReportManager.GetAsync(l => l.LitterReportId == litterReportId, cancellationToken);
 
             var lastEventLitterReport = result.OrderByDescending(e => e.CreatedDate).FirstOrDefault();
 
@@ -84,15 +82,14 @@
             try
             {
                 var updatedEventLitterReport = await eventLitterReportManager
-                    .UpdateAsync(eventLitterReport, UserId, cancellationToken).ConfigureAwait(false);
+                    .UpdateAsync(eventLitterReport, UserId, cancellationToken);
                 TrackEvent(nameof(UpdateEventLitterReport));
 
                 return Ok(updatedEventLitterReport);
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!await EventLitterReportExists(eventLitterReport.EventId, eventLitterReport.LitterReportId, cancellationToken)
-                        .ConfigureAwait(false))
+                if (!await EventLitterReportExists(eventLitterReport.EventId, eventLitterReport.LitterReportId, cancellationToken))
                 {
                     return NotFound();
                 }
@@ -113,7 +110,7 @@
         public async Task<IActionResult> AddEventLitterReport(EventLitterReport eventLitterReport,
             CancellationToken cancellationToken)
         {
-            await eventLitterReportManager.AddAsync(eventLitterReport, UserId, cancellationToken).ConfigureAwait(false);
+            await eventLitterReportManager.AddAsync(eventLitterReport, UserId, cancellationToken);
             TrackEvent(nameof(AddEventLitterReport));
             return Ok();
         }
@@ -132,7 +129,7 @@
         public async Task<IActionResult> DeleteEventLitterReport(Guid eventId, Guid litterReportId,
             CancellationToken cancellationToken)
         {
-            await eventLitterReportManager.Delete(eventId, litterReportId, cancellationToken).ConfigureAwait(false);
+            await eventLitterReportManager.Delete(eventId, litterReportId, cancellationToken);
             TrackEvent(nameof(DeleteEventLitterReport));
 
             return new NoContentResult();
@@ -141,7 +138,7 @@
         private async Task<bool> EventLitterReportExists(Guid eventId, Guid litterReportId, CancellationToken cancellationToken)
         {
             var litterReport = await eventLitterReportManager
-                .GetAsync(ea => ea.EventId == eventId && ea.LitterReportId == litterReportId, cancellationToken).ConfigureAwait(false);
+                .GetAsync(ea => ea.EventId == eventId && ea.LitterReportId == litterReportId, cancellationToken);
 
             return litterReport?.FirstOrDefault() != null;
         }

--- a/TrashMob/Controllers/EventPartnerLocationServicesController.cs
+++ b/TrashMob/Controllers/EventPartnerLocationServicesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -114,7 +114,7 @@
             }
 
             var updatedEventPartnerLocationService = await eventPartnerLocationServiceManager
-                .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken).ConfigureAwait(false);
+                .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken);
 
             TrackEvent(nameof(UpdateEventPartnerLocationService));
 
@@ -165,7 +165,7 @@
                 (int)EventPartnerLocationServiceStatusEnum.Accepted;
 
             var updatedEventPartnerLocationService = await eventPartnerLocationServiceManager
-                .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken).ConfigureAwait(false);
+                .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken);
 
             TrackEvent(nameof(ApproveEventPartnerLocationService));
 
@@ -216,7 +216,7 @@
                 (int)EventPartnerLocationServiceStatusEnum.Declined;
 
             var updatedEventPartnerLocationService = await eventPartnerLocationServiceManager
-                .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken).ConfigureAwait(false);
+                .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken);
 
             TrackEvent(nameof(ApproveEventPartnerLocationService));
 
@@ -251,7 +251,7 @@
             }
 
             var result = await eventPartnerLocationServiceManager
-                .AddAsync(eventPartnerLocationService, UserId, cancellationToken).ConfigureAwait(false);
+                .AddAsync(eventPartnerLocationService, UserId, cancellationToken);
 
             TrackEvent(nameof(AddEventPartnerLocationService));
 
@@ -288,7 +288,7 @@
             }
 
             var result = await eventPartnerLocationServiceManager
-                .DeleteAsync(eventId, partnerLocationId, serviceTypeId, cancellationToken).ConfigureAwait(false);
+                .DeleteAsync(eventId, partnerLocationId, serviceTypeId, cancellationToken);
 
             TrackEvent(nameof(DeleteEventPartnerLocationService));
 

--- a/TrashMob/Controllers/EventRoutesController.cs
+++ b/TrashMob/Controllers/EventRoutesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -24,8 +24,7 @@
         public async Task<IActionResult> GetEventRoutes(Guid eventId, CancellationToken cancellationToken)
         {
             var routes = await eventAttendeeRouteManager
-                .GetAnonymizedRoutesForEventAsync(eventId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetAnonymizedRoutesForEventAsync(eventId, cancellationToken);
 
             TrackEvent(nameof(GetEventRoutes));
             return Ok(routes);
@@ -41,8 +40,7 @@
         public async Task<IActionResult> GetEventRouteStats(Guid eventId, CancellationToken cancellationToken)
         {
             var stats = await eventAttendeeRouteManager
-                .GetEventRouteStatsAsync(eventId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetEventRouteStatsAsync(eventId, cancellationToken);
 
             TrackEvent(nameof(GetEventRouteStats));
             return Ok(stats);

--- a/TrashMob/Controllers/EventSummariesController.cs
+++ b/TrashMob/Controllers/EventSummariesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Linq;
@@ -41,8 +41,7 @@
         public async Task<IActionResult> GetEventSummary(Guid eventId, CancellationToken cancellationToken = default)
         {
             var eventSummary =
-                (await eventSummaryManager.GetAsync(es => es.EventId == eventId, cancellationToken)
-                    .ConfigureAwait(false)).FirstOrDefault();
+                (await eventSummaryManager.GetAsync(es => es.EventId == eventId, cancellationToken)).FirstOrDefault();
 
             if (eventSummary != null)
             {
@@ -62,8 +61,7 @@
         public async Task<IActionResult> GetEventSummaryV2(Guid eventId, CancellationToken cancellationToken = default)
         {
             var eventSummary =
-                (await eventSummaryManager.GetAsync(es => es.EventId == eventId, cancellationToken)
-                    .ConfigureAwait(false)).FirstOrDefault();
+                (await eventSummaryManager.GetAsync(es => es.EventId == eventId, cancellationToken)).FirstOrDefault();
 
             if (eventSummary == null)
             {
@@ -120,8 +118,7 @@
                 return Forbid();
             }
 
-            var updatedEvent = await eventSummaryManager.UpdateAsync(eventSummary, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var updatedEvent = await eventSummaryManager.UpdateAsync(eventSummary, UserId, cancellationToken);
             TrackEvent(nameof(UpdateEventSummary));
 
             return Ok(updatedEvent);
@@ -143,8 +140,7 @@
                 return Forbid();
             }
 
-            var result = await eventSummaryManager.AddAsync(eventSummary, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await eventSummaryManager.AddAsync(eventSummary, UserId, cancellationToken);
 
             TrackEvent(nameof(AddEventSummary));
 
@@ -162,14 +158,14 @@
         [RequiredScope(Constants.TrashMobWriteScope)]
         public async Task<IActionResult> DeleteEventSummary(Guid eventId, CancellationToken cancellationToken)
         {
-            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken).ConfigureAwait(false);
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
 
             if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
                 return Forbid();
             }
 
-            await eventSummaryManager.DeleteAsync(eventId, cancellationToken).ConfigureAwait(false);
+            await eventSummaryManager.DeleteAsync(eventId, cancellationToken);
             TrackEvent(nameof(DeleteEventSummary));
 
             return Ok(eventId);

--- a/TrashMob/Controllers/EventsController.cs
+++ b/TrashMob/Controllers/EventsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -32,7 +32,7 @@
         [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEvents(CancellationToken cancellationToken)
         {
-            var result = await eventManager.GetAsync(cancellationToken).ConfigureAwait(false);
+            var result = await eventManager.GetAsync(cancellationToken);
             return Ok(result);
         }
 
@@ -45,7 +45,7 @@
         [ProducesResponseType(typeof(List<DisplayEvent>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetActiveEvents(CancellationToken cancellationToken)
         {
-            var results = await eventManager.GetActiveEventsAsync(cancellationToken).ConfigureAwait(false);
+            var results = await eventManager.GetActiveEventsAsync(cancellationToken);
 
             // CreatedByUser is already included via the manager query
             var displayResults = results
@@ -64,7 +64,7 @@
         [ProducesResponseType(typeof(List<DisplayEvent>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCompletedEvents(CancellationToken cancellationToken)
         {
-            var results = await eventManager.GetCompletedEventsAsync(cancellationToken).ConfigureAwait(false);
+            var results = await eventManager.GetCompletedEventsAsync(cancellationToken);
 
             // CreatedByUser is included via the manager query; canceled events already filtered
             var displayResults = results
@@ -84,8 +84,7 @@
         public async Task<IActionResult> GetNotCanceledEvents(CancellationToken cancellationToken)
         {
             // Use filtered query which excludes canceled events and includes CreatedByUser
-            var results = await eventManager.GetFilteredEventsAsync(new EventFilter(), cancellationToken)
-                .ConfigureAwait(false);
+            var results = await eventManager.GetFilteredEventsAsync(new EventFilter(), cancellationToken);
 
             var displayResults = results
                 .Select(e => e.ToDisplayEvent(e.CreatedByUserName ?? string.Empty))
@@ -107,7 +106,7 @@
         public async Task<IActionResult> GetEventsUserIsAttending(Guid userId, CancellationToken cancellationToken)
         {
             var result = await eventAttendeeManager
-                .GetEventsUserIsAttendingAsync(userId, cancellationToken: cancellationToken).ConfigureAwait(false);
+                .GetEventsUserIsAttendingAsync(userId, cancellationToken: cancellationToken);
             return Ok(result);
         }
 
@@ -125,10 +124,9 @@
         public async Task<IActionResult> GetUserEvents(Guid userId, bool futureEventsOnly,
             CancellationToken cancellationToken)
         {
-            var result1 = await eventManager.GetUserEventsAsync(userId, futureEventsOnly, cancellationToken)
-                .ConfigureAwait(false);
+            var result1 = await eventManager.GetUserEventsAsync(userId, futureEventsOnly, cancellationToken);
             var result2 = await eventAttendeeManager
-                .GetEventsUserIsAttendingAsync(userId, futureEventsOnly, cancellationToken).ConfigureAwait(false);
+                .GetEventsUserIsAttendingAsync(userId, futureEventsOnly, cancellationToken);
 
             var allResults = result1.Union(result2, new EventComparer());
             return Ok(allResults);
@@ -148,11 +146,9 @@
         public async Task<IActionResult> GetCanceledUserEvents(Guid userId, bool futureEventsOnly,
             CancellationToken cancellationToken)
         {
-            var result1 = await eventManager.GetCanceledUserEventsAsync(userId, futureEventsOnly, cancellationToken)
-                .ConfigureAwait(false);
+            var result1 = await eventManager.GetCanceledUserEventsAsync(userId, futureEventsOnly, cancellationToken);
             var result2 = await eventAttendeeManager
-                .GetCanceledEventsUserIsAttendingAsync(userId, futureEventsOnly, cancellationToken)
-                .ConfigureAwait(false);
+                .GetCanceledEventsUserIsAttendingAsync(userId, futureEventsOnly, cancellationToken);
 
             var allResults = result1.Union(result2, new EventComparer());
             return Ok(allResults);
@@ -167,7 +163,7 @@
         [ProducesResponseType(typeof(Event), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEvent(Guid id, CancellationToken cancellationToken = default)
         {
-            var mobEvent = await eventManager.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            var mobEvent = await eventManager.GetAsync(id, cancellationToken);
 
             if (mobEvent == null)
             {
@@ -188,7 +184,7 @@
         public async Task<IActionResult> GetFilteredEvents([FromBody] EventFilter filter,
             CancellationToken cancellationToken)
         {
-            var result = await eventManager.GetFilteredEventsAsync(filter, cancellationToken).ConfigureAwait(false);
+            var result = await eventManager.GetFilteredEventsAsync(filter, cancellationToken);
 
             if (filter.PageSize != null)
             {
@@ -211,11 +207,10 @@
         [ProducesResponseType(typeof(PaginatedList<Event>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPagedUserEvents([FromBody] EventFilter filter, Guid userId, CancellationToken cancellationToken)
         {
-            var result1 = await eventManager.GetUserEventsAsync(filter, userId, cancellationToken)
-                .ConfigureAwait(false);
+            var result1 = await eventManager.GetUserEventsAsync(filter, userId, cancellationToken);
 
             var result2 = await eventAttendeeManager
-                .GetEventsUserIsAttendingAsync(filter, userId, cancellationToken).ConfigureAwait(false);
+                .GetEventsUserIsAttendingAsync(filter, userId, cancellationToken);
 
             var allResults = result1.Union(result2, new EventComparer());
 
@@ -240,7 +235,7 @@
         public async Task<IActionResult> GetPagedFilteredEvents([FromBody] EventFilter filter,
             CancellationToken cancellationToken)
         {
-            var result = await eventManager.GetFilteredEventsAsync(filter, cancellationToken).ConfigureAwait(false);
+            var result = await eventManager.GetFilteredEventsAsync(filter, cancellationToken);
 
             if (filter.PageSize != null)
             {
@@ -270,8 +265,7 @@
         public async Task<IActionResult> GetEventLocationsByTimeRange([FromQuery] DateTimeOffset? startTime,
             [FromQuery] DateTimeOffset? endTime, CancellationToken cancellationToken)
         {
-            var result = await eventManager.GetEventLocationsByTimeRangeAsync(startTime, endTime, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await eventManager.GetEventLocationsByTimeRangeAsync(startTime, endTime, cancellationToken);
 
             return Ok(result);
         }
@@ -304,7 +298,7 @@
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!await EventExists(mobEvent.Id, cancellationToken).ConfigureAwait(false))
+                if (!await EventExists(mobEvent.Id, cancellationToken))
                 {
                     return NotFound();
                 }
@@ -325,7 +319,7 @@
         [ProducesResponseType(typeof(Event), StatusCodes.Status200OK)]
         public async Task<IActionResult> AddEvent(Event mobEvent, CancellationToken cancellationToken)
         {
-            var newEvent = await eventManager.AddAsync(mobEvent, UserId, cancellationToken).ConfigureAwait(false);
+            var newEvent = await eventManager.AddAsync(mobEvent, UserId, cancellationToken);
             TrackEvent(nameof(AddEvent));
 
             return Ok(newEvent);
@@ -345,8 +339,7 @@
         public async Task<IActionResult> DeleteEvent(EventCancellationRequest eventCancellationRequest,
             CancellationToken cancellationToken)
         {
-            var mobEvent = await eventManager.GetAsync(eventCancellationRequest.EventId, cancellationToken)
-                .ConfigureAwait(false);
+            var mobEvent = await eventManager.GetAsync(eventCancellationRequest.EventId, cancellationToken);
 
             if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLeadOrIsAdmin))
             {
@@ -354,7 +347,7 @@
             }
 
             await eventManager.DeleteAsync(eventCancellationRequest.EventId,
-                eventCancellationRequest.CancellationReason, UserId, cancellationToken).ConfigureAwait(false);
+                eventCancellationRequest.CancellationReason, UserId, cancellationToken);
             TrackEvent(nameof(DeleteEvent));
 
             return Ok(eventCancellationRequest.EventId);
@@ -362,7 +355,7 @@
 
         private async Task<bool> EventExists(Guid id, CancellationToken cancellationToken)
         {
-            var mobEvent = await eventManager.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            var mobEvent = await eventManager.GetAsync(id, cancellationToken);
 
             return mobEvent != null;
         }

--- a/TrashMob/Controllers/IFTTT/v1/UserController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/UserController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers.IFTTT
+namespace TrashMob.Controllers.IFTTT
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -34,7 +34,7 @@
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         public async Task<ActionResult> GetInfo(CancellationToken cancellationToken)
         {
-            var user = await userManager.GetAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetAsync(UserId, cancellationToken);
 
             if (user == null)
             {

--- a/TrashMob/Controllers/ImageController.cs
+++ b/TrashMob/Controllers/ImageController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -45,7 +45,7 @@
         public async Task<IActionResult> UploadImage([FromForm] ImageUpload imageUpload,
             CancellationToken cancellationToken)
         {
-            var mobEvent = await eventManager.GetAsync(imageUpload.ParentId, cancellationToken).ConfigureAwait(false);
+            var mobEvent = await eventManager.GetAsync(imageUpload.ParentId, cancellationToken);
 
             if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
@@ -70,7 +70,7 @@
         public async Task<IActionResult> DeleteImage(Guid parentId, ImageTypeEnum imageType,
             CancellationToken cancellationToken)
         {
-            var mobEvent = await eventManager.GetAsync(parentId, cancellationToken).ConfigureAwait(false);
+            var mobEvent = await eventManager.GetAsync(parentId, cancellationToken);
 
             if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {

--- a/TrashMob/Controllers/JobOpportunityController.cs
+++ b/TrashMob/Controllers/JobOpportunityController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -35,7 +35,7 @@
         [HttpGet("{jobOpportunityId}")]
         public async Task<IActionResult> Get(Guid jobOpportunityId, CancellationToken cancellationToken)
         {
-            return Ok(await Manager.GetAsync(jobOpportunityId, cancellationToken).ConfigureAwait(false));
+            return Ok(await Manager.GetAsync(jobOpportunityId, cancellationToken));
         }
 
         /// <summary>
@@ -54,7 +54,7 @@
                 return Forbid();
             }
 
-            var result = await Manager.UpdateAsync(jobOpportunity, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await Manager.UpdateAsync(jobOpportunity, UserId, cancellationToken);
             TrackEvent(nameof(Update) + typeof(JobOpportunity));
 
             return Ok(result);
@@ -76,7 +76,7 @@
                 return Forbid();
             }
 
-            var result = await Manager.AddAsync(jobOpportunity, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await Manager.AddAsync(jobOpportunity, UserId, cancellationToken);
             TrackEvent(nameof(Add) + typeof(JobOpportunity));
 
             return Ok(result);
@@ -98,7 +98,7 @@
                 return Forbid();
             }
 
-            var result = await Manager.DeleteAsync(jobOpportunityId, cancellationToken).ConfigureAwait(false);
+            var result = await Manager.DeleteAsync(jobOpportunityId, cancellationToken);
             TrackEvent(nameof(Add) + typeof(JobOpportunity));
 
             return Ok(result);

--- a/TrashMob/Controllers/KeyedController.cs
+++ b/TrashMob/Controllers/KeyedController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -38,7 +38,7 @@
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         public virtual async Task<IActionResult> Add(T instance, CancellationToken cancellationToken)
         {
-            await Manager.AddAsync(instance, UserId, cancellationToken).ConfigureAwait(false);
+            await Manager.AddAsync(instance, UserId, cancellationToken);
 
             TrackEvent("Add" + nameof(T));
 
@@ -53,7 +53,7 @@
         [HttpGet]
         public virtual async Task<IActionResult> Get(CancellationToken cancellationToken)
         {
-            var results = await Manager.GetAsync(cancellationToken).ConfigureAwait(false);
+            var results = await Manager.GetAsync(cancellationToken);
 
             TrackEvent("Get" + nameof(T));
 
@@ -69,14 +69,14 @@
         [HttpDelete("{id}")]
         public virtual async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
         {
-            var entity = await Manager.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            var entity = await Manager.GetAsync(id, cancellationToken);
 
             if (!await IsAuthorizedAsync(entity, AuthorizationPolicyConstants.UserOwnsEntity))
             {
                 return Forbid();
             }
 
-            var results = await Manager.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            var results = await Manager.DeleteAsync(id, cancellationToken);
 
             TrackEvent("Delete" + nameof(T));
 

--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         [HttpGet("{litterReportId}")]
         public async Task<IActionResult> GetLitterReport(Guid litterReportId, CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetAsync(litterReportId, cancellationToken).ConfigureAwait(false);
+            var result = await litterReportManager.GetAsync(litterReportId, cancellationToken);
             return Ok(result);
         }
 
@@ -50,7 +50,7 @@ namespace TrashMob.Controllers
         [HttpGet]
         public async Task<IActionResult> GetLitterReports(CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetAsync(cancellationToken).ConfigureAwait(false);
+            var result = await litterReportManager.GetAsync(cancellationToken);
             var fullLitterReports = await ToFullLitterReport(result, cancellationToken);
 
             return Ok(fullLitterReports);
@@ -65,7 +65,7 @@ namespace TrashMob.Controllers
         [Route("new")]
         public async Task<IActionResult> GetNewLitterReports(CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetNewLitterReportsAsync(cancellationToken).ConfigureAwait(false);
+            var result = await litterReportManager.GetNewLitterReportsAsync(cancellationToken);
             var fullLitterReports = await ToFullLitterReport(result, cancellationToken);
 
             return Ok(fullLitterReports);
@@ -80,8 +80,7 @@ namespace TrashMob.Controllers
         [Route("cleaned")]
         public async Task<IActionResult> GetCleanedLitterReports(CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetCleanedLitterReportsAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var result = await litterReportManager.GetCleanedLitterReportsAsync(cancellationToken);
             var fullLitterReports = await ToFullLitterReport(result, cancellationToken);
 
             return Ok(fullLitterReports);
@@ -96,8 +95,7 @@ namespace TrashMob.Controllers
         [Route("notcancelled")]
         public async Task<IActionResult> GetNotCancelledLitterReports(CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetNotCancelledLitterReportsAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var result = await litterReportManager.GetNotCancelledLitterReportsAsync(cancellationToken);
             var fullLitterReports = await ToFullLitterReport(result, cancellationToken);
 
             return Ok(fullLitterReports);
@@ -112,8 +110,7 @@ namespace TrashMob.Controllers
         [Route("assigned")]
         public async Task<IActionResult> GetAssignedLitterReports(CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetAssignedLitterReportsAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var result = await litterReportManager.GetAssignedLitterReportsAsync(cancellationToken);
             var fullLitterReports = await ToFullLitterReport(result, cancellationToken);
 
             return Ok(fullLitterReports);
@@ -129,8 +126,7 @@ namespace TrashMob.Controllers
         [Route("cancelled")]
         public async Task<IActionResult> GetCancelledLitterReports(CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetCancelledLitterReportsAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var result = await litterReportManager.GetCancelledLitterReportsAsync(cancellationToken);
             var fullLitterReports = await ToFullLitterReport(result, cancellationToken);
 
             return Ok(fullLitterReports);
@@ -148,8 +144,7 @@ namespace TrashMob.Controllers
         [Route("userlitterreports/{userId}")]
         public async Task<IActionResult> GetUserLitterReports(Guid userId, CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetUserLitterReportsAsync(userId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await litterReportManager.GetUserLitterReportsAsync(userId, cancellationToken);
             var fullLitterReports = await ToFullLitterReport(result, cancellationToken);
 
             return Ok(fullLitterReports);
@@ -166,8 +161,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetFilteredLitterReports([FromBody] LitterReportFilter filter,
             CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken);
 
             if (filter.PageSize != null)
             {
@@ -193,8 +187,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetPagedFilteredLitterReports([FromBody] LitterReportFilter filter,
             CancellationToken cancellationToken)
         {
-            var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken);
 
             if (filter.PageSize != null)
             {
@@ -219,7 +212,7 @@ namespace TrashMob.Controllers
             [FromQuery] DateTimeOffset? endTime, CancellationToken cancellationToken)
         {
             var result = await litterReportManager
-                .GeLitterLocationsByTimeRangeAsync(startTime, endTime, cancellationToken).ConfigureAwait(false);
+                .GeLitterLocationsByTimeRangeAsync(startTime, endTime, cancellationToken);
 
             return Ok(result);
         }
@@ -317,14 +310,14 @@ namespace TrashMob.Controllers
         [RequiredScope(Constants.TrashMobWriteScope)]
         public async Task<IActionResult> DeleteLitterReport(Guid id, CancellationToken cancellationToken)
         {
-            var litterReport = await litterReportManager.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            var litterReport = await litterReportManager.GetAsync(id, cancellationToken);
 
             if (!await IsAuthorizedAsync(litterReport, AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin))
             {
                 return Forbid();
             }
 
-            var result = await litterReportManager.DeleteAsync(id, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await litterReportManager.DeleteAsync(id, UserId, cancellationToken);
 
             if (result != -1)
             {
@@ -364,7 +357,7 @@ namespace TrashMob.Controllers
             {
                 var url = await imageManager.GetImageUrlAsync(litterImageId, ImageTypeEnum.LitterImage, imageSize, cancellationToken);
 
-                if (string.IsNullOrEmpty(url))
+                if (string.IsNullOrWhiteSpace(url))
                 {
                     return NoContent();
                 }

--- a/TrashMob/Controllers/MessageRequestController.cs
+++ b/TrashMob/Controllers/MessageRequestController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authorization;
@@ -36,7 +36,7 @@
         [RequiredScope(Constants.TrashMobWriteScope)]
         public async Task<IActionResult> SendMessageRequest(MessageRequest messageRequest)
         {
-            await messageRequestManager.SendMessageRequestAsync(messageRequest).ConfigureAwait(false);
+            await messageRequestManager.SendMessageRequestAsync(messageRequest);
 
             TrackEvent(nameof(SendMessageRequest));
 

--- a/TrashMob/Controllers/NewsletterPreferencesController.cs
+++ b/TrashMob/Controllers/NewsletterPreferencesController.cs
@@ -150,7 +150,7 @@ namespace TrashMob.Controllers
         [HttpPost("unsubscribe")]
         public async Task<IActionResult> ProcessUnsubscribe([FromBody] UnsubscribeRequest request, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(request?.Token))
+            if (string.IsNullOrWhiteSpace(request?.Token))
             {
                 return BadRequest(new { success = false, errorMessage = "Token is required." });
             }

--- a/TrashMob/Controllers/NewslettersController.cs
+++ b/TrashMob/Controllers/NewslettersController.cs
@@ -127,7 +127,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            if (string.IsNullOrEmpty(request.Subject))
+            if (string.IsNullOrWhiteSpace(request.Subject))
             {
                 return BadRequest("Subject is required.");
             }

--- a/TrashMob/Controllers/PartnerAdminInvitationsController.cs
+++ b/TrashMob/Controllers/PartnerAdminInvitationsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Linq;
@@ -131,8 +131,7 @@
                 return NotFound($"User with Email {partnerAdminInvitation.Email} not found.");
             }
 
-            var result = await partnerAdminInvitationManager.AddAsync(partnerAdminInvitation, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await partnerAdminInvitationManager.AddAsync(partnerAdminInvitation, UserId, cancellationToken);
             TrackEvent(nameof(AddPartnerAdminInvitation));
 
             return CreatedAtAction(nameof(GetPartnerAdminInvite),
@@ -159,8 +158,7 @@
             }
 
             var result = await partnerAdminInvitationManager
-                .ResendPartnerAdminInvitation(partnerAdminInvitationId, UserId, cancellationToken)
-                .ConfigureAwait(false);
+                .ResendPartnerAdminInvitation(partnerAdminInvitationId, UserId, cancellationToken);
             TrackEvent(nameof(ResendPartnerAdminInvitation));
 
             return Ok(result);
@@ -177,8 +175,7 @@
         public async Task<IActionResult> AcceptPartnerAdminInvitation(Guid partnerAdminInvitationId,
             CancellationToken cancellationToken)
         {
-            await partnerAdminInvitationManager.AcceptInvitation(partnerAdminInvitationId, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            await partnerAdminInvitationManager.AcceptInvitation(partnerAdminInvitationId, UserId, cancellationToken);
             TrackEvent(nameof(AcceptPartnerAdminInvitation));
 
             return Ok();
@@ -195,8 +192,7 @@
         public async Task<IActionResult> DeclinePartnerAdminInvitation(Guid partnerAdminInvitationId,
             CancellationToken cancellationToken)
         {
-            await partnerAdminInvitationManager.DeclineInvitation(partnerAdminInvitationId, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            await partnerAdminInvitationManager.DeclineInvitation(partnerAdminInvitationId, UserId, cancellationToken);
             TrackEvent(nameof(AcceptPartnerAdminInvitation));
 
             return Ok();
@@ -222,8 +218,7 @@
                 return Forbid();
             }
 
-            var result = await partnerAdminInvitationManager.DeleteAsync(partnerAdminInvitationId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await partnerAdminInvitationManager.DeleteAsync(partnerAdminInvitationId, cancellationToken);
             TrackEvent(nameof(AddPartnerAdminInvitation));
 
             return Ok(result);

--- a/TrashMob/Controllers/PartnerAdminsController.cs
+++ b/TrashMob/Controllers/PartnerAdminsController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 
 namespace TrashMob.Controllers
 {
@@ -155,7 +155,7 @@ namespace TrashMob.Controllers
 
             foreach (var pu in partnerAdmins)
             {
-                var user = await userManager.GetAsync(pu.UserId, cancellationToken).ConfigureAwait(false);
+                var user = await userManager.GetAsync(pu.UserId, cancellationToken);
                 users.Add(user.ToDisplayUser());
             }
 
@@ -194,8 +194,7 @@ namespace TrashMob.Controllers
                 LastUpdatedByUserId = UserId,
             };
 
-            var result = await partnerAdminManager.AddAsync(partnerUser, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await partnerAdminManager.AddAsync(partnerUser, UserId, cancellationToken);
             TrackEvent(nameof(AddPartnerUser));
 
             return CreatedAtAction(nameof(GetPartnerUser), new { partnerId, userId }, result);

--- a/TrashMob/Controllers/PartnerContactsController.cs
+++ b/TrashMob/Controllers/PartnerContactsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -106,8 +106,7 @@
                 return Forbid();
             }
 
-            var result = await partnerContactManager.UpdateAsync(partnerContact, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await partnerContactManager.UpdateAsync(partnerContact, UserId, cancellationToken);
             TrackEvent(nameof(UpdatePartnerContact));
 
             return Ok(result);
@@ -129,7 +128,7 @@
                 return Forbid();
             }
 
-            await partnerContactManager.DeleteAsync(partnerContactId, cancellationToken).ConfigureAwait(false);
+            await partnerContactManager.DeleteAsync(partnerContactId, cancellationToken);
             TrackEvent(nameof(DeletePartnerContact));
 
             return Ok(partnerContactId);

--- a/TrashMob/Controllers/PartnerController.cs
+++ b/TrashMob/Controllers/PartnerController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -33,7 +33,7 @@
         [HttpGet("{partnerId}")]
         public async Task<IActionResult> Get(Guid partnerId, CancellationToken cancellationToken)
         {
-            return Ok(await Manager.GetAsync(partnerId, cancellationToken).ConfigureAwait(false));
+            return Ok(await Manager.GetAsync(partnerId, cancellationToken));
         }
 
         /// <summary>
@@ -51,7 +51,7 @@
                 return Forbid();
             }
 
-            var result = await Manager.UpdateAsync(partner, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await Manager.UpdateAsync(partner, UserId, cancellationToken);
             TrackEvent(nameof(Update) + typeof(Partner));
 
             return Ok(result);

--- a/TrashMob/Controllers/PartnerDocumentAdminController.cs
+++ b/TrashMob/Controllers/PartnerDocumentAdminController.cs
@@ -41,7 +41,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(typeof(IEnumerable<PartnerDocument>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetAll(CancellationToken cancellationToken = default)
         {
-            var result = await manager.GetAllWithPartnerAsync(cancellationToken).ConfigureAwait(false);
+            var result = await manager.GetAllWithPartnerAsync(cancellationToken);
             TrackEvent(nameof(GetAll) + typeof(PartnerDocument));
 
             return Ok(result);

--- a/TrashMob/Controllers/PartnerDocumentsController.cs
+++ b/TrashMob/Controllers/PartnerDocumentsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -101,7 +101,7 @@
                 return Forbid();
             }
 
-            await manager.AddAsync(partnerDocument, UserId, cancellationToken).ConfigureAwait(false);
+            await manager.AddAsync(partnerDocument, UserId, cancellationToken);
             TrackEvent(nameof(Add) + typeof(PartnerDocument));
 
             return Ok();
@@ -165,11 +165,11 @@
                 ExpirationDate = expirationDate,
             };
 
-            await manager.AddAsync(document, UserId, cancellationToken).ConfigureAwait(false);
+            await manager.AddAsync(document, UserId, cancellationToken);
 
             var blobPath = await storageManager.UploadDocumentAsync(partnerId, document.Id, formFile, cancellationToken);
             document.BlobStoragePath = blobPath;
-            await manager.UpdateAsync(document, UserId, cancellationToken).ConfigureAwait(false);
+            await manager.UpdateAsync(document, UserId, cancellationToken);
 
             TrackEvent(nameof(Upload) + typeof(PartnerDocument));
 
@@ -192,7 +192,7 @@
             }
 
             var document = await manager.GetAsync(partnerDocumentId, cancellationToken);
-            if (string.IsNullOrEmpty(document?.BlobStoragePath))
+            if (string.IsNullOrWhiteSpace(document?.BlobStoragePath))
             {
                 return BadRequest("This document has no uploaded file.");
             }
@@ -236,7 +236,7 @@
                 return Forbid();
             }
 
-            var result = await manager.UpdateAsync(partnerDocument, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await manager.UpdateAsync(partnerDocument, UserId, cancellationToken);
             TrackEvent(nameof(Update) + typeof(PartnerDocument));
 
             return Ok(result);
@@ -259,12 +259,12 @@
             }
 
             var document = await manager.GetAsync(partnerDocumentId, cancellationToken);
-            if (!string.IsNullOrEmpty(document?.BlobStoragePath))
+            if (!string.IsNullOrWhiteSpace(document?.BlobStoragePath))
             {
                 await storageManager.DeleteDocumentAsync(document.BlobStoragePath, cancellationToken);
             }
 
-            await manager.DeleteAsync(partnerDocumentId, cancellationToken).ConfigureAwait(false);
+            await manager.DeleteAsync(partnerDocumentId, cancellationToken);
             TrackEvent(nameof(Delete) + typeof(PartnerDocument));
 
             return Ok(partnerDocumentId);

--- a/TrashMob/Controllers/PartnerLocationContactsController.cs
+++ b/TrashMob/Controllers/PartnerLocationContactsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -88,8 +88,7 @@
                 return Forbid();
             }
 
-            await partnerLocationContactManager.AddAsync(partnerLocationContact, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            await partnerLocationContactManager.AddAsync(partnerLocationContact, UserId, cancellationToken);
             TrackEvent(nameof(AddPartnerLocationContact));
 
             return Ok();
@@ -115,7 +114,7 @@
             }
 
             var result = await partnerLocationContactManager
-                .UpdateAsync(partnerLocationContact, UserId, cancellationToken).ConfigureAwait(false);
+                .UpdateAsync(partnerLocationContact, UserId, cancellationToken);
             TrackEvent(nameof(UpdatePartnerLocationContact));
 
             return Ok(result);
@@ -139,8 +138,7 @@
                 return Forbid();
             }
 
-            await partnerLocationContactManager.DeleteAsync(partnerLocationContactId, cancellationToken)
-                .ConfigureAwait(false);
+            await partnerLocationContactManager.DeleteAsync(partnerLocationContactId, cancellationToken);
             TrackEvent(nameof(DeletePartnerLocationContact));
 
             return Ok(partnerLocationContactId);

--- a/TrashMob/Controllers/PartnerLocationEventServicesController.cs
+++ b/TrashMob/Controllers/PartnerLocationEventServicesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -47,7 +47,7 @@
             }
 
             var events = await eventPartnerLocationServicesManager
-                .GetByPartnerLocationAsync(partnerLocationId, cancellationToken).ConfigureAwait(false);
+                .GetByPartnerLocationAsync(partnerLocationId, cancellationToken);
 
             return Ok(events);
         }
@@ -63,8 +63,7 @@
         public async Task<IActionResult> GetPartnerLocationEventServicesByUser(Guid userId,
             CancellationToken cancellationToken)
         {
-            var events = await eventPartnerLocationServicesManager.GetByUserAsync(userId, cancellationToken)
-                .ConfigureAwait(false);
+            var events = await eventPartnerLocationServicesManager.GetByUserAsync(userId, cancellationToken);
 
             return Ok(events);
         }

--- a/TrashMob/Controllers/PartnerLocationServicesController.cs
+++ b/TrashMob/Controllers/PartnerLocationServicesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -117,8 +117,7 @@
                 return Forbid();
             }
 
-            await partnerLocationServicesManager.UpdateAsync(partnerLocationService, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            await partnerLocationServicesManager.UpdateAsync(partnerLocationService, UserId, cancellationToken);
             TrackEvent(nameof(UpdatePartnerLocationService));
 
             return Ok(partnerLocationService);
@@ -143,8 +142,7 @@
                 return Forbid();
             }
 
-            await partnerLocationServicesManager.Delete(partnerLocationId, serviceTypeId, cancellationToken)
-                .ConfigureAwait(false);
+            await partnerLocationServicesManager.Delete(partnerLocationId, serviceTypeId, cancellationToken);
             TrackEvent(nameof(DeletePartnerLocationService));
 
             return Ok(partnerLocationId);

--- a/TrashMob/Controllers/PartnerLocationsController.cs
+++ b/TrashMob/Controllers/PartnerLocationsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -95,8 +95,7 @@
                 return Forbid();
             }
 
-            var result = await partnerLocationManager.AddAsync(partnerLocation, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await partnerLocationManager.AddAsync(partnerLocation, UserId, cancellationToken);
             TrackEvent(nameof(AddPartnerLocation));
 
             return CreatedAtAction(nameof(GetPartnerLocation), new { partnerLocationId = partnerLocation.Id }, result);
@@ -120,7 +119,7 @@
                 return Forbid();
             }
 
-            await partnerLocationManager.UpdateAsync(partnerLocation, UserId, cancellationToken).ConfigureAwait(false);
+            await partnerLocationManager.UpdateAsync(partnerLocation, UserId, cancellationToken);
             TrackEvent(nameof(UpdatePartnerLocation));
 
             return Ok(partnerLocation);
@@ -142,7 +141,7 @@
                 return Forbid();
             }
 
-            await partnerLocationManager.DeleteAsync(partnerLocationId, cancellationToken).ConfigureAwait(false);
+            await partnerLocationManager.DeleteAsync(partnerLocationId, cancellationToken);
             TrackEvent(nameof(DeletePartnerLocation));
 
             return Ok(partnerLocationId);

--- a/TrashMob/Controllers/PartnerRequestsController.cs
+++ b/TrashMob/Controllers/PartnerRequestsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
@@ -40,7 +40,7 @@
         public async Task<IActionResult> AddPartnerRequest(PartnerRequest partnerRequest,
             CancellationToken cancellationToken)
         {
-            await partnerRequestManager.AddAsync(partnerRequest, UserId, cancellationToken).ConfigureAwait(false);
+            await partnerRequestManager.AddAsync(partnerRequest, UserId, cancellationToken);
             TrackEvent(nameof(AddPartnerRequest));
 
             return Ok();
@@ -59,7 +59,7 @@
             CancellationToken cancellationToken)
         {
             var partnerRequest = await partnerRequestManager
-                .ApproveBecomeAPartnerAsync(partnerRequestId, UserId, cancellationToken).ConfigureAwait(false);
+                .ApproveBecomeAPartnerAsync(partnerRequestId, UserId, cancellationToken);
             TrackEvent(nameof(ApprovePartnerRequest));
 
             return Ok();
@@ -77,7 +77,7 @@
         public async Task<IActionResult> DenyPartnerRequest(Guid partnerRequestId, CancellationToken cancellationToken)
         {
             var partnerRequest = await partnerRequestManager
-                .DenyBecomeAPartnerAsync(partnerRequestId, UserId, cancellationToken).ConfigureAwait(false);
+                .DenyBecomeAPartnerAsync(partnerRequestId, UserId, cancellationToken);
 
             TrackEvent(nameof(DenyPartnerRequest));
 
@@ -108,7 +108,7 @@
         [ProducesResponseType(typeof(PartnerRequest), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPartnerRequest(Guid partnerRequestId, CancellationToken cancellationToken)
         {
-            return Ok(await partnerRequestManager.GetAsync(partnerRequestId, cancellationToken).ConfigureAwait(false));
+            return Ok(await partnerRequestManager.GetAsync(partnerRequestId, cancellationToken));
         }
 
         /// <summary>
@@ -122,8 +122,7 @@
         [ProducesResponseType(typeof(IEnumerable<PartnerRequest>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPartnerRequestsByUser(Guid userId, CancellationToken cancellationToken)
         {
-            return Ok(await partnerRequestManager.GetByCreatedUserIdAsync(userId, cancellationToken)
-                .ConfigureAwait(false));
+            return Ok(await partnerRequestManager.GetByCreatedUserIdAsync(userId, cancellationToken));
         }
     }
 }

--- a/TrashMob/Controllers/PartnerSocialMediaAccountsController.cs
+++ b/TrashMob/Controllers/PartnerSocialMediaAccountsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -82,7 +82,7 @@
                 return Forbid();
             }
 
-            await manager.AddAsync(partnerSocialMediaAccount, UserId, cancellationToken).ConfigureAwait(false);
+            await manager.AddAsync(partnerSocialMediaAccount, UserId, cancellationToken);
             TrackEvent(nameof(AddPartnerSocialMediaAccount));
 
             return Ok();
@@ -105,8 +105,7 @@
                 return Forbid();
             }
 
-            var result = await manager.UpdateAsync(partnerSocialMediaAccount, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await manager.UpdateAsync(partnerSocialMediaAccount, UserId, cancellationToken);
             TrackEvent(nameof(UpdatePartnerSocialMediaAccount));
 
             return Ok(result);
@@ -128,7 +127,7 @@
                 return Forbid();
             }
 
-            await manager.DeleteAsync(partnerSocialMediaAccountId, cancellationToken).ConfigureAwait(false);
+            await manager.DeleteAsync(partnerSocialMediaAccountId, cancellationToken);
             TrackEvent(nameof(DeletePartnerSocialMediaAccount));
 
             return Ok(partnerSocialMediaAccountId);

--- a/TrashMob/Controllers/PhotoModerationController.cs
+++ b/TrashMob/Controllers/PhotoModerationController.cs
@@ -43,8 +43,7 @@ namespace TrashMob.Controllers
             [FromQuery] int pageSize = 50,
             CancellationToken cancellationToken = default)
         {
-            var result = await photoModerationManager.GetPendingPhotosAsync(page, pageSize, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await photoModerationManager.GetPendingPhotosAsync(page, pageSize, cancellationToken);
             TrackEvent(nameof(GetPendingPhotos));
 
             return Ok(result);
@@ -66,8 +65,7 @@ namespace TrashMob.Controllers
             [FromQuery] int pageSize = 50,
             CancellationToken cancellationToken = default)
         {
-            var result = await photoModerationManager.GetFlaggedPhotosAsync(page, pageSize, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await photoModerationManager.GetFlaggedPhotosAsync(page, pageSize, cancellationToken);
             TrackEvent(nameof(GetFlaggedPhotos));
 
             return Ok(result);
@@ -89,8 +87,7 @@ namespace TrashMob.Controllers
             [FromQuery] int pageSize = 50,
             CancellationToken cancellationToken = default)
         {
-            var result = await photoModerationManager.GetRecentlyModeratedAsync(page, pageSize, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await photoModerationManager.GetRecentlyModeratedAsync(page, pageSize, cancellationToken);
             TrackEvent(nameof(GetRecentlyModerated));
 
             return Ok(result);
@@ -115,8 +112,7 @@ namespace TrashMob.Controllers
         {
             try
             {
-                var result = await photoModerationManager.ApprovePhotoAsync(photoType, id, UserId, cancellationToken)
-                    .ConfigureAwait(false);
+                var result = await photoModerationManager.ApprovePhotoAsync(photoType, id, UserId, cancellationToken);
                 TrackEvent(nameof(ApprovePhoto));
 
                 return Ok(result);
@@ -154,8 +150,7 @@ namespace TrashMob.Controllers
 
             try
             {
-                var result = await photoModerationManager.RejectPhotoAsync(photoType, id, request.Reason, UserId, cancellationToken)
-                    .ConfigureAwait(false);
+                var result = await photoModerationManager.RejectPhotoAsync(photoType, id, request.Reason, UserId, cancellationToken);
                 TrackEvent(nameof(RejectPhoto));
 
                 return Ok(result);
@@ -185,8 +180,7 @@ namespace TrashMob.Controllers
         {
             try
             {
-                var result = await photoModerationManager.DismissFlagAsync(photoType, id, UserId, cancellationToken)
-                    .ConfigureAwait(false);
+                var result = await photoModerationManager.DismissFlagAsync(photoType, id, UserId, cancellationToken);
                 TrackEvent(nameof(DismissFlag));
 
                 return Ok(result);
@@ -238,8 +232,7 @@ namespace TrashMob.Controllers
 
             try
             {
-                var result = await photoModerationManager.FlagPhotoAsync(photoType, id, request.Reason, UserId, cancellationToken)
-                    .ConfigureAwait(false);
+                var result = await photoModerationManager.FlagPhotoAsync(photoType, id, request.Reason, UserId, cancellationToken);
                 TrackEvent(nameof(FlagPhoto));
 
                 return Ok(result);

--- a/TrashMob/Controllers/PickupLocationsController.cs
+++ b/TrashMob/Controllers/PickupLocationsController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -31,7 +31,7 @@
         [HttpGet("{pickupLocationId}")]
         public async Task<IActionResult> Get(Guid pickupLocationId, CancellationToken cancellationToken)
         {
-            return Ok(await Manager.GetAsync(pickupLocationId, cancellationToken).ConfigureAwait(false));
+            return Ok(await Manager.GetAsync(pickupLocationId, cancellationToken));
         }
 
         /// <summary>
@@ -43,7 +43,7 @@
         [HttpGet("getbyevent/{eventId}")]
         public async Task<IActionResult> GetByEvent(Guid eventId, CancellationToken cancellationToken)
         {
-            return Ok(await Manager.GetByParentIdAsync(eventId, cancellationToken).ConfigureAwait(false));
+            return Ok(await Manager.GetByParentIdAsync(eventId, cancellationToken));
         }
 
         /// <summary>
@@ -55,7 +55,7 @@
         [HttpGet("getbyuser/{userId}")]
         public async Task<IActionResult> GetByUser(Guid userId, CancellationToken cancellationToken)
         {
-            return Ok(await pickupLocationManager.GetByUserAsync(userId, cancellationToken).ConfigureAwait(false));
+            return Ok(await pickupLocationManager.GetByUserAsync(userId, cancellationToken));
         }
 
         /// <summary>
@@ -95,7 +95,7 @@
             localPickupLocation.HasBeenPickedUp = pickupLocation.HasBeenPickedUp;
             localPickupLocation.HasBeenSubmitted = pickupLocation.HasBeenSubmitted; 
 
-            var result = await Manager.UpdateAsync(localPickupLocation, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await Manager.UpdateAsync(localPickupLocation, UserId, cancellationToken);
             TrackEvent(nameof(Update) + typeof(PickupLocation));
 
             return Ok(result);
@@ -112,7 +112,7 @@
         [RequiredScope(Constants.TrashMobWriteScope)]
         public async Task<IActionResult> MarkAsPickedUp(Guid pickupLocationId, CancellationToken cancellationToken)
         {
-            var pickupLocation = await Manager.GetAsync(pickupLocationId, cancellationToken).ConfigureAwait(false);
+            var pickupLocation = await Manager.GetAsync(pickupLocationId, cancellationToken);
 
             if (!await IsAuthorizedAsync(pickupLocation, AuthorizationPolicyConstants.UserIsEventLead))
             {
@@ -125,8 +125,7 @@
                 }
             }
 
-            await pickupLocationManager.MarkAsPickedUpAsync(pickupLocationId, UserId, cancellationToken)
-                .ConfigureAwait(false);
+            await pickupLocationManager.MarkAsPickedUpAsync(pickupLocationId, UserId, cancellationToken);
             TrackEvent("MarkAsPickedUp");
 
             return Ok();
@@ -150,7 +149,7 @@
                 return Forbid();
             }
 
-            var result = await Manager.AddAsync(instance, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await Manager.AddAsync(instance, UserId, cancellationToken);
 
             TrackEvent("AddPickupLocation");
 
@@ -175,7 +174,7 @@
                 return Forbid();
             }
 
-            await pickupLocationManager.SubmitPickupLocations(eventId, UserId, cancellationToken).ConfigureAwait(false);
+            await pickupLocationManager.SubmitPickupLocations(eventId, UserId, cancellationToken);
 
             TrackEvent("SubmitPickupLocations");
 
@@ -218,7 +217,7 @@
         {
             var url = await imageManager.GetImageUrlAsync(pickupLocationId, ImageTypeEnum.Pickup, ImageSizeEnum.Raw, cancellationToken);
 
-            if (string.IsNullOrEmpty(url))
+            if (string.IsNullOrWhiteSpace(url))
             {
                 return NoContent();
             }
@@ -239,7 +238,7 @@
         {
             var url = await imageManager.GetImageUrlAsync(pickupLocationId, ImageTypeEnum.Pickup, imageSize, cancellationToken);
 
-            if (string.IsNullOrEmpty(url))
+            if (string.IsNullOrWhiteSpace(url))
             {
                 return NoContent();
             }
@@ -270,7 +269,7 @@
                 }
             }
 
-            var results = await Manager.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            var results = await Manager.DeleteAsync(id, cancellationToken);
 
             TrackEvent("Delete" + nameof(PickupLocation));
 

--- a/TrashMob/Controllers/RouteMetadataController.cs
+++ b/TrashMob/Controllers/RouteMetadataController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -34,8 +34,7 @@
             CancellationToken cancellationToken)
         {
             var result = await eventAttendeeRouteManager
-                .UpdateRouteMetadataAsync(routeId, UserId, request, cancellationToken)
-                .ConfigureAwait(false);
+                .UpdateRouteMetadataAsync(routeId, UserId, request, cancellationToken);
 
             if (!result.IsSuccess)
             {

--- a/TrashMob/Controllers/SponsorPortalController.cs
+++ b/TrashMob/Controllers/SponsorPortalController.cs
@@ -157,7 +157,7 @@ namespace TrashMob.Controllers
 
         private static string EscapeCsvField(string field)
         {
-            if (string.IsNullOrEmpty(field))
+            if (string.IsNullOrWhiteSpace(field))
             {
                 return "";
             }

--- a/TrashMob/Controllers/TeamInvitesController.cs
+++ b/TrashMob/Controllers/TeamInvitesController.cs
@@ -68,7 +68,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            var result = await emailInviteManager.GetTeamBatchesAsync(teamId, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetTeamBatchesAsync(teamId, cancellationToken);
             TrackEvent(nameof(GetBatches));
 
             return Ok(result);
@@ -101,7 +101,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
             if (result == null || result.TeamId != teamId)
             {
@@ -156,10 +156,10 @@ namespace TrashMob.Controllers
                 "Team",
                 null,
                 teamId,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
 
             // Process the batch (send emails)
-            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken);
 
             TrackEvent(nameof(CreateBatch));
 

--- a/TrashMob/Controllers/TeamsController.cs
+++ b/TrashMob/Controllers/TeamsController.cs
@@ -481,7 +481,7 @@ namespace TrashMob.Controllers
             }
 
             // Delete existing logo if present
-            if (!string.IsNullOrEmpty(team.LogoUrl))
+            if (!string.IsNullOrWhiteSpace(team.LogoUrl))
             {
                 await imageManager.DeleteImage(teamId, ImageTypeEnum.TeamLogo);
             }
@@ -530,7 +530,7 @@ namespace TrashMob.Controllers
             }
 
             // Delete logo from blob storage
-            if (!string.IsNullOrEmpty(team.LogoUrl))
+            if (!string.IsNullOrWhiteSpace(team.LogoUrl))
             {
                 await imageManager.DeleteImage(teamId, ImageTypeEnum.TeamLogo);
             }

--- a/TrashMob/Controllers/UserFeedbackController.cs
+++ b/TrashMob/Controllers/UserFeedbackController.cs
@@ -148,7 +148,7 @@ namespace TrashMob.Controllers
 
             // Validate status
             var validStatuses = new[] { "New", "Reviewed", "Resolved", "Deferred" };
-            if (!string.IsNullOrEmpty(request.Status) && !Array.Exists(validStatuses, s => s.Equals(request.Status, StringComparison.OrdinalIgnoreCase)))
+            if (!string.IsNullOrWhiteSpace(request.Status) && !Array.Exists(validStatuses, s => s.Equals(request.Status, StringComparison.OrdinalIgnoreCase)))
             {
                 return BadRequest("Invalid status. Must be one of: New, Reviewed, Resolved, Deferred");
             }

--- a/TrashMob/Controllers/UserInvitesController.cs
+++ b/TrashMob/Controllers/UserInvitesController.cs
@@ -51,7 +51,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(typeof(IEnumerable<EmailInviteBatch>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetBatches(CancellationToken cancellationToken = default)
         {
-            var result = await emailInviteManager.GetUserBatchesAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetUserBatchesAsync(UserId, cancellationToken);
             TrackEvent(nameof(GetBatches));
 
             return Ok(result);
@@ -71,7 +71,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetBatch(System.Guid id, CancellationToken cancellationToken = default)
         {
-            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
             if (result == null)
             {
@@ -99,7 +99,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(typeof(UserInviteQuota), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetQuota(CancellationToken cancellationToken = default)
         {
-            var monthlyCount = await emailInviteManager.GetUserMonthlyInviteCountAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var monthlyCount = await emailInviteManager.GetUserMonthlyInviteCountAsync(UserId, cancellationToken);
             var remaining = MaxInvitesPerMonth - monthlyCount;
 
             var quota = new UserInviteQuota
@@ -145,7 +145,7 @@ namespace TrashMob.Controllers
             }
 
             // Check monthly quota
-            var monthlyCount = await emailInviteManager.GetUserMonthlyInviteCountAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var monthlyCount = await emailInviteManager.GetUserMonthlyInviteCountAsync(UserId, cancellationToken);
             var remaining = MaxInvitesPerMonth - monthlyCount;
 
             if (remaining <= 0)
@@ -177,10 +177,10 @@ namespace TrashMob.Controllers
                 "User",
                 null,
                 null,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
 
             // Process the batch (send emails)
-            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken).ConfigureAwait(false);
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken);
 
             TrackEvent(nameof(CreateBatch));
 

--- a/TrashMob/Controllers/UserRoutesController.cs
+++ b/TrashMob/Controllers/UserRoutesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System.Collections.Generic;
     using System.Threading;
@@ -28,8 +28,7 @@
         public async Task<IActionResult> GetMyRoutes(CancellationToken cancellationToken)
         {
             var routes = await eventAttendeeRouteManager
-                .GetUserRouteHistoryAsync(UserId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetUserRouteHistoryAsync(UserId, cancellationToken);
 
             TrackEvent(nameof(GetMyRoutes));
             return Ok(routes);

--- a/TrashMob/Controllers/UserWaiverController.cs
+++ b/TrashMob/Controllers/UserWaiverController.cs
@@ -60,8 +60,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var result = await userWaiverManager
-                .GetPendingWaiversForUserAsync(UserId, communityId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetPendingWaiversForUserAsync(UserId, communityId, cancellationToken);
             TrackEvent(nameof(GetRequiredWaivers));
 
             return Ok(result);
@@ -82,8 +81,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var result = await userWaiverManager
-                .GetRequiredWaiversForEventAsync(UserId, eventId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetRequiredWaiversForEventAsync(UserId, eventId, cancellationToken);
             TrackEvent(nameof(GetRequiredWaiversForEvent));
 
             return Ok(result);
@@ -101,8 +99,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetMyWaivers(CancellationToken cancellationToken = default)
         {
             var result = await userWaiverManager
-                .GetUserWaiversAsync(UserId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetUserWaiversAsync(UserId, cancellationToken);
             TrackEvent(nameof(GetMyWaivers));
 
             return Ok(result);
@@ -156,7 +153,7 @@ namespace TrashMob.Controllers
                 GuardianRelationship = request.GuardianRelationship,
             };
 
-            var result = await userWaiverManager.AcceptWaiverAsync(acceptRequest, cancellationToken).ConfigureAwait(false);
+            var result = await userWaiverManager.AcceptWaiverAsync(acceptRequest, cancellationToken);
 
             if (!result.IsSuccess)
             {
@@ -165,22 +162,20 @@ namespace TrashMob.Controllers
 
             // Generate and store PDF
             var userWaiver = result.Data;
-            var user = await userManager.GetAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetAsync(UserId, cancellationToken);
 
             try
             {
                 // Get the full waiver with version details
                 var waiverWithDetails = await userWaiverManager
-                    .GetUserWaiverWithDetailsAsync(userWaiver.Id, cancellationToken)
-                    .ConfigureAwait(false);
+                    .GetUserWaiverWithDetailsAsync(userWaiver.Id, cancellationToken);
 
                 var documentUrl = await waiverDocumentManager
-                    .GenerateAndStoreWaiverPdfAsync(waiverWithDetails, user, cancellationToken)
-                    .ConfigureAwait(false);
+                    .GenerateAndStoreWaiverPdfAsync(waiverWithDetails, user, cancellationToken);
 
                 // Update the user waiver with the document URL
                 userWaiver.DocumentUrl = documentUrl;
-                await userWaiverManager.UpdateAsync(userWaiver, cancellationToken).ConfigureAwait(false);
+                await userWaiverManager.UpdateAsync(userWaiver, cancellationToken);
             }
             catch (Exception)
             {
@@ -210,8 +205,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var waiver = await userWaiverManager
-                .GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken);
 
             if (waiver == null)
             {
@@ -246,8 +240,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var waiver = await userWaiverManager
-                .GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken);
 
             if (waiver == null)
             {
@@ -263,7 +256,7 @@ namespace TrashMob.Controllers
             // If no stored document, generate one on-the-fly
             if (string.IsNullOrWhiteSpace(waiver.DocumentUrl))
             {
-                var user = await userManager.GetAsync(waiver.UserId, cancellationToken).ConfigureAwait(false);
+                var user = await userManager.GetAsync(waiver.UserId, cancellationToken);
                 var pdfBytes = waiverDocumentManager.GenerateWaiverPdf(waiver, user);
 
                 TrackEvent(nameof(DownloadWaiverPdf));
@@ -292,8 +285,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var hasValidWaiver = await userWaiverManager
-                .HasValidWaiverForEventAsync(UserId, eventId, cancellationToken)
-                .ConfigureAwait(false);
+                .HasValidWaiverForEventAsync(UserId, eventId, cancellationToken);
 
             TrackEvent(nameof(CheckWaiversForEvent));
 
@@ -349,8 +341,7 @@ namespace TrashMob.Controllers
             if (request.EventId.HasValue)
             {
                 isEventLead = await eventAttendeeManager
-                    .IsEventLeadAsync(request.EventId.Value, UserId, cancellationToken)
-                    .ConfigureAwait(false);
+                    .IsEventLeadAsync(request.EventId.Value, UserId, cancellationToken);
             }
 
             // Event leads can only upload for their events, admins can upload for anyone
@@ -373,8 +364,7 @@ namespace TrashMob.Controllers
             };
 
             var result = await userWaiverManager
-                .UploadPaperWaiverAsync(uploadRequest, UserId, cancellationToken)
-                .ConfigureAwait(false);
+                .UploadPaperWaiverAsync(uploadRequest, UserId, cancellationToken);
 
             if (!result.IsSuccess)
             {
@@ -405,8 +395,7 @@ namespace TrashMob.Controllers
             // Check if user is event lead or admin
             var isAdmin = User.IsInRole("Admin");
             var isEventLead = await eventAttendeeManager
-                .IsEventLeadAsync(eventId, UserId, cancellationToken)
-                .ConfigureAwait(false);
+                .IsEventLeadAsync(eventId, UserId, cancellationToken);
 
             if (!isAdmin && !isEventLead)
             {
@@ -414,8 +403,7 @@ namespace TrashMob.Controllers
             }
 
             var result = await userWaiverManager
-                .GetEventAttendeeWaiverStatusAsync(eventId, cancellationToken)
-                .ConfigureAwait(false);
+                .GetEventAttendeeWaiverStatusAsync(eventId, cancellationToken);
 
             TrackEvent(nameof(GetEventAttendeeWaiverStatus));
 
@@ -426,7 +414,7 @@ namespace TrashMob.Controllers
         {
             // Check for X-Forwarded-For header (when behind a proxy/load balancer)
             var forwardedFor = Request.Headers["X-Forwarded-For"].ToString();
-            if (!string.IsNullOrEmpty(forwardedFor))
+            if (!string.IsNullOrWhiteSpace(forwardedFor))
             {
                 // X-Forwarded-For can contain multiple IPs, take the first one
                 return forwardedFor.Split(',')[0].Trim();

--- a/TrashMob/Controllers/UsersController.cs
+++ b/TrashMob/Controllers/UsersController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers
+namespace TrashMob.Controllers
 {
     using System;
     using System.Threading;
@@ -28,7 +28,7 @@
         [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
         public async Task<IActionResult> GetUsers(CancellationToken cancellationToken)
         {
-            var result = await userManager.GetAsync(cancellationToken).ConfigureAwait(false);
+            var result = await userManager.GetAsync(cancellationToken);
             return Ok(result);
         }
 
@@ -42,7 +42,7 @@
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         public async Task<IActionResult> GetUser(string userName, CancellationToken cancellationToken)
         {
-            var user = await userManager.GetUserByUserNameAsync(userName, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetUserByUserNameAsync(userName, cancellationToken);
 
             if (user == null)
             {
@@ -62,7 +62,7 @@
         [Authorize(Policy = "ValidUser")]
         public async Task<IActionResult> GetUserByEmail(string email, CancellationToken cancellationToken)
         {
-            var user = await userManager.GetUserByEmailAsync(email, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetUserByEmailAsync(email, cancellationToken);
 
             if (user == null)
             {
@@ -83,7 +83,7 @@
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         public async Task<IActionResult> VerifyUnique(Guid userId, string userName, CancellationToken cancellationToken)
         {
-            var user = await userManager.GetUserByUserNameAsync(userName, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetUserByUserNameAsync(userName, cancellationToken);
 
             if (user == null)
             {
@@ -108,7 +108,7 @@
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         public async Task<IActionResult> GetUserByInternalId(Guid id, CancellationToken cancellationToken = default)
         {
-            var user = await userManager.GetUserByInternalIdAsync(id, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetUserByInternalIdAsync(id, cancellationToken);
 
             if (user == null)
             {
@@ -131,7 +131,7 @@
         public async Task<IActionResult> PutUser(User user, CancellationToken cancellationToken)
         {
             // Users can only update themselves unless they are a site admin
-            var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
 
             if (currentUser == null)
             {
@@ -145,13 +145,13 @@
 
             try
             {
-                var updatedUser = await userManager.UpdateAsync(user, cancellationToken).ConfigureAwait(false);
+                var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
                 TrackEvent("UpdateUser");
                 return Ok(updatedUser);
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!await userManager.UserExistsAsync(user.Id, cancellationToken).ConfigureAwait(false))
+                if (!await userManager.UserExistsAsync(user.Id, cancellationToken))
                 {
                     return NotFound();
                 }
@@ -172,7 +172,7 @@
         public async Task<IActionResult> DeleteUser(Guid id, CancellationToken cancellationToken)
         {
             // Users can only delete themselves unless they are a site admin
-            var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
 
             if (currentUser == null)
             {
@@ -184,7 +184,7 @@
                 return Forbid();
             }
 
-            await userManager.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            await userManager.DeleteAsync(id, cancellationToken);
             TrackEvent(nameof(DeleteUser));
 
             return Ok(id);
@@ -201,14 +201,14 @@
         [RequiredScope(Constants.TrashMobReadScope)]
         public async Task<IActionResult> GetUserImpact(Guid userId, CancellationToken cancellationToken)
         {
-            var user = await userManager.GetUserByInternalIdAsync(userId, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetUserByInternalIdAsync(userId, cancellationToken);
 
             if (user == null)
             {
                 return NotFound();
             }
 
-            var impactStats = await metricsManager.GetUserImpactStatsAsync(userId, cancellationToken).ConfigureAwait(false);
+            var impactStats = await metricsManager.GetUserImpactStatsAsync(userId, cancellationToken);
             return Ok(impactStats);
         }
 
@@ -225,14 +225,14 @@
             [FromForm] ImageUpload imageUpload,
             CancellationToken cancellationToken)
         {
-            var user = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken).ConfigureAwait(false);
+            var user = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
             if (user == null)
             {
                 return NotFound();
             }
 
             // Delete existing profile photo if present
-            if (!string.IsNullOrEmpty(user.ProfilePhotoUrl))
+            if (!string.IsNullOrWhiteSpace(user.ProfilePhotoUrl))
             {
                 await imageManager.DeleteImage(UserId, ImageTypeEnum.UserProfilePhoto);
             }
@@ -246,7 +246,7 @@
             var imageUrl = await imageManager.GetImageUrlAsync(UserId, ImageTypeEnum.UserProfilePhoto, ImageSizeEnum.Reduced, cancellationToken);
             user.ProfilePhotoUrl = imageUrl;
 
-            var updatedUser = await userManager.UpdateAsync(user, cancellationToken).ConfigureAwait(false);
+            var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
             TrackEvent(nameof(UploadProfilePhoto));
             return Ok(updatedUser);
         }

--- a/TrashMob/Controllers/WaiverAdminController.cs
+++ b/TrashMob/Controllers/WaiverAdminController.cs
@@ -42,7 +42,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(typeof(IEnumerable<WaiverVersion>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetAll(CancellationToken cancellationToken = default)
         {
-            var result = await waiverVersionManager.GetAllAsync(cancellationToken).ConfigureAwait(false);
+            var result = await waiverVersionManager.GetAllAsync(cancellationToken);
             TrackEvent(nameof(GetAll));
 
             return Ok(result);
@@ -59,7 +59,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(typeof(IEnumerable<WaiverVersion>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetActive(CancellationToken cancellationToken = default)
         {
-            var result = await waiverVersionManager.GetActiveWaiversAsync(cancellationToken).ConfigureAwait(false);
+            var result = await waiverVersionManager.GetActiveWaiversAsync(cancellationToken);
             TrackEvent(nameof(GetActive));
 
             return Ok(result);
@@ -78,7 +78,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken = default)
         {
-            var result = await waiverVersionManager.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            var result = await waiverVersionManager.GetAsync(id, cancellationToken);
 
             if (result == null)
             {
@@ -125,7 +125,7 @@ namespace TrashMob.Controllers
                 return BadRequest("Waiver text is required.");
             }
 
-            var result = await waiverVersionManager.AddAsync(waiverVersion, UserId, cancellationToken).ConfigureAwait(false);
+            var result = await waiverVersionManager.AddAsync(waiverVersion, UserId, cancellationToken);
             TrackEvent(nameof(Create));
 
             return CreatedAtAction(nameof(Get), new { id = result.Id }, result);
@@ -154,7 +154,7 @@ namespace TrashMob.Controllers
                 return BadRequest("Waiver version ID mismatch.");
             }
 
-            var existing = await waiverVersionManager.GetAsync(id, cancellationToken).ConfigureAwait(false);
+            var existing = await waiverVersionManager.GetAsync(id, cancellationToken);
             if (existing == null)
             {
                 return NotFound();
@@ -163,7 +163,7 @@ namespace TrashMob.Controllers
             waiverVersion.LastUpdatedByUserId = UserId;
             waiverVersion.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            var result = await waiverVersionManager.UpdateAsync(waiverVersion, cancellationToken).ConfigureAwait(false);
+            var result = await waiverVersionManager.UpdateAsync(waiverVersion, cancellationToken);
             TrackEvent(nameof(Update));
 
             return Ok(result);
@@ -184,7 +184,7 @@ namespace TrashMob.Controllers
         {
             try
             {
-                await waiverVersionManager.DeactivateAsync(id, UserId, cancellationToken).ConfigureAwait(false);
+                await waiverVersionManager.DeactivateAsync(id, UserId, cancellationToken);
                 TrackEvent(nameof(Deactivate));
 
                 return NoContent();
@@ -229,8 +229,7 @@ namespace TrashMob.Controllers
             Guid communityId,
             CancellationToken cancellationToken = default)
         {
-            var result = await waiverVersionManager.GetCommunityWaiverAssignmentsAsync(communityId, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await waiverVersionManager.GetCommunityWaiverAssignmentsAsync(communityId, cancellationToken);
             TrackEvent(nameof(GetCommunityWaivers));
 
             return Ok(result);
@@ -264,7 +263,7 @@ namespace TrashMob.Controllers
                     request.WaiverId,
                     communityId,
                     UserId,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken);
                 TrackEvent(nameof(AssignWaiver));
 
                 return CreatedAtAction(nameof(GetCommunityWaivers), new { communityId }, result);
@@ -291,8 +290,7 @@ namespace TrashMob.Controllers
             Guid waiverId,
             CancellationToken cancellationToken = default)
         {
-            await waiverVersionManager.RemoveFromCommunityAsync(waiverId, communityId, cancellationToken)
-                .ConfigureAwait(false);
+            await waiverVersionManager.RemoveFromCommunityAsync(waiverId, communityId, cancellationToken);
             TrackEvent(nameof(RemoveWaiver));
 
             return NoContent();

--- a/TrashMob/Controllers/WaiverComplianceController.cs
+++ b/TrashMob/Controllers/WaiverComplianceController.cs
@@ -45,7 +45,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(typeof(WaiverComplianceSummary), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetComplianceSummary(CancellationToken cancellationToken = default)
         {
-            var result = await userWaiverManager.GetComplianceSummaryAsync(cancellationToken).ConfigureAwait(false);
+            var result = await userWaiverManager.GetComplianceSummaryAsync(cancellationToken);
             TrackEvent(nameof(GetComplianceSummary));
 
             return Ok(result);
@@ -72,7 +72,7 @@ namespace TrashMob.Controllers
             if (filter.PageSize < 1) filter.PageSize = 50;
             if (filter.PageSize > 100) filter.PageSize = 100;
 
-            var result = await userWaiverManager.GetUserWaiversFilteredAsync(filter, cancellationToken).ConfigureAwait(false);
+            var result = await userWaiverManager.GetUserWaiversFilteredAsync(filter, cancellationToken);
             TrackEvent(nameof(GetUserWaivers));
 
             return Ok(result);
@@ -95,7 +95,7 @@ namespace TrashMob.Controllers
             if (days < 1) days = 1;
             if (days > 365) days = 365;
 
-            var result = await userWaiverManager.GetUsersWithExpiringWaiversAsync(days, cancellationToken).ConfigureAwait(false);
+            var result = await userWaiverManager.GetUsersWithExpiringWaiversAsync(days, cancellationToken);
             TrackEvent(nameof(GetUsersWithExpiringWaivers));
 
             return Ok(result);
@@ -117,7 +117,7 @@ namespace TrashMob.Controllers
         {
             filter ??= new UserWaiverFilter();
 
-            var records = await userWaiverManager.GetWaiversForExportAsync(filter, cancellationToken).ConfigureAwait(false);
+            var records = await userWaiverManager.GetWaiversForExportAsync(filter, cancellationToken);
             TrackEvent(nameof(ExportWaivers));
 
             // Generate CSV
@@ -143,7 +143,7 @@ namespace TrashMob.Controllers
             Guid userWaiverId,
             CancellationToken cancellationToken = default)
         {
-            var result = await userWaiverManager.GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken).ConfigureAwait(false);
+            var result = await userWaiverManager.GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken);
 
             if (result == null)
             {
@@ -189,7 +189,7 @@ namespace TrashMob.Controllers
 
         private static string EscapeCsvField(string field)
         {
-            if (string.IsNullOrEmpty(field))
+            if (string.IsNullOrWhiteSpace(field))
             {
                 return "";
             }


### PR DESCRIPTION
## Summary
- **Remove 397 `.ConfigureAwait(false)` calls** across 61 files (39 controllers, 22 managers). ASP.NET Core doesn't use a synchronization context, so these calls add noise without any behavioral benefit.
- **Standardize `string.IsNullOrEmpty` to `string.IsNullOrWhiteSpace`** across 28 files. `IsNullOrWhiteSpace` is strictly more robust — it catches whitespace-only strings in addition to null/empty, which is always the correct behavior for validation.

Net result: **-150 lines**, cleaner async code, and tighter input validation.

## Test plan
- [x] Solution builds with 0 errors, 0 warnings
- [x] All 442 backend tests pass
- [x] Verified no remaining `.ConfigureAwait(false)` in controllers or managers
- [ ] Manual smoke test of key API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)