### PR TITLE
Convert manager classes to C# 12 primary constructors

### DIFF
--- a/TrashMob.Shared.Tests/Managers/EmailInviteManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/EmailInviteManagerTests.cs
@@ -24,7 +24,6 @@ namespace TrashMob.Shared.Tests.Managers
         private readonly Mock<IKeyedRepository<EmailInviteBatch>> _batchRepository;
         private readonly Mock<IKeyedRepository<EmailInvite>> _inviteRepository;
         private readonly Mock<IEmailManager> _emailManager;
-        private readonly Mock<IUserManager> _userManager;
         private readonly Mock<IKeyedManager<Partner>> _partnerManager;
         private readonly Mock<ITeamManager> _teamManager;
         private readonly EmailInviteManager _sut;
@@ -34,7 +33,6 @@ namespace TrashMob.Shared.Tests.Managers
             _batchRepository = new Mock<IKeyedRepository<EmailInviteBatch>>();
             _inviteRepository = new Mock<IKeyedRepository<EmailInvite>>();
             _emailManager = new Mock<IEmailManager>();
-            _userManager = new Mock<IUserManager>();
             _partnerManager = new Mock<IKeyedManager<Partner>>();
             _teamManager = new Mock<ITeamManager>();
 
@@ -58,7 +56,6 @@ namespace TrashMob.Shared.Tests.Managers
                 _batchRepository.Object,
                 _inviteRepository.Object,
                 _emailManager.Object,
-                _userManager.Object,
                 _partnerManager.Object,
                 _teamManager.Object);
         }

--- a/TrashMob.Shared/Managers/ActiveDirectoryManager.cs
+++ b/TrashMob.Shared/Managers/ActiveDirectoryManager.cs
@@ -10,18 +10,8 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages Azure Active Directory B2C user lifecycle operations including creation, validation, and profile updates.
     /// </summary>
