### PR TITLE
Convert remaining controllers to primary constructors

### DIFF
--- a/TrashMob/Controllers/CmsController.cs
+++ b/TrashMob/Controllers/CmsController.cs
@@ -29,7 +29,6 @@ namespace TrashMob.Controllers
         IConfiguration configuration,
         ILogger<CmsController> logger) : BaseController(logger)
     {
-        private readonly IHttpClientFactory httpClientFactory = httpClientFactory;
         private readonly string strapiBaseUrl = configuration["StrapiBaseUrl"] ?? string.Empty;
 
         /// <summary>

--- a/TrashMob/Controllers/EmailInvitesController.cs
+++ b/TrashMob/Controllers/EmailInvitesController.cs
@@ -19,18 +19,9 @@ namespace TrashMob.Controllers
     /// All endpoints require site admin privileges.
     /// </summary>
     [Route("api/admin/invites")]
-    public class EmailInvitesController : SecureController
+    public class EmailInvitesController(IEmailInviteManager emailInviteManager)
+        : SecureController
     {
-        private readonly IEmailInviteManager emailInviteManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EmailInvitesController"/> class.
-        /// </summary>
-        /// <param name="emailInviteManager">The email invite manager.</param>
-        public EmailInvitesController(IEmailInviteManager emailInviteManager)
-        {
-            this.emailInviteManager = emailInviteManager;
-        }
 
         /// <summary>
         /// Gets all email invite batches. Admin only.

--- a/TrashMob/Controllers/EventAttendeeMetricsController.cs
+++ b/TrashMob/Controllers/EventAttendeeMetricsController.cs
@@ -17,23 +17,11 @@ namespace TrashMob.Controllers
     /// Controller for attendee-submitted event metrics.
     /// </summary>
     [Route("api/events/{eventId}/attendee-metrics")]
-    public class EventAttendeeMetricsController : SecureController
+    public class EventAttendeeMetricsController(
+        IEventAttendeeMetricsManager metricsManager,
+        IKeyedManager<Event> eventManager)
+        : SecureController
     {
-        private readonly IEventAttendeeMetricsManager metricsManager;
-        private readonly IKeyedManager<Event> eventManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventAttendeeMetricsController"/> class.
-        /// </summary>
-        /// <param name="metricsManager">The attendee metrics manager.</param>
-        /// <param name="eventManager">The event manager.</param>
-        public EventAttendeeMetricsController(
-            IEventAttendeeMetricsManager metricsManager,
-            IKeyedManager<Event> eventManager)
-        {
-            this.metricsManager = metricsManager;
-            this.eventManager = eventManager;
-        }
 
         /// <summary>
         /// Gets the current user's metrics submission for an event.

--- a/TrashMob/Controllers/EventAttendeesController.cs
+++ b/TrashMob/Controllers/EventAttendeesController.cs
@@ -18,18 +18,11 @@ namespace TrashMob.Controllers
     using TrashMob.Shared.Poco;
 
     [Route("api/eventattendees")]
-    public class EventAttendeesController : SecureController
+    public class EventAttendeesController(
+        IEventAttendeeManager eventAttendeeManager,
+        IUserWaiverManager userWaiverManager)
+        : SecureController
     {
-        private readonly IEventAttendeeManager eventAttendeeManager;
-        private readonly IUserWaiverManager userWaiverManager;
-
-        public EventAttendeesController(
-            IEventAttendeeManager eventAttendeeManager,
-            IUserWaiverManager userWaiverManager)
-        {
-            this.eventAttendeeManager = eventAttendeeManager;
-            this.userWaiverManager = userWaiverManager;
-        }
 
         /// <summary>
         /// Gets all attendees for a given event.

--- a/TrashMob/Controllers/EventPartnerLocationServiceStatusesController.cs
+++ b/TrashMob/Controllers/EventPartnerLocationServiceStatusesController.cs
@@ -5,11 +5,8 @@
     using TrashMob.Shared.Managers.Interfaces;
 
     [Route("api/eventpartnerlocationservicestatuses")]
-    public class EventPartnerLocationServiceStatusesController : LookupController<EventPartnerLocationServiceStatus>
+    public class EventPartnerLocationServiceStatusesController(ILookupManager<EventPartnerLocationServiceStatus> manager)
+        : LookupController<EventPartnerLocationServiceStatus>(manager)
     {
-        public EventPartnerLocationServiceStatusesController(ILookupManager<EventPartnerLocationServiceStatus> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/EventPartnerLocationServicesController.cs
+++ b/TrashMob/Controllers/EventPartnerLocationServicesController.cs
@@ -16,26 +16,12 @@ namespace TrashMob.Controllers
     using TrashMob.Shared.Managers.Interfaces;
 
     [Route("api/eventpartnerlocationservices")]
-    public class EventPartnerLocationServicesController : SecureController
+    public class EventPartnerLocationServicesController(
+        IKeyedManager<Event> eventManager,
+        IEventPartnerLocationServiceManager eventPartnerLocationServiceManager,
+        IPartnerLocationManager partnerLocationManager)
+        : SecureController
     {
-        private readonly IKeyedManager<Event> eventManager;
-        private readonly IEventPartnerLocationServiceManager eventPartnerLocationServiceManager;
-        private readonly IPartnerLocationContactManager partnerLocationContactManager;
-        private readonly IPartnerLocationManager partnerLocationManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        public EventPartnerLocationServicesController(IKeyedManager<Event> eventManager,
-            IKeyedManager<Partner> partnerManager,
-            IEventPartnerLocationServiceManager eventPartnerLocationServiceManager,
-            IPartnerLocationManager partnerLocationManager,
-            IPartnerLocationContactManager partnerLocationContactManager)
-        {
-            this.eventPartnerLocationServiceManager = eventPartnerLocationServiceManager;
-            this.eventManager = eventManager;
-            this.partnerManager = partnerManager;
-            this.partnerLocationManager = partnerLocationManager;
-            this.partnerLocationContactManager = partnerLocationContactManager;
-        }
 
         /// <summary>
         /// Gets a list of all event partner location services for a given event.

--- a/TrashMob/Controllers/EventStatusesController.cs
+++ b/TrashMob/Controllers/EventStatusesController.cs
@@ -5,11 +5,8 @@
     using TrashMob.Shared.Managers.Interfaces;
 
     [Route("api/eventstatuses")]
-    public class EventStatusesController : LookupController<EventStatus>
+    public class EventStatusesController(ILookupManager<EventStatus> manager)
+        : LookupController<EventStatus>(manager)
     {
-        public EventStatusesController(ILookupManager<EventStatus> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/EventSummariesController.cs
+++ b/TrashMob/Controllers/EventSummariesController.cs
@@ -14,22 +14,11 @@ namespace TrashMob.Controllers
     using TrashMob.Shared.Managers.Interfaces;
 
     [Route("api/eventsummaries")]
-    public class EventSummariesController : SecureController
+    public class EventSummariesController(
+        IEventSummaryManager eventSummaryManager,
+        IKeyedManager<Event> eventManager)
+        : SecureController
     {
-        private readonly IKeyedManager<Event> eventManager;
-        private readonly IEventSummaryManager eventSummaryManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventSummariesController"/> class.
-        /// </summary>
-        /// <param name="eventSummaryManager">The event summary manager.</param>
-        /// <param name="eventManager">The event manager.</param>
-        public EventSummariesController(IEventSummaryManager eventSummaryManager,
-            IKeyedManager<Event> eventManager)
-        {
-            this.eventSummaryManager = eventSummaryManager;
-            this.eventManager = eventManager;
-        }
 
         /// <summary>
         /// Gets the event summary for a given event.

--- a/TrashMob/Controllers/EventTypesController.cs
+++ b/TrashMob/Controllers/EventTypesController.cs
@@ -8,15 +8,8 @@
     /// Controller for event type lookup operations.
     /// </summary>
     [Route("api/eventtypes")]
-    public class EventsTypesController : LookupController<EventType>
+    public class EventsTypesController(ILookupManager<EventType> manager)
+        : LookupController<EventType>(manager)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventsTypesController"/> class.
-        /// </summary>
-        /// <param name="manager">The event type lookup manager.</param>
-        public EventsTypesController(ILookupManager<EventType> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/IFTTT/v1/QueriesController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/QueriesController.cs
@@ -15,18 +15,9 @@ namespace TrashMob.Controllers.IFTTT
     /// </summary>
     [Route("api/ifttt/v1/[controller]")]
     [RequiredScope(Constants.TrashMobIFTTTScope)]
-    public class QueriesController : SecureController
+    public class QueriesController(IQueriesManager queriesManager)
+        : SecureController
     {
-        private readonly IQueriesManager queriesManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QueriesController"/> class.
-        /// </summary>
-        /// <param name="queriesManager">The queries manager.</param>
-        public QueriesController(IQueriesManager queriesManager)
-        {
-            this.queriesManager = queriesManager;
-        }
 
         /// <summary>
         /// Gets all events for IFTTT queries.

--- a/TrashMob/Controllers/IFTTT/v1/SetupController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/SetupController.cs
@@ -9,18 +9,9 @@
     /// </summary>
     [Route("api/ifttt/v1/test/[controller]")]
     [ApiController]
-    public class SetupController : Controller
+    public class SetupController(IKeyVaultManager keyVaultManager)
+        : Controller
     {
-        private readonly IKeyVaultManager keyVaultManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SetupController"/> class.
-        /// </summary>
-        /// <param name="keyVaultManager">The key vault manager.</param>
-        public SetupController(IKeyVaultManager keyVaultManager)
-        {
-            this.keyVaultManager = keyVaultManager;
-        }
 
         /// <summary>
         /// Gets test setup information for IFTTT authentication.

--- a/TrashMob/Controllers/IFTTT/v1/TriggersController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/TriggersController.cs
@@ -15,18 +15,9 @@ namespace TrashMob.Controllers.IFTTT
     /// </summary>
     [Route("api/ifttt/v1/[controller]")]
     [RequiredScope(Constants.TrashMobIFTTTScope)]
-    public class TriggersController : SecureController
+    public class TriggersController(ITriggersManager triggersManager)
+        : SecureController
     {
-        private readonly ITriggersManager triggersManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TriggersController"/> class.
-        /// </summary>
-        /// <param name="triggersManager">The triggers manager.</param>
-        public TriggersController(ITriggersManager triggersManager)
-        {
-            this.triggersManager = triggersManager;
-        }
 
         /// <summary>
         /// Gets all new events created (IFTTT trigger).

--- a/TrashMob/Controllers/IFTTT/v1/UserController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/UserController.cs
@@ -11,18 +11,9 @@ namespace TrashMob.Controllers.IFTTT
     /// Controller for IFTTT user info, providing endpoints for user information retrieval.
     /// </summary>
     [Route("api/ifttt/v1/[controller]")]
-    public class UserController : SecureController
+    public class UserController(IUserManager userManager)
+        : SecureController
     {
-        private readonly IUserManager userManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserController"/> class.
-        /// </summary>
-        /// <param name="userManager">The user manager.</param>
-        public UserController(IUserManager userManager)
-        {
-            this.userManager = userManager;
-        }
 
         /// <summary>
         /// Gets user info for IFTTT integration.

--- a/TrashMob/Controllers/InvitationStatusesController.cs
+++ b/TrashMob/Controllers/InvitationStatusesController.cs
@@ -8,15 +8,8 @@
     /// Controller for invitation status lookup operations.
     /// </summary>
     [Route("api/invitationstatuses")]
-    public class InvitationStatusesController : LookupController<InvitationStatus>
+    public class InvitationStatusesController(ILookupManager<InvitationStatus> manager)
+        : LookupController<InvitationStatus>(manager)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvitationStatusesController"/> class.
-        /// </summary>
-        /// <param name="manager">The invitation status lookup manager.</param>
-        public InvitationStatusesController(ILookupManager<InvitationStatus> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/JobOpportunityController.cs
+++ b/TrashMob/Controllers/JobOpportunityController.cs
@@ -15,16 +15,9 @@ namespace TrashMob.Controllers
     /// Controller for managing job opportunities, including CRUD operations.
     /// </summary>
     [Route("api/jobopportunities")]
-    public class JobOpportunitiesController : KeyedController<JobOpportunity>
+    public class JobOpportunitiesController(IKeyedManager<JobOpportunity> jobOpportunityManager)
+        : KeyedController<JobOpportunity>(jobOpportunityManager)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JobOpportunitiesController"/> class.
-        /// </summary>
-        /// <param name="jobOpportunityManager">The job opportunity manager.</param>
-        public JobOpportunitiesController(IKeyedManager<JobOpportunity> jobOpportunityManager)
-            : base(jobOpportunityManager)
-        {
-        }
 
         /// <summary>
         /// Gets a job opportunity by its unique identifier.

--- a/TrashMob/Controllers/KeyedController.cs
+++ b/TrashMob/Controllers/KeyedController.cs
@@ -12,21 +12,13 @@ namespace TrashMob.Controllers
     /// <summary>
     /// Abstract controller for keyed entities, providing add, get, and delete operations.
     /// </summary>
-    public abstract class KeyedController<T> : SecureController where T : KeyedModel
+    public abstract class KeyedController<T>(IKeyedManager<T> manager)
+        : SecureController where T : KeyedModel
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="KeyedController{T}"/> class.
-        /// </summary>
-        /// <param name="manager">The keyed manager.</param>
-        public KeyedController(IKeyedManager<T> manager)
-        {
-            Manager = manager;
-        }
-
         /// <summary>
         /// Gets the keyed manager.
         /// </summary>
-        protected IKeyedManager<T> Manager { get; }
+        protected IKeyedManager<T> Manager { get; } = manager;
 
         /// <summary>
         /// Adds a new entity. Requires a valid user.

--- a/TrashMob/Controllers/MapsController.cs
+++ b/TrashMob/Controllers/MapsController.cs
@@ -12,18 +12,9 @@
     /// Controller for map-related operations, including map key retrieval and address lookup.
     /// </summary>
     [Route("api/maps")]
-    public class MapsController : SecureController
+    public class MapsController(IMapManager mapRepository)
+        : SecureController
     {
-        private readonly IMapManager mapRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MapsController"/> class.
-        /// </summary>
-        /// <param name="mapRepository">The map manager.</param>
-        public MapsController(IMapManager mapRepository)
-        {
-            this.mapRepository = mapRepository;
-        }
 
         /// <summary>
         /// Gets the map key.

--- a/TrashMob/Controllers/MessageRequestController.cs
+++ b/TrashMob/Controllers/MessageRequestController.cs
@@ -13,18 +13,9 @@ namespace TrashMob.Controllers
     /// Controller for sending message requests. Admin only.
     /// </summary>
     [Route("api/messagerequest")]
-    public class MessageRequestController : SecureController
+    public class MessageRequestController(IMessageRequestManager messageRequestManager)
+        : SecureController
     {
-        private readonly IMessageRequestManager messageRequestManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageRequestController"/> class.
-        /// </summary>
-        /// <param name="messageRequestManager">The message request manager.</param>
-        public MessageRequestController(IMessageRequestManager messageRequestManager)
-        {
-            this.messageRequestManager = messageRequestManager;
-        }
 
         /// <summary>
         /// Sends a message request. Admin only.

--- a/TrashMob/Controllers/NewsletterPreferencesController.cs
+++ b/TrashMob/Controllers/NewsletterPreferencesController.cs
@@ -15,23 +15,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/newsletter-preferences")]
-    public class NewsletterPreferencesController : SecureController
+    public class NewsletterPreferencesController(
+        IUserNewsletterPreferenceManager preferenceManager,
+        ILookupRepository<NewsletterCategory> categoryRepository)
+        : SecureController
     {
-        private readonly IUserNewsletterPreferenceManager preferenceManager;
-        private readonly ILookupRepository<NewsletterCategory> categoryRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NewsletterPreferencesController"/> class.
-        /// </summary>
-        /// <param name="preferenceManager">The preference manager.</param>
-        /// <param name="categoryRepository">The category repository.</param>
-        public NewsletterPreferencesController(
-            IUserNewsletterPreferenceManager preferenceManager,
-            ILookupRepository<NewsletterCategory> categoryRepository)
-        {
-            this.preferenceManager = preferenceManager;
-            this.categoryRepository = categoryRepository;
-        }
 
         /// <summary>
         /// Gets all newsletter categories.

--- a/TrashMob/Controllers/NewsletterWebhooksController.cs
+++ b/TrashMob/Controllers/NewsletterWebhooksController.cs
@@ -15,23 +15,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Route("api/webhooks/sendgrid")]
     [ApiController]
-    public class NewsletterWebhooksController : ControllerBase
+    public class NewsletterWebhooksController(
+        INewsletterManager newsletterManager,
+        ILogger<NewsletterWebhooksController> logger)
+        : ControllerBase
     {
-        private readonly INewsletterManager newsletterManager;
-        private readonly ILogger<NewsletterWebhooksController> logger;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NewsletterWebhooksController"/> class.
-        /// </summary>
-        /// <param name="newsletterManager">The newsletter manager.</param>
-        /// <param name="logger">The logger.</param>
-        public NewsletterWebhooksController(
-            INewsletterManager newsletterManager,
-            ILogger<NewsletterWebhooksController> logger)
-        {
-            this.newsletterManager = newsletterManager;
-            this.logger = logger;
-        }
 
         /// <summary>
         /// Processes SendGrid webhook events for newsletter tracking.

--- a/TrashMob/Controllers/NewslettersController.cs
+++ b/TrashMob/Controllers/NewslettersController.cs
@@ -20,27 +20,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/admin/newsletters")]
-    public class NewslettersController : SecureController
+    public class NewslettersController(
+        INewsletterManager newsletterManager,
+        ILookupRepository<NewsletterTemplate> templateRepository)
+        : SecureController
     {
-        private readonly INewsletterManager newsletterManager;
-        private readonly ILookupRepository<NewsletterCategory> categoryRepository;
-        private readonly ILookupRepository<NewsletterTemplate> templateRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NewslettersController"/> class.
-        /// </summary>
-        /// <param name="newsletterManager">The newsletter manager.</param>
-        /// <param name="categoryRepository">The category repository.</param>
-        /// <param name="templateRepository">The template repository.</param>
-        public NewslettersController(
-            INewsletterManager newsletterManager,
-            ILookupRepository<NewsletterCategory> categoryRepository,
-            ILookupRepository<NewsletterTemplate> templateRepository)
-        {
-            this.newsletterManager = newsletterManager;
-            this.categoryRepository = categoryRepository;
-            this.templateRepository = templateRepository;
-        }
 
         /// <summary>
         /// Gets all newsletters with optional status filter.

--- a/TrashMob/Controllers/PartnerAdminsController.cs
+++ b/TrashMob/Controllers/PartnerAdminsController.cs
@@ -20,26 +20,12 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/partneradmins")]
-    public class PartnerAdminsController : SecureController
+    public class PartnerAdminsController(
+        IKeyedManager<User> userManager,
+        IPartnerAdminManager partnerAdminManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly IPartnerAdminManager partnerAdminManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IKeyedManager<User> userManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerAdminsController"/> class.
-        /// </summary>
-        /// <param name="userManager">The user manager.</param>
-        /// <param name="partnerAdminManager">The partner admin manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public PartnerAdminsController(IKeyedManager<User> userManager,
-            IPartnerAdminManager partnerAdminManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.partnerManager = partnerManager;
-            this.userManager = userManager;
-            this.partnerAdminManager = partnerAdminManager;
-        }
 
         /// <summary>
         /// Gets all partner admins for a given partner.

--- a/TrashMob/Controllers/PartnerContactsController.cs
+++ b/TrashMob/Controllers/PartnerContactsController.cs
@@ -14,22 +14,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/partnercontacts")]
-    public class PartnerContactsController : SecureController
+    public class PartnerContactsController(
+        IKeyedManager<Partner> partnerManager,
+        IPartnerContactManager partnerContactManager)
+        : SecureController
     {
-        private readonly IPartnerContactManager partnerContactManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerContactsController"/> class.
-        /// </summary>
-        /// <param name="partnerManager">The partner manager.</param>
-        /// <param name="partnerContactManager">The partner contact manager.</param>
-        public PartnerContactsController(IKeyedManager<Partner> partnerManager,
-            IPartnerContactManager partnerContactManager)
-        {
-            this.partnerManager = partnerManager;
-            this.partnerContactManager = partnerContactManager;
-        }
 
         /// <summary>
         /// Gets all contacts for a given partner. Requires a valid user.

--- a/TrashMob/Controllers/PartnerController.cs
+++ b/TrashMob/Controllers/PartnerController.cs
@@ -13,16 +13,9 @@ namespace TrashMob.Controllers
     /// Controller for managing partners, including retrieval and update.
     /// </summary>
     [Route("api/partners")]
-    public class PartnersController : KeyedController<Partner>
+    public class PartnersController(IKeyedManager<Partner> partnerManager)
+        : KeyedController<Partner>(partnerManager)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnersController"/> class.
-        /// </summary>
-        /// <param name="partnerManager">The partner manager.</param>
-        public PartnersController(IKeyedManager<Partner> partnerManager)
-            : base(partnerManager)
-        {
-        }
 
         /// <summary>
         /// Gets a partner by its unique identifier.

--- a/TrashMob/Controllers/PartnerDocumentAdminController.cs
+++ b/TrashMob/Controllers/PartnerDocumentAdminController.cs
@@ -17,18 +17,9 @@ namespace TrashMob.Controllers
     /// All endpoints require site admin privileges.
     /// </summary>
     [Route("api/admin/partnerdocuments")]
-    public class PartnerDocumentAdminController : SecureController
+    public class PartnerDocumentAdminController(IPartnerDocumentManager manager)
+        : SecureController
     {
-        private readonly IPartnerDocumentManager manager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerDocumentAdminController"/> class.
-        /// </summary>
-        /// <param name="manager">The partner document manager.</param>
-        public PartnerDocumentAdminController(IPartnerDocumentManager manager)
-        {
-            this.manager = manager;
-        }
 
         /// <summary>
         /// Gets all partner documents across all partners, with partner information included.

--- a/TrashMob/Controllers/PartnerDocumentsController.cs
+++ b/TrashMob/Controllers/PartnerDocumentsController.cs
@@ -16,12 +16,12 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/partnerdocuments")]
-    public class PartnerDocumentsController : SecureController
+    public class PartnerDocumentsController(
+        IKeyedManager<Partner> partnerManager,
+        IPartnerDocumentManager manager,
+        IPartnerDocumentStorageManager storageManager)
+        : SecureController
     {
-        private readonly IPartnerDocumentManager manager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IPartnerDocumentStorageManager storageManager;
-
         private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
         {
             "application/pdf",
@@ -33,22 +33,6 @@ namespace TrashMob.Controllers
 
         private const long MaxFileSizeBytes = 25 * 1024 * 1024; // 25 MB
         private const long MaxPartnerStorageBytes = 500 * 1024 * 1024; // 500 MB
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerDocumentsController"/> class.
-        /// </summary>
-        /// <param name="partnerManager">The partner manager.</param>
-        /// <param name="manager">The partner document manager.</param>
-        /// <param name="storageManager">The partner document storage manager.</param>
-        public PartnerDocumentsController(
-            IKeyedManager<Partner> partnerManager,
-            IPartnerDocumentManager manager,
-            IPartnerDocumentStorageManager storageManager)
-        {
-            this.manager = manager;
-            this.partnerManager = partnerManager;
-            this.storageManager = storageManager;
-        }
 
         /// <summary>
         /// Gets all documents for a given partner.

--- a/TrashMob/Controllers/PartnerLocationContactsController.cs
+++ b/TrashMob/Controllers/PartnerLocationContactsController.cs
@@ -14,22 +14,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/partnerlocationcontacts")]
-    public class PartnerLocationContactsController : SecureController
+    public class PartnerLocationContactsController(
+        IPartnerLocationManager partnerLocationManager,
+        IPartnerLocationContactManager partnerLocationContactManager)
+        : SecureController
     {
-        private readonly IPartnerLocationContactManager partnerLocationContactManager;
-        private readonly IPartnerLocationManager partnerLocationManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerLocationContactsController"/> class.
-        /// </summary>
-        /// <param name="partnerLocationManager">The partner location manager.</param>
-        /// <param name="partnerLocationContactManager">The partner location contact manager.</param>
-        public PartnerLocationContactsController(IPartnerLocationManager partnerLocationManager,
-            IPartnerLocationContactManager partnerLocationContactManager)
-        {
-            this.partnerLocationManager = partnerLocationManager;
-            this.partnerLocationContactManager = partnerLocationContactManager;
-        }
 
         /// <summary>
         /// Gets all contacts for a given partner location. Requires a valid user.

--- a/TrashMob/Controllers/PartnerLocationEventServicesController.cs
+++ b/TrashMob/Controllers/PartnerLocationEventServicesController.cs
@@ -12,23 +12,11 @@ namespace TrashMob.Controllers
     /// Controller for managing partner location event services, including retrieval by location and user.
     /// </summary>
     [Route("api/partnerlocationeventservices")]
-    public class PartnerLocationEventServicesController : SecureController
+    public class PartnerLocationEventServicesController(
+        IEventPartnerLocationServiceManager eventPartnerLocationServicesManager,
+        IPartnerLocationManager partnerLocationManager)
+        : SecureController
     {
-        private readonly IEventPartnerLocationServiceManager eventPartnerLocationServicesManager;
-        private readonly IPartnerLocationManager partnerLocationManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerLocationEventServicesController"/> class.
-        /// </summary>
-        /// <param name="eventPartnerLocationServicesManager">The event partner location services manager.</param>
-        /// <param name="partnerLocationManager">The partner location manager.</param>
-        public PartnerLocationEventServicesController(
-            IEventPartnerLocationServiceManager eventPartnerLocationServicesManager,
-            IPartnerLocationManager partnerLocationManager)
-        {
-            this.eventPartnerLocationServicesManager = eventPartnerLocationServicesManager;
-            this.partnerLocationManager = partnerLocationManager;
-        }
 
         /// <summary>
         /// Gets all event services for a given partner location.

--- a/TrashMob/Controllers/PartnerLocationServicesController.cs
+++ b/TrashMob/Controllers/PartnerLocationServicesController.cs
@@ -13,26 +13,12 @@ namespace TrashMob.Controllers
     /// Controller for managing partner location services, including retrieval and creation.
     /// </summary>
     [Route("api/partnerlocationservices")]
-    public class PartnerLocationServicesController : SecureController
+    public class PartnerLocationServicesController(
+        IBaseManager<PartnerLocationService> partnerLocationServicesManager,
+        IKeyedManager<Partner> partnerManager,
+        IKeyedManager<PartnerLocation> partnerLocationManager)
+        : SecureController
     {
-        private readonly IKeyedManager<PartnerLocation> partnerLocationManager;
-        private readonly IBaseManager<PartnerLocationService> partnerLocationServicesManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerLocationServicesController"/> class.
-        /// </summary>
-        /// <param name="partnerLocationServicesManager">The partner location services manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        /// <param name="partnerLocationManager">The partner location manager.</param>
-        public PartnerLocationServicesController(IBaseManager<PartnerLocationService> partnerLocationServicesManager,
-            IKeyedManager<Partner> partnerManager,
-            IKeyedManager<PartnerLocation> partnerLocationManager)
-        {
-            this.partnerLocationServicesManager = partnerLocationServicesManager;
-            this.partnerManager = partnerManager;
-            this.partnerLocationManager = partnerLocationManager;
-        }
 
         /// <summary>
         /// Gets all partner location services for a given partner location. Requires a valid user.

--- a/TrashMob/Controllers/PartnerLocationsController.cs
+++ b/TrashMob/Controllers/PartnerLocationsController.cs
@@ -17,22 +17,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/partnerlocations")]
-    public class PartnerLocationsController : SecureController
+    public class PartnerLocationsController(
+        IPartnerLocationManager partnerLocationManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly IPartnerLocationManager partnerLocationManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerLocationsController"/> class.
-        /// </summary>
-        /// <param name="partnerLocationManager">The partner location manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public PartnerLocationsController(IPartnerLocationManager partnerLocationManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.partnerLocationManager = partnerLocationManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all partner locations for a given partner.

--- a/TrashMob/Controllers/PartnerRequestStatusesController.cs
+++ b/TrashMob/Controllers/PartnerRequestStatusesController.cs
@@ -8,15 +8,8 @@
     /// Controller for partner request status lookup operations.
     /// </summary>
     [Route("api/partnerrequeststatuses")]
-    public class PartnerRequestStatusesController : LookupController<PartnerRequestStatus>
+    public class PartnerRequestStatusesController(ILookupManager<PartnerRequestStatus> manager)
+        : LookupController<PartnerRequestStatus>(manager)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerRequestStatusesController"/> class.
-        /// </summary>
-        /// <param name="manager">The partner request status lookup manager.</param>
-        public PartnerRequestStatusesController(ILookupManager<PartnerRequestStatus> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/PartnerRequestsController.cs
+++ b/TrashMob/Controllers/PartnerRequestsController.cs
@@ -15,18 +15,9 @@ namespace TrashMob.Controllers
     /// Controller for managing partner requests, including creation, approval, and denial.
     /// </summary>
     [Route("api/partnerrequests")]
-    public class PartnerRequestsController : SecureController
+    public class PartnerRequestsController(IPartnerRequestManager partnerRequestManager)
+        : SecureController
     {
-        private readonly IPartnerRequestManager partnerRequestManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerRequestsController"/> class.
-        /// </summary>
-        /// <param name="partnerRequestManager">The partner request manager.</param>
-        public PartnerRequestsController(IPartnerRequestManager partnerRequestManager)
-        {
-            this.partnerRequestManager = partnerRequestManager;
-        }
 
         /// <summary>
         /// Adds a new partner request. Requires a valid user.

--- a/TrashMob/Controllers/PartnerSocialMediaAccountsController.cs
+++ b/TrashMob/Controllers/PartnerSocialMediaAccountsController.cs
@@ -14,22 +14,11 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/partnersocialmediaaccounts")]
-    public class PartnerSocialMediaAccountController : SecureController
+    public class PartnerSocialMediaAccountController(
+        IPartnerSocialMediaAccountManager manager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly IPartnerSocialMediaAccountManager manager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerSocialMediaAccountController"/> class.
-        /// </summary>
-        /// <param name="partnerSocialMediaAccountManager">The partner social media account manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public PartnerSocialMediaAccountController(IPartnerSocialMediaAccountManager partnerSocialMediaAccountManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            manager = partnerSocialMediaAccountManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all social media accounts for a given partner.

--- a/TrashMob/Controllers/PartnerStatusesController.cs
+++ b/TrashMob/Controllers/PartnerStatusesController.cs
@@ -8,15 +8,8 @@
     /// Controller for partner status lookup operations.
     /// </summary>
     [Route("api/partnerstatuses")]
-    public class PartnerStatusesController : LookupController<PartnerStatus>
+    public class PartnerStatusesController(ILookupManager<PartnerStatus> manager)
+        : LookupController<PartnerStatus>(manager)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerStatusesController"/> class.
-        /// </summary>
-        /// <param name="manager">The partner status lookup manager.</param>
-        public PartnerStatusesController(ILookupManager<PartnerStatus> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/PartnerTypesController.cs
+++ b/TrashMob/Controllers/PartnerTypesController.cs
@@ -8,15 +8,8 @@
     /// Controller for partner type lookup operations.
     /// </summary>
     [Route("api/partnertypes")]
-    public class PartnerTypesController : LookupController<PartnerType>
+    public class PartnerTypesController(ILookupManager<PartnerType> manager)
+        : LookupController<PartnerType>(manager)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerTypesController"/> class.
-        /// </summary>
-        /// <param name="manager">The partner type lookup manager.</param>
-        public PartnerTypesController(ILookupManager<PartnerType> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/PhotoModerationController.cs
+++ b/TrashMob/Controllers/PhotoModerationController.cs
@@ -18,14 +18,9 @@ namespace TrashMob.Controllers
     /// Includes admin endpoints for moderation and user endpoints for flagging.
     /// </summary>
     [Route("api/admin/photos")]
-    public class PhotoModerationController : SecureController
+    public class PhotoModerationController(IPhotoModerationManager photoModerationManager)
+        : SecureController
     {
-        private readonly IPhotoModerationManager photoModerationManager;
-
-        public PhotoModerationController(IPhotoModerationManager photoModerationManager)
-        {
-            this.photoModerationManager = photoModerationManager;
-        }
 
         /// <summary>
         /// Gets photos pending moderation review. Admin only.
@@ -196,14 +191,9 @@ namespace TrashMob.Controllers
     /// Controller for user photo flagging.
     /// </summary>
     [Route("api/photos")]
-    public class PhotoFlagController : SecureController
+    public class PhotoFlagController(IPhotoModerationManager photoModerationManager)
+        : SecureController
     {
-        private readonly IPhotoModerationManager photoModerationManager;
-
-        public PhotoFlagController(IPhotoModerationManager photoModerationManager)
-        {
-            this.photoModerationManager = photoModerationManager;
-        }
 
         /// <summary>
         /// Flags a photo for review. Any authenticated user.

--- a/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
+++ b/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
@@ -17,27 +17,12 @@ namespace TrashMob.Controllers
     /// Controller for professional cleanup log operations.
     /// </summary>
     [Route("api/professional-companies/{companyId}/cleanup-logs")]
-    public class ProfessionalCleanupLogsController : SecureController
+    public class ProfessionalCleanupLogsController(
+        IProfessionalCleanupLogManager logManager,
+        IProfessionalCompanyManager companyManager,
+        ISponsoredAdoptionManager adoptionManager)
+        : SecureController
     {
-        private readonly IProfessionalCleanupLogManager logManager;
-        private readonly IProfessionalCompanyManager companyManager;
-        private readonly ISponsoredAdoptionManager adoptionManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProfessionalCleanupLogsController"/> class.
-        /// </summary>
-        /// <param name="logManager">The cleanup log manager.</param>
-        /// <param name="companyManager">The professional company manager.</param>
-        /// <param name="adoptionManager">The sponsored adoption manager.</param>
-        public ProfessionalCleanupLogsController(
-            IProfessionalCleanupLogManager logManager,
-            IProfessionalCompanyManager companyManager,
-            ISponsoredAdoptionManager adoptionManager)
-        {
-            this.logManager = logManager;
-            this.companyManager = companyManager;
-            this.adoptionManager = adoptionManager;
-        }
 
         /// <summary>
         /// Gets all cleanup logs for a professional company.

--- a/TrashMob/Controllers/ProfessionalCompanyPortalController.cs
+++ b/TrashMob/Controllers/ProfessionalCompanyPortalController.cs
@@ -16,18 +16,9 @@ namespace TrashMob.Controllers
     /// Portal endpoints for professional company users.
     /// </summary>
     [Route("api/professional-companies")]
-    public class ProfessionalCompanyPortalController : SecureController
+    public class ProfessionalCompanyPortalController(IProfessionalCompanyUserManager companyUserManager)
+        : SecureController
     {
-        private readonly IProfessionalCompanyUserManager companyUserManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProfessionalCompanyPortalController"/> class.
-        /// </summary>
-        /// <param name="companyUserManager">The professional company user manager.</param>
-        public ProfessionalCompanyPortalController(IProfessionalCompanyUserManager companyUserManager)
-        {
-            this.companyUserManager = companyUserManager;
-        }
 
         /// <summary>
         /// Gets all professional companies the authenticated user is assigned to.

--- a/TrashMob/Controllers/SecretsController.cs
+++ b/TrashMob/Controllers/SecretsController.cs
@@ -11,18 +11,9 @@
     /// Controller for managing application secrets.
     /// </summary>
     [Route("api/secrets")]
-    public class SecretsController : SecureController
+    public class SecretsController(ISecretRepository secretRepository)
+        : SecureController
     {
-        private readonly ISecretRepository secretRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SecretsController"/> class.
-        /// </summary>
-        /// <param name="secretRepository">The secret repository.</param>
-        public SecretsController(ISecretRepository secretRepository)
-        {
-            this.secretRepository = secretRepository;
-        }
 
         /// <summary>
         /// Gets a secret by name. Requires a valid user.

--- a/TrashMob/Controllers/ServiceTypesController.cs
+++ b/TrashMob/Controllers/ServiceTypesController.cs
@@ -5,11 +5,8 @@
     using TrashMob.Shared.Managers.Interfaces;
 
     [Route("api/servicetypes")]
-    public class ServiceTypesController : LookupController<ServiceType>
+    public class ServiceTypesController(ILookupManager<ServiceType> manager)
+        : LookupController<ServiceType>(manager)
     {
-        public ServiceTypesController(ILookupManager<ServiceType> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/SocialMediaAccountTypesController.cs
+++ b/TrashMob/Controllers/SocialMediaAccountTypesController.cs
@@ -5,11 +5,8 @@
     using TrashMob.Shared.Managers.Interfaces;
 
     [Route("api/socialmediaaccounttypes")]
-    public class SocialMediaAccountTypesController : LookupController<SocialMediaAccountType>
+    public class SocialMediaAccountTypesController(ILookupManager<SocialMediaAccountType> manager)
+        : LookupController<SocialMediaAccountType>(manager)
     {
-        public SocialMediaAccountTypesController(ILookupManager<SocialMediaAccountType> manager)
-            : base(manager)
-        {
-        }
     }
 }

--- a/TrashMob/Controllers/SponsorPortalController.cs
+++ b/TrashMob/Controllers/SponsorPortalController.cs
@@ -19,31 +19,13 @@ namespace TrashMob.Controllers
     /// Portal endpoints for sponsor users (read-only views of adoptions and cleanup logs).
     /// </summary>
     [Route("api/sponsors")]
-    public class SponsorPortalController : SecureController
+    public class SponsorPortalController(
+        ISponsorManager sponsorManager,
+        IPartnerAdminManager partnerAdminManager,
+        IProfessionalCleanupLogManager logManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly ISponsorManager sponsorManager;
-        private readonly IPartnerAdminManager partnerAdminManager;
-        private readonly IProfessionalCleanupLogManager logManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SponsorPortalController"/> class.
-        /// </summary>
-        /// <param name="sponsorManager">The sponsor manager.</param>
-        /// <param name="partnerAdminManager">The partner admin manager.</param>
-        /// <param name="logManager">The cleanup log manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public SponsorPortalController(
-            ISponsorManager sponsorManager,
-            IPartnerAdminManager partnerAdminManager,
-            IProfessionalCleanupLogManager logManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.sponsorManager = sponsorManager;
-            this.partnerAdminManager = partnerAdminManager;
-            this.logManager = logManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all sponsors the authenticated user has access to via partner admin memberships.

--- a/TrashMob/Controllers/SponsorReportsController.cs
+++ b/TrashMob/Controllers/SponsorReportsController.cs
@@ -17,31 +17,13 @@ namespace TrashMob.Controllers
     /// Controller for sponsor adoption reports and cleanup log summaries.
     /// </summary>
     [Route("api/sponsors/{sponsorId}/adoptions")]
-    public class SponsorReportsController : SecureController
+    public class SponsorReportsController(
+        ISponsoredAdoptionManager adoptionManager,
+        IProfessionalCleanupLogManager logManager,
+        ISponsorManager sponsorManager,
+        IKeyedManager<Partner> partnerManager)
+        : SecureController
     {
-        private readonly ISponsoredAdoptionManager adoptionManager;
-        private readonly IProfessionalCleanupLogManager logManager;
-        private readonly ISponsorManager sponsorManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SponsorReportsController"/> class.
-        /// </summary>
-        /// <param name="adoptionManager">The sponsored adoption manager.</param>
-        /// <param name="logManager">The cleanup log manager.</param>
-        /// <param name="sponsorManager">The sponsor manager.</param>
-        /// <param name="partnerManager">The partner manager.</param>
-        public SponsorReportsController(
-            ISponsoredAdoptionManager adoptionManager,
-            IProfessionalCleanupLogManager logManager,
-            ISponsorManager sponsorManager,
-            IKeyedManager<Partner> partnerManager)
-        {
-            this.adoptionManager = adoptionManager;
-            this.logManager = logManager;
-            this.sponsorManager = sponsorManager;
-            this.partnerManager = partnerManager;
-        }
 
         /// <summary>
         /// Gets all sponsored adoptions for a specific sponsor.

--- a/TrashMob/Controllers/TeamAdoptionsController.cs
+++ b/TrashMob/Controllers/TeamAdoptionsController.cs
@@ -17,31 +17,13 @@ namespace TrashMob.Controllers
     /// Controller for team adoption operations (team-centric view).
     /// </summary>
     [Route("api/teams/{teamId}/adoptions")]
-    public class TeamAdoptionsController : SecureController
+    public class TeamAdoptionsController(
+        ITeamAdoptionManager adoptionManager,
+        ITeamAdoptionEventManager adoptionEventManager,
+        IKeyedManager<Team> teamManager,
+        ITeamMemberManager teamMemberManager)
+        : SecureController
     {
-        private readonly ITeamAdoptionManager adoptionManager;
-        private readonly ITeamAdoptionEventManager adoptionEventManager;
-        private readonly IKeyedManager<Team> teamManager;
-        private readonly ITeamMemberManager teamMemberManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamAdoptionsController"/> class.
-        /// </summary>
-        /// <param name="adoptionManager">The team adoption manager.</param>
-        /// <param name="adoptionEventManager">The team adoption event manager.</param>
-        /// <param name="teamManager">The team manager.</param>
-        /// <param name="teamMemberManager">The team member manager.</param>
-        public TeamAdoptionsController(
-            ITeamAdoptionManager adoptionManager,
-            ITeamAdoptionEventManager adoptionEventManager,
-            IKeyedManager<Team> teamManager,
-            ITeamMemberManager teamMemberManager)
-        {
-            this.adoptionManager = adoptionManager;
-            this.adoptionEventManager = adoptionEventManager;
-            this.teamManager = teamManager;
-            this.teamMemberManager = teamMemberManager;
-        }
 
         /// <summary>
         /// Gets all adoption applications for a team.

--- a/TrashMob/Controllers/TeamInvitesController.cs
+++ b/TrashMob/Controllers/TeamInvitesController.cs
@@ -20,27 +20,12 @@ namespace TrashMob.Controllers
     /// </summary>
     [Authorize]
     [Route("api/teams/{teamId}/invites")]
-    public class TeamInvitesController : SecureController
+    public class TeamInvitesController(
+        IEmailInviteManager emailInviteManager,
+        ITeamManager teamManager,
+        ITeamMemberManager teamMemberManager)
+        : SecureController
     {
-        private readonly IEmailInviteManager emailInviteManager;
-        private readonly ITeamManager teamManager;
-        private readonly ITeamMemberManager teamMemberManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamInvitesController"/> class.
-        /// </summary>
-        /// <param name="emailInviteManager">The email invite manager.</param>
-        /// <param name="teamManager">The team manager.</param>
-        /// <param name="teamMemberManager">The team member manager.</param>
-        public TeamInvitesController(
-            IEmailInviteManager emailInviteManager,
-            ITeamManager teamManager,
-            ITeamMemberManager teamMemberManager)
-        {
-            this.emailInviteManager = emailInviteManager;
-            this.teamManager = teamManager;
-            this.teamMemberManager = teamMemberManager;
-        }
 
         /// <summary>
         /// Gets all email invite batches for a team.

--- a/TrashMob/Controllers/UserFeedbackController.cs
+++ b/TrashMob/Controllers/UserFeedbackController.cs
@@ -17,18 +17,9 @@ namespace TrashMob.Controllers
     /// Controller for managing user feedback submissions.
     /// </summary>
     [Route("api/feedback")]
-    public class UserFeedbackController : SecureController
+    public class UserFeedbackController(IUserFeedbackManager feedbackManager)
+        : SecureController
     {
-        private readonly IUserFeedbackManager feedbackManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserFeedbackController"/> class.
-        /// </summary>
-        /// <param name="feedbackManager">The feedback manager.</param>
-        public UserFeedbackController(IUserFeedbackManager feedbackManager)
-        {
-            this.feedbackManager = feedbackManager;
-        }
 
         /// <summary>
         /// Submits new user feedback. Can be called by authenticated or anonymous users.

--- a/TrashMob/Controllers/UserInvitesController.cs
+++ b/TrashMob/Controllers/UserInvitesController.cs
@@ -18,7 +18,8 @@ namespace TrashMob.Controllers
     /// </summary>
     [Route("api/invites")]
     [Authorize]
-    public class UserInvitesController : SecureController
+    public class UserInvitesController(IEmailInviteManager emailInviteManager)
+        : SecureController
     {
         /// <summary>
         /// Maximum number of emails per batch for user invites.
@@ -29,17 +30,6 @@ namespace TrashMob.Controllers
         /// Maximum number of invites per month for each user.
         /// </summary>
         private const int MaxInvitesPerMonth = 50;
-
-        private readonly IEmailInviteManager emailInviteManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserInvitesController"/> class.
-        /// </summary>
-        /// <param name="emailInviteManager">The email invite manager.</param>
-        public UserInvitesController(IEmailInviteManager emailInviteManager)
-        {
-            this.emailInviteManager = emailInviteManager;
-        }
 
         /// <summary>
         /// Gets the current user's invite batches.

--- a/TrashMob/Controllers/UserWaiverController.cs
+++ b/TrashMob/Controllers/UserWaiverController.cs
@@ -20,31 +20,13 @@ namespace TrashMob.Controllers
     /// Handles waiver signing, viewing, and downloading.
     /// </summary>
     [Route("api/waivers")]
-    public class UserWaiverController : SecureController
+    public class UserWaiverController(
+        IUserWaiverManager userWaiverManager,
+        IWaiverDocumentManager waiverDocumentManager,
+        IUserManager userManager,
+        IEventAttendeeManager eventAttendeeManager)
+        : SecureController
     {
-        private readonly IUserWaiverManager userWaiverManager;
-        private readonly IWaiverDocumentManager waiverDocumentManager;
-        private readonly IUserManager userManager;
-        private readonly IEventAttendeeManager eventAttendeeManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserWaiverController"/> class.
-        /// </summary>
-        /// <param name="userWaiverManager">The user waiver manager.</param>
-        /// <param name="waiverDocumentManager">The waiver document manager.</param>
-        /// <param name="userManager">The user manager.</param>
-        /// <param name="eventAttendeeManager">The event attendee manager.</param>
-        public UserWaiverController(
-            IUserWaiverManager userWaiverManager,
-            IWaiverDocumentManager waiverDocumentManager,
-            IUserManager userManager,
-            IEventAttendeeManager eventAttendeeManager)
-        {
-            this.userWaiverManager = userWaiverManager;
-            this.waiverDocumentManager = waiverDocumentManager;
-            this.userManager = userManager;
-            this.eventAttendeeManager = eventAttendeeManager;
-        }
 
         /// <summary>
         /// Gets waivers the current user needs to sign.

--- a/TrashMob/Controllers/WaiverAdminController.cs
+++ b/TrashMob/Controllers/WaiverAdminController.cs
@@ -18,18 +18,9 @@ namespace TrashMob.Controllers
     /// All endpoints require site admin privileges.
     /// </summary>
     [Route("api/admin/waivers")]
-    public class WaiverAdminController : SecureController
+    public class WaiverAdminController(IWaiverVersionManager waiverVersionManager)
+        : SecureController
     {
-        private readonly IWaiverVersionManager waiverVersionManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaiverAdminController"/> class.
-        /// </summary>
-        /// <param name="waiverVersionManager">The waiver version manager.</param>
-        public WaiverAdminController(IWaiverVersionManager waiverVersionManager)
-        {
-            this.waiverVersionManager = waiverVersionManager;
-        }
 
         /// <summary>
         /// Gets all waiver versions. Admin only.
@@ -201,19 +192,9 @@ namespace TrashMob.Controllers
     /// All endpoints require site admin privileges.
     /// </summary>
     [Route("api/admin/communities/{communityId}/waivers")]
-    public class CommunityWaiverAdminController : SecureController
+    public class CommunityWaiverAdminController(IWaiverVersionManager waiverVersionManager)
+        : SecureController
     {
-        private readonly IWaiverVersionManager waiverVersionManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommunityWaiverAdminController"/> class
-        /// for managing waiver assignments to communities.
-        /// </summary>
-        /// <param name="waiverVersionManager">The manager for waiver version operations.</param>
-        public CommunityWaiverAdminController(IWaiverVersionManager waiverVersionManager)
-        {
-            this.waiverVersionManager = waiverVersionManager;
-        }
 
         /// <summary>
         /// Gets all waiver assignments for a community. Admin only.

--- a/TrashMob/Controllers/WaiverComplianceController.cs
+++ b/TrashMob/Controllers/WaiverComplianceController.cs
@@ -21,18 +21,9 @@ namespace TrashMob.Controllers
     /// All endpoints require site admin privileges.
     /// </summary>
     [Route("api/admin/waivers/compliance")]
-    public class WaiverComplianceController : SecureController
+    public class WaiverComplianceController(IUserWaiverManager userWaiverManager)
+        : SecureController
     {
-        private readonly IUserWaiverManager userWaiverManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaiverComplianceController"/> class.
-        /// </summary>
-        /// <param name="userWaiverManager">The user waiver manager.</param>
-        public WaiverComplianceController(IUserWaiverManager userWaiverManager)
-        {
-            this.userWaiverManager = userWaiverManager;
-        }
 
         /// <summary>
         /// Gets waiver compliance summary statistics for the admin dashboard.


### PR DESCRIPTION
## Summary
- Converts all remaining old-style constructors to C# 12 primary constructors across **50 controller files**
- Covers regular controllers, lookup controllers, keyed controllers, IFTTT controllers, and the `KeyedController<T>` abstract base class
- Removes 3 unused DI parameters discovered during conversion (`partnerManager` and `partnerLocationContactManager` in `EventPartnerLocationServicesController`, `categoryRepository` in `NewslettersController`)
- Removes a redundant field declaration in `CmsController`
- Net reduction of **512 lines** of boilerplate code

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442/442 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)