### PR TITLE
Fix async method naming and remove redundant [ApiController]

### DIFF
--- a/TrashMob.Shared.Tests/Managers/Partners/PartnerAdminInvitationManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Partners/PartnerAdminInvitationManagerTests.cs
@@ -130,7 +130,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
                 .ReturnsAsync((PartnerAdmin pa, CancellationToken _) => pa);
 
             // Act
-            await _sut.AcceptInvitation(invitationId, userId, CancellationToken.None);
+            await _sut.AcceptInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _invitationRepository.Verify(r => r.UpdateAsync(It.Is<PartnerAdminInvitation>(
@@ -157,7 +157,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
                 .ReturnsAsync((PartnerAdmin pa, CancellationToken _) => pa);
 
             // Act
-            await _sut.AcceptInvitation(invitationId, userId, CancellationToken.None);
+            await _sut.AcceptInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _partnerAdminManager.Verify(m => m.AddAsync(
@@ -176,7 +176,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
             _invitationRepository.SetupGetWithFilter(new List<PartnerAdminInvitation>());
 
             // Act
-            await _sut.AcceptInvitation(invitationId, userId, CancellationToken.None);
+            await _sut.AcceptInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _partnerAdminManager.Verify(m => m.AddAsync(It.IsAny<PartnerAdmin>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -203,7 +203,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
             _invitationRepository.SetupGetWithFilter(new List<PartnerAdminInvitation> { invitation });
 
             // Act
-            await _sut.DeclineInvitation(invitationId, userId, CancellationToken.None);
+            await _sut.DeclineInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _invitationRepository.Verify(r => r.UpdateAsync(It.Is<PartnerAdminInvitation>(
@@ -226,7 +226,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
             _invitationRepository.SetupGetWithFilter(new List<PartnerAdminInvitation> { invitation });
 
             // Act
-            await _sut.DeclineInvitation(invitationId, userId, CancellationToken.None);
+            await _sut.DeclineInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _partnerAdminManager.Verify(m => m.AddAsync(It.IsAny<PartnerAdmin>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -243,7 +243,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
             _invitationRepository.SetupGetWithFilter(new List<PartnerAdminInvitation>());
 
             // Act
-            await _sut.DeclineInvitation(invitationId, userId, CancellationToken.None);
+            await _sut.DeclineInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _invitationRepository.Verify(r => r.UpdateAsync(It.IsAny<PartnerAdminInvitation>()), Times.Never);
@@ -471,7 +471,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
                 .ReturnsAsync(partner);
 
             // Act
-            var result = await _sut.ResendPartnerAdminInvitation(invitationId, userId, CancellationToken.None);
+            var result = await _sut.ResendPartnerAdminInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _emailManager.Verify(e => e.GetHtmlEmailCopy(NotificationTypeEnum.InviteNewUserToBePartnerAdmin.ToString()), Times.Once);
@@ -512,7 +512,7 @@ namespace TrashMob.Shared.Tests.Managers.Partners
                 .ReturnsAsync(partner);
 
             // Act
-            var result = await _sut.ResendPartnerAdminInvitation(invitationId, userId, CancellationToken.None);
+            var result = await _sut.ResendPartnerAdminInvitationAsync(invitationId, userId, CancellationToken.None);
 
             // Assert
             _emailManager.Verify(e => e.GetHtmlEmailCopy(NotificationTypeEnum.InviteExistingUserToBePartnerAdmin.ToString()), Times.Once);

--- a/TrashMob.Shared/Managers/EventPhotoManager.cs
+++ b/TrashMob.Shared/Managers/EventPhotoManager.cs
@@ -109,7 +109,7 @@ namespace TrashMob.Shared.Managers
                     FormFile = new FormFileWrapper(stream, "eventphoto.jpg")
                 };
 
-                await imageManager.UploadImage(imageUpload);
+                await imageManager.UploadImageAsync(imageUpload);
 
                 // Get the URLs
                 photo.ImageUrl = await imageManager.GetImageUrlAsync(

--- a/TrashMob.Shared/Managers/ImageManager.cs
+++ b/TrashMob.Shared/Managers/ImageManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers
+namespace TrashMob.Shared.Managers
 {
     using System;
     using System.IO;
@@ -42,7 +42,7 @@
         }
 
         /// <inheritdoc />
-        public async Task UploadImage(ImageUpload imageUpload)
+        public async Task UploadImageAsync(ImageUpload imageUpload)
         {
             if (imageUpload?.FormFile == null)
             {
@@ -114,7 +114,7 @@
         }
 
         /// <inheritdoc />
-        public async Task<bool> DeleteImage(Guid parentId, ImageTypeEnum imageType)
+        public async Task<bool> DeleteImageAsync(Guid parentId, ImageTypeEnum imageType)
         {
             var imageName = await GetImageNameAsync(parentId, imageType);
 

--- a/TrashMob.Shared/Managers/Interfaces/IImageManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IImageManager.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Shared.Managers.Interfaces
+namespace TrashMob.Shared.Managers.Interfaces
 {
     using System;
     using System.Threading;
@@ -15,7 +15,7 @@
         /// Uploads an image to blob storage.
         /// </summary>
         /// <param name="imageUpload">The image upload request containing image data.</param>
-        public Task UploadImage(ImageUpload imageUpload);
+        public Task UploadImageAsync(ImageUpload imageUpload);
 
         /// <summary>
         /// Gets the URL for an image in blob storage.
@@ -33,6 +33,6 @@
         /// <param name="parentId">The parent entity ID.</param>
         /// <param name="imageType">The type of image to delete.</param>
         /// <returns>True if the image was deleted, false otherwise.</returns>
-        public Task<bool> DeleteImage(Guid parentId, ImageTypeEnum imageType);
+        public Task<bool> DeleteImageAsync(Guid parentId, ImageTypeEnum imageType);
     }
 }

--- a/TrashMob.Shared/Managers/Interfaces/IPartnerAdminInvitationManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IPartnerAdminInvitationManager.cs
@@ -36,7 +36,7 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="UserId">The unique identifier of the user accepting the invitation.</param>
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        Task AcceptInvitation(Guid partnerAdminInvitationId, Guid UserId, CancellationToken cancellationToken);
+        Task AcceptInvitationAsync(Guid partnerAdminInvitationId, Guid UserId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Declines a partner admin invitation for a user.
@@ -45,7 +45,7 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="UserId">The unique identifier of the user declining the invitation.</param>
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        Task DeclineInvitation(Guid partnerAdminInvitationId, Guid UserId, CancellationToken cancellationToken);
+        Task DeclineInvitationAsync(Guid partnerAdminInvitationId, Guid UserId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Resends a partner admin invitation.
@@ -54,7 +54,7 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="UserId">The unique identifier of the user resending the invitation.</param>
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>The resent partner admin invitation.</returns>
-        Task<PartnerAdminInvitation> ResendPartnerAdminInvitation(Guid partnerAdminInvitationId, Guid UserId,
+        Task<PartnerAdminInvitation> ResendPartnerAdminInvitationAsync(Guid partnerAdminInvitationId, Guid UserId,
             CancellationToken cancellationToken);
     }
 }

--- a/TrashMob.Shared/Managers/Interfaces/IPickupLocationManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IPickupLocationManager.cs
@@ -18,7 +18,7 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="userId">The unique identifier of the user submitting the locations.</param>
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        Task SubmitPickupLocations(Guid eventId, Guid userId, CancellationToken cancellationToken);
+        Task SubmitPickupLocationsAsync(Guid eventId, Guid userId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Marks a pickup location as picked up.

--- a/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
@@ -76,7 +76,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         public async Task<int> HardDeleteAsync(Guid id, CancellationToken cancellationToken = default)
         {
             await base.DeleteAsync(id, cancellationToken);
-            await imageManager.DeleteImage(id, ImageTypeEnum.LitterImage);
+            await imageManager.DeleteImageAsync(id, ImageTypeEnum.LitterImage);
 
             return 1;
         }

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
@@ -160,7 +160,7 @@ namespace TrashMob.Shared.Managers.Partners
         }
 
         /// <inheritdoc />
-        public async Task AcceptInvitation(Guid partnerAdminInviationId, Guid userId,
+        public async Task AcceptInvitationAsync(Guid partnerAdminInviationId, Guid userId,
             CancellationToken cancellationToken)
         {
             var partnerAdminInvitation = await Repository.Get(pa => pa.Id == partnerAdminInviationId)
@@ -183,7 +183,7 @@ namespace TrashMob.Shared.Managers.Partners
         }
 
         /// <inheritdoc />
-        public async Task DeclineInvitation(Guid partnerAdminInviationId, Guid userId,
+        public async Task DeclineInvitationAsync(Guid partnerAdminInviationId, Guid userId,
             CancellationToken cancellationToken)
         {
             var partnerAdminInvitation = await Repository.Get(pa => pa.Id == partnerAdminInviationId)
@@ -199,7 +199,7 @@ namespace TrashMob.Shared.Managers.Partners
         }
 
         /// <inheritdoc />
-        public async Task<PartnerAdminInvitation> ResendPartnerAdminInvitation(Guid partnerAdminInvitationId,
+        public async Task<PartnerAdminInvitation> ResendPartnerAdminInvitationAsync(Guid partnerAdminInvitationId,
             Guid UserId, CancellationToken cancellationToken)
         {
             // Check to see if this user already exists in the system.

--- a/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
@@ -56,7 +56,7 @@ namespace TrashMob.Shared.Managers.Partners
             await base.DeleteAsync(id, cancellationToken);
 
             // Then delete from blob storage
-            await imageManager.DeleteImage(id, ImageTypeEnum.PartnerPhoto);
+            await imageManager.DeleteImageAsync(id, ImageTypeEnum.PartnerPhoto);
 
             return 1;
         }

--- a/TrashMob.Shared/Managers/PickupLocationManager.cs
+++ b/TrashMob.Shared/Managers/PickupLocationManager.cs
@@ -82,7 +82,7 @@ namespace TrashMob.Shared.Managers
         }
 
         /// <inheritdoc />
-        public async Task SubmitPickupLocations(Guid eventId, Guid userId, CancellationToken cancellationToken)
+        public async Task SubmitPickupLocationsAsync(Guid eventId, Guid userId, CancellationToken cancellationToken)
         {
             // Get the Event
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);

--- a/TrashMob.Shared/Managers/Teams/TeamPhotoManager.cs
+++ b/TrashMob.Shared/Managers/Teams/TeamPhotoManager.cs
@@ -54,7 +54,7 @@ namespace TrashMob.Shared.Managers.Teams
         public async Task<int> HardDeleteAsync(Guid id, CancellationToken cancellationToken = default)
         {
             await base.DeleteAsync(id, cancellationToken);
-            await imageManager.DeleteImage(id, ImageTypeEnum.TeamPhoto);
+            await imageManager.DeleteImageAsync(id, ImageTypeEnum.TeamPhoto);
 
             return 1;
         }

--- a/TrashMob/Controllers/AdoptableAreasController.cs
+++ b/TrashMob/Controllers/AdoptableAreasController.cs
@@ -20,7 +20,6 @@ namespace TrashMob.Controllers
     /// Controller for managing adoptable areas within a community.
     /// </summary>
     [Route("api/communities/{partnerId}/areas")]
-    [ApiController]
     public class AdoptableAreasController : SecureController
     {
         private readonly IAdoptableAreaManager areaManager;

--- a/TrashMob/Controllers/AdoptionEventsController.cs
+++ b/TrashMob/Controllers/AdoptionEventsController.cs
@@ -17,7 +17,6 @@ namespace TrashMob.Controllers
     /// Controller for managing event links to team adoptions.
     /// </summary>
     [Route("api/adoptions/{adoptionId}/events")]
-    [ApiController]
     public class AdoptionEventsController : SecureController
     {
         private readonly ITeamAdoptionEventManager adoptionEventManager;

--- a/TrashMob/Controllers/CommunitiesController.cs
+++ b/TrashMob/Controllers/CommunitiesController.cs
@@ -376,7 +376,7 @@ namespace TrashMob.Controllers
             // Upload to blob storage
             imageUpload.ParentId = photoId;
             imageUpload.ImageType = ImageTypeEnum.PartnerPhoto;
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             // Get the image URL and save photo record
             var imageUrl = await imageManager.GetImageUrlAsync(photoId, ImageTypeEnum.PartnerPhoto, ImageSizeEnum.Reduced, cancellationToken);

--- a/TrashMob/Controllers/CommunityAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunityAdoptionsController.cs
@@ -18,7 +18,6 @@ namespace TrashMob.Controllers
     /// Controller for community admin adoption management.
     /// </summary>
     [Route("api/communities/{partnerId}/adoptions")]
-    [ApiController]
     public class CommunityAdoptionsController : SecureController
     {
         private readonly ITeamAdoptionManager adoptionManager;

--- a/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
+++ b/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
@@ -17,7 +17,6 @@ namespace TrashMob.Controllers
     /// Controller for managing professional cleanup companies within a community.
     /// </summary>
     [Route("api/communities/{partnerId}/professional-companies")]
-    [ApiController]
     public class CommunityProfessionalCompaniesController : SecureController
     {
         private readonly IProfessionalCompanyManager companyManager;

--- a/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
@@ -18,7 +18,6 @@ namespace TrashMob.Controllers
     /// Controller for managing sponsored adoptions within a community.
     /// </summary>
     [Route("api/communities/{partnerId}/sponsored-adoptions")]
-    [ApiController]
     public class CommunitySponsoredAdoptionsController : SecureController
     {
         private readonly ISponsoredAdoptionManager adoptionManager;

--- a/TrashMob/Controllers/CommunitySponsorsController.cs
+++ b/TrashMob/Controllers/CommunitySponsorsController.cs
@@ -17,7 +17,6 @@ namespace TrashMob.Controllers
     /// Controller for managing sponsors within a community's sponsored adoption program.
     /// </summary>
     [Route("api/communities/{partnerId}/sponsors")]
-    [ApiController]
     public class CommunitySponsorsController : SecureController
     {
         private readonly ISponsorManager sponsorManager;

--- a/TrashMob/Controllers/EventAttendeeMetricsController.cs
+++ b/TrashMob/Controllers/EventAttendeeMetricsController.cs
@@ -17,7 +17,6 @@ namespace TrashMob.Controllers
     /// Controller for attendee-submitted event metrics.
     /// </summary>
     [Route("api/events/{eventId}/attendee-metrics")]
-    [ApiController]
     public class EventAttendeeMetricsController : SecureController
     {
         private readonly IEventAttendeeMetricsManager metricsManager;

--- a/TrashMob/Controllers/EventPhotosController.cs
+++ b/TrashMob/Controllers/EventPhotosController.cs
@@ -127,7 +127,7 @@ namespace TrashMob.Controllers
             // Upload to blob storage
             imageUpload.ParentId = photoId;
             imageUpload.ImageType = ImageTypeEnum.EventPhoto;
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             // Get the image URLs and save photo record
             var imageUrl = await imageManager.GetImageUrlAsync(photoId, ImageTypeEnum.EventPhoto, ImageSizeEnum.Reduced, cancellationToken);

--- a/TrashMob/Controllers/IFTTT/v1/QueriesController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/QueriesController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers.IFTTT
+namespace TrashMob.Controllers.IFTTT
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -15,7 +15,6 @@
     /// </summary>
     [Route("api/ifttt/v1/[controller]")]
     [RequiredScope(Constants.TrashMobIFTTTScope)]
-    [ApiController]
     public class QueriesController : SecureController
     {
         private readonly IQueriesManager queriesManager;

--- a/TrashMob/Controllers/IFTTT/v1/TriggersController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/TriggersController.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMob.Controllers.IFTTT
+namespace TrashMob.Controllers.IFTTT
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -15,7 +15,6 @@
     /// </summary>
     [Route("api/ifttt/v1/[controller]")]
     [RequiredScope(Constants.TrashMobIFTTTScope)]
-    [ApiController]
     public class TriggersController : SecureController
     {
         private readonly ITriggersManager triggersManager;

--- a/TrashMob/Controllers/IFTTT/v1/UserController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/UserController.cs
@@ -11,7 +11,6 @@ namespace TrashMob.Controllers.IFTTT
     /// Controller for IFTTT user info, providing endpoints for user information retrieval.
     /// </summary>
     [Route("api/ifttt/v1/[controller]")]
-    [ApiController]
     public class UserController : SecureController
     {
         private readonly IUserManager userManager;

--- a/TrashMob/Controllers/ImageController.cs
+++ b/TrashMob/Controllers/ImageController.cs
@@ -16,7 +16,6 @@ namespace TrashMob.Controllers
     /// Controller for managing images, including upload and deletion.
     /// </summary>
     [Route("api/image")]
-    [ApiController]
     public class ImageController : SecureController
     {
         private readonly IEventManager eventManager;
@@ -42,7 +41,7 @@ namespace TrashMob.Controllers
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        public async Task<IActionResult> UploadImage([FromForm] ImageUpload imageUpload,
+        public async Task<IActionResult> UploadImageAsync([FromForm] ImageUpload imageUpload,
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(imageUpload.ParentId, cancellationToken);
@@ -52,7 +51,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             return Ok();
         }
@@ -67,7 +66,7 @@ namespace TrashMob.Controllers
         [HttpDelete]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        public async Task<IActionResult> DeleteImage(Guid parentId, ImageTypeEnum imageType,
+        public async Task<IActionResult> DeleteImageAsync(Guid parentId, ImageTypeEnum imageType,
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(parentId, cancellationToken);
@@ -77,7 +76,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            var deleted = await imageManager.DeleteImage(parentId, imageType);
+            var deleted = await imageManager.DeleteImageAsync(parentId, imageType);
             if (deleted)
             {
                 return NoContent();

--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -256,7 +256,7 @@ namespace TrashMob.Controllers
         /// <remarks>Result of the upload operation.</remarks>
         [HttpPost("image/{litterImageId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
-        public async Task<IActionResult> UploadImage([FromForm] ImageUpload imageUpload, Guid litterImageId,
+        public async Task<IActionResult> UploadImageAsync([FromForm] ImageUpload imageUpload, Guid litterImageId,
             CancellationToken cancellationToken)
         {
             var litterImage = await litterImageManager.GetAsync(litterImageId, cancellationToken);
@@ -266,7 +266,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             return Ok();
         }

--- a/TrashMob/Controllers/PartnerAdminInvitationsController.cs
+++ b/TrashMob/Controllers/PartnerAdminInvitationsController.cs
@@ -145,7 +145,7 @@ namespace TrashMob.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <remarks>Updated partner admin invitation.</remarks>
         [HttpPost("resend/{partnerAdminInvitationId}")]
-        public async Task<IActionResult> ResendPartnerAdminInvitation(Guid partnerAdminInvitationId,
+        public async Task<IActionResult> ResendPartnerAdminInvitationAsync(Guid partnerAdminInvitationId,
             CancellationToken cancellationToken)
         {
             // Make sure the person adding the user is either an admin or already a user for the partner
@@ -158,8 +158,8 @@ namespace TrashMob.Controllers
             }
 
             var result = await partnerAdminInvitationManager
-                .ResendPartnerAdminInvitation(partnerAdminInvitationId, UserId, cancellationToken);
-            TrackEvent(nameof(ResendPartnerAdminInvitation));
+                .ResendPartnerAdminInvitationAsync(partnerAdminInvitationId, UserId, cancellationToken);
+            TrackEvent(nameof(ResendPartnerAdminInvitationAsync));
 
             return Ok(result);
         }
@@ -175,7 +175,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> AcceptPartnerAdminInvitation(Guid partnerAdminInvitationId,
             CancellationToken cancellationToken)
         {
-            await partnerAdminInvitationManager.AcceptInvitation(partnerAdminInvitationId, UserId, cancellationToken);
+            await partnerAdminInvitationManager.AcceptInvitationAsync(partnerAdminInvitationId, UserId, cancellationToken);
             TrackEvent(nameof(AcceptPartnerAdminInvitation));
 
             return Ok();
@@ -192,7 +192,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> DeclinePartnerAdminInvitation(Guid partnerAdminInvitationId,
             CancellationToken cancellationToken)
         {
-            await partnerAdminInvitationManager.DeclineInvitation(partnerAdminInvitationId, UserId, cancellationToken);
+            await partnerAdminInvitationManager.DeclineInvitationAsync(partnerAdminInvitationId, UserId, cancellationToken);
             TrackEvent(nameof(AcceptPartnerAdminInvitation));
 
             return Ok();

--- a/TrashMob/Controllers/PickupLocationsController.cs
+++ b/TrashMob/Controllers/PickupLocationsController.cs
@@ -165,7 +165,7 @@ namespace TrashMob.Controllers
         [HttpPost("submit/{eventId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        public async Task<IActionResult> SubmitPickupLocations(Guid eventId, CancellationToken cancellationToken)
+        public async Task<IActionResult> SubmitPickupLocationsAsync(Guid eventId, CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
 
@@ -174,7 +174,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            await pickupLocationManager.SubmitPickupLocations(eventId, UserId, cancellationToken);
+            await pickupLocationManager.SubmitPickupLocationsAsync(eventId, UserId, cancellationToken);
 
             TrackEvent("SubmitPickupLocations");
 
@@ -191,7 +191,7 @@ namespace TrashMob.Controllers
         [HttpPost("image/{eventId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        public async Task<IActionResult> UploadImage([FromForm] ImageUpload imageUpload, Guid eventId,
+        public async Task<IActionResult> UploadImageAsync([FromForm] ImageUpload imageUpload, Guid eventId,
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
@@ -201,7 +201,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             return Ok();
         }

--- a/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
+++ b/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
@@ -17,7 +17,6 @@ namespace TrashMob.Controllers
     /// Controller for professional cleanup log operations.
     /// </summary>
     [Route("api/professional-companies/{companyId}/cleanup-logs")]
-    [ApiController]
     public class ProfessionalCleanupLogsController : SecureController
     {
         private readonly IProfessionalCleanupLogManager logManager;

--- a/TrashMob/Controllers/ProfessionalCompanyPortalController.cs
+++ b/TrashMob/Controllers/ProfessionalCompanyPortalController.cs
@@ -16,7 +16,6 @@ namespace TrashMob.Controllers
     /// Portal endpoints for professional company users.
     /// </summary>
     [Route("api/professional-companies")]
-    [ApiController]
     public class ProfessionalCompanyPortalController : SecureController
     {
         private readonly IProfessionalCompanyUserManager companyUserManager;

--- a/TrashMob/Controllers/SecureController.cs
+++ b/TrashMob/Controllers/SecureController.cs
@@ -6,8 +6,6 @@ namespace TrashMob.Controllers
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
-
-    [ApiController]
     public abstract class SecureController : BaseController
     {
         private IAuthorizationService authorizationService;

--- a/TrashMob/Controllers/SponsorPortalController.cs
+++ b/TrashMob/Controllers/SponsorPortalController.cs
@@ -19,7 +19,6 @@ namespace TrashMob.Controllers
     /// Portal endpoints for sponsor users (read-only views of adoptions and cleanup logs).
     /// </summary>
     [Route("api/sponsors")]
-    [ApiController]
     public class SponsorPortalController : SecureController
     {
         private readonly ISponsorManager sponsorManager;

--- a/TrashMob/Controllers/SponsorReportsController.cs
+++ b/TrashMob/Controllers/SponsorReportsController.cs
@@ -17,7 +17,6 @@ namespace TrashMob.Controllers
     /// Controller for sponsor adoption reports and cleanup log summaries.
     /// </summary>
     [Route("api/sponsors/{sponsorId}/adoptions")]
-    [ApiController]
     public class SponsorReportsController : SecureController
     {
         private readonly ISponsoredAdoptionManager adoptionManager;

--- a/TrashMob/Controllers/TeamAdoptionsController.cs
+++ b/TrashMob/Controllers/TeamAdoptionsController.cs
@@ -17,7 +17,6 @@ namespace TrashMob.Controllers
     /// Controller for team adoption operations (team-centric view).
     /// </summary>
     [Route("api/teams/{teamId}/adoptions")]
-    [ApiController]
     public class TeamAdoptionsController : SecureController
     {
         private readonly ITeamAdoptionManager adoptionManager;

--- a/TrashMob/Controllers/TeamsController.cs
+++ b/TrashMob/Controllers/TeamsController.cs
@@ -348,7 +348,7 @@ namespace TrashMob.Controllers
             // Upload to blob storage
             imageUpload.ParentId = photoId;
             imageUpload.ImageType = ImageTypeEnum.TeamPhoto;
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             // Get the image URL and save photo record
             var imageUrl = await imageManager.GetImageUrlAsync(photoId, ImageTypeEnum.TeamPhoto, ImageSizeEnum.Reduced, cancellationToken);
@@ -483,13 +483,13 @@ namespace TrashMob.Controllers
             // Delete existing logo if present
             if (!string.IsNullOrWhiteSpace(team.LogoUrl))
             {
-                await imageManager.DeleteImage(teamId, ImageTypeEnum.TeamLogo);
+                await imageManager.DeleteImageAsync(teamId, ImageTypeEnum.TeamLogo);
             }
 
             // Upload new logo to blob storage
             imageUpload.ParentId = teamId;
             imageUpload.ImageType = ImageTypeEnum.TeamLogo;
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             // Get the image URL and update team
             var logoUrl = await imageManager.GetImageUrlAsync(teamId, ImageTypeEnum.TeamLogo, ImageSizeEnum.Reduced, cancellationToken);
@@ -532,7 +532,7 @@ namespace TrashMob.Controllers
             // Delete logo from blob storage
             if (!string.IsNullOrWhiteSpace(team.LogoUrl))
             {
-                await imageManager.DeleteImage(teamId, ImageTypeEnum.TeamLogo);
+                await imageManager.DeleteImageAsync(teamId, ImageTypeEnum.TeamLogo);
             }
 
             // Clear logo URL on team

--- a/TrashMob/Controllers/UsersController.cs
+++ b/TrashMob/Controllers/UsersController.cs
@@ -234,13 +234,13 @@ namespace TrashMob.Controllers
             // Delete existing profile photo if present
             if (!string.IsNullOrWhiteSpace(user.ProfilePhotoUrl))
             {
-                await imageManager.DeleteImage(UserId, ImageTypeEnum.UserProfilePhoto);
+                await imageManager.DeleteImageAsync(UserId, ImageTypeEnum.UserProfilePhoto);
             }
 
             // Upload new photo to blob storage
             imageUpload.ParentId = UserId;
             imageUpload.ImageType = ImageTypeEnum.UserProfilePhoto;
-            await imageManager.UploadImage(imageUpload);
+            await imageManager.UploadImageAsync(imageUpload);
 
             // Get the reduced-size URL and update user
             var imageUrl = await imageManager.GetImageUrlAsync(UserId, ImageTypeEnum.UserProfilePhoto, ImageSizeEnum.Reduced, cancellationToken);


### PR DESCRIPTION
## Summary
- Add `Async` suffix to 6 methods that were missing it: `UploadImage`, `DeleteImage`, `SubmitPickupLocations`, `AcceptInvitation`, `DeclineInvitation`, `ResendPartnerAdminInvitation` — updated across interfaces, implementations, controllers, and tests (35 files)
- Remove redundant `[ApiController]` attribute from 17 controllers that already inherit it from `BaseController`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442/442 passed
- [ ] Verify API endpoints still work (no route changes, only internal method renames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)