### PR TITLE
Standardize mobile page layouts with card styling

### DIFF
--- a/TrashMobMobile/Pages/ContactUsPage.xaml
+++ b/TrashMobMobile/Pages/ContactUsPage.xaml
@@ -11,115 +11,129 @@
              Title="Contact Us">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Grid RowDefinitions="Auto, Auto, *, Auto">
-                    <VerticalStackLayout Grid.Row="0">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
+                <Label
+                    Text="We'd love to hear from you"
+                    FontSize="Small"
+                    HorizontalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                    Margin="5,8,5,0" />
 
-                        <controls:TMEntry Text="{Binding Name}" >
-                            <controls:TMEntry.Behaviors>
-                                <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
-                                                                    x:Name="nameValidator" />
-                            </controls:TMEntry.Behaviors>
-                        </controls:TMEntry>
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Your Details" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEntry Text="{Binding Name}" >
+                                <controls:TMEntry.Behaviors>
+                                    <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
+                                                                        x:Name="nameValidator" />
+                                </controls:TMEntry.Behaviors>
+                            </controls:TMEntry>
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Email" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEntry
+                                    Text="{Binding Email}"
+                                    Keyboard="Email" >
+                                <controls:TMEntry.Behaviors>
+                                    <toolkit:MultiValidationBehavior x:Name="EmailValidator">
+                                        <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged"
+                                                                            MinimumLength="5"
+                                                                            toolkit:MultiValidationBehavior.Error="Email is required and must be at least 5 characters." />
+                                        <toolkit:EmailValidationBehavior Flags="ValidateOnValueChanged"
+                                                                             toolkit:MultiValidationBehavior.Error="Email format is invalid." />
+                                    </toolkit:MultiValidationBehavior>
+                                </controls:TMEntry.Behaviors>
+                            </controls:TMEntry>
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
+                </Border>
 
-                    <VerticalStackLayout Grid.Row="1">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Email" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-
-                        <controls:TMEntry
-                                Text="{Binding Email}"
-                                Keyboard="Email" >
-                            <controls:TMEntry.Behaviors>
-                                <toolkit:MultiValidationBehavior x:Name="EmailValidator">
-                                    <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged"
-                                                                        MinimumLength="5"
-                                                                        toolkit:MultiValidationBehavior.Error="Email is required and must be at least 5 characters." />
-                                    <toolkit:EmailValidationBehavior Flags="ValidateOnValueChanged"
-                                                                         toolkit:MultiValidationBehavior.Error="Email format is invalid." />
-                                </toolkit:MultiValidationBehavior>
-                            </controls:TMEntry.Behaviors>
-                        </controls:TMEntry>
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Message" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Message" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEditor
+                                    Text="{Binding Message}"
+                                    VerticalOptions="StartAndExpand"
+                                    MinimumHeightRequest="200">
+                                <controls:TMEditor.Behaviors>
+                                    <toolkit:TextValidationBehavior x:Name="messageValidator"
+                                                                        Flags="ValidateOnValueChanged" MinimumLength="10" />
+                                </controls:TMEditor.Behaviors>
+                            </controls:TMEditor>
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
+                </Border>
 
-                    <VerticalStackLayout Grid.Row="2">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Message" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                <Button
+                    Text="Submit"
+                    Command="{Binding SubmitMessageCommand}"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Margin="10,8,10,10">
+                    <Button.Triggers>
+                        <MultiTrigger TargetType="Button">
+                            <MultiTrigger.Conditions>
+                                <BindingCondition
+                                    Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
+                                    Value="True" />
+                                <BindingCondition
+                                    Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
+                                    Value="True" />
+                                <BindingCondition
+                                    Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
+                                    Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="IsEnabled" Value="True" />
+                        </MultiTrigger>
+                    </Button.Triggers>
+                </Button>
 
