### PR TITLE
Fix HTTP status code, redundant field, and code style issues

### DIFF
--- a/TrashMob.Shared/Managers/Areas/AreaFileParser.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaFileParser.cs
@@ -22,7 +22,6 @@ namespace TrashMob.Shared.Managers.Areas
     /// </summary>
     public class AreaFileParser(ILogger<AreaFileParser> logger) : IAreaFileParser
     {
-        private readonly ILogger<AreaFileParser> _logger = logger;
 
         private const int MaxFeatures = 500;
 
@@ -64,7 +63,7 @@ namespace TrashMob.Shared.Managers.Areas
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to parse area import file: {FileName}", fileName);
+                logger.LogError(ex, "Failed to parse area import file: {FileName}", fileName);
                 result.Error = $"Failed to parse file: {ex.Message}";
                 return result;
             }
@@ -457,7 +456,7 @@ namespace TrashMob.Shared.Managers.Areas
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to clean up temp directory: {TempDir}", tempDir);
+                    logger.LogWarning(ex, "Failed to clean up temp directory: {TempDir}", tempDir);
                 }
             }
         }

--- a/TrashMob/Controllers/KeyedController.cs
+++ b/TrashMob/Controllers/KeyedController.cs
@@ -30,11 +30,11 @@ namespace TrashMob.Controllers
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         public virtual async Task<IActionResult> Add(T instance, CancellationToken cancellationToken)
         {
-            await Manager.AddAsync(instance, UserId, cancellationToken);
+            var result = await Manager.AddAsync(instance, UserId, cancellationToken);
 
             TrackEvent("Add" + nameof(T));
 
-            return Ok();
+            return CreatedAtAction(nameof(Get), result);
         }
 
         /// <summary>

--- a/TrashMob/Controllers/PartnerAdminsController.cs
+++ b/TrashMob/Controllers/PartnerAdminsController.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace TrashMob.Controllers
 {
     using System;
@@ -8,6 +6,7 @@ namespace TrashMob.Controllers
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using TrashMob.Models;
     using TrashMob.Models.Poco;

--- a/TrashMob/Controllers/WeightUnitsController.cs
+++ b/TrashMob/Controllers/WeightUnitsController.cs
@@ -1,17 +1,15 @@
-namespace TrashMob.Controllers;
-
-using Microsoft.AspNetCore.Mvc;
-using TrashMob.Models;
-using TrashMob.Shared.Managers.Interfaces;
-
-/// <summary>
-/// Controller for managing weight unit lookup data.
-/// </summary>
-/// <remarks>
-/// Initializes a new instance of the <see cref="WeightUnitsController"/> class.
-/// </remarks>
-/// <param name="manager">The weight unit lookup manager.</param>
-[Route("api/weightunits")]
-public class WeightUnitsController(ILookupManager<WeightUnit> manager) : LookupController<WeightUnit>(manager)
+﻿namespace TrashMob.Controllers
 {
+    using Microsoft.AspNetCore.Mvc;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// Controller for managing weight unit lookup data.
+    /// </summary>
+    [Route("api/weightunits")]
+    public class WeightUnitsController(ILookupManager<WeightUnit> manager)
+        : LookupController<WeightUnit>(manager)
+    {
+    }
 }


### PR DESCRIPTION
## Summary
- **KeyedController.Add()**: Return `CreatedAtAction` (201) instead of `Ok()` (200) — affects all KeyedController subclasses (PartnersController, JobOpportunitiesController, etc.)
- **PartnerAdminsController**: Move `using Microsoft.AspNetCore.Http` from outside namespace to inside, matching codebase convention
- **AreaFileParser**: Remove redundant `_logger` field that shadowed the primary constructor parameter; use `logger` directly
- **WeightUnitsController**: Standardize from file-scoped namespace to traditional block namespace, matching all other controllers

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442/442 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)