### PR TITLE
Convert constructors to primary pattern and fix POST return types

### DIFF
--- a/TrashMob/Controllers/AdminController.cs
+++ b/TrashMob/Controllers/AdminController.cs
@@ -15,16 +15,11 @@ namespace TrashMob.Controllers
     using TrashMob.Shared.Poco;
 
     [Route("api/admin")]
-    public class AdminController : SecureController
+    public class AdminController(
+        IKeyedManager<PartnerRequest> partnerRequestManager,
+        IEmailManager emailManager)
+        : SecureController
     {
-        private readonly IEmailManager emailManager;
-        private readonly IKeyedManager<PartnerRequest> partnerRequestManager;
-
-        public AdminController(IKeyedManager<PartnerRequest> partnerRequestManager, IEmailManager emailManager)
-        {
-            this.partnerRequestManager = partnerRequestManager;
-            this.emailManager = emailManager;
-        }
 
         /// <summary>
         /// Updates a partner request. Admin only.

--- a/TrashMob/Controllers/AdoptableAreasController.cs
+++ b/TrashMob/Controllers/AdoptableAreasController.cs
@@ -20,31 +20,13 @@ namespace TrashMob.Controllers
     /// Controller for managing adoptable areas within a community.
     /// </summary>
     [Route("api/communities/{partnerId}/areas")]
-    public class AdoptableAreasController : SecureController
+    public class AdoptableAreasController(
+        IAdoptableAreaManager areaManager,
+        IKeyedManager<Partner> partnerManager,
+        IAreaSuggestionService areaSuggestionService,
+        IAreaFileParser areaFileParser)
+        : SecureController
     {
-        private readonly IAdoptableAreaManager areaManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IAreaSuggestionService areaSuggestionService;
-        private readonly IAreaFileParser areaFileParser;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AdoptableAreasController"/> class.
-        /// </summary>
-        /// <param name="areaManager">The adoptable area manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        /// <param name="areaSuggestionService">The AI area suggestion service.</param>
-        /// <param name="areaFileParser">The area file parser for bulk import.</param>
-        public AdoptableAreasController(
-            IAdoptableAreaManager areaManager,
-            IKeyedManager<Partner> partnerManager,
-            IAreaSuggestionService areaSuggestionService,
-            IAreaFileParser areaFileParser)
-        {
-            this.areaManager = areaManager;
-            this.partnerManager = partnerManager;
-            this.areaSuggestionService = areaSuggestionService;
-            this.areaFileParser = areaFileParser;
-        }
 
         /// <summary>
         /// Gets all adoptable areas for a community.

--- a/TrashMob/Controllers/AdoptionEventsController.cs
+++ b/TrashMob/Controllers/AdoptionEventsController.cs
@@ -17,27 +17,12 @@ namespace TrashMob.Controllers
     /// Controller for managing event links to team adoptions.
     /// </summary>
     [Route("api/adoptions/{adoptionId}/events")]
-    public class AdoptionEventsController : SecureController
+    public class AdoptionEventsController(
+        ITeamAdoptionEventManager adoptionEventManager,
+        ITeamAdoptionManager adoptionManager,
+        ITeamMemberManager teamMemberManager)
+        : SecureController
     {
-        private readonly ITeamAdoptionEventManager adoptionEventManager;
-        private readonly ITeamAdoptionManager adoptionManager;
-        private readonly ITeamMemberManager teamMemberManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AdoptionEventsController"/> class.
-        /// </summary>
-        /// <param name="adoptionEventManager">The team adoption event manager.</param>
-        /// <param name="adoptionManager">The team adoption manager.</param>
-        /// <param name="teamMemberManager">The team member manager.</param>
-        public AdoptionEventsController(
-            ITeamAdoptionEventManager adoptionEventManager,
-            ITeamAdoptionManager adoptionManager,
-            ITeamMemberManager teamMemberManager)
-        {
-            this.adoptionEventManager = adoptionEventManager;
-            this.adoptionManager = adoptionManager;
-            this.teamMemberManager = teamMemberManager;
-        }
 
         /// <summary>
         /// Gets all events linked to an adoption.

--- a/TrashMob/Controllers/AuthenticationController.cs
+++ b/TrashMob/Controllers/AuthenticationController.cs
@@ -11,16 +11,11 @@ namespace TrashMob.Controllers
 
     [Route("api/authentication")]
     [ApiController]
-    public class AuthenticationController : ControllerBase
+    public class AuthenticationController(
+        IActiveDirectoryManager activeDirectoryManager,
+        ILogger<AuthenticationController> logger)
+        : ControllerBase
     {
-        private readonly IActiveDirectoryManager activeDirectoryManager;
-        private readonly ILogger<AuthenticationController> logger;
-
-        public AuthenticationController(IActiveDirectoryManager activeDirectoryManager, ILogger<AuthenticationController> logger)
-        {
-            this.activeDirectoryManager = activeDirectoryManager;
-            this.logger = logger;
-        }
 
         /// <summary>Validates whether a new user can be created in Active Directory.</summary>
         /// <param name="request">The new user details to validate.</param>

--- a/TrashMob/Controllers/CommunityAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunityAdoptionsController.cs
@@ -18,23 +18,11 @@ namespace TrashMob.Controllers
     /// Controller for community admin adoption management.
     /// </summary>
     [Route("api/communities/{partnerId}/adoptions")]
-    public class CommunityAdoptionsController : SecureController
+    public class CommunityAdoptionsController(
+        ITeamAdoptionManager adoptionManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly ITeamAdoptionManager adoptionManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommunityAdoptionsController"/> class.
-        /// </summary>
-        /// <param name="adoptionManager">The team adoption manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public CommunityAdoptionsController(
-            ITeamAdoptionManager adoptionManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.adoptionManager = adoptionManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all pending adoption applications for a community.

--- a/TrashMob/Controllers/CommunityInvitesController.cs
+++ b/TrashMob/Controllers/CommunityInvitesController.cs
@@ -20,23 +20,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/communities/{communityId}/invites")]
-    public class CommunityInvitesController : SecureController
+    public class CommunityInvitesController(
+        IEmailInviteManager emailInviteManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly IEmailInviteManager emailInviteManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommunityInvitesController"/> class.
-        /// </summary>
-        /// <param name="emailInviteManager">The email invite manager.</param>
-        /// <param name="partnerManager">The partner manager for authorization.</param>
-        public CommunityInvitesController(
-            IEmailInviteManager emailInviteManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.emailInviteManager = emailInviteManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all email invite batches for a community.

--- a/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
+++ b/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
@@ -17,27 +17,12 @@ namespace TrashMob.Controllers
     /// Controller for managing professional cleanup companies within a community.
     /// </summary>
     [Route("api/communities/{partnerId}/professional-companies")]
-    public class CommunityProfessionalCompaniesController : SecureController
+    public class CommunityProfessionalCompaniesController(
+        IProfessionalCompanyManager companyManager,
+        IProfessionalCompanyUserManager companyUserManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly IProfessionalCompanyManager companyManager;
-        private readonly IProfessionalCompanyUserManager companyUserManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommunityProfessionalCompaniesController"/> class.
-        /// </summary>
-        /// <param name="companyManager">The professional company manager.</param>
-        /// <param name="companyUserManager">The professional company user manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public CommunityProfessionalCompaniesController(
-            IProfessionalCompanyManager companyManager,
-            IProfessionalCompanyUserManager companyUserManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.companyManager = companyManager;
-            this.companyUserManager = companyUserManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all active professional companies for a community.

--- a/TrashMob/Controllers/CommunityProspectsController.cs
+++ b/TrashMob/Controllers/CommunityProspectsController.cs
@@ -89,11 +89,11 @@ namespace TrashMob.Controllers
         /// <param name="prospect">The prospect to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         [HttpPost]
-        [ProducesResponseType(typeof(CommunityProspect), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(CommunityProspect), StatusCodes.Status201Created)]
         public async Task<IActionResult> Create(CommunityProspect prospect, CancellationToken cancellationToken)
         {
             var result = await communityProspectManager.AddAsync(prospect, UserId, cancellationToken);
-            return Ok(result);
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
         }
 
         /// <summary>
@@ -164,12 +164,12 @@ namespace TrashMob.Controllers
         /// <param name="activity">The activity to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         [HttpPost("{id}/activities")]
-        [ProducesResponseType(typeof(ProspectActivity), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProspectActivity), StatusCodes.Status201Created)]
         public async Task<IActionResult> CreateActivity(Guid id, ProspectActivity activity, CancellationToken cancellationToken)
         {
             activity.ProspectId = id;
             var result = await prospectActivityManager.AddAsync(activity, UserId, cancellationToken);
-            return Ok(result);
+            return CreatedAtAction(nameof(GetActivities), new { id }, result);
         }
 
         /// <summary>

--- a/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
@@ -18,23 +18,11 @@ namespace TrashMob.Controllers
     /// Controller for managing sponsored adoptions within a community.
     /// </summary>
     [Route("api/communities/{partnerId}/sponsored-adoptions")]
-    public class CommunitySponsoredAdoptionsController : SecureController
+    public class CommunitySponsoredAdoptionsController(
+        ISponsoredAdoptionManager adoptionManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly ISponsoredAdoptionManager adoptionManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommunitySponsoredAdoptionsController"/> class.
-        /// </summary>
-        /// <param name="adoptionManager">The sponsored adoption manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public CommunitySponsoredAdoptionsController(
-            ISponsoredAdoptionManager adoptionManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.adoptionManager = adoptionManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all sponsored adoptions for a community.

--- a/TrashMob/Controllers/CommunitySponsorsController.cs
+++ b/TrashMob/Controllers/CommunitySponsorsController.cs
@@ -17,23 +17,11 @@ namespace TrashMob.Controllers
     /// Controller for managing sponsors within a community's sponsored adoption program.
     /// </summary>
     [Route("api/communities/{partnerId}/sponsors")]
-    public class CommunitySponsorsController : SecureController
+    public class CommunitySponsorsController(
+        ISponsorManager sponsorManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly ISponsorManager sponsorManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommunitySponsorsController"/> class.
-        /// </summary>
-        /// <param name="sponsorManager">The sponsor manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public CommunitySponsorsController(
-            ISponsorManager sponsorManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.sponsorManager = sponsorManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all active sponsors for a community.

--- a/TrashMob/Controllers/EventAttendeeRoutesController.cs
+++ b/TrashMob/Controllers/EventAttendeeRoutesController.cs
@@ -19,8 +19,6 @@ namespace TrashMob.Controllers
     [Route("api/eventattendeeroutes")]
     public class EventAttendeeRoutesController(IEventAttendeeRouteManager eventAttendeeRouteManager) : SecureController
     {
-        private readonly IEventAttendeeRouteManager eventAttendeeRouteManager = eventAttendeeRouteManager;
-
         /// <summary>
         /// Gets a list of event attendee routes for a specific event and user.
         /// </summary>
@@ -132,15 +130,15 @@ namespace TrashMob.Controllers
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status201Created)]
         public async Task<IActionResult> AddEventAttendeeRoute(DisplayEventAttendeeRoute displayEventAttendeeRoute,
             CancellationToken cancellationToken)
         {
             var eventAttendeeRoute = displayEventAttendeeRoute.ToEventAttendeeRoute();
 
-            await eventAttendeeRouteManager.AddAsync(eventAttendeeRoute, UserId, cancellationToken);
+            var result = await eventAttendeeRouteManager.AddAsync(eventAttendeeRoute, UserId, cancellationToken);
             TrackEvent(nameof(AddEventAttendeeRoute));
-            return Ok();
+            return CreatedAtAction(nameof(GetEventAttendeeRoute), new { id = result.Id }, result);
         }
 
         /// <summary>

--- a/TrashMob/Controllers/EventsController.cs
+++ b/TrashMob/Controllers/EventsController.cs
@@ -316,13 +316,13 @@ namespace TrashMob.Controllers
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(Event), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(Event), StatusCodes.Status201Created)]
         public async Task<IActionResult> AddEvent(Event mobEvent, CancellationToken cancellationToken)
         {
             var newEvent = await eventManager.AddAsync(mobEvent, UserId, cancellationToken);
             TrackEvent(nameof(AddEvent));
 
-            return Ok(newEvent);
+            return CreatedAtAction(nameof(GetEvent), new { id = newEvent.Id }, newEvent);
         }
 
         /// <summary>

--- a/TrashMob/Controllers/ImageController.cs
+++ b/TrashMob/Controllers/ImageController.cs
@@ -16,21 +16,11 @@ namespace TrashMob.Controllers
     /// Controller for managing images, including upload and deletion.
     /// </summary>
     [Route("api/image")]
-    public class ImageController : SecureController
+    public class ImageController(
+        IImageManager imageManager,
+        IEventManager eventManager)
+        : SecureController
     {
-        private readonly IEventManager eventManager;
-        private readonly IImageManager imageManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ImageController"/> class.
-        /// </summary>
-        /// <param name="imageManager">The image manager.</param>
-        /// <param name="eventManager">The event manager.</param>
-        public ImageController(IImageManager imageManager, IEventManager eventManager)
-        {
-            this.imageManager = imageManager;
-            this.eventManager = eventManager;
-        }
 
         /// <summary>
         /// Uploads an image for an event.

--- a/TrashMob/Controllers/PartnerAdminInvitationsController.cs
+++ b/TrashMob/Controllers/PartnerAdminInvitationsController.cs
@@ -15,26 +15,12 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/partneradmininvitations")]
-    public class PartnerAdminInvitationsController : SecureController
+    public class PartnerAdminInvitationsController(
+        IKeyedManager<User> userManager,
+        IPartnerAdminInvitationManager partnerAdminInvitationManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly IPartnerAdminInvitationManager partnerAdminInvitationManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IKeyedManager<User> userManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerAdminInvitationsController"/> class.
-        /// </summary>
-        /// <param name="userManager">The user manager.</param>
-        /// <param name="partnerAdminInvitationManager">The partner admin invitation manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public PartnerAdminInvitationsController(IKeyedManager<User> userManager,
-            IPartnerAdminInvitationManager partnerAdminInvitationManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.partnerManager = partnerManager;
-            this.userManager = userManager;
-            this.partnerAdminInvitationManager = partnerAdminInvitationManager;
-        }
 
         /// <summary>
         /// Gets all partner admin invitations for a given partner.


### PR DESCRIPTION
## Summary
- Convert 11 controllers from old-style constructors to C# 12 primary constructors, removing boilerplate field declarations and assignments
- Fix 4 POST endpoints to return `201 Created` with `CreatedAtAction()` instead of `200 Ok` for resource creation (AddEvent, Create prospect, CreateActivity, AddEventAttendeeRoute)
- Remove redundant duplicate field declaration in `EventAttendeeRoutesController` (primary constructor parameter was re-declared as a field)

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442/442 passed
- [ ] Verify POST endpoints return 201 status (frontend callers typically check `response.ok` which covers both 200 and 201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)