-                        <controls:TMEditor
-                                Text="{Binding Message}"
-                                VerticalOptions="StartAndExpand"
-                                MinimumHeightRequest="200">
-                            <controls:TMEditor.Behaviors>
-                                <toolkit:TextValidationBehavior x:Name="messageValidator"
-                                                                    Flags="ValidateOnValueChanged" MinimumLength="10" />
-                            </controls:TMEditor.Behaviors>
-                        </controls:TMEditor>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="3">
-                        <Button
-                            Text="Submit"
-                            Command="{Binding SubmitMessageCommand}">
-                            <Button.Triggers>
-                                <MultiTrigger TargetType="Button">
-                                    <MultiTrigger.Conditions>
-                                        <BindingCondition
-                                            Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                            Value="True" />
-                                        <BindingCondition
-                                            Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
-                                            Value="True" />
-                                        <BindingCondition
-                                            Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
-                                            Value="True" />
-                                    </MultiTrigger.Conditions>
-                                    <Setter Property="IsEnabled" Value="True" />
-                                </MultiTrigger>
-                            </Button.Triggers>
-                        </Button>
-
-                        <Label
-                            Margin="10"
-                            FontSize="Micro"
-                            VerticalOptions="Center"
-                            HorizontalOptions="Center"
-                            HorizontalTextAlignment="Center"
-                            TextColor="Red">
-                            <Label.Triggers>
-                                <MultiTrigger TargetType="Label">
-                                    <MultiTrigger.Conditions>
-                                        <BindingCondition
-                                            Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                            Value="True" />
-                                        <BindingCondition
-                                            Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
-                                            Value="True" />
-                                        <BindingCondition
-                                            Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
-                                            Value="True" />
-                                    </MultiTrigger.Conditions>
-                                    <Setter Property="IsVisible" Value="False" />
-                                </MultiTrigger>
-                                <DataTrigger TargetType="Label"
-                                             Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                             Value="False">
-                                    <Setter Property="Text" Value="Name is required and must be at least 5 characters." />
-                                </DataTrigger>
-                                <DataTrigger TargetType="Label"
-                                             Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
-                                             Value="False">
-                                    <Setter Property="Text"
-                                            Value="{Binding Source={x:Reference EmailValidator}, Path=Errors[0]}" />
-                                </DataTrigger>
-                                <DataTrigger TargetType="Label"
-                                             Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
-                                             Value="False">
-                                    <Setter Property="Text"
-                                            Value="Message is required and must be at least 10 characters." />
-                                </DataTrigger>
-                            </Label.Triggers>
-                        </Label>
-                    </VerticalStackLayout>
-                </Grid>
+                <Label
+                    Margin="10,0"
+                    FontSize="Micro"
+                    VerticalOptions="Center"
+                    HorizontalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    TextColor="Red">
+                    <Label.Triggers>
+                        <MultiTrigger TargetType="Label">
+                            <MultiTrigger.Conditions>
+                                <BindingCondition
+                                    Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
+                                    Value="True" />
+                                <BindingCondition
+                                    Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
+                                    Value="True" />
+                                <BindingCondition
+                                    Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
+                                    Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="IsVisible" Value="False" />
+                        </MultiTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
+                                     Value="False">
+                            <Setter Property="Text" Value="Name is required and must be at least 5 characters." />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
+                                     Value="False">
+                            <Setter Property="Text"
+                                    Value="{Binding Source={x:Reference EmailValidator}, Path=Errors[0]}" />
+                        </DataTrigger>
+                        <DataTrigger TargetType="Label"
+                                     Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
+                                     Value="False">
+                            <Setter Property="Text"
+                                    Value="Message is required and must be at least 10 characters." />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/CreateLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/CreateLitterReportPage.xaml
@@ -10,68 +10,82 @@
              Title="Submit Litter Report">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                <!--  Litter Report Top  -->
-                <Grid RowDefinitions="Auto, *, Auto">
-                    <VerticalStackLayout Grid.Row="0">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <controls:TMEntry Text="{Binding Name}" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <controls:TMEditor Text="{Binding Description}"  HeightRequest="100"/>
-                    </VerticalStackLayout>
+                <Label
+                    Text="Report litter in your area so it can be cleaned up"
+                    FontSize="Small"
+                    HorizontalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                    Margin="5,8,5,0" />
 
-                    <Button Grid.Row="2"
-                            Margin="10"
+                <!-- Report Details -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Report Details" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEntry Text="{Binding Name}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEditor Text="{Binding Description}" HeightRequest="100"/>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Litter Images -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Litter Images" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Label
+                            FontSize="Small"
+                            HorizontalTextAlignment="Center"
+                            IsVisible="{Binding HasNoImages}"
+                            TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                            Text="Please add between 1 and 5 images of the litter to your report." />
+
+                        <Button
                             Clicked="TakePhoto_Clicked"
                             IsEnabled="{Binding CanAddImages}"
+                            Style="{StaticResource SecondarySmallButton}"
                             Text="Add Litter Image" />
-                </Grid>
 
-                <Grid Margin="10"
-                      RowDefinitions="Auto, *">
-                    <Label Grid.Row="0"
-                           Margin="10"
-                           FontAttributes="Bold"
-                           FontSize="Small"
-                           HorizontalTextAlignment="Center"
-                           IsVisible="{Binding HasNoImages}"
-                           Text="Please add between 1 and 5 images of the litter to your report." />
+                        <CollectionView x:Name="LitterImagesCollection"
+                                        ItemsSource="{Binding LitterImageViewModels}"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                    <Border Style="{StaticResource RoundBorder}" Margin="0,4">
+                                        <Grid ColumnDefinitions="Auto, *, Auto">
+                                            <Image Grid.Column="0"
+                                                   Margin="5"
+                                                   MaximumWidthRequest="100"
+                                                   Source="{Binding FilePath}" />
+                                            <Label Grid.Column="1"
+                                                   Margin="5"
+                                                   FontSize="Small"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                                                   Text="{Binding Address.DisplayAddress}" />
+                                            <Button Grid.Column="2"
+                                                    Margin="5"
+                                                    Clicked="DeleteLitterImage_Clicked"
+                                                    HeightRequest="40"
+                                                    Text="Delete Image"
+                                                    WidthRequest="80" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
 
-                    <CollectionView x:Name="LitterImagesCollection"
-                                    Grid.Row="1"
-                                    Margin="10"
-                                    ItemsSource="{Binding LitterImageViewModels}"
-                                    SelectionMode="None">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                <Border Style="{StaticResource RoundBorder}">
-                                    <Grid ColumnDefinitions="Auto, *, Auto">
-                                        <Image Grid.Column="0"
-                                               Margin="5"
-                                               MaximumWidthRequest="100"
-                                               Source="{Binding FilePath}" />
-                                        <Label Grid.Column="1"
-                                               Margin="5"
-                                               Text="{Binding Address.DisplayAddress}" />
-                                        <Button Grid.Column="2"
-                                                Margin="5"
-                                                Clicked="DeleteLitterImage_Clicked"
-                                                HeightRequest="40"
-                                                Text="Delete Image"
-                                                WidthRequest="80" />
-                                    </Grid>
-                                </Border>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </Grid>
-
-                <Button Margin="10"
+                <Button Margin="10,8,10,10"
                         Command="{Binding SaveLitterReportCommand}"
                         IsEnabled="{Binding ReportIsValid}"
