### PR TITLE
Replace new List<T>() with C# 12 collection expressions

### DIFF
--- a/TrashMob.Shared/Engine/EventSummaryAttendeeNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryAttendeeNotifier.cs
@@ -47,7 +47,7 @@
             // for each user
             foreach (var user in users)
             {
-                var eventsToNotifyUserFor = new List<Event>();
+                List<Event> eventsToNotifyUserFor = [];
 
                 // Get list of active events
                 var events = await EventManager.GetCompletedEventsAsync(cancellationToken).ConfigureAwait(false);

--- a/TrashMob.Shared/Engine/EventSummaryHostReminderNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryHostReminderNotifier.cs
@@ -48,7 +48,7 @@
             // for each user
             foreach (var user in users)
             {
-                var eventsToNotifyUserFor = new List<Event>();
+                List<Event> eventsToNotifyUserFor = [];
 
                 // Get list of active events
                 var events = await EventManager.GetCompletedEventsAsync(cancellationToken).ConfigureAwait(false);

--- a/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
@@ -50,7 +50,7 @@
             // for each user
             foreach (var user in users)
             {
-                var eventsToNotifyUserFor = new List<Event>();
+                List<Event> eventsToNotifyUserFor = [];
 
                 // Get list of completed events
                 var events = await EventManager.GetCompletedEventsAsync(cancellationToken).ConfigureAwait(false);

--- a/TrashMob.Shared/Engine/NotificationEngineBase.cs
+++ b/TrashMob.Shared/Engine/NotificationEngineBase.cs
@@ -181,10 +181,10 @@
                         googleMapsUrl = mobEvent.GoogleMapsUrl(),
                     };
 
-                    var recipients = new List<EmailAddress>
-                    {
+                    List<EmailAddress> recipients =
+                    [
                         new() { Name = user.UserName, Email = user.Email },
-                    };
+                    ];
 
                     Logger.LogInformation("Sending email to {0}, Subject {0}", user.Email, EmailSubject);
 
@@ -227,10 +227,10 @@
                 subject = EmailSubject,
             };
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = user.UserName, Email = user.Email },
-            };
+            ];
 
             Logger.LogInformation("Sending email to {0}, Subject {0}", user.Email, EmailSubject);
 

--- a/TrashMob.Shared/Engine/UpcomingEventAttendingBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventAttendingBaseNotifier.cs
@@ -40,7 +40,7 @@
             // for each user
             foreach (var user in users)
             {
-                var eventsToNotifyUserFor = new List<Event>();
+                List<Event> eventsToNotifyUserFor = [];
 
                 // Get list of active events
                 var events = await EventManager.GetActiveEventsAsync(cancellationToken).ConfigureAwait(false);

--- a/TrashMob.Shared/Engine/UpcomingEventHostingBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventHostingBaseNotifier.cs
@@ -40,7 +40,7 @@
             // for each user
             foreach (var user in users)
             {
-                var eventsToNotifyUserFor = new List<Event>();
+                List<Event> eventsToNotifyUserFor = [];
 
                 // Get list of active events
                 var events = await EventManager.GetActiveEventsAsync(cancellationToken).ConfigureAwait(false);

--- a/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
@@ -46,7 +46,7 @@
                     continue;
                 }
 
-                var eventsToNotifyUserFor = new List<Event>();
+                List<Event> eventsToNotifyUserFor = [];
 
                 // Get list of active events
                 var events = await EventManager.GetActiveEventsAsync(cancellationToken).ConfigureAwait(false);

--- a/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
+++ b/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
@@ -69,7 +69,7 @@ namespace TrashMob.Shared.Engine
                     continue;
                 }
 
