### PR TITLE
Convert repository, engine, and service classes to primary constructors

### DIFF
--- a/TrashMob.Shared/Engine/EventSummaryAttendeeNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryAttendeeNotifier.cs
@@ -11,24 +11,19 @@
     /// <summary>
     /// Notification engine that sends thank-you emails to event attendees after an event completes.
     /// </summary>
-    public class EventSummaryAttendeeNotifier : NotificationEngineBase, INotificationEngine
+    public class EventSummaryAttendeeNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventSummaryAttendeeNotifier"/> class.
-        /// </summary>
-        public EventSummaryAttendeeNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.EventSummaryAttendee;
 

--- a/TrashMob.Shared/Engine/EventSummaryHostReminderNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryHostReminderNotifier.cs
@@ -11,24 +11,19 @@
     /// <summary>
     /// Notification engine that reminds event hosts to complete their event summary after an event.
     /// </summary>
-    public class EventSummaryHostReminderNotifier : NotificationEngineBase, INotificationEngine
+    public class EventSummaryHostReminderNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventSummaryHostReminderNotifier"/> class.
-        /// </summary>
-        public EventSummaryHostReminderNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.EventSummaryHostReminder;
 

--- a/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
@@ -12,28 +12,20 @@
     /// <summary>
     /// Notification engine that sends a weekly reminder to event hosts who haven't completed their event summary.
     /// </summary>
-    public class EventSummaryHostWeekReminderNotifier : NotificationEngineBase, INotificationEngine
+    public class EventSummaryHostWeekReminderNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        IBaseManager<EventSummary> eventSummaryManager,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        private readonly IBaseManager<EventSummary> eventSummaryManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventSummaryHostWeekReminderNotifier"/> class.
-        /// </summary>
-        public EventSummaryHostWeekReminderNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            IBaseManager<EventSummary> eventSummaryManager,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-            this.eventSummaryManager = eventSummaryManager;
-        }
 
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.EventSummaryHostWeekReminder;
 

--- a/TrashMob.Shared/Engine/UpcomingEventAttendingBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventAttendingBaseNotifier.cs
@@ -12,24 +12,19 @@
     /// <summary>
     /// Base class for notification engines that notify users about events they are attending.
     /// </summary>
-    public abstract class UpcomingEventAttendingBaseNotifier : NotificationEngineBase, INotificationEngine
+    public abstract class UpcomingEventAttendingBaseNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventAttendingBaseNotifier"/> class.
-        /// </summary>
-        public UpcomingEventAttendingBaseNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Engine/UpcomingEventAttendingSoonNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventAttendingSoonNotifier.cs
@@ -7,24 +7,19 @@
     /// <summary>
     /// Notification engine that reminds users about events they are attending within the next 24 hours.
     /// </summary>