+                        Style="{StaticResource PrimaryLargeButton}"
                         Text="Save Litter Report" />
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"

--- a/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
@@ -12,33 +12,42 @@
              Title="Create Pickup Location">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                <Grid RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="*">
-                    <Label
-                        Text="To add a pickup location, click the Take Photo button. The location will be auto-determined from that."
-                        Grid.Row="0" FontSize="Micro" Margin="10" HorizontalTextAlignment="Center"
-                        HorizontalOptions="Center" />
-                    <Button Text="Take Photo" Clicked="TakePhoto_Clicked" Grid.Row="1" Margin="10" />
-                    <VerticalStackLayout Grid.Row="2">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <controls:TMEntry Text="{Binding PickupLocationViewModel.Name}">
-                            <controls:TMEntry.Behaviors>
-                                <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
-                                                                    x:Name="nameValidator" />
-                            </controls:TMEntry.Behaviors>
-                        </controls:TMEntry>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="3">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
-                            <controls:TMEditor.Behaviors>
+                <Label
+                    Text="Take a photo to auto-detect the pickup location"
+                    FontSize="Small"
+                    HorizontalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                    Margin="5,8,5,0" />
+
+                <!-- Details -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Details" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Button Text="Take Photo" Clicked="TakePhoto_Clicked"
+                                Style="{StaticResource SecondarySmallButton}" />
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEntry Text="{Binding PickupLocationViewModel.Name}">
+                                <controls:TMEntry.Behaviors>
+                                    <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
+                                                                        x:Name="nameValidator" />
+                                </controls:TMEntry.Behaviors>
+                            </controls:TMEntry>
+                        </VerticalStackLayout>
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
+                                <controls:TMEditor.Behaviors>
                                     <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"
-                                                                    x:Name="notesValidator" />
+                                                                        x:Name="notesValidator" />
                                 </controls:TMEditor.Behaviors>
                             </controls:TMEditor>
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
-                </Grid>
+                </Border>
 
                 <Image x:Name="pickupPhoto" IsVisible="false" MaximumHeightRequest="200" />
 
@@ -53,30 +62,43 @@
                     </maps:Map.ItemTemplate>
                 </controls:CustomMap>
 
-                <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *">
-                    <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2">
-                        <Label Text="Address" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding PickupLocationViewModel.Address.StreetAddress }" FontSize="Micro" />
+                <!-- Location -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Location" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *" ColumnSpacing="12" RowSpacing="8">
+                            <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2" Spacing="2">
+                                <Label Text="Address" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.StreetAddress}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="1" Grid.Column="0" Spacing="2">
+                                <Label Text="City" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.City}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="2">
+                                <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.Region}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="2" Grid.Column="0" Spacing="2">
+                                <Label Text="Country" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.Country}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="2" Grid.Column="1" Spacing="2">
+                                <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.PostalCode}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                        </Grid>
                     </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1" Grid.Column="0">
-                        <Label Text="City" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding PickupLocationViewModel.Address.City }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1" Grid.Column="1">
-                        <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding PickupLocationViewModel.Address.Region }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2" Grid.Column="0">
-                        <Label Text="Country" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding PickupLocationViewModel.Address.Country }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2" Grid.Column="1">
-                        <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding PickupLocationViewModel.Address.PostalCode }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                </Grid>
+                </Border>
 
-                <Button Text="Save Pickup Location" Command="{Binding SavePickupLocationCommand}" Margin="10">
+                <Button Text="Save Pickup Location" Command="{Binding SavePickupLocationCommand}"
+                        Style="{StaticResource PrimaryLargeButton}"
+                        Margin="10,8,10,10">
                     <Button.Triggers>
                         <MultiTrigger TargetType="Button">
                             <MultiTrigger.Conditions>

--- a/TrashMobMobile/Pages/EditEventSummaryPage.xaml
+++ b/TrashMobMobile/Pages/EditEventSummaryPage.xaml
@@ -10,70 +10,78 @@
              Title="Event Summary">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Grid RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="*">