-                var nearbyReports = new List<LitterReport>();
+                List<LitterReport> nearbyReports = [];
 
                 foreach (var report in recentReports)
                 {
@@ -144,10 +144,10 @@ namespace TrashMob.Shared.Engine
 
                 var subject = $"Weekly Digest: {reports.Count} new litter report(s) in your area";
 
-                var recipients = new List<EmailAddress>
-                {
+                List<EmailAddress> recipients =
+                [
                     new() { Name = user.UserName, Email = user.Email },
-                };
+                ];
 
                 var dynamicTemplateData = new
                 {

--- a/TrashMob.Shared/Managers/Areas/AreaFileParser.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaFileParser.cs
@@ -472,10 +472,10 @@ namespace TrashMob.Shared.Managers.Areas
         {
             if (string.IsNullOrWhiteSpace(coordString))
             {
-                return new List<double[]>();
+                return [];
             }
 
-            var coords = new List<double[]>();
+            List<double[]> coords = [];
             var tuples = coordString.Trim().Split(new[] { ' ', '\n', '\r', '\t' },
                 StringSplitOptions.RemoveEmptyEntries);
 

--- a/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
@@ -168,10 +168,10 @@ namespace TrashMob.Shared.Managers.Areas
 
         private static string BuildUserPrompt(AreaSuggestionRequest request)
         {
-            var parts = new List<string>
-            {
+            List<string> parts =
+            [
                 $"Area description: \"{request.Description}\"",
-            };
+            ];
 
             if (!string.IsNullOrWhiteSpace(request.CommunityName))
             {
@@ -190,7 +190,7 @@ namespace TrashMob.Shared.Managers.Areas
             List<GeocodingQuery>? queries,
             CancellationToken cancellationToken)
         {
-            var coordinates = new List<(double Lat, double Lon)>();
+            List<(double Lat, double Lon)> coordinates = [];
 
             if (queries == null || queries.Count == 0)
             {

--- a/TrashMob.Shared/Managers/Communities/CommunityManager.cs
+++ b/TrashMob.Shared/Managers/Communities/CommunityManager.cs
@@ -389,9 +389,9 @@ namespace TrashMob.Shared.Managers.Communities
             {
                 Community = community,
                 Stats = new Stats(),
-                RecentEvents = new List<Event>(),
-                UpcomingEvents = new List<Event>(),
-                RecentActivity = new List<CommunityActivity>(),
+                RecentEvents = [],
+                UpcomingEvents = [],
+                RecentActivity = [],
             };
 
             // Get stats if we have city/region
@@ -445,7 +445,7 @@ namespace TrashMob.Shared.Managers.Communities
                 dashboard.RecentEvents = recentEvents;
 
                 // Build recent activity from completed events
-                var recentActivity = new List<CommunityActivity>();
+                List<CommunityActivity> recentActivity = [];
                 foreach (var evt in recentEvents.Take(10))
                 {
                     recentActivity.Add(new CommunityActivity

--- a/TrashMob.Shared/Managers/ContactRequestManager.cs
+++ b/TrashMob.Shared/Managers/ContactRequestManager.cs
@@ -37,10 +37,10 @@ namespace TrashMob.Shared.Managers
             message = message.Replace("{UserEmail}", contactRequest.Email);
             message = message.Replace("{Message}", contactRequest.Message);
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-            };
+            ];
 
             var dynamicTemplateData = new
             {

--- a/TrashMob.Shared/Managers/EmailInviteManager.cs
+++ b/TrashMob.Shared/Managers/EmailInviteManager.cs
@@ -232,10 +232,10 @@ namespace TrashMob.Shared.Managers
                 emailCopy,
             };
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = invite.Email, Email = invite.Email },
-            };
+            ];
 
             await emailManager.SendTemplatedEmailAsync(
                 subject,

--- a/TrashMob.Shared/Managers/EmailManager.cs
+++ b/TrashMob.Shared/Managers/EmailManager.cs
@@ -71,7 +71,7 @@ namespace TrashMob.Shared.Managers
         /// <inheritdoc />
         public Task<IEnumerable<EmailTemplate>> GetEmailTemplatesAsync(CancellationToken cancellationToken)
         {
-            var emailTemplates = new List<EmailTemplate>();
+            List<EmailTemplate> emailTemplates = [];
             foreach (var notificationType in Enum.GetValues(typeof(NotificationTypeEnum)))
             {
                 var content = GetHtmlEmailCopy(notificationType.ToString());

--- a/TrashMob.Shared/Managers/EmailSender.cs
+++ b/TrashMob.Shared/Managers/EmailSender.cs
@@ -31,7 +31,7 @@ namespace TrashMob.Shared.Managers
 
             var from = new EmailAddress(Constants.TrashMobEmailAddress, Constants.TrashMobEmailName);
 
-            var tos = new List<EmailAddress>();
+            List<EmailAddress> tos = [];
             foreach (var address in email.Addresses)
             {
                 tos.Add(new EmailAddress(address.Email, address.Name));
@@ -62,7 +62,7 @@ namespace TrashMob.Shared.Managers
 
             var from = new EmailAddress(Constants.TrashMobEmailAddress, Constants.TrashMobEmailName);
 
-            var tos = new List<EmailAddress>();
+            List<EmailAddress> tos = [];
             foreach (var address in email.Addresses)
             {
                 tos.Add(new EmailAddress(address.Email, address.Name));
@@ -78,11 +78,11 @@ namespace TrashMob.Shared.Managers
                 message.Asm = new ASM
                 {
                     GroupId = email.GroupId,
-                    GroupsToDisplay = new List<int>
-                    {
+                    GroupsToDisplay =
+                    [
                         SendGridEmailGroupId.EventRelated,
                         SendGridEmailGroupId.General,
-                    },
+                    ],
                 };
 
                 var response = await client.SendEmailAsync(message, cancellationToken);

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -57,7 +57,7 @@ namespace TrashMob.Shared.Managers.Events
                 return events;
             }
 
-            return new List<Event>();
+            return [];
         }
 
         /// <inheritdoc />
@@ -76,7 +76,7 @@ namespace TrashMob.Shared.Managers.Events
                 return events;
             }
 
-            return new List<Event>();
+            return [];
         }
 
         /// <inheritdoc />
@@ -217,10 +217,10 @@ namespace TrashMob.Shared.Managers.Events
             message = message.Replace("{EventDate}", eventDate.ToString("D"));
             message = message.Replace("{EventTime}", eventDate.ToString("t"));
 
-            var recipients = new List<EmailAddress>
-            {
-                new() { Name = user.UserName ?? "TrashMob User", Email = user.Email }
-            };
+            List<EmailAddress> recipients =
+            [
+                new() { Name = user.UserName ?? "TrashMob User", Email = user.Email },
+            ];
 
             var dynamicTemplateData = new
             {

--- a/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
@@ -247,7 +247,7 @@ namespace TrashMob.Shared.Managers.Events
                 return coords.ToList();
             }
 
-            var result = new List<Coordinate>();
+            List<Coordinate> result = [];
             var cumulativeDistance = 0.0;
 
             for (var i = 0; i < coords.Length; i++)

--- a/TrashMob.Shared/Managers/Events/EventLitterReportManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventLitterReportManager.cs
@@ -90,7 +90,7 @@ namespace TrashMob.Shared.Managers.Events
                 return events;
             }
 
-            return new List<Event>();
+            return [];
         }
     }
 }

