### PR TITLE
Add exception logging and remove redundant .AsEnumerable() calls

### DIFF
--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -38,10 +38,9 @@ namespace TrashMob.Shared.Managers.Events
         public override async Task<IEnumerable<EventAttendee>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.EventId == parentId)
+            return await Repository.Get().Where(p => p.EventId == parentId)
                     .Include(p => p.User)
-                    .ToListAsync(cancellationToken))
-                .AsEnumerable();
+                    .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
@@ -38,10 +38,9 @@ namespace TrashMob.Shared.Managers.Events
         public override async Task<IEnumerable<EventAttendeeRoute>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.EventId == parentId)
+            return await Repository.Get().Where(p => p.EventId == parentId)
                     .Include(p => p.User)
-                    .ToListAsync(cancellationToken))
-                .AsEnumerable();
+                    .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Events/EventLitterReportManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventLitterReportManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Events
+namespace TrashMob.Shared.Managers.Events
 {
     using System;
     using System.Collections.Generic;
@@ -43,11 +43,10 @@
         public override async Task<IEnumerable<EventLitterReport>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.EventId == parentId)
+            return await Repository.Get().Where(p => p.EventId == parentId)
                     .Include(p => p.LitterReport)
                     .Include(p => p.LitterReport.LitterImages)
-                    .ToListAsync(cancellationToken))
-                .AsEnumerable();
+                    .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
@@ -85,9 +85,8 @@ namespace TrashMob.Shared.Managers.LitterReport
         public override async Task<IEnumerable<LitterImage>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.LitterReportId == parentId)
-                    .ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.LitterReportId == parentId)
+                    .ToListAsync(cancellationToken);
         }
     }
 }

--- a/TrashMob.Shared/Managers/LookupManager.cs
+++ b/TrashMob.Shared/Managers/LookupManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Collections.Generic;
@@ -34,13 +34,13 @@
         /// <inheritdoc />
         public virtual async Task<IEnumerable<T>> GetAsync()
         {
-            return (await Repository.Get().ToListAsync()).AsEnumerable();
+            return await Repository.Get().ToListAsync();
         }
 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<T>> GetAsync(Expression<Func<T, bool>> expression)
         {
-            return (await Repository.Get(expression).ToListAsync()).AsEnumerable();
+            return await Repository.Get(expression).ToListAsync();
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/NonEventUserNotificationManager.cs
+++ b/TrashMob.Shared/Managers/NonEventUserNotificationManager.cs
@@ -29,8 +29,8 @@
         public async Task<IEnumerable<NonEventUserNotification>> GetByUserIdAsync(Guid userId,
             int userNotificationTypeId, CancellationToken cancellationToken = default)
         {
-            return (await Repository.Get(n => n.UserId == userId && n.UserNotificationTypeId == userNotificationTypeId)
-                .ToListAsync(cancellationToken)).AsEnumerable();
+            return await Repository.Get(n => n.UserId == userId && n.UserNotificationTypeId == userNotificationTypeId)
+                .ToListAsync(cancellationToken);
         }
     }
 }

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
@@ -48,8 +48,7 @@ namespace TrashMob.Shared.Managers.Partners
         public override async Task<IEnumerable<PartnerAdminInvitation>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -42,8 +42,7 @@
         public override async Task<IEnumerable<PartnerAdmin>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Partners/PartnerContactManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerContactManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -37,8 +37,7 @@
         public override async Task<IEnumerable<PartnerContact>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Partners/PartnerDocumentManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerDocumentManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -36,8 +36,7 @@
         public override async Task<IEnumerable<PartnerDocument>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Partners/PartnerLocationContactManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerLocationContactManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -39,8 +39,7 @@
         public override async Task<IEnumerable<PartnerLocationContact>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerLocationId == parentId).ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerLocationId == parentId).ToListAsync(cancellationToken);
         }
     }
 }

--- a/TrashMob.Shared/Managers/Partners/PartnerLocationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerLocationManager.cs
@@ -41,8 +41,8 @@
         public override async Task<IEnumerable<PartnerLocation>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerId == parentId).Include(p => p.PartnerLocationContacts)