-                    <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*" Grid.Row="0">
-                        <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *">
-                                <Label Text="Please lets us know what TrashMob volunteers accomplished at this event!"
-                                   Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" FontSize="Micro"
-                                   Margin="0, 0, 0, 10" />
-                                <Image Grid.Row="1" Grid.Column="0" Source="person" MaximumWidthRequest="25" />
-                                <controls:TMEntry Grid.Row="2" Grid.Column="0" Padding="5"
-                                   Text="{ Binding EventSummaryViewModel.ActualNumberOfAttendees }" Keyboard="Numeric" />
-                                <Label Grid.Row="3" Grid.Column="0" Text="Attendees" FontSize="Micro"
-                                   HorizontalTextAlignment="Center" />
-                                <Image Grid.Row="1" Grid.Column="1" Source="trashbag" WidthRequest="25" />
-                                <controls:TMEntry Grid.Row="2" Grid.Column="1" Padding="5" Text="{ Binding EventSummaryViewModel.NumberOfBags }"
-                                   Keyboard="Numeric" />
-                                <Label Grid.Row="3" Grid.Column="1" Text="Bags Collected" FontSize="Micro"
-                                   HorizontalTextAlignment="Center" />
-                                <Image Grid.Row="1" Grid.Column="2" Source="clock" WidthRequest="25" />
-                                <controls:TMEntry Grid.Row="2" Grid.Column="2" Padding="5"
-                                   Text="{ Binding EventSummaryViewModel.DurationInMinutes }" Keyboard="Numeric" />
-                                <Label Grid.Row="3" Grid.Column="2" Text="Duration in Minutes" FontSize="Micro"
-                                   HorizontalTextAlignment="Center" />
-                            </Grid>
-                        </Border>
-                    </Grid>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                    <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Margin="0,10">
-                        <VerticalStackLayout>
-                            <Label Text="Weight Collected (optional)" Style="{StaticResource FieldLabel}" Margin="0,0,0,5" />
-                            <HorizontalStackLayout Spacing="10" HorizontalOptions="Center">
-                                <controls:TMEntry
-                                    Text="{Binding EventSummaryViewModel.PickedWeight}"
-                                    Keyboard="Numeric"
-                                    WidthRequest="100"
-                                    Placeholder="0.0" />
-                                <Picker
-                                    ItemsSource="{Binding WeightUnits}"
-                                    ItemDisplayBinding="{Binding Name}"
-                                    SelectedItem="{Binding SelectedWeightUnit}"
-                                    WidthRequest="80" />
-                            </HorizontalStackLayout>
-                            <Label Text="A full 33-gallon bag typically weighs 15-25 lbs"
-                                   FontSize="Micro"
-                                   TextColor="{StaticResource Gray400}"
-                                   HorizontalTextAlignment="Center"
-                                   Margin="0,5,0,0" />
-                        </VerticalStackLayout>
-                    </Border>
+                <Label
+                    Text="Tell us what your volunteers accomplished"
+                    FontSize="Small"
+                    HorizontalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                    Margin="5,8,5,0" />
 
-                    <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Notes" Style="{StaticResource FieldLabel}" />
+                <!-- Event Metrics -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Event Metrics" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *, *" ColumnSpacing="8">
+                            <Image Grid.Row="0" Grid.Column="0" Source="person" MaximumWidthRequest="25" />
+                            <controls:TMEntry Grid.Row="1" Grid.Column="0" Padding="5"
+                               Text="{ Binding EventSummaryViewModel.ActualNumberOfAttendees }" Keyboard="Numeric" />
+                            <Label Grid.Row="2" Grid.Column="0" Text="Attendees" FontSize="Micro"
+                               HorizontalTextAlignment="Center" />
+                            <Image Grid.Row="0" Grid.Column="1" Source="trashbag" WidthRequest="25" />
+                            <controls:TMEntry Grid.Row="1" Grid.Column="1" Padding="5" Text="{ Binding EventSummaryViewModel.NumberOfBags }"
+                               Keyboard="Numeric" />
+                            <Label Grid.Row="2" Grid.Column="1" Text="Bags Collected" FontSize="Micro"
+                               HorizontalTextAlignment="Center" />
+                            <Image Grid.Row="0" Grid.Column="2" Source="clock" WidthRequest="25" />
+                            <controls:TMEntry Grid.Row="1" Grid.Column="2" Padding="5"
+                               Text="{ Binding EventSummaryViewModel.DurationInMinutes }" Keyboard="Numeric" />
+                            <Label Grid.Row="2" Grid.Column="2" Text="Duration (min)" FontSize="Micro"
+                               HorizontalTextAlignment="Center" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Weight Collected -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Weight Collected" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <HorizontalStackLayout Spacing="10" HorizontalOptions="Center">
+                            <controls:TMEntry
+                                Text="{Binding EventSummaryViewModel.PickedWeight}"
+                                Keyboard="Numeric"
+                                WidthRequest="100"
+                                Placeholder="0.0" />
+                            <Picker
+                                ItemsSource="{Binding WeightUnits}"
+                                ItemDisplayBinding="{Binding Name}"
+                                SelectedItem="{Binding SelectedWeightUnit}"
+                                WidthRequest="80" />
+                        </HorizontalStackLayout>
+                        <Label Text="A full 33-gallon bag typically weighs 15-25 lbs"
+                               FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                               HorizontalTextAlignment="Center" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Notes -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Notes" Style="{StaticResource SectionHeader}" Margin="0" />
                         <controls:TMEntry
                             Text="{Binding EventSummaryViewModel.Notes}"
                             VerticalOptions="StartAndExpand"
-                            MinimumHeightRequest="200"
-                            HorizontalTextAlignment="Center"/>
+                            MinimumHeightRequest="200" />
                     </VerticalStackLayout>
+                </Border>
 
-                    <Button Text="Save Event Summary" Command="{Binding SaveEventSummaryCommand}" Grid.Row="3"
-                        IsVisible="{Binding EnableSaveEventSummary}"
-                        Style="{StaticResource PrimarySmallButton}"
-                        Margin="10" />
-                </Grid>
+                <Button Text="Save Event Summary" Command="{Binding SaveEventSummaryCommand}"
+                    IsVisible="{Binding EnableSaveEventSummary}"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Margin="10,8,10,10" />
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/EditLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/EditLitterReportPage.xaml
@@ -11,88 +11,92 @@
              Title="Edit Litter Report">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                <Grid RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="*, *">