--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -159,10 +159,10 @@ namespace TrashMob.Shared.Managers.Events
                     googleMapsUrl = instance.GoogleMapsUrl(),
                 };
 
-                var recipients = new List<EmailAddress>
-                {
+                List<EmailAddress> recipients =
+                [
                     new() { Name = attendee.User.UserName, Email = attendee.User.Email },
-                };
+                ];
 
                 await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.EventEmail,
                         SendGridEmailGroupId.EventRelated, dynamicTemplateData, recipients, CancellationToken.None);
@@ -189,10 +189,10 @@ namespace TrashMob.Shared.Managers.Events
             var message = $"A new event: {instance.Name} in {instance.City} has been created on TrashMob.eco!";
             var subject = "New Event Alert";
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-            };
+            ];
 
             var localTime = await instance.GetLocalEventTime(mapManager);
 
@@ -258,10 +258,10 @@ namespace TrashMob.Shared.Managers.Events
                         googleMapsUrl = instance.GoogleMapsUrl(),
                     };
 
-                    var recipients = new List<EmailAddress>
-                    {
+                    List<EmailAddress> recipients =
+                    [
                         new() { Name = attendee.User.UserName, Email = attendee.User.Email },
-                    };
+                    ];
 
                     await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.EventEmail,
                             SendGridEmailGroupId.EventRelated, dynamicTemplateData, recipients, CancellationToken.None);