-    public class ActiveDirectoryManager : IActiveDirectoryManager
+    public class ActiveDirectoryManager(IUserManager userManager) : IActiveDirectoryManager
     {
-        private readonly IUserManager userManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ActiveDirectoryManager"/> class.
-        /// </summary>
-        /// <param name="userManager">The user manager for user data operations.</param>
-        public ActiveDirectoryManager(IUserManager userManager)
-        {
-            this.userManager = userManager;
-        }
 
         /// <inheritdoc />
         public async Task<ActiveDirectoryResponseBase> CreateUserAsync(

--- a/TrashMob.Shared/Managers/Adoptions/AdoptableAreaManager.cs
+++ b/TrashMob.Shared/Managers/Adoptions/AdoptableAreaManager.cs
@@ -15,20 +15,9 @@ namespace TrashMob.Shared.Managers.Adoptions
     /// <summary>
     /// Manager for adoptable area operations.
     /// </summary>
-    public class AdoptableAreaManager : KeyedManager<AdoptableArea>, IAdoptableAreaManager
+    public class AdoptableAreaManager(IKeyedRepository<AdoptableArea> repository, ILogger<AdoptableAreaManager> logger)
+        : KeyedManager<AdoptableArea>(repository), IAdoptableAreaManager
     {
-        private readonly ILogger<AdoptableAreaManager> logger;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AdoptableAreaManager"/> class.
-        /// </summary>
-        /// <param name="repository">The adoptable area repository.</param>
-        /// <param name="logger">The logger.</param>
-        public AdoptableAreaManager(IKeyedRepository<AdoptableArea> repository, ILogger<AdoptableAreaManager> logger)
-            : base(repository)
-        {
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<AdoptableArea>> GetByCommunityAsync(

--- a/TrashMob.Shared/Managers/Adoptions/TeamAdoptionEventManager.cs
+++ b/TrashMob.Shared/Managers/Adoptions/TeamAdoptionEventManager.cs
@@ -14,26 +14,13 @@ namespace TrashMob.Shared.Managers.Adoptions
     /// <summary>
     /// Manager for team adoption event linking operations.
     /// </summary>
-    public class TeamAdoptionEventManager : KeyedManager<TeamAdoptionEvent>, ITeamAdoptionEventManager
+    public class TeamAdoptionEventManager(
+        IKeyedRepository<TeamAdoptionEvent> repository,
+        ITeamAdoptionManager adoptionManager,
+        IKeyedManager<Event> eventManager,
+        IKeyedRepository<TeamAdoption> adoptionRepository)
+        : KeyedManager<TeamAdoptionEvent>(repository), ITeamAdoptionEventManager
     {
-        private readonly ITeamAdoptionManager adoptionManager;
-        private readonly IKeyedManager<Event> eventManager;
-        private readonly IKeyedRepository<TeamAdoption> adoptionRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamAdoptionEventManager"/> class.
-        /// </summary>
-        public TeamAdoptionEventManager(
-            IKeyedRepository<TeamAdoptionEvent> repository,
-            ITeamAdoptionManager adoptionManager,
-            IKeyedManager<Event> eventManager,
-            IKeyedRepository<TeamAdoption> adoptionRepository)
-            : base(repository)
-        {
-            this.adoptionManager = adoptionManager;
-            this.eventManager = eventManager;
-            this.adoptionRepository = adoptionRepository;
-        }
 
         /// <inheritdoc />
         public async Task<ServiceResult<TeamAdoptionEvent>> LinkEventAsync(

--- a/TrashMob.Shared/Managers/Adoptions/TeamAdoptionManager.cs
+++ b/TrashMob.Shared/Managers/Adoptions/TeamAdoptionManager.cs
@@ -15,35 +15,16 @@ namespace TrashMob.Shared.Managers.Adoptions
     /// <summary>
     /// Manager for team adoption application operations.
     /// </summary>
-    public class TeamAdoptionManager : KeyedManager<TeamAdoption>, ITeamAdoptionManager
+    public class TeamAdoptionManager(
+        IKeyedRepository<TeamAdoption> repository,
+        IEmailManager emailManager,
+        ITeamManager teamManager,
+        ITeamMemberManager teamMemberManager,
+        IAdoptableAreaManager adoptableAreaManager,
+        IKeyedManager<Partner> partnerManager,
+        IPartnerAdminManager partnerAdminManager)
+        : KeyedManager<TeamAdoption>(repository), ITeamAdoptionManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly ITeamManager teamManager;
-        private readonly ITeamMemberManager teamMemberManager;
-        private readonly IAdoptableAreaManager adoptableAreaManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IPartnerAdminManager partnerAdminManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamAdoptionManager"/> class.
-        /// </summary>
-        public TeamAdoptionManager(
-            IKeyedRepository<TeamAdoption> repository,
-            IEmailManager emailManager,
-            ITeamManager teamManager,
-            ITeamMemberManager teamMemberManager,
-            IAdoptableAreaManager adoptableAreaManager,
-            IKeyedManager<Partner> partnerManager,
-            IPartnerAdminManager partnerAdminManager)
-            : base(repository)
-        {
-            this.emailManager = emailManager;
-            this.teamManager = teamManager;
-            this.teamMemberManager = teamMemberManager;
-            this.adoptableAreaManager = adoptableAreaManager;
-            this.partnerManager = partnerManager;
-            this.partnerAdminManager = partnerAdminManager;
-        }
 
         /// <inheritdoc />
         public async Task<ServiceResult<TeamAdoption>> SubmitApplicationAsync(

--- a/TrashMob.Shared/Managers/BaseManager.cs
+++ b/TrashMob.Shared/Managers/BaseManager.cs
@@ -15,21 +15,13 @@
     /// Abstract base manager class providing common CRUD operations for entities derived from BaseModel.
     /// </summary>
     /// <typeparam name="T">The entity type derived from BaseModel.</typeparam>
-    public abstract class BaseManager<T> : IBaseManager<T> where T : BaseModel
+    public abstract class BaseManager<T>(IBaseRepository<T> repository)
+        : IBaseManager<T> where T : BaseModel
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BaseManager{T}"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for data access operations.</param>
-        public BaseManager(IBaseRepository<T> repository)
-        {
-            Repository = repository;
-        }
-
         /// <summary>
         /// Gets the repository used for data access operations.
         /// </summary>
-        protected virtual IBaseRepository<T> Repository { get; }
+        protected virtual IBaseRepository<T> Repository { get; } = repository;
 
         /// <inheritdoc />
         public virtual Task<T> AddAsync(T instance, Guid userId, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/Communities/CommunityManager.cs
+++ b/TrashMob.Shared/Managers/Communities/CommunityManager.cs
@@ -15,40 +15,16 @@ namespace TrashMob.Shared.Managers.Communities
     /// Manager for community page operations.
     /// Communities are partners with enabled home pages.
     /// </summary>
-    public class CommunityManager : ICommunityManager
+    public class CommunityManager(
+        IKeyedRepository<Partner> partnerRepository,
+        IKeyedRepository<Event> eventRepository,
+        IKeyedRepository<Team> teamRepository,
+        IKeyedRepository<LitterReport> litterReportRepository,
+        IKeyedRepository<LitterImage> litterImageRepository,
+        IBaseRepository<EventSummary> eventSummaryRepository)
+        : ICommunityManager
     {
-        private readonly IKeyedRepository<Partner> partnerRepository;
-        private readonly IKeyedRepository<Event> eventRepository;
-        private readonly IKeyedRepository<Team> teamRepository;
-        private readonly IKeyedRepository<LitterReport> litterReportRepository;
-        private readonly IKeyedRepository<LitterImage> litterImageRepository;
-        private readonly IBaseRepository<EventSummary> eventSummaryRepository;
         private const int CancelledEventStatusId = 3;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommunityManager"/> class.
-        /// </summary>
-        /// <param name="partnerRepository">The partner repository.</param>
-        /// <param name="eventRepository">The event repository.</param>
-        /// <param name="teamRepository">The team repository.</param>
-        /// <param name="litterReportRepository">The litter report repository.</param>
-        /// <param name="litterImageRepository">The litter image repository.</param>
-        /// <param name="eventSummaryRepository">The event summary repository.</param>
-        public CommunityManager(
-            IKeyedRepository<Partner> partnerRepository,
-            IKeyedRepository<Event> eventRepository,
-            IKeyedRepository<Team> teamRepository,
-            IKeyedRepository<LitterReport> litterReportRepository,
-            IKeyedRepository<LitterImage> litterImageRepository,
-            IBaseRepository<EventSummary> eventSummaryRepository)
-        {
-            this.partnerRepository = partnerRepository;
-            this.eventRepository = eventRepository;
-            this.teamRepository = teamRepository;
-            this.litterReportRepository = litterReportRepository;
-            this.litterImageRepository = litterImageRepository;
-            this.eventSummaryRepository = eventSummaryRepository;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<Partner>> GetEnabledCommunitiesAsync(

--- a/TrashMob.Shared/Managers/ContactRequestManager.cs
+++ b/TrashMob.Shared/Managers/ContactRequestManager.cs
@@ -13,20 +13,9 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages contact request submissions from the website, sending notification emails to administrators.
     /// </summary>
-    public class ContactRequestManager : KeyedManager<ContactRequest>, IKeyedManager<ContactRequest>
+    public class ContactRequestManager(IKeyedRepository<ContactRequest> repository, IEmailManager emailManager)
+        : KeyedManager<ContactRequest>(repository), IKeyedManager<ContactRequest>
     {
-        private readonly IEmailManager emailManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ContactRequestManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for contact request data access.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        public ContactRequestManager(IKeyedRepository<ContactRequest> repository, IEmailManager emailManager) :
-            base(repository)
-        {
-            this.emailManager = emailManager;
-        }
 
         /// <inheritdoc />
         public override async Task<ContactRequest> AddAsync(ContactRequest contactRequest,

--- a/TrashMob.Shared/Managers/EmailInviteManager.cs
+++ b/TrashMob.Shared/Managers/EmailInviteManager.cs
@@ -15,38 +15,14 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages bulk email invitation operations including creating batches and sending emails.
     /// </summary>
-    public class EmailInviteManager : KeyedManager<EmailInviteBatch>, IEmailInviteManager
+    public class EmailInviteManager(
+        IKeyedRepository<EmailInviteBatch> emailInviteBatchRepository,
+        IKeyedRepository<EmailInvite> emailInviteRepository,
+        IEmailManager emailManager,
+        IKeyedManager<Partner> partnerManager,
+        ITeamManager teamManager)
+        : KeyedManager<EmailInviteBatch>(emailInviteBatchRepository), IEmailInviteManager
     {
-        private readonly IKeyedRepository<EmailInvite> emailInviteRepository;
-        private readonly IEmailManager emailManager;
-        private readonly IUserManager userManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly ITeamManager teamManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EmailInviteManager"/> class.
-        /// </summary>
-        /// <param name="emailInviteBatchRepository">The repository for email invite batch data access.</param>
-        /// <param name="emailInviteRepository">The repository for individual email invite data access.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        /// <param name="userManager">The manager for user operations.</param>
-        /// <param name="partnerManager">The manager for partner/community operations.</param>
-        /// <param name="teamManager">The manager for team operations.</param>
-        public EmailInviteManager(
-            IKeyedRepository<EmailInviteBatch> emailInviteBatchRepository,
-            IKeyedRepository<EmailInvite> emailInviteRepository,
-            IEmailManager emailManager,
-            IUserManager userManager,
-            IKeyedManager<Partner> partnerManager,
-            ITeamManager teamManager)
-            : base(emailInviteBatchRepository)
-        {
-            this.emailInviteRepository = emailInviteRepository;
-            this.emailManager = emailManager;
-            this.userManager = userManager;
-            this.partnerManager = partnerManager;
-            this.teamManager = teamManager;
-        }
 
         /// <inheritdoc />
         public async Task<EmailInviteBatch> CreateBatchAsync(

--- a/TrashMob.Shared/Managers/EventPhotoManager.cs
+++ b/TrashMob.Shared/Managers/EventPhotoManager.cs
@@ -17,26 +17,12 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages event photos including CRUD operations and image storage integration.
     /// </summary>
-    public class EventPhotoManager : KeyedManager<EventPhoto>, IEventPhotoManager
+    public class EventPhotoManager(
+        IKeyedRepository<EventPhoto> repository,
+        IImageManager imageManager,
+        MobDbContext dbContext)
+        : KeyedManager<EventPhoto>(repository), IEventPhotoManager
     {
-        private readonly IImageManager imageManager;
-        private readonly MobDbContext dbContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventPhotoManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for event photo data access.</param>
-        /// <param name="imageManager">The image manager for blob storage operations.</param>
-        /// <param name="dbContext">The database context.</param>
-        public EventPhotoManager(
-            IKeyedRepository<EventPhoto> repository,
-            IImageManager imageManager,
-            MobDbContext dbContext)
-            : base(repository)
-        {
-            this.imageManager = imageManager;
-            this.dbContext = dbContext;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<EventPhoto>> GetByEventIdAsync(

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -16,23 +16,12 @@ namespace TrashMob.Shared.Managers.Events
     /// <summary>
     /// Manages event attendee registrations and tracks which events users are attending.
     /// </summary>
-    public class EventAttendeeManager : BaseManager<EventAttendee>, IBaseManager<EventAttendee>, IEventAttendeeManager
+    public class EventAttendeeManager(
+        IBaseRepository<EventAttendee> repository,
+        IKeyedRepository<Event> eventRepository,
+        IEmailManager emailManager)
+        : BaseManager<EventAttendee>(repository), IBaseManager<EventAttendee>, IEventAttendeeManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly IKeyedRepository<Event> eventRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventAttendeeManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for event attendee data access.</param>
-        /// <param name="eventRepository">The repository for event data access.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        public EventAttendeeManager(IBaseRepository<EventAttendee> repository, IKeyedRepository<Event> eventRepository,
-            IEmailManager emailManager) : base(repository)
-        {
-            this.eventRepository = eventRepository;
-            this.emailManager = emailManager;
-        }
 
         /// <inheritdoc />
         public override async Task<IEnumerable<EventAttendee>> GetByParentIdAsync(Guid parentId,

--- a/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
@@ -14,27 +14,15 @@ namespace TrashMob.Shared.Managers.Events
     /// <summary>
     /// Manager for attendee-submitted event metrics operations.
     /// </summary>
-    public class EventAttendeeMetricsManager : KeyedManager<EventAttendeeMetrics>, IEventAttendeeMetricsManager
+    public class EventAttendeeMetricsManager(
+        IKeyedRepository<EventAttendeeMetrics> repository,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<Event> eventManager)
+        : KeyedManager<EventAttendeeMetrics>(repository), IEventAttendeeMetricsManager
     {
         private const decimal KgToLbsConversion = 2.20462m;
         private const int WeightUnitPounds = 1;
         private const int WeightUnitKilograms = 2;
-
-        private readonly IEventAttendeeManager eventAttendeeManager;
-        private readonly IKeyedManager<Event> eventManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventAttendeeMetricsManager"/> class.
-        /// </summary>
-        public EventAttendeeMetricsManager(
-            IKeyedRepository<EventAttendeeMetrics> repository,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<Event> eventManager)
-            : base(repository)
-        {
-            this.eventAttendeeManager = eventAttendeeManager;
-            this.eventManager = eventManager;
-        }
 
         /// <inheritdoc />
         public async Task<ServiceResult<EventAttendeeMetrics>> SubmitMetricsAsync(

--- a/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
@@ -17,22 +17,11 @@ namespace TrashMob.Shared.Managers.Events
     /// <summary>
     /// Manages event attendee GPS routes recorded during cleanup events.
     /// </summary>
-    public class EventAttendeeRouteManager : KeyedManager<EventAttendeeRoute>, IBaseManager<EventAttendeeRoute>,
-        IEventAttendeeRouteManager
+    public class EventAttendeeRouteManager(
+        IKeyedRepository<EventAttendeeRoute> eventAttendeeRouteRepository)
+        : KeyedManager<EventAttendeeRoute>(eventAttendeeRouteRepository), IBaseManager<EventAttendeeRoute>,
+            IEventAttendeeRouteManager
     {
-        private readonly IKeyedRepository<Event> eventRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventAttendeeRouteManager"/> class.
-        /// </summary>
-        /// <param name="eventAttendeeRouteRepository">The repository for event attendee route data access.</param>
-        /// <param name="eventRepository">The repository for event data access.</param>
-        public EventAttendeeRouteManager(
-            IKeyedRepository<EventAttendeeRoute> eventAttendeeRouteRepository,
-            IKeyedRepository<Event> eventRepository) : base(eventAttendeeRouteRepository)
-        {
-            this.eventRepository = eventRepository;
-        }
 
         /// <inheritdoc />
         public override async Task<IEnumerable<EventAttendeeRoute>> GetByParentIdAsync(Guid parentId,

--- a/TrashMob.Shared/Managers/Events/EventLitterReportManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventLitterReportManager.cs
@@ -15,29 +15,13 @@ namespace TrashMob.Shared.Managers.Events
     /// <summary>
     /// Manages associations between events and litter reports, tracking which reports are being cleaned by which events.
     /// </summary>
-    public class EventLitterReportManager : BaseManager<EventLitterReport>, IBaseManager<EventLitterReport>, IEventLitterReportManager
+    public class EventLitterReportManager(
+        IBaseRepository<EventLitterReport> repository,
+        IKeyedRepository<Event> eventRepository,
+        IKeyedRepository<LitterReport> litterReportRepository,
+        ILogger<EventLitterReportManager> logger)
+        : BaseManager<EventLitterReport>(repository), IBaseManager<EventLitterReport>, IEventLitterReportManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly ILogger<EventLitterReportManager> logger;
-        private readonly IKeyedRepository<Event> eventRepository;
-        private readonly IKeyedRepository<LitterReport> litterReportRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventLitterReportManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for event litter report data access.</param>
-        /// <param name="eventRepository">The repository for event data access.</param>
-        /// <param name="litterReportRepository">The repository for litter report data access.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        /// <param name="logger">The logger instance.</param>
-        public EventLitterReportManager(IBaseRepository<EventLitterReport> repository, IKeyedRepository<Event> eventRepository, IKeyedRepository<LitterReport> litterReportRepository,
-            IEmailManager emailManager, ILogger<EventLitterReportManager> logger) : base(repository)
-        {
-            this.eventRepository = eventRepository;
-            this.litterReportRepository = litterReportRepository;
-            this.emailManager = emailManager;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public override async Task<IEnumerable<EventLitterReport>> GetByParentIdAsync(Guid parentId,

--- a/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
@@ -16,38 +16,16 @@ namespace TrashMob.Shared.Managers.Events
     /// <summary>
     /// Manages event partner location services including partnership requests and approvals.
     /// </summary>
-    public class EventPartnerLocationServiceManager : BaseManager<EventPartnerLocationService>,
-        IEventPartnerLocationServiceManager
+    public class EventPartnerLocationServiceManager(
+        IBaseRepository<EventPartnerLocationService> repository,
+        IKeyedRepository<Event> eventRepository,
+        IKeyedRepository<PartnerLocation> partnerLocationRepository,
+        IBaseRepository<PartnerLocationService> partnerLocationServiceRepository,
+        IKeyedRepository<User> userRepository,
+        IBaseRepository<PartnerAdmin> partnerAdminRepository,
+        IEmailManager emailManager)
+        : BaseManager<EventPartnerLocationService>(repository), IEventPartnerLocationServiceManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly IKeyedRepository<Event> eventRepository;
-        private readonly IBaseRepository<PartnerAdmin> partnerAdminRepository;
-        private readonly IKeyedRepository<PartnerLocation> partnerLocationRepository;
-        private readonly IBaseRepository<PartnerLocationService> partnerLocationServiceRepository;
-        private readonly IKeyedRepository<Partner> partnerRepository;
-        private readonly IKeyedRepository<User> userRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventPartnerLocationServiceManager"/> class.
-        /// </summary>
-        public EventPartnerLocationServiceManager(IBaseRepository<EventPartnerLocationService> repository,
-            IKeyedRepository<Event> eventRepository,
-            IKeyedRepository<Partner> partnerRepository,
-            IKeyedRepository<PartnerLocation> partnerLocationRepository,
-            IBaseRepository<PartnerLocationService> partnerLocationServiceRepository,
-            IKeyedRepository<User> userRepository,
-            IBaseRepository<PartnerAdmin> partnerAdminRepository,
-            IEmailManager emailManager)
-            : base(repository)
-        {
-            this.eventRepository = eventRepository;
-            this.partnerRepository = partnerRepository;
-            this.partnerLocationRepository = partnerLocationRepository;
-            this.partnerLocationServiceRepository = partnerLocationServiceRepository;
-            this.userRepository = userRepository;
-            this.partnerAdminRepository = partnerAdminRepository;
-            this.emailManager = emailManager;
-        }
 
         /// <inheritdoc />
         public override async Task<EventPartnerLocationService> AddAsync(EventPartnerLocationService instance,

--- a/TrashMob.Shared/Managers/Events/EventSummaryManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventSummaryManager.cs
@@ -16,32 +16,16 @@ namespace TrashMob.Shared.Managers.Events
     /// <summary>
     /// Manages event summaries including statistics, post-event reports, and impact metrics.
     /// </summary>
-    public class EventSummaryManager : BaseManager<EventSummary>, IEventSummaryManager
+    public class EventSummaryManager(
+        IBaseRepository<EventSummary> repository,
+        IKeyedRepository<Event> eventRepository,
+        IEventManager eventManager,
+        IEventAttendeeManager eventAttendeeManager,
+        ILitterReportManager litterReportManager,
+        IEventLitterReportManager eventLitterReportManager)
+        : BaseManager<EventSummary>(repository), IEventSummaryManager
     {
-        private readonly IEventAttendeeManager eventAttendeeManager;
-        private readonly ILitterReportManager litterReportManager;
-        private readonly IEventLitterReportManager eventLitterReportManager;
-        private readonly IEventManager eventManager;
-        private readonly IKeyedRepository<Event> eventRepository;
         private const int CancelledEventStatusId = 3;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventSummaryManager"/> class.
-        /// </summary>
-        public EventSummaryManager(IBaseRepository<EventSummary> repository,
-            IKeyedRepository<Event> eventRepository,
-            IEventManager eventManager,
-            IEventAttendeeManager eventAttendeeManager,
-            ILitterReportManager litterReportManager,
-            IEventLitterReportManager eventLitterReportManager) 
-            : base(repository)
-        {
-            this.eventRepository = eventRepository;
-            this.eventManager = eventManager;
-            this.eventAttendeeManager = eventAttendeeManager;
-            this.litterReportManager = litterReportManager;
-            this.eventLitterReportManager = eventLitterReportManager;
-        }
 
         /// <inheritdoc />
         public async Task<Stats> GetStatsAsync(CancellationToken cancellationToken)

--- a/TrashMob.Shared/Managers/Gamification/AchievementManager.cs
+++ b/TrashMob.Shared/Managers/Gamification/AchievementManager.cs
@@ -14,18 +14,8 @@ namespace TrashMob.Shared.Managers.Gamification
     /// <summary>
     /// Manager for handling user achievements.
     /// </summary>
-    public class AchievementManager : IAchievementManager
+    public class AchievementManager(MobDbContext dbContext) : IAchievementManager
     {
-        private readonly MobDbContext dbContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AchievementManager"/> class.
-        /// </summary>
-        /// <param name="dbContext">The database context.</param>
-        public AchievementManager(MobDbContext dbContext)
-        {
-            this.dbContext = dbContext;
-        }
 
         /// <inheritdoc />
         public async Task<UserAchievementsResponse> GetUserAchievementsAsync(

--- a/TrashMob.Shared/Managers/Gamification/LeaderboardManager.cs
+++ b/TrashMob.Shared/Managers/Gamification/LeaderboardManager.cs
@@ -14,22 +14,11 @@ namespace TrashMob.Shared.Managers.Gamification
     /// <summary>
     /// Manager for retrieving leaderboard data from the pre-computed cache.
     /// </summary>
-    public class LeaderboardManager : ILeaderboardManager
+    public class LeaderboardManager(MobDbContext dbContext) : ILeaderboardManager
     {
         private static readonly string[] TimeRanges = { "Week", "Month", "Year", "AllTime" };
         private static readonly string[] LeaderboardTypes = { "Events", "Bags", "Weight", "Hours" };
         private static readonly string[] LocationScopes = { "Global", "Region", "City" };
-
-        private readonly MobDbContext dbContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LeaderboardManager"/> class.
-        /// </summary>
-        /// <param name="dbContext">The database context.</param>
-        public LeaderboardManager(MobDbContext dbContext)
-        {
-            this.dbContext = dbContext;
-        }
 
         /// <inheritdoc />
         public async Task<LeaderboardResponse> GetLeaderboardAsync(

--- a/TrashMob.Shared/Managers/IFTTT/QueriesManager.cs
+++ b/TrashMob.Shared/Managers/IFTTT/QueriesManager.cs
@@ -14,20 +14,9 @@
     /// <summary>
     /// Manages IFTTT query requests for retrieving event data based on location filters.
     /// </summary>
-    internal class QueriesManager : BaseManager<IftttTrigger>, IQueriesManager
+    internal class QueriesManager(IBaseRepository<IftttTrigger> repository, IKeyedRepository<Event> eventRepository)
+        : BaseManager<IftttTrigger>(repository), IQueriesManager
     {
-        private readonly IKeyedRepository<Event> eventRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QueriesManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for IFTTT trigger data access.</param>
-        /// <param name="eventRepository">The repository for event data access.</param>
-        public QueriesManager(IBaseRepository<IftttTrigger> repository, IKeyedRepository<Event> eventRepository) :
-            base(repository)
-        {
-            this.eventRepository = eventRepository;
-        }
 
         /// <inheritdoc />
         public async Task<List<IftttEventResponse>> GetEventsQueryDataAsync(QueriesRequest queryRequest, Guid userId,

--- a/TrashMob.Shared/Managers/IFTTT/TriggersManager.cs
+++ b/TrashMob.Shared/Managers/IFTTT/TriggersManager.cs
@@ -16,20 +16,9 @@
     /// <summary>
     /// Manages IFTTT triggers for event notifications and validates trigger request fields.
     /// </summary>
-    internal class TriggersManager : BaseManager<IftttTrigger>, ITriggersManager
+    internal class TriggersManager(IBaseRepository<IftttTrigger> repository, IKeyedRepository<Event> eventRepository)
+        : BaseManager<IftttTrigger>(repository), ITriggersManager
     {
-        private readonly IKeyedRepository<Event> eventRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TriggersManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for IFTTT trigger data access.</param>
-        /// <param name="eventRepository">The repository for event data access.</param>
-        public TriggersManager(IBaseRepository<IftttTrigger> repository, IKeyedRepository<Event> eventRepository) :
-            base(repository)
-        {
-            this.eventRepository = eventRepository;
-        }
 
         /// <inheritdoc />
         public async Task<List<IftttEventResponse>> GetEventsTriggerDataAsync(TriggersRequest triggersRequest,

--- a/TrashMob.Shared/Managers/KeyVaultManager.cs
+++ b/TrashMob.Shared/Managers/KeyVaultManager.cs
@@ -9,18 +9,8 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Azure Key Vault implementation for retrieving secrets and certificates.
     /// </summary>
-    public class KeyVaultManager : IKeyVaultManager
+    public class KeyVaultManager(SecretClient secretClient) : IKeyVaultManager
     {
-        private readonly SecretClient secretClient;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="KeyVaultManager"/> class.
-        /// </summary>
-        /// <param name="secretClient">The Azure Key Vault secret client.</param>
-        public KeyVaultManager(SecretClient secretClient)
-        {
-            this.secretClient = secretClient;
-        }
 
         /// <inheritdoc />
         public async Task<X509Certificate2> GetCertificateAsync(string certificateSecretName)

--- a/TrashMob.Shared/Managers/KeyedManager.cs
+++ b/TrashMob.Shared/Managers/KeyedManager.cs
@@ -11,16 +11,9 @@
     /// Manager class for entities with a GUID primary key, extending BaseManager with key-based operations.
     /// </summary>
     /// <typeparam name="T">The entity type derived from KeyedModel.</typeparam>
-    public class KeyedManager<T> : BaseManager<T>, IKeyedManager<T> where T : KeyedModel
+    public class KeyedManager<T>(IKeyedRepository<T> repository)
+        : BaseManager<T>(repository), IKeyedManager<T> where T : KeyedModel
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="KeyedManager{T}"/> class.
-        /// </summary>
-        /// <param name="repository">The keyed repository for data access operations.</param>
-        public KeyedManager(IKeyedRepository<T> repository) : base(repository)
-        {
-        }
-
         /// <summary>
         /// Gets the repository cast to the keyed repository interface.
         /// </summary>

--- a/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
@@ -15,23 +15,11 @@ namespace TrashMob.Shared.Managers.LitterReport
     /// <summary>
     /// Manages litter images including CRUD operations and image storage integration.
     /// </summary>
-    public class LitterImageManager : KeyedManager<LitterImage>, ILitterImageManager
+    public class LitterImageManager(
+        IKeyedRepository<LitterImage> repository,
+        IImageManager imageManager)
+        : KeyedManager<LitterImage>(repository), ILitterImageManager
     {
-        private readonly IImageManager imageManager;
-        private IDbTransaction dbTransaction;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LitterImageManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for litter image data access.</param>
-        /// <param name="dbTransaction">The database transaction manager.</param>
-        /// <param name="imageManager">The image manager for blob storage operations.</param>
-        public LitterImageManager(IKeyedRepository<LitterImage> repository, IDbTransaction dbTransaction,
-            IImageManager imageManager) : base(repository)
-        {
-            this.dbTransaction = dbTransaction;
-            this.imageManager = imageManager;
-        }
 
         /// <inheritdoc />
         public async Task<LitterImage> AddAsync(FullLitterImage instance, Guid userId,

--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -19,36 +19,15 @@ namespace TrashMob.Shared.Managers.LitterReport
     /// <summary>
     /// Manages litter reports including CRUD operations, status tracking, filtering, and email notifications.
     /// </summary>
-    public class LitterReportManager : KeyedManager<LitterReport>, ILitterReportManager
+    public class LitterReportManager(
+        IKeyedRepository<LitterReport> repository,
+        ILitterImageManager litterImageManager,
+        ILogger<LitterReportManager> logger,
+        IDbTransaction dbTransaction,
+        IEmailManager emailManager,
+        IUserManager userManager)
+        : KeyedManager<LitterReport>(repository), ILitterReportManager
     {
-        private readonly IDbTransaction dbTransaction;
-        private readonly IEmailManager emailManager;
-        private readonly ILitterImageManager litterImageManager;
-        private readonly ILogger<LitterReportManager> logger;
-        private readonly IUserManager userManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LitterReportManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for litter report data access.</param>
-        /// <param name="litterImageManager">The manager for litter image operations.</param>
-        /// <param name="logger">The logger instance.</param>
-        /// <param name="dbTransaction">The database transaction manager.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        /// <param name="userManager">The user manager for looking up report creators.</param>
-        public LitterReportManager(IKeyedRepository<LitterReport> repository,
-            ILitterImageManager litterImageManager,
-            ILogger<LitterReportManager> logger,
-            IDbTransaction dbTransaction,
-            IEmailManager emailManager,
-            IUserManager userManager) : base(repository)
-        {
-            this.litterImageManager = litterImageManager;
-            this.logger = logger;
-            this.dbTransaction = dbTransaction;
-            this.emailManager = emailManager;
-            this.userManager = userManager;
-        }
 
         /// <inheritdoc />
         public override async Task<LitterReport> UpdateAsync(LitterReport litterReport, Guid userId,

--- a/TrashMob.Shared/Managers/LocalKeyVaultManager.cs
+++ b/TrashMob.Shared/Managers/LocalKeyVaultManager.cs
@@ -8,18 +8,8 @@
     /// <summary>
     /// Local development implementation of key vault manager that retrieves secrets from configuration.
     /// </summary>
-    public class LocalKeyVaultManager : IKeyVaultManager
+    public class LocalKeyVaultManager(IConfiguration configuration) : IKeyVaultManager
     {
-        private readonly IConfiguration configuration;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocalKeyVaultManager"/> class.
-        /// </summary>
-        /// <param name="configuration">The configuration to retrieve secrets from.</param>
-        public LocalKeyVaultManager(IConfiguration configuration)
-        {
-            this.configuration = configuration;
-        }
 
         /// <inheritdoc />
         public Task<X509Certificate2> GetCertificateAsync(string certificateName)

--- a/TrashMob.Shared/Managers/LookupManager.cs
+++ b/TrashMob.Shared/Managers/LookupManager.cs
@@ -15,21 +15,13 @@ namespace TrashMob.Shared.Managers
     /// Manager class for lookup/reference data entities with integer primary keys.
     /// </summary>
     /// <typeparam name="T">The entity type derived from LookupModel.</typeparam>
-    public class LookupManager<T> : ILookupManager<T> where T : LookupModel
+    public class LookupManager<T>(ILookupRepository<T> repository)
+        : ILookupManager<T> where T : LookupModel
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LookupManager{T}"/> class.
-        /// </summary>
-        /// <param name="repository">The lookup repository for data access operations.</param>
-        public LookupManager(ILookupRepository<T> repository)
-        {
-            Repository = repository;
-        }
-
         /// <summary>
         /// Gets the repository used for data access operations.
         /// </summary>
-        protected ILookupRepository<T> Repository { get; }
+        protected ILookupRepository<T> Repository { get; } = repository;
 
         /// <inheritdoc />
         public virtual async Task<IEnumerable<T>> GetAsync()

--- a/TrashMob.Shared/Managers/MapManager.cs
+++ b/TrashMob.Shared/Managers/MapManager.cs
@@ -20,7 +20,7 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Provides map-related services including distance calculations, timezone lookups, and address resolution using Azure Maps.
     /// </summary>
-    public class MapManager : IMapManager
+    public class MapManager(IConfiguration configuration, ILogger<MapManager> logger) : IMapManager
     {
         private const string AzureMapKeyName = "AzureMapsKey";
         private const string AzureMapsClientIdName = "AzureMapsClientId";
@@ -29,21 +29,7 @@ namespace TrashMob.Shared.Managers
 
         private const int MetersPerKilometer = 1000;
         private const int MetersPerMile = 1609;
-        private readonly IConfiguration configuration;
-        private readonly ILogger<MapManager> logger;
-        private readonly TokenCredential tokenCredential;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MapManager"/> class.
-        /// </summary>
-        /// <param name="configuration">The configuration containing map API keys.</param>
-        /// <param name="logger">The logger instance.</param>
-        public MapManager(IConfiguration configuration, ILogger<MapManager> logger)
-        {
-            this.configuration = configuration;
-            this.logger = logger;
-            this.tokenCredential = new DefaultAzureCredential();
-        }
+        private readonly TokenCredential tokenCredential = new DefaultAzureCredential();
 
         /// <summary>
         /// Gets the Azure Maps Client ID for managed identity authentication.

--- a/TrashMob.Shared/Managers/NewsletterManager.cs
+++ b/TrashMob.Shared/Managers/NewsletterManager.cs
@@ -17,39 +17,15 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages newsletter creation, scheduling, and sending operations.
     /// </summary>
-    public class NewsletterManager : KeyedManager<Newsletter>, INewsletterManager
+    public class NewsletterManager(
+        IKeyedRepository<Newsletter> repository,
+        MobDbContext dbContext,
+        IUserNewsletterPreferenceManager preferenceManager,
+        IEmailManager emailManager,
+        ILogger<NewsletterManager> logger)
+        : KeyedManager<Newsletter>(repository), INewsletterManager
     {
-        private readonly MobDbContext dbContext;
-        private readonly IUserNewsletterPreferenceManager preferenceManager;
-        private readonly IEmailManager emailManager;
-        private readonly ILogger<NewsletterManager> logger;
-
-        /// <summary>
-        /// Batch size for sending emails.
-        /// </summary>
         private const int BatchSize = 100;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NewsletterManager"/> class.
-        /// </summary>
-        /// <param name="repository">The newsletter repository.</param>
-        /// <param name="dbContext">The database context.</param>
-        /// <param name="preferenceManager">The user preference manager.</param>
-        /// <param name="emailManager">The email manager.</param>
-        /// <param name="logger">The logger.</param>
-        public NewsletterManager(
-            IKeyedRepository<Newsletter> repository,
-            MobDbContext dbContext,
-            IUserNewsletterPreferenceManager preferenceManager,
-            IEmailManager emailManager,
-            ILogger<NewsletterManager> logger)
-            : base(repository)
-        {
-            this.dbContext = dbContext;
-            this.preferenceManager = preferenceManager;
-            this.emailManager = emailManager;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<Newsletter>> GetNewslettersAsync(string status = null, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/NonEventUserNotificationManager.cs
+++ b/TrashMob.Shared/Managers/NonEventUserNotificationManager.cs
@@ -13,17 +13,9 @@
     /// <summary>
     /// Manages non-event user notifications such as profile reminders and general announcements.
     /// </summary>
-    public class NonEventUserNotificationManager : KeyedManager<NonEventUserNotification>,
-        INonEventUserNotificationManager
+    public class NonEventUserNotificationManager(IKeyedRepository<NonEventUserNotification> repository)
+        : KeyedManager<NonEventUserNotification>(repository), INonEventUserNotificationManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NonEventUserNotificationManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for non-event user notification data access.</param>
-        public NonEventUserNotificationManager(IKeyedRepository<NonEventUserNotification> repository)
-            : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<NonEventUserNotification>> GetByUserIdAsync(Guid userId,

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
@@ -16,33 +16,14 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner admin invitations including sending, accepting, declining, and resending invitations.
     /// </summary>
-    public class PartnerAdminInvitationManager : KeyedManager<PartnerAdminInvitation>, IPartnerAdminInvitationManager
+    public class PartnerAdminInvitationManager(
+        IKeyedRepository<PartnerAdminInvitation> partnerAdminInvitationRepository,
+        IPartnerAdminManager partnerAdminManager,
+        IUserManager userManager,
+        IKeyedManager<Partner> partnerManager,
+        IEmailManager emailManager)
+        : KeyedManager<PartnerAdminInvitation>(partnerAdminInvitationRepository), IPartnerAdminInvitationManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly IPartnerAdminManager partnerAdminManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IUserManager userManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerAdminInvitationManager"/> class.
-        /// </summary>
-        /// <param name="partnerAdminInvitationRepository">The repository for partner admin invitation data access.</param>
-        /// <param name="partnerAdminManager">The manager for partner admin operations.</param>
-        /// <param name="userManager">The manager for user operations.</param>
-        /// <param name="partnerManager">The manager for partner operations.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        public PartnerAdminInvitationManager(IKeyedRepository<PartnerAdminInvitation> partnerAdminInvitationRepository,
-            IPartnerAdminManager partnerAdminManager,
-            IUserManager userManager,
-            IKeyedManager<Partner> partnerManager,
-            IEmailManager emailManager)
-            : base(partnerAdminInvitationRepository)
-        {
-            this.partnerAdminManager = partnerAdminManager;
-            this.userManager = userManager;
-            this.partnerManager = partnerManager;
-            this.emailManager = emailManager;
-        }
 
         /// <inheritdoc />
         public override async Task<IEnumerable<PartnerAdminInvitation>> GetByParentIdAsync(Guid parentId,

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminManager.cs
@@ -13,19 +13,11 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner administrator relationships, including retrieving admins for partners and partners for users.
     /// </summary>
-    public class PartnerAdminManager : BaseManager<PartnerAdmin>, IPartnerAdminManager
+    public class PartnerAdminManager(
+        IBaseRepository<PartnerAdmin> partnerAdminRepository,
+        IKeyedRepository<Partner> partnerRepository)
+        : BaseManager<PartnerAdmin>(partnerAdminRepository), IPartnerAdminManager
     {
-        private readonly IKeyedRepository<Partner> partnerRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerAdminManager"/> class.
-        /// </summary>
-        /// <param name="partnerAdminRepository">The repository for partner admin data access.</param>
-        /// <param name="partnerRepository">The repository for partner data access.</param>
-        public PartnerAdminManager(IBaseRepository<PartnerAdmin> partnerAdminRepository, IKeyedRepository<Partner> partnerRepository) : base(partnerAdminRepository)
-        {
-            this.partnerRepository = partnerRepository;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<User>> GetAdminsForPartnerAsync(Guid partnerId,

--- a/TrashMob.Shared/Managers/Partners/PartnerContactManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerContactManager.cs
@@ -13,16 +13,9 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner contacts including CRUD operations and retrieving the partner associated with a contact.
     /// </summary>
-    public class PartnerContactManager : KeyedManager<PartnerContact>, IPartnerContactManager
+    public class PartnerContactManager(IKeyedRepository<PartnerContact> partnerContactRepository)
+        : KeyedManager<PartnerContact>(partnerContactRepository), IPartnerContactManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerContactManager"/> class.
-        /// </summary>
-        /// <param name="partnerContactRepository">The repository for partner contact data access.</param>
-        public PartnerContactManager(IKeyedRepository<PartnerContact> partnerContactRepository) : base(
-            partnerContactRepository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<Partner> GetPartnerForContact(Guid partnerContactId, CancellationToken cancellationToken)

--- a/TrashMob.Shared/Managers/Partners/PartnerDocumentManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerDocumentManager.cs
@@ -13,15 +13,9 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner documents including CRUD operations and retrieving the partner associated with a document.
     /// </summary>
-    public class PartnerDocumentManager : KeyedManager<PartnerDocument>, IPartnerDocumentManager
+    public class PartnerDocumentManager(IKeyedRepository<PartnerDocument> repository)
+        : KeyedManager<PartnerDocument>(repository), IPartnerDocumentManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerDocumentManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for partner document data access.</param>
-        public PartnerDocumentManager(IKeyedRepository<PartnerDocument> repository) : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<Partner> GetPartnerForDocument(Guid partnerDocumentId, CancellationToken cancellationToken)

--- a/TrashMob.Shared/Managers/Partners/PartnerDocumentStorageManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerDocumentStorageManager.cs
@@ -14,24 +14,12 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner document file storage in Azure Blob Storage.
     /// </summary>
-    public class PartnerDocumentStorageManager : IPartnerDocumentStorageManager
+    public class PartnerDocumentStorageManager(
+        ILogger<PartnerDocumentStorageManager> logger,
+        BlobServiceClient blobServiceClient)
+        : IPartnerDocumentStorageManager
     {
         private const string ContainerName = "partner-documents";
-        private readonly ILogger<PartnerDocumentStorageManager> logger;
-        private readonly BlobServiceClient blobServiceClient;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerDocumentStorageManager"/> class.
-        /// </summary>
-        /// <param name="logger">The logger.</param>
-        /// <param name="blobServiceClient">The blob service client.</param>
-        public PartnerDocumentStorageManager(
-            ILogger<PartnerDocumentStorageManager> logger,
-            BlobServiceClient blobServiceClient)
-        {
-            this.logger = logger;
-            this.blobServiceClient = blobServiceClient;
-        }
 
         /// <inheritdoc />
         public async Task<string> UploadDocumentAsync(Guid partnerId, Guid documentId, IFormFile file, CancellationToken cancellationToken)

--- a/TrashMob.Shared/Managers/Partners/PartnerLocationContactManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerLocationContactManager.cs
@@ -13,16 +13,9 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner location contacts including CRUD operations and retrieving the parent partner.
     /// </summary>
-    public class PartnerLocationContactManager : KeyedManager<PartnerLocationContact>, IPartnerLocationContactManager
+    public class PartnerLocationContactManager(IKeyedRepository<PartnerLocationContact> partnerLocationContactRepository)
+        : KeyedManager<PartnerLocationContact>(partnerLocationContactRepository), IPartnerLocationContactManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerLocationContactManager"/> class.
-        /// </summary>
-        /// <param name="partnerLocationContactRepository">The repository for partner location contact data access.</param>
-        public PartnerLocationContactManager(IKeyedRepository<PartnerLocationContact> partnerLocationContactRepository)
-            : base(partnerLocationContactRepository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<Partner> GetPartnerForLocationContact(Guid partnerLocationContactId,

--- a/TrashMob.Shared/Managers/Partners/PartnerLocationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerLocationManager.cs
@@ -13,18 +13,10 @@
     /// <summary>
     /// Manages partner locations including CRUD operations and retrieving locations with their contacts.
     /// </summary>
-    public class PartnerLocationManager : KeyedManager<PartnerLocation>, IPartnerLocationManager
+    public class PartnerLocationManager(IKeyedRepository<PartnerLocation> partnerLocationRepository)
+        : KeyedManager<PartnerLocation>(partnerLocationRepository), IPartnerLocationManager
     {
         private const double EarthRadiusMiles = 3959.0;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerLocationManager"/> class.
-        /// </summary>
-        /// <param name="partnerLocationRepository">The repository for partner location data access.</param>
-        public PartnerLocationManager(IKeyedRepository<PartnerLocation> partnerLocationRepository) : base(
-            partnerLocationRepository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<Partner> GetPartnerForLocationAsync(Guid partnerLocationId,

--- a/TrashMob.Shared/Managers/Partners/PartnerLocationServiceManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerLocationServiceManager.cs
@@ -13,17 +13,10 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages services offered at partner locations including CRUD operations by location and service type.
     /// </summary>
-    public class PartnerLocationServiceManager : BaseManager<PartnerLocationService>,
-        IBaseManager<PartnerLocationService>
+    public class PartnerLocationServiceManager(IBaseRepository<PartnerLocationService> partnerLocationServiceRepository)
+        : BaseManager<PartnerLocationService>(partnerLocationServiceRepository),
+            IBaseManager<PartnerLocationService>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerLocationServiceManager"/> class.
-        /// </summary>
-        /// <param name="partnerLocationServiceRepository">The repository for partner location service data access.</param>
-        public PartnerLocationServiceManager(IBaseRepository<PartnerLocationService> partnerLocationServiceRepository) :
-            base(partnerLocationServiceRepository)
-        {
-        }
 
         /// <inheritdoc />
         public override async Task<PartnerLocationService> GetAsync(Guid parentId, int secondId,

--- a/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
@@ -13,17 +13,11 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manager for partner/community photo operations.
     /// </summary>
-    public class PartnerPhotoManager : KeyedManager<PartnerPhoto>, IPartnerPhotoManager
+    public class PartnerPhotoManager(
+        IKeyedRepository<PartnerPhoto> repository,
+        IImageManager imageManager)
+        : KeyedManager<PartnerPhoto>(repository), IPartnerPhotoManager
     {
-        private readonly IImageManager imageManager;
-
-        public PartnerPhotoManager(
-            IKeyedRepository<PartnerPhoto> repository,
-            IImageManager imageManager)
-            : base(repository)
-        {
-            this.imageManager = imageManager;
-        }
 
         /// <inheritdoc/>
         public async Task<IEnumerable<PartnerPhoto>> GetByPartnerIdAsync(Guid partnerId, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/Partners/PartnerRequestManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerRequestManager.cs
@@ -14,28 +14,13 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner requests including creation, approval, denial, and email notifications for partnership applications.
     /// </summary>
-    public class PartnerRequestManager : KeyedManager<PartnerRequest>, IPartnerRequestManager
+    public class PartnerRequestManager(
+        IKeyedRepository<PartnerRequest> partnerRequestRepository,
+        IKeyedManager<Partner> partnerManager,
+        IBaseManager<PartnerAdmin> partnerUserManager,
+        IEmailManager emailManager)
+        : KeyedManager<PartnerRequest>(partnerRequestRepository), IPartnerRequestManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IBaseManager<PartnerAdmin> partnerUserManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerRequestManager"/> class.
-        /// </summary>
-        /// <param name="partnerRequestRepository">The repository for partner request data access.</param>
-        /// <param name="partnerManager">The manager for partner operations.</param>
-        /// <param name="partnerUserManager">The manager for partner admin operations.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        public PartnerRequestManager(IKeyedRepository<PartnerRequest> partnerRequestRepository,
-            IKeyedManager<Partner> partnerManager,
-            IBaseManager<PartnerAdmin> partnerUserManager,
-            IEmailManager emailManager) : base(partnerRequestRepository)
-        {
-            this.partnerManager = partnerManager;
-            this.partnerUserManager = partnerUserManager;
-            this.emailManager = emailManager;
-        }
 
         /// <inheritdoc />
         public override async Task<PartnerRequest> AddAsync(PartnerRequest instance, Guid userId,

--- a/TrashMob.Shared/Managers/Partners/PartnerSocialMediaAccountManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerSocialMediaAccountManager.cs
@@ -13,17 +13,9 @@ namespace TrashMob.Shared.Managers.Partners
     /// <summary>
     /// Manages partner social media accounts including CRUD operations and retrieving the associated partner.
     /// </summary>
-    public class PartnerSocialMediaAccountManager : KeyedManager<PartnerSocialMediaAccount>,
-        IPartnerSocialMediaAccountManager
+    public class PartnerSocialMediaAccountManager(IKeyedRepository<PartnerSocialMediaAccount> repository)
+        : KeyedManager<PartnerSocialMediaAccount>(repository), IPartnerSocialMediaAccountManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartnerSocialMediaAccountManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for partner social media account data access.</param>
-        public PartnerSocialMediaAccountManager(IKeyedRepository<PartnerSocialMediaAccount> repository) : base(
-            repository)
-        {
-        }
 
         /// <inheritdoc />
         public override async Task<IEnumerable<PartnerSocialMediaAccount>> GetByParentIdAsync(Guid parentId,

--- a/TrashMob.Shared/Managers/Prospects/CommunityProspectManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/CommunityProspectManager.cs
@@ -9,12 +9,9 @@ namespace TrashMob.Shared.Managers.Prospects
     using TrashMob.Models;
     using TrashMob.Shared.Persistence.Interfaces;
 
-    public class CommunityProspectManager : KeyedManager<CommunityProspect>, ICommunityProspectManager
+    public class CommunityProspectManager(IKeyedRepository<CommunityProspect> repository)
+        : KeyedManager<CommunityProspect>(repository), ICommunityProspectManager
     {
-        public CommunityProspectManager(IKeyedRepository<CommunityProspect> repository)
-            : base(repository)
-        {
-        }
 
         public async Task<IEnumerable<CommunityProspect>> GetByPipelineStageAsync(int stage, CancellationToken cancellationToken = default)
         {

--- a/TrashMob.Shared/Managers/Prospects/PipelineAnalyticsManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/PipelineAnalyticsManager.cs
@@ -10,21 +10,13 @@ namespace TrashMob.Shared.Managers.Prospects
     using TrashMob.Models.Poco;
     using TrashMob.Shared.Persistence.Interfaces;
 
-    public class PipelineAnalyticsManager : IPipelineAnalyticsManager
+    public class PipelineAnalyticsManager(
+        IKeyedRepository<CommunityProspect> prospectRepository,
+        IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository)
+        : IPipelineAnalyticsManager
     {
         private static readonly string[] StageLabels =
             ["New", "Contacted", "Responded", "Interested", "Onboarding", "Active", "Declined"];
-
-        private readonly IKeyedRepository<CommunityProspect> prospectRepository;
-        private readonly IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository;
-
-        public PipelineAnalyticsManager(
-            IKeyedRepository<CommunityProspect> prospectRepository,
-            IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository)
-        {
-            this.prospectRepository = prospectRepository;
-            this.outreachEmailRepository = outreachEmailRepository;
-        }
 
         public async Task<PipelineAnalytics> GetAnalyticsAsync(CancellationToken cancellationToken = default)
         {

--- a/TrashMob.Shared/Managers/Prospects/ProspectActivityManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectActivityManager.cs
@@ -9,20 +9,12 @@ namespace TrashMob.Shared.Managers.Prospects
     using TrashMob.Models;
     using TrashMob.Shared.Persistence.Interfaces;
 
-    public class ProspectActivityManager : KeyedManager<ProspectActivity>, IProspectActivityManager
+    public class ProspectActivityManager(
+        IKeyedRepository<ProspectActivity> repository,
+        IKeyedRepository<CommunityProspect> prospectRepository,
+        ISentimentAnalysisService sentimentAnalysisService)
+        : KeyedManager<ProspectActivity>(repository), IProspectActivityManager
     {
-        private readonly IKeyedRepository<CommunityProspect> prospectRepository;
-        private readonly ISentimentAnalysisService sentimentAnalysisService;
-
-        public ProspectActivityManager(
-            IKeyedRepository<ProspectActivity> repository,
-            IKeyedRepository<CommunityProspect> prospectRepository,
-            ISentimentAnalysisService sentimentAnalysisService)
-            : base(repository)
-        {
-            this.prospectRepository = prospectRepository;
-            this.sentimentAnalysisService = sentimentAnalysisService;
-        }
 
         public async Task<IEnumerable<ProspectActivity>> GetByProspectIdAsync(Guid prospectId, CancellationToken cancellationToken = default)
         {

--- a/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
@@ -15,30 +15,15 @@ namespace TrashMob.Shared.Managers.Prospects
     /// <summary>
     /// Manages the conversion of community prospects to partner organizations.
     /// </summary>
-    public class ProspectConversionManager : IProspectConversionManager
+    public class ProspectConversionManager(
+        IKeyedRepository<CommunityProspect> prospectRepository,
+        IKeyedManager<Partner> partnerManager,
+        IBaseManager<PartnerAdmin> partnerAdminManager,
+        IKeyedRepository<ProspectActivity> activityRepository,
+        IEmailManager emailManager,
+        ILogger<ProspectConversionManager> logger)
+        : IProspectConversionManager
     {
-        private readonly IKeyedRepository<CommunityProspect> prospectRepository;
-        private readonly IKeyedManager<Partner> partnerManager;
-        private readonly IBaseManager<PartnerAdmin> partnerAdminManager;
-        private readonly IKeyedRepository<ProspectActivity> activityRepository;
-        private readonly IEmailManager emailManager;
-        private readonly ILogger<ProspectConversionManager> logger;
-
-        public ProspectConversionManager(
-            IKeyedRepository<CommunityProspect> prospectRepository,
-            IKeyedManager<Partner> partnerManager,
-            IBaseManager<PartnerAdmin> partnerAdminManager,
-            IKeyedRepository<ProspectActivity> activityRepository,
-            IEmailManager emailManager,
-            ILogger<ProspectConversionManager> logger)
-        {
-            this.prospectRepository = prospectRepository;
-            this.partnerManager = partnerManager;
-            this.partnerAdminManager = partnerAdminManager;
-            this.activityRepository = activityRepository;
-            this.emailManager = emailManager;
-            this.logger = logger;
-        }
 
         public async Task<ProspectConversionResult> ConvertToPartnerAsync(
             ProspectConversionRequest request, Guid userId,

--- a/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
@@ -18,35 +18,17 @@ namespace TrashMob.Shared.Managers.Prospects
     /// <summary>
     /// Core business logic for prospect outreach emails including cadence management, send/preview, and follow-up processing.
     /// </summary>
-    public class ProspectOutreachManager : IProspectOutreachManager
+    public class ProspectOutreachManager(
+        IKeyedRepository<CommunityProspect> prospectRepository,
+        IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository,
+        IKeyedRepository<ProspectActivity> activityRepository,
+        IOutreachContentService contentService,
+        IEmailManager emailManager,
+        IConfiguration configuration,
+        ILogger<ProspectOutreachManager> logger)
+        : IProspectOutreachManager
     {
-        private readonly IKeyedRepository<CommunityProspect> prospectRepository;
-        private readonly IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository;
-        private readonly IKeyedRepository<ProspectActivity> activityRepository;
-        private readonly IOutreachContentService contentService;
-        private readonly IEmailManager emailManager;
-        private readonly IConfiguration configuration;
-        private readonly ILogger<ProspectOutreachManager> logger;
-
         private const int MaxBatchSize = 20;
-
-        public ProspectOutreachManager(
-            IKeyedRepository<CommunityProspect> prospectRepository,
-            IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository,
-            IKeyedRepository<ProspectActivity> activityRepository,
-            IOutreachContentService contentService,
-            IEmailManager emailManager,
-            IConfiguration configuration,
-            ILogger<ProspectOutreachManager> logger)
-        {
-            this.prospectRepository = prospectRepository;
-            this.outreachEmailRepository = outreachEmailRepository;
-            this.activityRepository = activityRepository;
-            this.contentService = contentService;
-            this.emailManager = emailManager;
-            this.configuration = configuration;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task<OutreachPreview> PreviewOutreachAsync(Guid prospectId,

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCleanupLogManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCleanupLogManager.cs
@@ -14,25 +14,12 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
     /// <summary>
     /// Manager for professional cleanup log operations.
     /// </summary>
-    public class ProfessionalCleanupLogManager : KeyedManager<ProfessionalCleanupLog>, IProfessionalCleanupLogManager
+    public class ProfessionalCleanupLogManager(
+        IKeyedRepository<ProfessionalCleanupLog> repository,
+        IKeyedRepository<SponsoredAdoption> sponsoredAdoptionRepository,
+        IProfessionalCompanyUserManager companyUserManager)
+        : KeyedManager<ProfessionalCleanupLog>(repository), IProfessionalCleanupLogManager
     {
-        private readonly IKeyedRepository<SponsoredAdoption> sponsoredAdoptionRepository;
-        private readonly IProfessionalCompanyUserManager companyUserManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProfessionalCleanupLogManager"/> class.
-        /// </summary>
-        /// <param name="repository">The cleanup log repository.</param>
-        /// <param name="sponsoredAdoptionRepository">The sponsored adoption repository.</param>
-        /// <param name="companyUserManager">The company user manager for authorization checks.</param>
-        public ProfessionalCleanupLogManager(
-            IKeyedRepository<ProfessionalCleanupLog> repository,
-            IKeyedRepository<SponsoredAdoption> sponsoredAdoptionRepository,
-            IProfessionalCompanyUserManager companyUserManager) : base(repository)
-        {
-            this.sponsoredAdoptionRepository = sponsoredAdoptionRepository;
-            this.companyUserManager = companyUserManager;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<ProfessionalCleanupLog>> GetByCompanyIdAsync(

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCompanyManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCompanyManager.cs
@@ -13,15 +13,9 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
     /// <summary>
     /// Manager for professional cleanup company operations within a community.
     /// </summary>
-    public class ProfessionalCompanyManager : KeyedManager<ProfessionalCompany>, IProfessionalCompanyManager
+    public class ProfessionalCompanyManager(IKeyedRepository<ProfessionalCompany> repository)
+        : KeyedManager<ProfessionalCompany>(repository), IProfessionalCompanyManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProfessionalCompanyManager"/> class.
-        /// </summary>
-        /// <param name="repository">The professional company repository.</param>
-        public ProfessionalCompanyManager(IKeyedRepository<ProfessionalCompany> repository) : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<ProfessionalCompany>> GetByCommunityAsync(

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCompanyUserManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCompanyUserManager.cs
@@ -14,15 +14,9 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
     /// Manager for user assignments to professional cleanup companies.
     /// Uses composite key pattern (like PartnerAdminManager).
     /// </summary>
-    public class ProfessionalCompanyUserManager : BaseManager<ProfessionalCompanyUser>, IProfessionalCompanyUserManager
+    public class ProfessionalCompanyUserManager(IBaseRepository<ProfessionalCompanyUser> repository)
+        : BaseManager<ProfessionalCompanyUser>(repository), IProfessionalCompanyUserManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProfessionalCompanyUserManager"/> class.
-        /// </summary>
-        /// <param name="repository">The professional company user repository.</param>
-        public ProfessionalCompanyUserManager(IBaseRepository<ProfessionalCompanyUser> repository) : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<User>> GetUsersForCompanyAsync(

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/SponsorManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/SponsorManager.cs
@@ -13,15 +13,9 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
     /// <summary>
     /// Manager for sponsor operations within a community's sponsored adoption program.
     /// </summary>
-    public class SponsorManager : KeyedManager<Sponsor>, ISponsorManager
+    public class SponsorManager(IKeyedRepository<Sponsor> repository)
+        : KeyedManager<Sponsor>(repository), ISponsorManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SponsorManager"/> class.
-        /// </summary>
-        /// <param name="repository">The sponsor repository.</param>
-        public SponsorManager(IKeyedRepository<Sponsor> repository) : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<Sponsor>> GetByCommunityAsync(

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/SponsoredAdoptionManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/SponsoredAdoptionManager.cs
@@ -14,15 +14,9 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
     /// <summary>
     /// Manager for sponsored adoption operations within a community.
     /// </summary>
-    public class SponsoredAdoptionManager : KeyedManager<SponsoredAdoption>, ISponsoredAdoptionManager
+    public class SponsoredAdoptionManager(IKeyedRepository<SponsoredAdoption> repository)
+        : KeyedManager<SponsoredAdoption>(repository), ISponsoredAdoptionManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SponsoredAdoptionManager"/> class.
-        /// </summary>
-        /// <param name="repository">The sponsored adoption repository.</param>
-        public SponsoredAdoptionManager(IKeyedRepository<SponsoredAdoption> repository) : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<SponsoredAdoption>> GetByCommunityAsync(

--- a/TrashMob.Shared/Managers/Teams/TeamManager.cs
+++ b/TrashMob.Shared/Managers/Teams/TeamManager.cs
@@ -13,22 +13,11 @@ namespace TrashMob.Shared.Managers.Teams
     /// <summary>
     /// Manager for team operations.
     /// </summary>
-    public class TeamManager : KeyedManager<Team>, ITeamManager
+    public class TeamManager(
+        IKeyedRepository<Team> repository,
+        IKeyedRepository<TeamMember> teamMemberRepository)
+        : KeyedManager<Team>(repository), ITeamManager
     {
-        private readonly IKeyedRepository<TeamMember> teamMemberRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamManager"/> class.
-        /// </summary>
-        /// <param name="repository">The team repository.</param>
-        /// <param name="teamMemberRepository">The team member repository.</param>
-        public TeamManager(
-            IKeyedRepository<Team> repository,
-            IKeyedRepository<TeamMember> teamMemberRepository)
-            : base(repository)
-        {
-            this.teamMemberRepository = teamMemberRepository;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<Team>> GetPublicTeamsAsync(

--- a/TrashMob.Shared/Managers/Teams/TeamMemberManager.cs
+++ b/TrashMob.Shared/Managers/Teams/TeamMemberManager.cs
@@ -13,16 +13,9 @@ namespace TrashMob.Shared.Managers.Teams
     /// <summary>
     /// Manager for team membership operations.
     /// </summary>
-    public class TeamMemberManager : KeyedManager<TeamMember>, ITeamMemberManager
+    public class TeamMemberManager(IKeyedRepository<TeamMember> repository)
+        : KeyedManager<TeamMember>(repository), ITeamMemberManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamMemberManager"/> class.
-        /// </summary>
-        /// <param name="repository">The team member repository.</param>
-        public TeamMemberManager(IKeyedRepository<TeamMember> repository)
-            : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<TeamMember>> GetByTeamIdAsync(Guid teamId, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/Teams/TeamPhotoManager.cs
+++ b/TrashMob.Shared/Managers/Teams/TeamPhotoManager.cs
@@ -13,19 +13,9 @@ namespace TrashMob.Shared.Managers.Teams
     /// <summary>
     /// Manages team photos including CRUD operations and image storage integration.
     /// </summary>
-    public class TeamPhotoManager : KeyedManager<TeamPhoto>, ITeamPhotoManager
+    public class TeamPhotoManager(IKeyedRepository<TeamPhoto> repository, IImageManager imageManager)
+        : KeyedManager<TeamPhoto>(repository), ITeamPhotoManager
     {
-        private readonly IImageManager imageManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamPhotoManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for team photo data access.</param>
-        /// <param name="imageManager">The image manager for blob storage operations.</param>
-        public TeamPhotoManager(IKeyedRepository<TeamPhoto> repository, IImageManager imageManager) : base(repository)
-        {
-            this.imageManager = imageManager;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<TeamPhoto>> GetByTeamIdAsync(Guid teamId, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/UserFeedbackManager.cs
+++ b/TrashMob.Shared/Managers/UserFeedbackManager.cs
@@ -15,20 +15,9 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages user feedback submissions, including email notifications to administrators.
     /// </summary>
-    public class UserFeedbackManager : KeyedManager<UserFeedback>, IUserFeedbackManager
+    public class UserFeedbackManager(IKeyedRepository<UserFeedback> repository, IEmailManager emailManager)
+        : KeyedManager<UserFeedback>(repository), IUserFeedbackManager
     {
-        private readonly IEmailManager emailManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserFeedbackManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for user feedback data access.</param>
-        /// <param name="emailManager">The email manager for sending notifications.</param>
-        public UserFeedbackManager(IKeyedRepository<UserFeedback> repository, IEmailManager emailManager)
-            : base(repository)
-        {
-            this.emailManager = emailManager;
-        }
 
         /// <inheritdoc />
         public override async Task<UserFeedback> AddAsync(UserFeedback feedback, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/UserManager.cs
+++ b/TrashMob.Shared/Managers/UserManager.cs
@@ -14,49 +14,22 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages user accounts including creation, updates, deletion, and related cascade operations.
     /// </summary>
-    public class UserManager : KeyedManager<User>, IUserManager
+    public class UserManager(
+        IKeyedRepository<User> repository,
+        IBaseRepository<EventAttendee> eventAttendeesRepository,
+        IKeyedRepository<UserNotification> userNotificationRepository,
+        IKeyedRepository<NonEventUserNotification> nonEventUserNotificationRepository,
+        IKeyedRepository<PartnerRequest> partnerRequestRepository,
+        IBaseRepository<EventSummary> eventSummaryRepository,
+        IBaseRepository<EventPartnerLocationService> eventPartnerRepository,
+        IKeyedRepository<Event> eventRepository,
+        IKeyedRepository<Partner> partnerRepository,
+        IBaseRepository<PartnerAdmin> partnerAdminRepository,
+        IKeyedRepository<PartnerLocation> partnerLocationRepository,
+        IEmailManager emailManager)
+        : KeyedManager<User>(repository), IUserManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly IBaseRepository<EventAttendee> eventAttendeesRepository;
-        private readonly IBaseRepository<EventPartnerLocationService> eventPartnerRepository;
-        private readonly IKeyedRepository<Event> eventRepository;
-        private readonly IBaseRepository<EventSummary> eventSummaryRepository;
-        private readonly IKeyedRepository<NonEventUserNotification> nonEventUserNotificationRepository;
-        private readonly IBaseRepository<PartnerAdmin> partnerAdminRepository;
-        private readonly IKeyedRepository<PartnerLocation> partnerLocationRepository;
-        private readonly IKeyedRepository<Partner> partnerRepository;
-        private readonly IKeyedRepository<PartnerRequest> partnerRequestRepository;
         private readonly Guid TrashMobUserId = Guid.Empty;
-        private readonly IKeyedRepository<UserNotification> userNotificationRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserManager"/> class.
-        /// </summary>
-        public UserManager(IKeyedRepository<User> repository,
-            IBaseRepository<EventAttendee> eventAttendeesRepository,
-            IKeyedRepository<UserNotification> userNotificationRepository,
-            IKeyedRepository<NonEventUserNotification> nonEventUserNotificationRepository,
-            IKeyedRepository<PartnerRequest> partnerRequestRepository,
-            IBaseRepository<EventSummary> eventSummaryRepository,
-            IBaseRepository<EventPartnerLocationService> eventPartnerRepository,
-            IKeyedRepository<Event> eventRepository,
-            IKeyedRepository<Partner> partnerRepository,
-            IBaseRepository<PartnerAdmin> partnerUserRepository,
-            IKeyedRepository<PartnerLocation> partnerLocationRepository,
-            IEmailManager emailManager) : base(repository)
-        {
-            this.eventAttendeesRepository = eventAttendeesRepository;
-            this.userNotificationRepository = userNotificationRepository;
-            this.nonEventUserNotificationRepository = nonEventUserNotificationRepository;
-            this.partnerRequestRepository = partnerRequestRepository;
-            this.eventSummaryRepository = eventSummaryRepository;
-            this.eventPartnerRepository = eventPartnerRepository;
-            this.eventRepository = eventRepository;
-            this.partnerRepository = partnerRepository;
-            partnerAdminRepository = partnerUserRepository;
-            this.partnerLocationRepository = partnerLocationRepository;
-            this.emailManager = emailManager;
-        }
 
         /// <inheritdoc />
         public async Task<User> GetUserByNameIdentifierAsync(string nameIdentifier,

--- a/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
+++ b/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
@@ -15,21 +15,9 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages user newsletter preferences including subscription status and initialization.
     /// </summary>
-    public class UserNewsletterPreferenceManager : IUserNewsletterPreferenceManager
+    public class UserNewsletterPreferenceManager(MobDbContext dbContext, ILogger<UserNewsletterPreferenceManager> logger)
+        : IUserNewsletterPreferenceManager
     {
-        private readonly MobDbContext dbContext;
-        private readonly ILogger<UserNewsletterPreferenceManager> logger;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserNewsletterPreferenceManager"/> class.
-        /// </summary>
-        /// <param name="dbContext">The database context.</param>
-        /// <param name="logger">The logger.</param>
-        public UserNewsletterPreferenceManager(MobDbContext dbContext, ILogger<UserNewsletterPreferenceManager> logger)
-        {
-            this.dbContext = dbContext;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<UserNewsletterPreference>> GetUserPreferencesAsync(Guid userId, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/UserNotificationManager.cs
+++ b/TrashMob.Shared/Managers/UserNotificationManager.cs
@@ -12,15 +12,9 @@
     /// <summary>
     /// Manages event-specific user notification records for tracking which notifications have been sent.
     /// </summary>
-    public class UserNotificationManager : KeyedManager<UserNotification>, IKeyedManager<UserNotification>
+    public class UserNotificationManager(IKeyedRepository<UserNotification> repository)
+        : KeyedManager<UserNotification>(repository), IKeyedManager<UserNotification>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserNotificationManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for user notification data access.</param>
-        public UserNotificationManager(IKeyedRepository<UserNotification> repository) : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public override async Task<IEnumerable<UserNotification>> GetCollectionAsync(Guid parentId, Guid secondId,

--- a/TrashMob.Shared/Managers/UserWaiverManager.cs
+++ b/TrashMob.Shared/Managers/UserWaiverManager.cs
@@ -14,7 +14,15 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manager for user waiver operations.
     /// </summary>
-    public class UserWaiverManager : KeyedManager<UserWaiver>, IUserWaiverManager
+    public class UserWaiverManager(
+        IKeyedRepository<UserWaiver> repository,
+        IKeyedRepository<WaiverVersion> waiverVersionRepository,
+        IBaseRepository<CommunityWaiver> communityWaiverRepository,
+        IBaseRepository<EventPartnerLocationService> eventPartnerLocationServiceRepository,
+        IKeyedRepository<User> userRepository,
+        IBaseRepository<EventAttendee> eventAttendeeRepository,
+        IWaiverDocumentManager waiverDocumentManager)
+        : KeyedManager<UserWaiver>(repository), IUserWaiverManager
     {
         private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -25,41 +33,6 @@ namespace TrashMob.Shared.Managers
         };
 
         private const long MaxFileSizeBytes = 10 * 1024 * 1024; // 10MB
-
-        private readonly IKeyedRepository<WaiverVersion> waiverVersionRepository;
-        private readonly IBaseRepository<CommunityWaiver> communityWaiverRepository;
-        private readonly IBaseRepository<EventPartnerLocationService> eventPartnerLocationServiceRepository;
-        private readonly IKeyedRepository<User> userRepository;
-        private readonly IBaseRepository<EventAttendee> eventAttendeeRepository;
-        private readonly IWaiverDocumentManager waiverDocumentManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserWaiverManager"/> class.
-        /// </summary>
-        /// <param name="repository">The user waiver repository.</param>
-        /// <param name="waiverVersionRepository">The waiver version repository.</param>
-        /// <param name="communityWaiverRepository">The community waiver repository.</param>
-        /// <param name="eventPartnerLocationServiceRepository">The event partner location service repository.</param>
-        /// <param name="userRepository">The user repository.</param>
-        /// <param name="eventAttendeeRepository">The event attendee repository.</param>
-        /// <param name="waiverDocumentManager">The waiver document manager.</param>
-        public UserWaiverManager(
-            IKeyedRepository<UserWaiver> repository,
-            IKeyedRepository<WaiverVersion> waiverVersionRepository,
-            IBaseRepository<CommunityWaiver> communityWaiverRepository,
-            IBaseRepository<EventPartnerLocationService> eventPartnerLocationServiceRepository,
-            IKeyedRepository<User> userRepository,
-            IBaseRepository<EventAttendee> eventAttendeeRepository,
-            IWaiverDocumentManager waiverDocumentManager)
-            : base(repository)
-        {
-            this.waiverVersionRepository = waiverVersionRepository;
-            this.communityWaiverRepository = communityWaiverRepository;
-            this.eventPartnerLocationServiceRepository = eventPartnerLocationServiceRepository;
-            this.userRepository = userRepository;
-            this.eventAttendeeRepository = eventAttendeeRepository;
-            this.waiverDocumentManager = waiverDocumentManager;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<WaiverVersion>> GetRequiredWaiversForEventAsync(Guid userId, Guid eventId, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/WaiverDocumentManager.cs
+++ b/TrashMob.Shared/Managers/WaiverDocumentManager.cs
@@ -20,30 +20,17 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manages waiver PDF document generation and storage.
     /// </summary>
-    public class WaiverDocumentManager : IWaiverDocumentManager
+    public class WaiverDocumentManager(
+        ILogger<WaiverDocumentManager> logger,
+        BlobServiceClient blobServiceClient) : IWaiverDocumentManager
     {
         private const string WaiversContainerName = "waivers";
-        private readonly ILogger<WaiverDocumentManager> logger;
-        private readonly BlobServiceClient blobServiceClient;
         private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder().Build();
 
         static WaiverDocumentManager()
         {
             // Configure QuestPDF for Community license (free for open source)
             QuestPDF.Settings.License = LicenseType.Community;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaiverDocumentManager"/> class.
-        /// </summary>
-        /// <param name="logger">The logger.</param>
-        /// <param name="blobServiceClient">The blob service client.</param>
-        public WaiverDocumentManager(
-            ILogger<WaiverDocumentManager> logger,
-            BlobServiceClient blobServiceClient)
-        {
-            this.logger = logger;
-            this.blobServiceClient = blobServiceClient;
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/WaiverManager.cs
+++ b/TrashMob.Shared/Managers/WaiverManager.cs
@@ -10,15 +10,9 @@
     /// <summary>
     /// Manages waiver documents and user waiver agreements.
     /// </summary>
-    public class WaiverManager : KeyedManager<Waiver>, IWaiverManager
+    public class WaiverManager(IKeyedRepository<Waiver> repository)
+        : KeyedManager<Waiver>(repository), IWaiverManager
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaiverManager"/> class.
-        /// </summary>
-        /// <param name="repository">The repository for waiver data access.</param>
-        public WaiverManager(IKeyedRepository<Waiver> repository) : base(repository)
-        {
-        }
 
         /// <inheritdoc />
         public async Task<Waiver> GetByNameAsync(string waiverName, CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/WaiverVersionManager.cs
+++ b/TrashMob.Shared/Managers/WaiverVersionManager.cs
@@ -13,22 +13,11 @@ namespace TrashMob.Shared.Managers
     /// <summary>
     /// Manager for waiver version operations and community waiver assignments.
     /// </summary>
-    public class WaiverVersionManager : KeyedManager<WaiverVersion>, IWaiverVersionManager
+    public class WaiverVersionManager(
+        IKeyedRepository<WaiverVersion> repository,
+        IBaseRepository<CommunityWaiver> communityWaiverRepository)
+        : KeyedManager<WaiverVersion>(repository), IWaiverVersionManager
     {
-        private readonly IBaseRepository<CommunityWaiver> communityWaiverRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaiverVersionManager"/> class.
-        /// </summary>
-        /// <param name="repository">The waiver version repository.</param>
-        /// <param name="communityWaiverRepository">The community waiver repository.</param>
-        public WaiverVersionManager(
-            IKeyedRepository<WaiverVersion> repository,
-            IBaseRepository<CommunityWaiver> communityWaiverRepository)
-            : base(repository)
-        {
-            this.communityWaiverRepository = communityWaiverRepository;
-        }
 
         /// <inheritdoc />
         public async Task<IEnumerable<WaiverVersion>> GetAllAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Converts ~55 manager classes to C# 12 primary constructor syntax, eliminating boilerplate constructor bodies and private readonly field assignments (~720 lines removed)
- Removes 5 unused DI parameters detected as dead code during conversion: `userManager` (EmailInviteManager), `eventRepository` (EventAttendeeRouteManager), `emailManager` (EventLitterReportManager), `partnerRepository` (EventPartnerLocationServiceManager), `dbTransaction` (LitterImageManager)
- Skips EmailManager (constructor side effect with API key assignment) and FormFileWrapper (complex stream copy logic)

## Test plan
- [x] Solution builds with zero errors and zero warnings
- [x] All 442 unit tests pass
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)