-                    <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <controls:TMEntry Text="{Binding Name}" />
+                <!-- Report Details -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Report Details" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEntry Text="{Binding Name}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEditor Text="{Binding Description}" HeightRequest="100"/>
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="2">
+                            <Label Text="Status" Style="{StaticResource FieldLabel}" />
+                            <Label
+                                    Text="{Binding LitterReportStatus}"
+                                    FontSize="Small"
+                                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                        <Grid ColumnDefinitions="*, *" ColumnSpacing="12">
+                            <Button Grid.Column="0"
+                                    Clicked="TakePhoto_Clicked"
+                                    Style="{StaticResource PrimarySmallButton}"
+                                    IsEnabled="{Binding CanAddImages}"
+                                    Text="Add Litter Image" />
+                            <Button Grid.Column="1"
+                                    Command="{Binding SaveLitterReportCommand}"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    IsEnabled="{Binding ReportIsValid}"
+                                    Text="Save Litter Report" />
+                        </Grid>
                     </VerticalStackLayout>
+                </Border>
 
-                    <VerticalStackLayout Grid.Row="1" Grid.ColumnSpan="2">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <controls:TMEditor Text="{Binding Description}" HeightRequest="100"/>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2" Grid.ColumnSpan="2">
-                        <Label Text="Status" Style="{StaticResource FieldLabel}" />
+                <!-- Litter Images -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Litter Images" Style="{StaticResource SectionHeader}" Margin="0" />
                         <Label
-                                Text="{Binding LitterReportStatus}"
-                                VerticalOptions="Center"
-                                HorizontalOptions="Start"
-                                HorizontalTextAlignment="Center" />
+                            FontSize="Small"
+                            HorizontalTextAlignment="Center"
+                            IsVisible="{Binding HasNoImages}"
+                            TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                            Text="Please add between 1 and 5 images of the litter to your report." />
+
+                        <controls:CustomMap x:Name="litterReportLocationMap"
+                                  ItemsSource="{Binding LitterImageViewModels}">
+                            <maps:Map.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                    <controls:CustomPin Location="{Binding Address.Location}"
+                                              Address="{Binding Address.StreetAddress}"
+                                              ImageSource="{Binding Address.IconFile}"
+                                              Label="Litter Image" />
+                                </DataTemplate>
+                            </maps:Map.ItemTemplate>
+                        </controls:CustomMap>
+
+                        <CollectionView x:Name="LitterImagesCollection"
+                                        ItemsSource="{Binding LitterImageViewModels}"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                    <Border Style="{StaticResource RoundBorder}" Margin="0,4">
+                                        <Grid ColumnDefinitions="Auto, *, Auto"
+                                              x:Name="LitterImageItem">
+                                            <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="100"
+                                                   Grid.Column="0" />
+                                            <Label Grid.Column="1" Margin="5"
+                                                   FontSize="Small"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                                                   Text="{Binding Address.DisplayAddress}" />
+                                            <Button Grid.Column="2"
+                                                    Margin="5"
+                                                    Clicked="DeleteLitterImage_Clicked"
+                                                    HeightRequest="40"
+                                                    Text="Delete Image"
+                                                    WidthRequest="80" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
                     </VerticalStackLayout>
-
-                    <Button Grid.Row="3" Grid.Column="0"
-                            Margin="10"
-                            Clicked="TakePhoto_Clicked"
-                            Style="{StaticResource PrimarySmallButton}"
-                            IsEnabled="{Binding CanAddImages}"
-                            Text="Add Litter Image" />
-
-                    <Button Grid.Row="3" Grid.Column="1" Margin="10"
-                            Command="{Binding SaveLitterReportCommand}"
-                            Style="{StaticResource SecondarySmallButton}"
-                            IsEnabled="{Binding ReportIsValid}"
-                            Text="Save Litter Report" />
-                </Grid>
-
-                <Grid Margin="10"
-                      RowDefinitions="Auto, Auto, *">
-                    <Label Grid.Row="0"
-                           Margin="10"
-                           FontAttributes="Bold"
-                           FontSize="Small"
-                           HorizontalTextAlignment="Center"
-                           IsVisible="{Binding HasNoImages}"
-                           Text="Please add between 1 and 5 images of the litter to your report." />
-
-                    <controls:CustomMap Grid.Row="1" x:Name="litterReportLocationMap"
-                              ItemsSource="{Binding LitterImageViewModels}">
-                        <maps:Map.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                <controls:CustomPin Location="{Binding Address.Location}"
-                                          Address="{Binding Address.StreetAddress}"
-                                          ImageSource="{Binding Address.IconFile}"
-                                          Label="Litter Image" />
-                            </DataTemplate>
-                        </maps:Map.ItemTemplate>
-                    </controls:CustomMap>
-
-                    <CollectionView x:Name="LitterImagesCollection" Grid.Row="2"
-                                    ItemsSource="{Binding LitterImageViewModels}"
-                                    SelectionMode="None">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                <Border Style="{StaticResource RoundBorder}">
-                                    <Grid WidthRequest="400"
-                                          ColumnDefinitions="*, *, *"
-                                          RowDefinitions="Auto"
-                                          x:Name="LitterImageItem">
-                                        <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="100"
-                                               Grid.Column="0" Grid.RowSpan="5" />
-                                        <Label Grid.Row="0" Grid.Column="1" Text="{Binding Address.DisplayAddress }" />
-                                        <Button Grid.Column="2"
-                                                Margin="5"
-                                                Clicked="DeleteLitterImage_Clicked"
-                                                HeightRequest="40"
-                                                Text="Delete Image"
-                                                WidthRequest="80" />
-                                    </Grid>
-                                </Border>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </Grid>
+                </Border>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/EditPickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/EditPickupLocationPage.xaml
@@ -11,33 +11,36 @@
              Title="Edit Pickup Location">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Grid RowDefinitions="Auto, Auto" ColumnDefinitions="*">