--- a/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
@@ -50,10 +50,10 @@ namespace TrashMob.Shared.Managers.Events
             var subject = "A New Partner Request for an Event has been made!";
             var message = $"A new partner request for an event has been made for event {existingService.Event.Name}!";
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-            };
+            ];
 
             var adminDynamicTemplateData = new
             {
@@ -79,7 +79,7 @@ namespace TrashMob.Shared.Managers.Events
                 subject,
             };
 
-            var partnerRecipients = new List<EmailAddress>();
+            List<EmailAddress> partnerRecipients = [];
 
             foreach (var contact in existingService.PartnerLocation.PartnerLocationContacts)
             {
@@ -121,10 +121,10 @@ namespace TrashMob.Shared.Managers.Events
             var message =
                 $"A partner request for an event has been responded to for event {existingService.Event.Name}!";
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-            };
+            ];
 
             var adminDynamicTemplateData = new
             {
@@ -145,10 +145,10 @@ namespace TrashMob.Shared.Managers.Events
                 string.Format("https://www.trashmob.eco/events/{0}/edit", existingService.EventId);
             partnerMessage = partnerMessage.Replace("{PartnerResponseUrl}", dashboardLink);
 
-            var partnerRecipients = new List<EmailAddress>
-            {
+            List<EmailAddress> partnerRecipients =
+            [
                 new() { Name = user.UserName, Email = user.Email },
-            };
+            ];
 
             var dynamicTemplateData = new
             {
@@ -167,7 +167,7 @@ namespace TrashMob.Shared.Managers.Events
         public async Task<IEnumerable<DisplayPartnerLocationServiceEvent>> GetByPartnerLocationAsync(
             Guid partnerLocationId, CancellationToken cancellationToken = default)
         {
-            var displayEventPartners = new List<DisplayPartnerLocationServiceEvent>();
+            List<DisplayPartnerLocationServiceEvent> displayEventPartners = [];
 
             var currentPartnerLocations = await Repository.Get(p => p.PartnerLocation.Id == partnerLocationId)
                 .Include(p => p.PartnerLocation)
@@ -209,7 +209,7 @@ namespace TrashMob.Shared.Managers.Events
         public async Task<IEnumerable<DisplayPartnerLocationServiceEvent>> GetByUserAsync(Guid userId,
             CancellationToken cancellationToken = default)
         {
-            var displayEventPartners = new List<DisplayPartnerLocationServiceEvent>();
+            List<DisplayPartnerLocationServiceEvent> displayEventPartners = [];
 
             // Get list of partners for a user
             var partners = await partnerAdminRepository.Get(p => p.UserId == userId)
@@ -271,7 +271,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Include(p => p.PartnerLocation.Partner)
                 .ToListAsync(cancellationToken);
 
-            var displayEventPartnerLocationServices = new List<DisplayEventPartnerLocationService>();
+            List<DisplayEventPartnerLocationService> displayEventPartnerLocationServices = [];
 
             foreach (var service in existingServices)
             {
@@ -332,7 +332,7 @@ namespace TrashMob.Shared.Managers.Events
         public async Task<IEnumerable<DisplayEventPartnerLocation>> GetByEventAsync(Guid eventId,
             CancellationToken cancellationToken = default)
         {
-            var displayEventPartners = new List<DisplayEventPartnerLocation>();
+            List<DisplayEventPartnerLocation> displayEventPartners = [];
             var currentPartners =
                 (await GetCurrentPartnersAsync(eventId, cancellationToken)).DistinctBy(p =>
                     new { p.EventId, p.PartnerLocationId });

--- a/TrashMob.Shared/Managers/IFTTT/QueriesManager.cs
+++ b/TrashMob.Shared/Managers/IFTTT/QueriesManager.cs
@@ -69,7 +69,7 @@
             }
 
 
-            var triggersResponses = new List<IftttEventResponse>();
+            List<IftttEventResponse> triggersResponses = [];
 
             // Get all the public events in the future
             foreach (var mobEvent in events.Where(e => e.IsEventPublic && e.EventDate >= DateTimeOffset.UtcNow)

--- a/TrashMob.Shared/Managers/IFTTT/TriggersManager.cs
+++ b/TrashMob.Shared/Managers/IFTTT/TriggersManager.cs
@@ -71,7 +71,7 @@
             }
 
 
-            var triggersResponses = new List<IftttEventResponse>();
+            List<IftttEventResponse> triggersResponses = [];
 
             // Get all the public events in the future
             foreach (var mobEvent in events.Where(e => e.IsEventPublic && e.EventDate >= DateTimeOffset.UtcNow).ToList()

--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -71,7 +71,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                     }
                 }
 
-                var deletedIds = new List<Guid>();
+                List<Guid> deletedIds = [];
                 foreach (var litterImage in existingInstance.LitterImages)
                 {
                     if (!litterReport.LitterImages.Select(x => x.Id).Contains(litterImage.Id))
@@ -125,10 +125,10 @@ namespace TrashMob.Shared.Managers.LitterReport
 
                 var subject = "Your litter report has been cleaned!";
 
-                var recipients = new List<EmailAddress>
-                {
+                List<EmailAddress> recipients =
+                [
                     new() { Name = creator.UserName, Email = creator.Email },
-                };
+                ];
 
                 var dynamicTemplateData = new
                 {
@@ -188,10 +188,10 @@ namespace TrashMob.Shared.Managers.LitterReport
                     $"A new litter report: {litterReport.Name} in {litterReport.LitterImages.First().City} has been created on TrashMob.eco!";
                 var subject = "New Litter Report Alert";
 
-                var recipients = new List<EmailAddress>
-                {
+                List<EmailAddress> recipients =
+                [
                     new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-                };
+                ];
 
                 var dynamicTemplateData = new
                 {
@@ -442,10 +442,10 @@ namespace TrashMob.Shared.Managers.LitterReport
                         $"A new litter report: {litterReport.Name} in {litterReport.LitterImages.First().City} has been created on TrashMob.eco!";
                     var subject = "New Litter Report Alert";
 
-                    var recipients = new List<EmailAddress>
-                    {
+                    List<EmailAddress> recipients =
+                    [
                         new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-                    };
+                    ];
 
                     var dynamicTemplateData = new
                     {

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
@@ -96,10 +96,10 @@ namespace TrashMob.Shared.Managers.Partners
                     subject = welcomeSubject,
                 };
 
-                var welcomeRecipients = new List<EmailAddress>
-                {
+                List<EmailAddress> welcomeRecipients =
+                [
                     new() { Name = instance.Email, Email = instance.Email },
-                };
+                ];
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
@@ -123,10 +123,10 @@ namespace TrashMob.Shared.Managers.Partners
                         subject = welcomeSubject,
                     };
 
-                    var welcomeRecipients = new List<EmailAddress>
-                    {
+                    List<EmailAddress> welcomeRecipients =
+                    [
                         new() { Name = existingUser.UserName, Email = instance.Email },
-                    };
+                    ];
 
                     await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
@@ -201,10 +201,10 @@ namespace TrashMob.Shared.Managers.Partners
                     subject = welcomeSubject,
                 };
 
-                var welcomeRecipients = new List<EmailAddress>
-                {
+                List<EmailAddress> welcomeRecipients =
+                [
                     new() { Name = instance.Email, Email = instance.Email },
-                };
+                ];
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
@@ -223,10 +223,10 @@ namespace TrashMob.Shared.Managers.Partners
                     subject = welcomeSubject,
                 };
 
-                var welcomeRecipients = new List<EmailAddress>
-                {
+                List<EmailAddress> welcomeRecipients =
+                [
                     new() { Name = existingUser.UserName, Email = instance.Email },
-                };
+                ];
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
@@ -250,7 +250,7 @@ namespace TrashMob.Shared.Managers.Partners
                 .Include(p => p.Partner)
                 .ToListAsync(cancellationToken);
 
-            var displayInvitations = new List<DisplayPartnerAdminInvitation>();
+            List<DisplayPartnerAdminInvitation> displayInvitations = [];
             foreach (var invitation in partnerInvitations)
             {
                 var displayInvitation = new DisplayPartnerAdminInvitation

--- a/TrashMob.Shared/Managers/Partners/PartnerRequestManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerRequestManager.cs
@@ -43,10 +43,10 @@ namespace TrashMob.Shared.Managers.Partners
                 var message = $"From Email: {instance.Email}\nFrom Name:{instance.Name}\nMessage:\n{instance.Notes}";
                 var subject = "Partner Request";
 
-                var recipients = new List<EmailAddress>
-                {
+                List<EmailAddress> recipients =
+                [
                     new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-                };
+                ];
 
                 var dynamicTemplateData = new
                 {
@@ -83,10 +83,10 @@ namespace TrashMob.Shared.Managers.Partners
                     subject = welcomeSubject,
                 };
 
-                var welcomeRecipients = new List<EmailAddress>
-                {
+                List<EmailAddress> welcomeRecipients =
+                [
                     new() { Name = instance.Name, Email = instance.Email },
-                };
+                ];
 
                 await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                         SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients,
@@ -97,10 +97,10 @@ namespace TrashMob.Shared.Managers.Partners
                     $"Sent to Email: {instance.Email}\nTo Partner Name:{instance.Name}\nCity: {instance.City}\nRegion: {instance.Region}\nMessage:\n{instance.Notes}";
                 var subject = "Partner Request Sent";
 
-                var recipients = new List<EmailAddress>
-                {
+                List<EmailAddress> recipients =
+                [
                     new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-                };
+                ];
 
                 var dynamicTemplateData = new
                 {
@@ -138,10 +138,10 @@ namespace TrashMob.Shared.Managers.Partners
                 subject = partnerSubject,
             };
 
-            var partnerRecipients = new List<EmailAddress>
-            {
+            List<EmailAddress> partnerRecipients =
+            [
                 new() { Name = partnerRequest.Name, Email = partnerRequest.Email },
-            };
+            ];
 
             await emailManager.SendTemplatedEmailAsync(partnerSubject, SendGridEmailTemplateId.GenericEmail,
                     SendGridEmailGroupId.General, dynamicTemplateData, partnerRecipients, CancellationToken.None);
@@ -169,10 +169,10 @@ namespace TrashMob.Shared.Managers.Partners
                 subject = partnerSubject,
             };
 
-            var partnerRecipients = new List<EmailAddress>
-            {
+            List<EmailAddress> partnerRecipients =
+            [
                 new() { Name = partnerRequest.Name, Email = partnerRequest.Email },
-            };
+            ];
 
             await emailManager.SendTemplatedEmailAsync(partnerSubject, SendGridEmailTemplateId.GenericEmail,
                     SendGridEmailGroupId.General, dynamicTemplateData, partnerRecipients, CancellationToken.None);

--- a/TrashMob.Shared/Managers/PhotoModerationManager.cs
+++ b/TrashMob.Shared/Managers/PhotoModerationManager.cs
@@ -542,10 +542,10 @@ namespace TrashMob.Shared.Managers
             message = message.Replace("{Context}", context);
             message = message.Replace("{Reason}", reason);
 
-            var recipients = new List<EmailAddress>
-            {
-                new() { Name = photo.UploaderName ?? "TrashMob User", Email = photo.UploaderEmail }
-            };
+            List<EmailAddress> recipients =
+            [
+                new() { Name = photo.UploaderName ?? "TrashMob User", Email = photo.UploaderEmail },
+            ];
 
             var dynamicTemplateData = new
             {
@@ -652,10 +652,10 @@ namespace TrashMob.Shared.Managers
             // Send to each admin separately
             foreach (var admin in admins)
             {
-                var recipients = new List<EmailAddress>
-                {
-                    new() { Name = admin.UserName ?? "Admin", Email = admin.Email }
-                };
+                List<EmailAddress> recipients =
+                [
+                    new() { Name = admin.UserName ?? "Admin", Email = admin.Email },
+                ];
 
                 var dynamicTemplateData = new
                 {

--- a/TrashMob.Shared/Managers/PickupLocationManager.cs
+++ b/TrashMob.Shared/Managers/PickupLocationManager.cs
@@ -48,7 +48,7 @@ namespace TrashMob.Shared.Managers
             var partnerLocations =
                 await partnerAdminManager.GetHaulingPartnerLocationsByUserIdAsync(userId, cancellationToken);
 
-            var pickupLocations = new List<PickupLocation>();
+            List<PickupLocation> pickupLocations = [];
 
             // For each partner location
             foreach (var partnerLocation in partnerLocations)
@@ -108,7 +108,7 @@ namespace TrashMob.Shared.Managers
 
             var emailSubject = "A Trashmob.eco Event has pickups ready!";
 
-            var recipients = new List<EmailAddress>();
+            List<EmailAddress> recipients = [];
 
             foreach (var contact in contacts)
             {

--- a/TrashMob.Shared/Managers/Prospects/CsvImportManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/CsvImportManager.cs
@@ -148,7 +148,7 @@ namespace TrashMob.Shared.Managers.Prospects
 
         private static async Task<List<string>> ReadLinesAsync(Stream stream)
         {
-            var lines = new List<string>();
+            List<string> lines = [];
             using var reader = new StreamReader(stream);
 
             while (await reader.ReadLineAsync() is { } line)
@@ -168,7 +168,7 @@ namespace TrashMob.Shared.Managers.Prospects
         /// </summary>
         public static List<string> ParseCsvLine(string line)
         {
-            var fields = new List<string>();
+            List<string> fields = [];
             var current = new System.Text.StringBuilder();
             var inQuotes = false;
 

--- a/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
@@ -114,14 +114,14 @@ namespace TrashMob.Shared.Managers.Prospects
                     subject,
                 };
 
-                var recipients = new List<Shared.Poco.EmailAddress>
-                {
+                List<Shared.Poco.EmailAddress> recipients =
+                [
                     new()
                     {
                         Name = prospect.ContactName ?? prospect.Name,
                         Email = prospect.ContactEmail,
                     },
-                };
+                ];
 
                 await emailManager.SendTemplatedEmailAsync(
                     subject,

--- a/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
@@ -141,10 +141,10 @@ namespace TrashMob.Shared.Managers.Prospects
                     emailCopy = fullHtml,
                 };
 
-                var recipients = new List<EmailAddress>
-                {
+                List<EmailAddress> recipients =
+                [
                     new() { Name = prospect.ContactName ?? prospect.Name, Email = recipientEmail },
-                };
+                ];
 
                 await emailManager.SendTemplatedEmailAsync(
                     subject,

--- a/TrashMob.Shared/Managers/Prospects/ProspectScoringManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectScoringManager.cs
@@ -95,7 +95,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 .Where(p => p.PartnerStatusId == (int)PartnerStatusEnum.Active && p.HomePageEnabled)
                 .ToListAsync(cancellationToken);
 
-            var gaps = new List<GeographicGap>();
+            List<GeographicGap> gaps = [];
 
             foreach (var group in eventGroups)
             {

--- a/TrashMob.Shared/Managers/UserFeedbackManager.cs
+++ b/TrashMob.Shared/Managers/UserFeedbackManager.cs
@@ -101,10 +101,10 @@ namespace TrashMob.Shared.Managers
                 : $"<p><strong>Screenshot:</strong> <a href=\"{feedback.ScreenshotUrl}\">View Screenshot</a></p>";
             message = message.Replace("{ScreenshotSection}", screenshotSection);
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-            };
+            ];
 
             var dynamicTemplateData = new
             {

--- a/TrashMob.Shared/Managers/UserManager.cs
+++ b/TrashMob.Shared/Managers/UserManager.cs
@@ -267,10 +267,10 @@ namespace TrashMob.Shared.Managers
                 subject,
             };
 
-            var recipients = new List<EmailAddress>
-            {
+            List<EmailAddress> recipients =
+            [
                 new() { Name = Constants.TrashMobEmailName, Email = Constants.TrashMobEmailAddress },
-            };
+            ];
 
             await emailManager.SendTemplatedEmailAsync(subject, SendGridEmailTemplateId.GenericEmail,
                     SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None);
@@ -286,10 +286,10 @@ namespace TrashMob.Shared.Managers
                 subject = welcomeSubject,
             };
 
-            var welcomeRecipients = new List<EmailAddress>
-            {
+            List<EmailAddress> welcomeRecipients =
+            [
                 new() { Name = user.UserName, Email = user.Email },
-            };
+            ];
 
             await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,
                     SendGridEmailGroupId.General, userDynamicTemplateData, welcomeRecipients, CancellationToken.None);

--- a/TrashMob.Shared/Managers/UserWaiverManager.cs
+++ b/TrashMob.Shared/Managers/UserWaiverManager.cs
@@ -80,10 +80,10 @@ namespace TrashMob.Shared.Managers
                         w.EffectiveDate <= now &&
                         (w.ExpiryDate == null || w.ExpiryDate > now))
                     .ToListAsync(cancellationToken)
-                : new List<WaiverVersion>();
+                : [];
 
             // Combine and filter out already signed waivers
-            var requiredWaivers = new List<WaiverVersion>();
+            List<WaiverVersion> requiredWaivers = [];
 
             if (globalWaiver != null && !signedWaiverVersionIds.Contains(globalWaiver.Id))
             {
@@ -118,7 +118,7 @@ namespace TrashMob.Shared.Managers
                 .OrderByDescending(w => w.EffectiveDate)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            var requiredWaivers = new List<WaiverVersion>();
+            List<WaiverVersion> requiredWaivers = [];
 
             if (globalWaiver != null && !signedWaiverVersionIds.Contains(globalWaiver.Id))
             {


### PR DESCRIPTION
## Summary
- Modernize collection initialization across 34 files in TrashMob.Shared to use C# 12 collection expressions
- Empty lists: `new List<T>()` → `[]`
- Collection initializers: `new List<T> { items }` → `[items]`  
- Return statements: `return new List<T>()` → `return []`

## Test plan
- [x] `dotnet build` passes with 0 errors, 0 warnings
- [x] All 442 unit tests pass
- [x] No behavioral changes — purely syntactic modernization

🤖 Generated with [Claude Code](https://claude.com/claude-code)