-    public class UpcomingEventAttendingSoonNotifier : UpcomingEventAttendingBaseNotifier, INotificationEngine
+    public class UpcomingEventAttendingSoonNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : UpcomingEventAttendingBaseNotifier(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventAttendingSoonNotifier"/> class.
-        /// </summary>
-        public UpcomingEventAttendingSoonNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.UpcomingEventAttendingSoon;

--- a/TrashMob.Shared/Engine/UpcomingEventAttendingThisWeekNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventAttendingThisWeekNotifier.cs
@@ -7,24 +7,19 @@
     /// <summary>
     /// Notification engine that reminds users about events they are attending within the next week (2-7 days).
     /// </summary>
-    public class UpcomingEventAttendingThisWeekNotifier : UpcomingEventAttendingBaseNotifier, INotificationEngine
+    public class UpcomingEventAttendingThisWeekNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : UpcomingEventAttendingBaseNotifier(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventAttendingThisWeekNotifier"/> class.
-        /// </summary>
-        public UpcomingEventAttendingThisWeekNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.UpcomingEventAttendingThisWeek;

--- a/TrashMob.Shared/Engine/UpcomingEventHostingBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventHostingBaseNotifier.cs
@@ -12,24 +12,19 @@
     /// <summary>
     /// Base class for notification engines that notify event hosts about their upcoming events.
     /// </summary>
-    public abstract class UpcomingEventHostingBaseNotifier : NotificationEngineBase, INotificationEngine
+    public abstract class UpcomingEventHostingBaseNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventHostingBaseNotifier"/> class.
-        /// </summary>
-        public UpcomingEventHostingBaseNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Engine/UpcomingEventHostingSoonNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventHostingSoonNotifier.cs
@@ -7,24 +7,19 @@
     /// <summary>
     /// Notification engine that reminds event hosts about events they are hosting within the next 24 hours.
     /// </summary>
-    public class UpcomingEventHostingSoonNotifier : UpcomingEventHostingBaseNotifier, INotificationEngine
+    public class UpcomingEventHostingSoonNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : UpcomingEventHostingBaseNotifier(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventHostingSoonNotifier"/> class.
-        /// </summary>
-        public UpcomingEventHostingSoonNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.UpcomingEventHostingSoon;

--- a/TrashMob.Shared/Engine/UpcomingEventHostingThisWeekNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventHostingThisWeekNotifier.cs
@@ -7,24 +7,19 @@
     /// <summary>
     /// Notification engine that reminds event hosts about events they are hosting within the next week (2-7 days).
     /// </summary>
-    public class UpcomingEventHostingThisWeekNotifier : UpcomingEventHostingBaseNotifier, INotificationEngine
+    public class UpcomingEventHostingThisWeekNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : UpcomingEventHostingBaseNotifier(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventHostingThisWeekNotifier"/> class.
-        /// </summary>
-        public UpcomingEventHostingThisWeekNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.UpcomingEventHostingThisWeek;

--- a/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
@@ -12,24 +12,19 @@
     /// <summary>
     /// Base class for notification engines that notify users about upcoming events in their geographic area.
     /// </summary>
-    public abstract class UpcomingEventsInYourAreaBaseNotifier : NotificationEngineBase, INotificationEngine
+    public abstract class UpcomingEventsInYourAreaBaseNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventsInYourAreaBaseNotifier"/> class.
-        /// </summary>
-        public UpcomingEventsInYourAreaBaseNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Engine/UpcomingEventsInYourAreaSoonNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventsInYourAreaSoonNotifier.cs
@@ -7,24 +7,19 @@
     /// <summary>
     /// Notification engine that notifies users about events in their area happening within the next 24 hours.
     /// </summary>
-    public class UpcomingEventsInYourAreaSoonNotifier : UpcomingEventsInYourAreaBaseNotifier, INotificationEngine
+    public class UpcomingEventsInYourAreaSoonNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : UpcomingEventsInYourAreaBaseNotifier(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventsInYourAreaSoonNotifier"/> class.
-        /// </summary>
-        public UpcomingEventsInYourAreaSoonNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.UpcomingEventsInYourAreaSoon;

--- a/TrashMob.Shared/Engine/UpcomingEventsInYourAreaThisWeekNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventsInYourAreaThisWeekNotifier.cs
@@ -7,24 +7,19 @@
     /// <summary>
     /// Notification engine that notifies users about events in their area happening within the next week (2-7 days).
     /// </summary>
-    public class UpcomingEventsInYourAreaThisWeekNotifier : UpcomingEventsInYourAreaBaseNotifier, INotificationEngine
+    public class UpcomingEventsInYourAreaThisWeekNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : UpcomingEventsInYourAreaBaseNotifier(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger), INotificationEngine
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpcomingEventsInYourAreaThisWeekNotifier"/> class.
-        /// </summary>
-        public UpcomingEventsInYourAreaThisWeekNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType =>

--- a/TrashMob.Shared/Engine/UserNotificationManager.cs
+++ b/TrashMob.Shared/Engine/UserNotificationManager.cs
@@ -8,62 +8,20 @@
     /// <summary>
     /// Manages and orchestrates all user notification engines.
     /// </summary>
-    public class UserNotificationManager : IUserNotificationManager
+    public class UserNotificationManager(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        IBaseManager<EventSummary> eventSummaryManager,
+        ILitterReportManager litterReportManager,
+        IUserWaiverManager userWaiverManager,
+        ILogger<UserNotificationManager> logger) : IUserNotificationManager
     {
-        private readonly IEmailManager emailManager;
-        private readonly IEmailSender emailSender;
-        private readonly IEventAttendeeManager eventAttendeeManager;
-        private readonly IEventManager eventManager;
-        private readonly IBaseManager<EventSummary> eventSummaryManager;
-        private readonly ILitterReportManager litterReportManager;
-        private readonly ILogger<UserNotificationManager> logger;
-        private readonly IMapManager mapRepository;
-        private readonly INonEventUserNotificationManager nonEventUserNotificationManager;
-        private readonly IKeyedManager<User> userManager;
-        private readonly IKeyedManager<UserNotification> userNotificationManager;
-        private readonly IUserWaiverManager userWaiverManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserNotificationManager"/> class.
-        /// </summary>
-        /// <param name="eventManager">Manager for event operations.</param>
-        /// <param name="userManager">Manager for user operations.</param>
-        /// <param name="eventAttendeeManager">Manager for event attendee operations.</param>
-        /// <param name="userNotificationManager">Manager for user notification tracking.</param>
-        /// <param name="nonEventUserNotificationManager">Manager for non-event notifications.</param>
-        /// <param name="emailSender">Service for sending emails.</param>
-        /// <param name="emailManager">Manager for email operations.</param>
-        /// <param name="mapRepository">Repository for map services.</param>
-        /// <param name="eventSummaryManager">Manager for event summaries.</param>
-        /// <param name="litterReportManager">Manager for litter report operations.</param>
-        /// <param name="userWaiverManager">Manager for user waiver operations.</param>
-        /// <param name="logger">Logger instance.</param>
-        public UserNotificationManager(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            IBaseManager<EventSummary> eventSummaryManager,
-            ILitterReportManager litterReportManager,
-            IUserWaiverManager userWaiverManager,
-            ILogger<UserNotificationManager> logger)
-        {
-            this.eventManager = eventManager;
-            this.userManager = userManager;
-            this.eventAttendeeManager = eventAttendeeManager;
-            this.userNotificationManager = userNotificationManager;
-            this.nonEventUserNotificationManager = nonEventUserNotificationManager;
-            this.emailSender = emailSender;
-            this.emailManager = emailManager;
-            this.mapRepository = mapRepository;
-            this.eventSummaryManager = eventSummaryManager;
-            this.litterReportManager = litterReportManager;
-            this.userWaiverManager = userWaiverManager;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task RunAllNotifications()
@@ -121,7 +79,7 @@
             await userProfileLocationNotifier.GenerateNotificationsAsync().ConfigureAwait(false);
 
             var weeklyLitterReportsNotifier = new WeeklyLitterReportsInYourAreaNotifier(userManager,
-                litterReportManager, nonEventUserNotificationManager, emailSender, emailManager, mapRepository,
+                litterReportManager, nonEventUserNotificationManager, emailManager, mapRepository,
                 logger);
             await weeklyLitterReportsNotifier.GenerateNotificationsAsync().ConfigureAwait(false);
 

--- a/TrashMob.Shared/Engine/UserProfileLocationNotifier.cs
+++ b/TrashMob.Shared/Engine/UserProfileLocationNotifier.cs
@@ -10,24 +10,19 @@
     /// <summary>
     /// Notification engine that reminds users to set their location in their profile to receive event notifications.
     /// </summary>
-    public class UserProfileLocationNotifier : NotificationEngineBase
+    public class UserProfileLocationNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserProfileLocationNotifier"/> class.
-        /// </summary>
-        public UserProfileLocationNotifier(IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger) :
-            base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.UserProfileUpdateLocation;

--- a/TrashMob.Shared/Engine/WaiverExpiringNotifier.cs
+++ b/TrashMob.Shared/Engine/WaiverExpiringNotifier.cs
@@ -10,30 +10,21 @@ namespace TrashMob.Shared.Engine
     /// <summary>
     /// Notification engine that reminds users when their waivers are expiring.
     /// </summary>
-    public class WaiverExpiringNotifier : NotificationEngineBase
+    public class WaiverExpiringNotifier(
+        IEventManager eventManager,
+        IKeyedManager<User> userManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IKeyedManager<UserNotification> userNotificationManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailSender emailSender,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        IUserWaiverManager userWaiverManager,
+        ILogger logger)
+        : NotificationEngineBase(eventManager, userManager, eventAttendeeManager, userNotificationManager,
+            nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
     {
-        private readonly IUserWaiverManager userWaiverManager;
         private const int DaysBeforeExpiry = 30;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaiverExpiringNotifier"/> class.
-        /// </summary>
-        public WaiverExpiringNotifier(
-            IEventManager eventManager,
-            IKeyedManager<User> userManager,
-            IEventAttendeeManager eventAttendeeManager,
-            IKeyedManager<UserNotification> userNotificationManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            IUserWaiverManager userWaiverManager,
-            ILogger logger)
-            : base(eventManager, userManager, eventAttendeeManager, userNotificationManager,
-                nonEventUserNotificationManager, emailSender, emailManager, mapRepository, logger)
-        {
-            this.userWaiverManager = userWaiverManager;
-        }
 
         /// <inheritdoc />
         protected override NotificationTypeEnum NotificationType => NotificationTypeEnum.WaiverExpiringReminder;

--- a/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
+++ b/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
@@ -14,36 +14,14 @@ namespace TrashMob.Shared.Engine
     /// Notification engine that sends weekly digest emails about new litter reports in users' geographic area.
     /// This notifier should only run once per week (e.g., on Mondays).
     /// </summary>
-    public class WeeklyLitterReportsInYourAreaNotifier : INotificationEngine
+    public class WeeklyLitterReportsInYourAreaNotifier(
+        IKeyedManager<User> userManager,
+        ILitterReportManager litterReportManager,
+        INonEventUserNotificationManager nonEventUserNotificationManager,
+        IEmailManager emailManager,
+        IMapManager mapRepository,
+        ILogger logger) : INotificationEngine
     {
-        private readonly IEmailManager emailManager;
-        private readonly IEmailSender emailSender;
-        private readonly ILitterReportManager litterReportManager;
-        private readonly ILogger logger;
-        private readonly IMapManager mapRepository;
-        private readonly INonEventUserNotificationManager nonEventUserNotificationManager;
-        private readonly IKeyedManager<User> userManager;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WeeklyLitterReportsInYourAreaNotifier"/> class.
-        /// </summary>
-        public WeeklyLitterReportsInYourAreaNotifier(
-            IKeyedManager<User> userManager,
-            ILitterReportManager litterReportManager,
-            INonEventUserNotificationManager nonEventUserNotificationManager,
-            IEmailSender emailSender,
-            IEmailManager emailManager,
-            IMapManager mapRepository,
-            ILogger logger)
-        {
-            this.userManager = userManager;
-            this.litterReportManager = litterReportManager;
-            this.nonEventUserNotificationManager = nonEventUserNotificationManager;
-            this.emailSender = emailSender;
-            this.emailManager = emailManager;
-            this.mapRepository = mapRepository;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)

--- a/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
@@ -16,11 +16,11 @@ namespace TrashMob.Shared.Managers.Areas
     using TrashMob.Models;
     using TrashMob.Shared.Managers.Interfaces;
 
-    public class AreaSuggestionService : IAreaSuggestionService
+    public class AreaSuggestionService(
+        IConfiguration configuration,
+        ILogger<AreaSuggestionService> logger,
+        IMapManager mapManager) : IAreaSuggestionService
     {
-        private readonly IConfiguration configuration;
-        private readonly ILogger<AreaSuggestionService> logger;
-        private readonly IMapManager mapManager;
         private static readonly SemaphoreSlim RateLimiter = new(1, 1);
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -47,16 +47,6 @@ namespace TrashMob.Shared.Managers.Areas
 
             Return ONLY the JSON object, no markdown fences, no other text.
             """;
-
-        public AreaSuggestionService(
-            IConfiguration configuration,
-            ILogger<AreaSuggestionService> logger,
-            IMapManager mapManager)
-        {
-            this.configuration = configuration;
-            this.logger = logger;
-            this.mapManager = mapManager;
-        }
 
         public async Task<AreaSuggestionResult> SuggestAreaAsync(
             AreaSuggestionRequest request,

--- a/TrashMob.Shared/Managers/Prospects/ClaudeDiscoveryService.cs
+++ b/TrashMob.Shared/Managers/Prospects/ClaudeDiscoveryService.cs
@@ -17,10 +17,10 @@ namespace TrashMob.Shared.Managers.Prospects
     /// Discovers community prospects using the Anthropic Claude API.
     /// Supports both freeform custom queries and location-based discovery.
     /// </summary>
-    public class ClaudeDiscoveryService : IClaudeDiscoveryService
+    public class ClaudeDiscoveryService(
+        IConfiguration configuration,
+        ILogger<ClaudeDiscoveryService> logger) : IClaudeDiscoveryService
     {
-        private readonly IConfiguration configuration;
-        private readonly ILogger<ClaudeDiscoveryService> logger;
         private static readonly SemaphoreSlim RateLimiter = new(1, 1);
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -38,13 +38,6 @@ namespace TrashMob.Shared.Managers.Prospects
 
             Return ONLY the JSON array, no markdown fences, no other text.
             """;
-
-        public ClaudeDiscoveryService(IConfiguration configuration,
-            ILogger<ClaudeDiscoveryService> logger)
-        {
-            this.configuration = configuration;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task<DiscoveryResult> DiscoverProspectsAsync(DiscoveryRequest request,

--- a/TrashMob.Shared/Managers/Prospects/OutreachContentService.cs
+++ b/TrashMob.Shared/Managers/Prospects/OutreachContentService.cs
@@ -15,10 +15,10 @@ namespace TrashMob.Shared.Managers.Prospects
     /// <summary>
     /// Generates AI-personalized outreach email content using the Anthropic Claude API.
     /// </summary>
-    public class OutreachContentService : IOutreachContentService
+    public class OutreachContentService(
+        IConfiguration configuration,
+        ILogger<OutreachContentService> logger) : IOutreachContentService
     {
-        private readonly IConfiguration configuration;
-        private readonly ILogger<OutreachContentService> logger;
         private static readonly SemaphoreSlim RateLimiter = new(1, 1);
         private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -42,13 +42,6 @@ namespace TrashMob.Shared.Managers.Prospects
 
             Return ONLY the JSON object, no markdown fences, no other text.
             """;
-
-        public OutreachContentService(IConfiguration configuration,
-            ILogger<OutreachContentService> logger)
-        {
-            this.configuration = configuration;
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public async Task<OutreachPreview> GenerateOutreachContentAsync(CommunityProspect prospect,

--- a/TrashMob.Shared/Managers/Prospects/SentimentAnalysisService.cs
+++ b/TrashMob.Shared/Managers/Prospects/SentimentAnalysisService.cs
@@ -12,10 +12,10 @@ namespace TrashMob.Shared.Managers.Prospects
     /// Analyzes sentiment of prospect replies using the Anthropic Claude API.
     /// Falls back to "Neutral" when the API is not configured.
     /// </summary>
-    public class SentimentAnalysisService : ISentimentAnalysisService
+    public class SentimentAnalysisService(
+        IConfiguration configuration,
+        ILogger<SentimentAnalysisService> logger) : ISentimentAnalysisService
     {
-        private readonly IConfiguration configuration;
-        private readonly ILogger<SentimentAnalysisService> logger;
         private static readonly SemaphoreSlim RateLimiter = new(1, 1);
 
         private const string SystemPrompt =
@@ -23,12 +23,6 @@ namespace TrashMob.Shared.Managers.Prospects
             "Respond with EXACTLY one word: \"Positive\", \"Neutral\", or \"Negative\". No other text.";
 
         private static readonly string[] ValidSentiments = ["Positive", "Neutral", "Negative"];
-
-        public SentimentAnalysisService(IConfiguration configuration, ILogger<SentimentAnalysisService> logger)
-        {
-            this.configuration = configuration;
-            this.logger = logger;
-        }
 
         public async Task<string> AnalyzeSentimentAsync(string replyText, CancellationToken cancellationToken = default)
         {

--- a/TrashMob.Shared/Persistence/BaseRepository.cs
+++ b/TrashMob.Shared/Persistence/BaseRepository.cs
@@ -12,27 +12,11 @@
     /// Provides data access implementation for entities derived from <see cref="BaseModel"/>.
     /// </summary>
     /// <typeparam name="T">The entity type that derives from <see cref="BaseModel"/>.</typeparam>
-    public class BaseRepository<T> : IBaseRepository<T> where T : BaseModel
+    public class BaseRepository<T>(MobDbContext mobDbContext)
+        : IBaseRepository<T> where T : BaseModel
     {
-        /// <summary>
-        /// The database set for the entity type.
-        /// </summary>
-        protected readonly DbSet<T> dbSet;
-
-        /// <summary>
-        /// The database context.
-        /// </summary>
-        protected readonly MobDbContext mobDbContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BaseRepository{T}"/> class.
-        /// </summary>
-        /// <param name="mobDbContext">The database context to use for data access.</param>
-        public BaseRepository(MobDbContext mobDbContext)
-        {
-            this.mobDbContext = mobDbContext;
-            dbSet = mobDbContext.Set<T>();
-        }
+        protected readonly DbSet<T> dbSet = mobDbContext.Set<T>();
+        protected readonly MobDbContext mobDbContext = mobDbContext;
 
         /// <inheritdoc />
         public virtual async Task<T> AddAsync(T instance)

--- a/TrashMob.Shared/Persistence/DbTransaction.cs
+++ b/TrashMob.Shared/Persistence/DbTransaction.cs
@@ -6,21 +6,8 @@ namespace TrashMob.Shared.Persistence
     /// <summary>
     /// Provides database transaction implementation for managing transactional data access.
     /// </summary>
-    public class DbTransaction : IDbTransaction
+    public class DbTransaction(MobDbContext mobDbContext) : IDbTransaction
     {
-        /// <summary>
-        /// The database context.
-        /// </summary>
-        protected readonly MobDbContext mobDbContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DbTransaction"/> class.
-        /// </summary>
-        /// <param name="mobDbContext">The database context to use for transaction management.</param>
-        public DbTransaction(MobDbContext mobDbContext)
-        {
-            this.mobDbContext = mobDbContext;
-        }
 
         /// <inheritdoc />
         public async Task BeginTransactionAsync()

--- a/TrashMob.Shared/Persistence/KeyedRepository.cs
+++ b/TrashMob.Shared/Persistence/KeyedRepository.cs
@@ -11,15 +11,9 @@
     /// Provides data access implementation for entities derived from <see cref="KeyedModel"/> that have a <see cref="Guid"/> identifier.
     /// </summary>
     /// <typeparam name="T">The entity type that derives from <see cref="KeyedModel"/>.</typeparam>
-    public class KeyedRepository<T> : BaseRepository<T>, IKeyedRepository<T> where T : KeyedModel
+    public class KeyedRepository<T>(MobDbContext mobDbContext)
+        : BaseRepository<T>(mobDbContext), IKeyedRepository<T> where T : KeyedModel
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="KeyedRepository{T}"/> class.
-        /// </summary>
-        /// <param name="mobDbContext">The database context to use for data access.</param>
-        public KeyedRepository(MobDbContext mobDbContext) : base(mobDbContext)
-        {
-        }
 
         /// <inheritdoc />
         public override async Task<T> AddAsync(T instance)

--- a/TrashMob.Shared/Persistence/LookupRepository.cs
+++ b/TrashMob.Shared/Persistence/LookupRepository.cs
@@ -13,27 +13,10 @@
     /// Provides read-only data access implementation for lookup entities derived from <see cref="LookupModel"/>.
     /// </summary>
     /// <typeparam name="T">The lookup entity type that derives from <see cref="LookupModel"/>.</typeparam>
-    public class LookupRepository<T> : ILookupRepository<T> where T : LookupModel
+    public class LookupRepository<T>(MobDbContext mobDbContext)
+        : ILookupRepository<T> where T : LookupModel
     {
-        /// <summary>
-        /// The database set for the lookup entity type.
-        /// </summary>
-        protected readonly DbSet<T> dbSet;
-
-        /// <summary>
-        /// The database context.
-        /// </summary>
-        protected readonly MobDbContext mobDbContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LookupRepository{T}"/> class.
-        /// </summary>
-        /// <param name="mobDbContext">The database context to use for data access.</param>
-        public LookupRepository(MobDbContext mobDbContext)
-        {
-            this.mobDbContext = mobDbContext;
-            dbSet = mobDbContext.Set<T>();
-        }
+        protected readonly DbSet<T> dbSet = mobDbContext.Set<T>();
 
         /// <inheritdoc />
         public IQueryable<T> Get()

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -9,21 +9,8 @@
     /// <summary>
     /// Provides the Entity Framework database context for the TrashMob application.
     /// </summary>
-    public class MobDbContext : DbContext
+    public class MobDbContext(IConfiguration configuration) : DbContext
     {
-        /// <summary>
-        /// The configuration provider.
-        /// </summary>
-        private readonly IConfiguration configuration;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MobDbContext"/> class.
-        /// </summary>
-        /// <param name="configuration">The configuration provider containing database connection settings.</param>
-        public MobDbContext(IConfiguration configuration)
-        {
-            this.configuration = configuration;
-        }
 
         public virtual DbSet<ContactRequest> ContactRequests { get; set; }
 

--- a/TrashMob.Shared/Persistence/SecretRepository.cs
+++ b/TrashMob.Shared/Persistence/SecretRepository.cs
@@ -6,21 +6,8 @@
     /// <summary>
     /// Provides data access implementation for retrieving application secrets and configuration values.
     /// </summary>
-    public class SecretRepository : ISecretRepository
+    public class SecretRepository(IConfiguration configuration) : ISecretRepository
     {
-        /// <summary>
-        /// The configuration provider.
-        /// </summary>
-        private readonly IConfiguration configuration;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SecretRepository"/> class.
-        /// </summary>
-        /// <param name="configuration">The configuration provider to use for retrieving secrets.</param>
-        public SecretRepository(IConfiguration configuration)
-        {
-            this.configuration = configuration;
-        }
 
         /// <inheritdoc />
         public string Get(string name)

--- a/TrashMob.Shared/Services/FeatureMetricsService.cs
+++ b/TrashMob.Shared/Services/FeatureMetricsService.cs
@@ -12,15 +12,9 @@ namespace TrashMob.Shared.Services
     /// <summary>
     /// Service for tracking feature usage metrics using OpenTelemetry Activities.
     /// </summary>
-    public class FeatureMetricsService : IFeatureMetricsService
+    public class FeatureMetricsService(ILogger<FeatureMetricsService> logger) : IFeatureMetricsService
     {
         private static readonly ActivitySource FeatureMetricsSource = new("TrashMob.FeatureMetrics", "1.0.0");
-        private readonly ILogger<FeatureMetricsService> logger;
-
-        public FeatureMetricsService(ILogger<FeatureMetricsService> logger)
-        {
-            this.logger = logger;
-        }
 
         /// <inheritdoc />
         public void TrackFeatureUsage(string category, string action, Dictionary<string, object>? properties = null)


### PR DESCRIPTION
## Summary
- Converts ~25 classes across repository, notification engine, and service layers to C# 12 primary constructor syntax (~255 lines removed)
- Repository layer: BaseRepository, KeyedRepository, LookupRepository, SecretRepository, DbTransaction, MobDbContext
- Notification engines: all 14 NotificationEngineBase subclasses, UserNotificationManager, WeeklyLitterReportsInYourAreaNotifier
- Services: AreaSuggestionService, ClaudeDiscoveryService, OutreachContentService, SentimentAnalysisService, FeatureMetricsService
- Removes 1 unused parameter (`emailSender` in WeeklyLitterReportsInYourAreaNotifier)
- Skips NotificationEngineBase, EmailManager, and FormFileWrapper (all have constructor side effects)

## Test plan
- [x] Solution builds with zero errors and zero warnings
- [x] All 442 unit tests pass
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)