-                    <VerticalStackLayout Grid.Row="0">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <Border Style="{x:StaticResource RoundBorder}">
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
+
+                <!-- Details -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Details" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                             <controls:TMEntry Text="{Binding PickupLocationViewModel.Name}">
                                 <controls:TMEntry.Behaviors>
                                     <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
                                                                     x:Name="nameValidator" />
                                 </controls:TMEntry.Behaviors>
                             </controls:TMEntry>
-                        </Border>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <Border Style="{x:StaticResource RoundBorder}">
+                        </VerticalStackLayout>
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                             <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
                                 <controls:TMEditor.Behaviors>
                                     <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"
                                                                     x:Name="notesValidator" />
                                 </controls:TMEditor.Behaviors>
                             </controls:TMEditor>
-                        </Border>
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
-                </Grid>
+                </Border>
 
-                <Button Text="Save Pickup Location" Command="{Binding SavePickupLocationCommand}" Margin="10">
+                <Button Text="Save Pickup Location" Command="{Binding SavePickupLocationCommand}"
+                        Style="{StaticResource PrimaryLargeButton}"
+                        Margin="10,8,10,10">
                     <Button.Triggers>
                         <MultiTrigger TargetType="Button">
                             <MultiTrigger.Conditions>

--- a/TrashMobMobile/Pages/SearchLitterReportsPage.xaml
+++ b/TrashMobMobile/Pages/SearchLitterReportsPage.xaml
@@ -9,86 +9,93 @@
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
              Title="Search Litter Reports">
     <Grid>
-        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
             <Grid RowDefinitions="Auto, Auto, Auto, *">
-                <Grid RowDefinitions="Auto, Auto" ColumnDefinitions="*, *, *, *" Grid.Row="0">
-                    <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="0" 
-                            Style="{StaticResource SecondarySmallButton}"
-                            Command="{Binding ViewNewCommand}"                                 
-                            Text="New">
-                        <Button.Triggers>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsNewSelected}" Value="true">
-                                <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
-                            </DataTrigger>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsNewSelected}" Value="false">
-                                <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
-                            </DataTrigger>
-                        </Button.Triggers>
-                    </Button>
-                    <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="1" 
-                            Style="{StaticResource SecondarySmallButton}"
-                            Command="{Binding ViewAssignedCommand}" 
-                            Text="Assigned">
-                        <Button.Triggers>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsAssignedSelected}" Value="true">
-                                <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
-                            </DataTrigger>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsAssignedSelected}" Value="false">
-                                <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
-                            </DataTrigger>
-                        </Button.Triggers>
-                    </Button>
-                    <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="2" 
-                            Style="{StaticResource SecondarySmallButton}"
-                            Command="{Binding ViewCleanedCommand}" 
-                            Text="Cleaned">
-                        <Button.Triggers>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsCleanedSelected}" Value="true">
-                                <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
-                            </DataTrigger>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsCleanedSelected}" Value="false">
-                                <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
-                            </DataTrigger>
-                        </Button.Triggers>
-                    </Button>
-                    <Label Text="Created Date" Grid.Row="1" Grid.Column="0" Style="{StaticResource FieldLabel}" Margin="10" />
-                    <controls:TMPicker Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
-                                          Title="Created Date Range"
-                                          HeightRequest="40"
-                                          Margin="10"
-                                          ItemsSource="{Binding CreatedDateRanges}"
-                                          SelectedItem="{Binding SelectedCreatedDateRange, Mode=TwoWay}" />
-                </Grid>
-                <Border Grid.Row="1" Style="{StaticResource RoundBorder}">
-                    <Grid ColumnDefinitions="*, *, *, *">
-                        <Picker x:Name="CountryPicker" Title="Select a country"
-                                    ItemsSource="{Binding CountryCollection}" SelectedItem="{Binding SelectedCountry}"
-                                    FontSize="Micro" Grid.Column="0" />
-                        <Picker x:Name="RegionPicker" Title="Select a state"
-                                    ItemsSource="{Binding RegionCollection}" SelectedItem="{Binding SelectedRegion}"
-                                    FontSize="Micro" Grid.Column="1" />
-                        <Picker x:Name="CityPicker" Title="Select a city" ItemsSource="{Binding CityCollection}"
-                                    SelectedItem="{Binding SelectedCity}" FontSize="Micro" Grid.Column="2" />
-                        <Button Text="Clear Selections" Command="{Binding ClearSelectionsCommand}" Margin="10"
-                                    FontSize="Micro" Grid.Column="3" />
-                    </Grid>
+                <!-- Status Filters -->
+                <Border Grid.Row="0" Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Filters" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*, *, *" ColumnSpacing="8">
+                            <Button Grid.Column="0"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    Command="{Binding ViewNewCommand}"
+                                    Text="New">
+                                <Button.Triggers>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsNewSelected}" Value="true">
+                                        <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
+                                    </DataTrigger>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsNewSelected}" Value="false">
+                                        <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
+                                    </DataTrigger>
+                                </Button.Triggers>
+                            </Button>
+                            <Button Grid.Column="1"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    Command="{Binding ViewAssignedCommand}"
+                                    Text="Assigned">
+                                <Button.Triggers>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsAssignedSelected}" Value="true">
+                                        <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
+                                    </DataTrigger>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsAssignedSelected}" Value="false">
+                                        <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
+                                    </DataTrigger>
+                                </Button.Triggers>
+                            </Button>
+                            <Button Grid.Column="2"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    Command="{Binding ViewCleanedCommand}"
+                                    Text="Cleaned">
+                                <Button.Triggers>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsCleanedSelected}" Value="true">
+                                        <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
+                                    </DataTrigger>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsCleanedSelected}" Value="false">
+                                        <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
+                                    </DataTrigger>
+                                </Button.Triggers>
+                            </Button>
+                        </Grid>
+                        <Grid ColumnDefinitions="Auto, *" ColumnSpacing="8">
+                            <Label Text="Created Date" Grid.Column="0" Style="{StaticResource FieldLabel}" VerticalOptions="Center" />
+                            <controls:TMPicker Grid.Column="1"
+                                                  Title="Created Date Range"
+                                                  HeightRequest="40"
+                                                  ItemsSource="{Binding CreatedDateRanges}"
+                                                  SelectedItem="{Binding SelectedCreatedDateRange, Mode=TwoWay}" />
+                        </Grid>
+                    </VerticalStackLayout>
                 </Border>