-                .ToListAsync(cancellationToken)).AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerId == parentId).Include(p => p.PartnerLocationContacts)
+                .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Partners/PartnerLocationServiceManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerLocationServiceManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -38,8 +38,7 @@
         public override async Task<IEnumerable<PartnerLocationService>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerLocationId == parentId).ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerLocationId == parentId).ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Partners/PartnerSocialMediaAccountManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerSocialMediaAccountManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Partners
+namespace TrashMob.Shared.Managers.Partners
 {
     using System;
     using System.Collections.Generic;
@@ -29,8 +29,7 @@
         public override async Task<IEnumerable<PartnerSocialMediaAccount>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.PartnerId == parentId).ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/PickupLocationManager.cs
+++ b/TrashMob.Shared/Managers/PickupLocationManager.cs
@@ -37,9 +37,8 @@ namespace TrashMob.Shared.Managers
         public override async Task<IEnumerable<PickupLocation>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {
-            return (await Repository.Get().Where(p => p.EventId == parentId)
-                    .ToListAsync(cancellationToken))
-                .AsEnumerable();
+            return await Repository.Get().Where(p => p.EventId == parentId)
+                    .ToListAsync(cancellationToken);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
+++ b/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
@@ -7,6 +7,7 @@ namespace TrashMob.Shared.Managers
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
     using TrashMob.Models;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Persistence;
@@ -17,14 +18,17 @@ namespace TrashMob.Shared.Managers
     public class UserNewsletterPreferenceManager : IUserNewsletterPreferenceManager
     {
         private readonly MobDbContext dbContext;
+        private readonly ILogger<UserNewsletterPreferenceManager> logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserNewsletterPreferenceManager"/> class.
         /// </summary>
         /// <param name="dbContext">The database context.</param>
-        public UserNewsletterPreferenceManager(MobDbContext dbContext)
+        /// <param name="logger">The logger.</param>
+        public UserNewsletterPreferenceManager(MobDbContext dbContext, ILogger<UserNewsletterPreferenceManager> logger)
         {
             this.dbContext = dbContext;
+            this.logger = logger;
         }
 
         /// <inheritdoc />
@@ -200,8 +204,9 @@ namespace TrashMob.Shared.Managers
                     };
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                logger.LogWarning(ex, "Failed to process unsubscribe token");
                 return new UnsubscribeResult { Success = false, ErrorMessage = "Invalid token." };
             }
         }

--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -364,8 +364,9 @@ namespace TrashMob.Controllers
 
                 return Ok(url);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                logger.LogWarning(ex, "Failed to get image URL for litter image {LitterImageId}", litterImageId);
                 return NoContent();
             }
         }

--- a/TrashMob/Controllers/UserWaiverController.cs
+++ b/TrashMob/Controllers/UserWaiverController.cs
@@ -7,6 +7,7 @@ namespace TrashMob.Controllers
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
     using TrashMob.Models;
     using TrashMob.Security;
@@ -177,10 +178,11 @@ namespace TrashMob.Controllers
                 userWaiver.DocumentUrl = documentUrl;
                 await userWaiverManager.UpdateAsync(userWaiver, cancellationToken);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Log but don't fail the waiver acceptance if PDF generation fails
+                // Don't fail the waiver acceptance if PDF generation fails
                 // The waiver is still valid, PDF can be regenerated later
+                Logger?.LogWarning(ex, "PDF generation failed for waiver {WaiverId}", userWaiver.Id);
             }
 
             TrackEvent(nameof(AcceptWaiver));


### PR DESCRIPTION
## Summary
- **Exception logging**: Added `LogWarning` to 3 catch blocks that were silently swallowing errors:
  - `UserWaiverController` — PDF generation failures now logged (waiver still accepted)
  - `LitterReportController` — image URL retrieval failures now logged
  - `UserNewsletterPreferenceManager` — unsubscribe token processing failures now logged (added `ILogger<T>` to constructor)
- **Remove redundant `.AsEnumerable()`**: Removed 16 unnecessary `.AsEnumerable()` calls after `.ToListAsync()` across manager files — `List<T>` already implements `IEnumerable<T>`, so the cast is a no-op

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442/442 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)