-                <Grid Margin="5" Grid.Row="2"
+
+                <!-- Location Filters -->
+                <Border Grid.Row="1" Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Location" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*, *, *, Auto" ColumnSpacing="4">
+                            <Picker x:Name="CountryPicker" Title="Country"
+                                        ItemsSource="{Binding CountryCollection}" SelectedItem="{Binding SelectedCountry}"
+                                        FontSize="Micro" Grid.Column="0" />
+                            <Picker x:Name="RegionPicker" Title="State"
+                                        ItemsSource="{Binding RegionCollection}" SelectedItem="{Binding SelectedRegion}"
+                                        FontSize="Micro" Grid.Column="1" />
+                            <Picker x:Name="CityPicker" Title="City" ItemsSource="{Binding CityCollection}"
+                                        SelectedItem="{Binding SelectedCity}" FontSize="Micro" Grid.Column="2" />
+                            <Button Text="Clear" Command="{Binding ClearSelectionsCommand}"
+                                        FontSize="Micro" Grid.Column="3" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Grid Margin="10,4" Grid.Row="2"
                       ColumnDefinitions="6*, *, *"
                       RowDefinitions="Auto">
                     <ImageButton Grid.Column="1"
                              HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
+                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
                              Command="{Binding MapSelectedCommand}" />
-                    <ImageButton Grid.Column="2" 
+                    <ImageButton Grid.Column="2"
                              HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
+                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
                              Command="{Binding ListSelectedCommand}" />
                 </Grid>
 

--- a/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
+++ b/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
@@ -11,14 +11,15 @@
              Title="Set Your Location">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
                 <Label
-                    Text="Click on the map to set your preferred location."
-                    FontSize="Micro"
+                    Text="Tap the map to set your preferred location"
+                    FontSize="Small"
                     VerticalOptions="Center"
                     HorizontalOptions="Center"
                     HorizontalTextAlignment="Center"
-                    Margin="5" />
+                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                    Margin="5,8,5,0" />
 
                 <controls:CustomMap x:Name="userLocationMap"
                           ItemsSource="{Binding Addresses}"
@@ -33,44 +34,63 @@
                     </maps:Map.ItemTemplate>
                 </controls:CustomMap>
 
-                <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*, *" Margin="10">
-                    <VerticalStackLayout Grid.Row="0" Grid.Column="0">
-                        <Label Text="Set the Max Travel Distance you are willing to travel for an event."
-                               Style="{StaticResource FieldLabel}" />
-                        <controls:TMEntry Text="{Binding TravelDistance}" Keyboard="Numeric" />
+                <!-- Travel Preferences -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Travel Preferences" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*, *" ColumnSpacing="12">
+                            <VerticalStackLayout Grid.Column="0">
+                                <Label Text="Max distance" Style="{StaticResource FieldLabel}" />
+                                <controls:TMEntry Text="{Binding TravelDistance}" Keyboard="Numeric" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Column="1">
+                                <Label Text="Units" Style="{StaticResource FieldLabel}" />
+                                <controls:TMPicker SelectedItem="{Binding Units, Mode=TwoWay}">
+                                    <controls:TMPicker.ItemsSource>
+                                        <x:Array Type="{x:Type x:String}">
+                                            <x:String>Kilometers</x:String>
+                                            <x:String>Miles</x:String>
+                                        </x:Array>
+                                    </controls:TMPicker.ItemsSource>
+                                </controls:TMPicker>
+                            </VerticalStackLayout>
+                        </Grid>
                     </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="0" Grid.Column="1">
-                        <Label Text="Set your preferred Units of measure." Style="{StaticResource FieldLabel}" />
-                        <controls:TMPicker SelectedItem="{Binding Units, Mode=TwoWay}" >
-                            <controls:TMPicker.ItemsSource>
-                                <x:Array Type="{x:Type x:String}">
-                                    <x:String>Kilometers</x:String>
-                                    <x:String>Miles</x:String>
-                                </x:Array>
-                            </controls:TMPicker.ItemsSource>
-                        </controls:TMPicker>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1" Grid.Column="0">
-                        <Label Text="City" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding Address.City }" FontSize="Small" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1" Grid.Column="1">
-                        <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding Address.Region }" FontSize="Small" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2" Grid.Column="0">
-                        <Label Text="Country" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding Address.Country }" FontSize="Small" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2" Grid.Column="1">
-                        <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding Address.PostalCode }" FontSize="Small" />
-                    </VerticalStackLayout>
-                </Grid>
+                </Border>
 
-                <Button Text="Update Location" 
+                <!-- Your Location -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Your Location" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid RowDefinitions="Auto, Auto" ColumnDefinitions="*, *" ColumnSpacing="12" RowSpacing="8">
+                            <VerticalStackLayout Grid.Row="0" Grid.Column="0" Spacing="2">
+                                <Label Text="City" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding Address.City}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="0" Grid.Column="1" Spacing="2">
+                                <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding Address.Region}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="1" Grid.Column="0" Spacing="2">
+                                <Label Text="Country" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding Address.Country}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="2">
+                                <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding Address.PostalCode}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Button Text="Update Location"
                         Command="{Binding UpdateLocationCommand}"
-                        Style="{StaticResource PrimaryLargeButton}"/>
+                        Style="{StaticResource PrimaryLargeButton}"
+                        Margin="10,8,10,10" />
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/ViewPickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/ViewPickupLocationPage.xaml
@@ -12,29 +12,34 @@
              Title="View Pickup Location">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*">
-                    <Image Source="{Binding PickupLocationViewModel.ImageUrl}" Margin="10" Grid.Row="0" />
-                    <VerticalStackLayout Grid.Row="1">
-                        <Label Text="Name" Style="{StaticResource FieldLabel}" />
-                        <controls:TMEntry Text="{Binding PickupLocationViewModel.Name}">
-                            <controls:TMEntry.Behaviors>
-                                <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
-                                                                    x:Name="nameValidator" />
-                            </controls:TMEntry.Behaviors>
-                        </controls:TMEntry>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Description" Style="{StaticResource FieldLabel}" />
-                        <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
-                            <controls:TMEditor.Behaviors>
-                                <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"
-                                                                    x:Name="notesValidator" />
-                            </controls:TMEditor.Behaviors>
-                        </controls:TMEditor>
-                    </VerticalStackLayout>
-                </Grid>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
+                <Image Source="{Binding PickupLocationViewModel.ImageUrl}" Margin="10,8,10,0" />
+
+                <!-- Details -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Details" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout>
+                            <Label Text="Name" Style="{StaticResource FieldLabel}" />
+                            <controls:TMEntry Text="{Binding PickupLocationViewModel.Name}">
+                                <controls:TMEntry.Behaviors>
+                                    <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="5"
+                                                                        x:Name="nameValidator" />
+                                </controls:TMEntry.Behaviors>
+                            </controls:TMEntry>
+                        </VerticalStackLayout>
+                        <VerticalStackLayout>
+                            <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                            <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
+                                <controls:TMEditor.Behaviors>
+                                    <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"
+                                                                        x:Name="notesValidator" />
+                                </controls:TMEditor.Behaviors>
+                            </controls:TMEditor>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
 
                 <controls:CustomMap x:Name="pickupLocationsMap"
                           ItemsSource="{Binding PickupLocations}"
@@ -50,33 +55,39 @@
                     </maps:Map.ItemTemplate>
                 </controls:CustomMap>
 
-                <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *">
-                    <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2">
-                        <Label Text="Address" Style="{StaticResource FieldLabel}" />
-
-                        <Label Text="{Binding PickupLocationViewModel.Address.StreetAddress }" FontSize="Micro" />
+                <!-- Location -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Location" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *" ColumnSpacing="12" RowSpacing="8">
+                            <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2" Spacing="2">
+                                <Label Text="Address" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.StreetAddress}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="1" Grid.Column="0" Spacing="2">
+                                <Label Text="City" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.City}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="2">
+                                <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.Region}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="2" Grid.Column="0" Spacing="2">
+                                <Label Text="Country" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.Country}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Row="2" Grid.Column="1" Spacing="2">
+                                <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding PickupLocationViewModel.Address.PostalCode}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                        </Grid>
                     </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1" Grid.Column="0">
-                        <Label Text="City" Style="{StaticResource FieldLabel}" />
-
-                        <Label Text="{Binding PickupLocationViewModel.Address.City }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="1" Grid.Column="1">
-                        <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
-
-                        <Label Text="{Binding PickupLocationViewModel.Address.Region }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2" Grid.Column="0">
-                        <Label Text="Country" Style="{StaticResource FieldLabel}" />
-
-                        <Label Text="{Binding PickupLocationViewModel.Address.Country }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="2" Grid.Column="1">
-                        <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
-
-                        <Label Text="{Binding PickupLocationViewModel.Address.PostalCode }" FontSize="Micro" />
-                    </VerticalStackLayout>
-                </Grid>
+                </Border>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />


### PR DESCRIPTION
## Summary
- Applied consistent `RoundBorder` card styling, `SectionHeader` labels, and `MutedForeground` colors across 9 mobile XAML pages
- Pages updated: SetUserLocationPreference, ContactUs, CreateLitterReport, EditLitterReport, CreatePickupLocation, ViewPickupLocation, EditEventSummary, SearchLitterReports, EditPickupLocation
- Standardized button styles (`PrimaryLargeButton`), spacing (`Spacing="8"`), and margins to match the design system used in WelcomePage and ProfilePage

## Test plan
- [ ] Build and deploy to Android emulator
- [ ] Navigate to each updated page and verify visual consistency
- [ ] Verify form inputs still work (text entry, pickers, editors)
- [ ] Verify map interactions still work on pages with maps
- [ ] Verify button actions still trigger correctly (save, submit, photo)
- [ ] Check dark mode appearance on updated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)