### PR TITLE
Replace Tuple with value tuples, string.Format with interpolation, remaining collection expressions

### DIFF
--- a/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
@@ -40,8 +40,8 @@ namespace TrashMob.Shared.Tests.Managers.Events
 
             // Default setup for common dependencies
             // Return the event date formatted as ISO 8601 string (parseable as DateTimeOffset)
-            _mapManager.Setup(m => m.GetTimeForPointAsync(It.IsAny<Tuple<double, double>>(), It.IsAny<DateTimeOffset>()))
-                .ReturnsAsync((Tuple<double, double> _, DateTimeOffset eventDate) => eventDate.ToString("o"));
+            _mapManager.Setup(m => m.GetTimeForPointAsync(It.IsAny<(double, double)>(), It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(((double, double) _, DateTimeOffset eventDate) => eventDate.ToString("o"));
             _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>())).Returns("Test email content");
             _emailManager.Setup(e => e.SendTemplatedEmailAsync(
                     It.IsAny<string>(),

--- a/TrashMob.Shared.Tests/NotifierTestsBase.cs
+++ b/TrashMob.Shared.Tests/NotifierTestsBase.cs
@@ -31,8 +31,8 @@
             Logger = new Mock<ILogger>();
 
             // Setup a default return of distance between User and Event of 10 (in whatever units)
-            MapRepository.Setup(mr => mr.GetDistanceBetweenTwoPointsAsync(It.IsAny<Tuple<double, double>>(),
-                It.IsAny<Tuple<double, double>>(), It.IsAny<bool>())).ReturnsAsync(10);
+            MapRepository.Setup(mr => mr.GetDistanceBetweenTwoPointsAsync(It.IsAny<(double, double)>(),
+                It.IsAny<(double, double)>(), It.IsAny<bool>())).ReturnsAsync(10);
             EmailManager.Setup(em => em.GetHtmlEmailCopy(It.IsAny<string>())).Returns("Test");
         }
 

--- a/TrashMob.Shared.Tests/UpcomingEventsInYourAreaNotifierTestsBase.cs
+++ b/TrashMob.Shared.Tests/UpcomingEventsInYourAreaNotifierTestsBase.cs
@@ -292,8 +292,8 @@ namespace TrashMob.Shared.Tests
             UserManager.Setup(u => u.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(users);
 
             // Setup a return of distance between User and Event of 50 (in whatever units)
-            MapRepository.Setup(mr => mr.GetDistanceBetweenTwoPointsAsync(It.IsAny<Tuple<double, double>>(),
-                It.IsAny<Tuple<double, double>>(), It.IsAny<bool>())).ReturnsAsync(50);
+            MapRepository.Setup(mr => mr.GetDistanceBetweenTwoPointsAsync(It.IsAny<(double, double)>(),
+                It.IsAny<(double, double)>(), It.IsAny<bool>())).ReturnsAsync(50);
 
             // Act
             await Engine.GenerateNotificationsAsync();

--- a/TrashMob.Shared/Engine/NotificationEngineBase.cs
+++ b/TrashMob.Shared/Engine/NotificationEngineBase.cs
@@ -171,8 +171,8 @@
                     {
                         username = user.UserName,
                         eventName = mobEvent.Name,
-                        eventDate = localDate.Item1,
-                        eventTime = localDate.Item2,
+                        eventDate = localDate.Date,
+                        eventTime = localDate.Time,
                         eventAddress = mobEvent.EventAddress(),
                         emailCopy,
                         subject = EmailSubject,

--- a/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
@@ -79,8 +79,8 @@
                     }
 
                     // Get the distance from the User's home location to the event location
-                    var userLocation = new Tuple<double, double>(user.Latitude.Value, user.Longitude.Value);
-                    var eventLocation = new Tuple<double, double>(mobEvent.Latitude.Value, mobEvent.Longitude.Value);
+                    var userLocation = (user.Latitude.Value, user.Longitude.Value);
+                    var eventLocation = (mobEvent.Latitude.Value, mobEvent.Longitude.Value);
 
                     var distance = await MapRepository
                         .GetDistanceBetweenTwoPointsAsync(userLocation, eventLocation, user.PrefersMetric)

--- a/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
+++ b/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
@@ -93,8 +93,8 @@ namespace TrashMob.Shared.Engine
                     }
 
                     // Calculate distance
-                    var userLocation = new Tuple<double, double>(user.Latitude.Value, user.Longitude.Value);
-                    var reportLocation = new Tuple<double, double>(firstImage.Latitude.Value, firstImage.Longitude.Value);
+                    var userLocation = (user.Latitude.Value, user.Longitude.Value);
+                    var reportLocation = (firstImage.Latitude.Value, firstImage.Longitude.Value);
 
                     var distance = await mapRepository
                         .GetDistanceBetweenTwoPointsAsync(userLocation, reportLocation, user.PrefersMetric)

--- a/TrashMob.Shared/Extensions/EventExtensions.cs
+++ b/TrashMob.Shared/Extensions/EventExtensions.cs
@@ -16,23 +16,22 @@
         /// <param name="mobEvent">The event to get local time for.</param>
         /// <param name="mapRepository">The map manager for timezone lookups.</param>
         /// <returns>A tuple containing the formatted local date and time strings.</returns>
-        public static async Task<Tuple<string, string>> GetLocalEventTime(this Event mobEvent,
+        public static async Task<(string Date, string Time)> GetLocalEventTime(this Event mobEvent,
             IMapManager mapRepository)
         {
             // Note that the UI should never be passing in a null latitude and longitude... but during testing, this is possible. This hack is bad and will have unintented consequences
             var localTime = await mapRepository
-                .GetTimeForPointAsync(new Tuple<double, double>(mobEvent.Latitude ?? 0, mobEvent.Longitude ?? 0),
+                .GetTimeForPointAsync((mobEvent.Latitude ?? 0, mobEvent.Longitude ?? 0),
                     mobEvent.EventDate).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(localTime))
             {
-                return new Tuple<string, string>(mobEvent.EventDate.ToString("MMMM dd, yyyy"),
+                return (mobEvent.EventDate.ToString("MMMM dd, yyyy"),
                     mobEvent.EventDate.ToString("h:mm tt"));
             }
 
             var localDate = DateTimeOffset.Parse(localTime);
-            var retVal = new Tuple<string, string>(localDate.ToString("MMMM dd, yyyy"), localDate.ToString("h:mm tt"));
-            return retVal;
+            return (localDate.ToString("MMMM dd, yyyy"), localDate.ToString("h:mm tt"));
         }
 
         /// <summary>

--- a/TrashMob.Shared/Managers/EmailManager.cs
+++ b/TrashMob.Shared/Managers/EmailManager.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Shared.Managers
         public string GetHtmlEmailCopy(string notificationType)
         {
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = string.Format("TrashMob.Shared.Engine.EmailCopy.{0}.html", notificationType);
+            var resourceName = $"TrashMob.Shared.Engine.EmailCopy.{notificationType}.html";
             logger.LogInformation("Getting email copy: {resourceName}", resourceName);
             string result;
 
@@ -92,7 +92,7 @@ namespace TrashMob.Shared.Managers
         public string GetEmailTemplate(string notificationType)
         {
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = string.Format("TrashMob.Shared.Engine.EmailTemplates.{0}.txt", notificationType);
+            var resourceName = $"TrashMob.Shared.Engine.EmailTemplates.{notificationType}.txt";
             logger.LogInformation("Getting email template: {resourceName}", resourceName);
             string result;
 
@@ -109,7 +109,7 @@ namespace TrashMob.Shared.Managers
         public string GetHtmlEmailTemplate(string notificationType)
         {
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = string.Format("TrashMob.Shared.Engine.EmailTemplates.{0}.html", notificationType);
+            var resourceName = $"TrashMob.Shared.Engine.EmailTemplates.{notificationType}.html";
             logger.LogInformation("Getting email template: {resourceName}", resourceName);
             string result;
 

--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -150,8 +150,8 @@ namespace TrashMob.Shared.Managers.Events
                 {
                     username = attendee.User.UserName,
                     eventName = instance.Name,
-                    eventDate = localDate.Item1,
-                    eventTime = localDate.Item2,
+                    eventDate = localDate.Date,
+                    eventTime = localDate.Time,
                     eventAddress = instance.EventAddress(),
                     emailCopy,
                     subject,
@@ -200,8 +200,8 @@ namespace TrashMob.Shared.Managers.Events
             {
                 username = Constants.TrashMobEmailName,
                 eventName = instance.Name,
-                eventDate = localTime.Item1,
-                eventTime = localTime.Item2,
+                eventDate = localTime.Date,
+                eventTime = localTime.Time,
                 eventAddress = instance.EventAddress(),
                 emailCopy = message,
                 subject,
@@ -236,8 +236,8 @@ namespace TrashMob.Shared.Managers.Events
                 var oldLocalDate = await oldEvent.GetLocalEventTime(mapManager);
                 var newLocalDate = await instance.GetLocalEventTime(mapManager);
 
-                emailCopy = emailCopy.Replace("{EventDate}", oldLocalDate.Item1);
-                emailCopy = emailCopy.Replace("{EventTime}", oldLocalDate.Item2);
+                emailCopy = emailCopy.Replace("{EventDate}", oldLocalDate.Date);
+                emailCopy = emailCopy.Replace("{EventTime}", oldLocalDate.Time);
 
                 var subject = "A TrashMob.eco event you were scheduled to attend has been updated!";
 
@@ -249,8 +249,8 @@ namespace TrashMob.Shared.Managers.Events
                     {
                         username = attendee.User.UserName,
                         eventName = instance.Name,
-                        eventDate = newLocalDate.Item1,
-                        eventTime = newLocalDate.Item2,
+                        eventDate = newLocalDate.Date,
+                        eventTime = newLocalDate.Time,
                         eventAddress = instance.EventAddress(),
                         emailCopy,
                         subject,

--- a/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
@@ -141,8 +141,7 @@ namespace TrashMob.Shared.Managers.Events
 
             partnerMessage = partnerMessage.Replace("{UserName}", user.UserName);
 
-            var dashboardLink =
-                string.Format("https://www.trashmob.eco/events/{0}/edit", existingService.EventId);
+            var dashboardLink = $"https://www.trashmob.eco/events/{existingService.EventId}/edit";
             partnerMessage = partnerMessage.Replace("{PartnerResponseUrl}", dashboardLink);
 
             List<EmailAddress> partnerRecipients =

--- a/TrashMob.Shared/Managers/ImageManager.cs
+++ b/TrashMob.Shared/Managers/ImageManager.cs
@@ -62,8 +62,7 @@ namespace TrashMob.Shared.Managers
             logger.LogInformation("ParentId: {ParentId}, ImageType: {ImageType}, File: {FileName}",
                 imageUpload.ParentId, imageUpload.ImageType, imageUpload.FormFile?.FileName);
 
-            var fileName = string.Format("{0}-{1}-{2}-{3}{4}", imageUpload.ParentId, imageUpload.ImageType.ToString(),
-                ImageSizeEnum.Raw.ToString(), fileTime, Path.GetExtension(imageUpload.FormFile?.FileName)).ToLower();
+            var fileName = $"{imageUpload.ParentId}-{imageUpload.ImageType}-{ImageSizeEnum.Raw}-{fileTime}{Path.GetExtension(imageUpload.FormFile?.FileName)}".ToLower();
 
             // Upload the raw file
             if (imageUpload.FormFile == null)
@@ -81,8 +80,7 @@ namespace TrashMob.Shared.Managers
             // Create a thumbnail
             using (var image = await Image.LoadAsync(memoryStream))
             {
-                var thumbNailFileName = string.Format("{0}-{1}-{2}-{3}.jpg", imageUpload.ParentId,
-                    imageUpload.ImageType.ToString(), ImageSizeEnum.Thumb.ToString(), fileTime).ToLower();
+                var thumbNailFileName = $"{imageUpload.ParentId}-{imageUpload.ImageType}-{ImageSizeEnum.Thumb}-{fileTime}.jpg".ToLower();
 
                 image.Mutate(x => x.Resize(thumbnailWidth, thumbnailHeight));
 
@@ -99,8 +97,7 @@ namespace TrashMob.Shared.Managers
             // Create a reduced image
             using (var image = await Image.LoadAsync(memoryStream))
             {
-                var reducedFileName = string.Format("{0}-{1}-{2}-{3}.jpg", imageUpload.ParentId,
-                    imageUpload.ImageType.ToString(), ImageSizeEnum.Reduced.ToString(), fileTime).ToLower();
+                var reducedFileName = $"{imageUpload.ParentId}-{imageUpload.ImageType}-{ImageSizeEnum.Reduced}-{fileTime}.jpg".ToLower();
 
                 image.Mutate(x => x.Resize(reducedWidth, reducedHeight));
 

--- a/TrashMob.Shared/Managers/Interfaces/IMapManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IMapManager.cs
@@ -24,20 +24,20 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <summary>
         /// Calculates the distance between two geographic points.
         /// </summary>
-        /// <param name="pointA">The first point as a tuple of latitude and longitude.</param>
-        /// <param name="pointB">The second point as a tuple of latitude and longitude.</param>
+        /// <param name="pointA">The first point as a tuple of (latitude, longitude).</param>
+        /// <param name="pointB">The second point as a tuple of (latitude, longitude).</param>
         /// <param name="IsMetric">Whether to return the distance in metric units. Defaults to true.</param>
         /// <returns>The distance between the two points.</returns>
-        Task<double> GetDistanceBetweenTwoPointsAsync(Tuple<double, double> pointA, Tuple<double, double> pointB,
+        Task<double> GetDistanceBetweenTwoPointsAsync((double Lat, double Lon) pointA, (double Lat, double Lon) pointB,
             bool IsMetric = true);
 
         /// <summary>
         /// Gets the timezone information for a geographic point at a specific time.
         /// </summary>
-        /// <param name="pointA">The geographic point as a tuple of latitude and longitude.</param>
+        /// <param name="pointA">The geographic point as a tuple of (latitude, longitude).</param>
         /// <param name="dateTimeOffset">The date and time for the timezone lookup.</param>
         /// <returns>The timezone identifier for the specified point and time.</returns>
-        Task<string> GetTimeForPointAsync(Tuple<double, double> pointA, DateTimeOffset dateTimeOffset);
+        Task<string> GetTimeForPointAsync((double Lat, double Lon) pointA, DateTimeOffset dateTimeOffset);
 
         /// <summary>
         /// Gets the address for a geographic coordinate.

--- a/TrashMob.Shared/Managers/MapManager.cs
+++ b/TrashMob.Shared/Managers/MapManager.cs
@@ -69,15 +69,15 @@ namespace TrashMob.Shared.Managers
         }
 
         /// <inheritdoc />
-        public async Task<double> GetDistanceBetweenTwoPointsAsync(Tuple<double, double> pointA,
-            Tuple<double, double> pointB, bool IsMetric = true)
+        public async Task<double> GetDistanceBetweenTwoPointsAsync((double Lat, double Lon) pointA,
+            (double Lat, double Lon) pointB, bool IsMetric = true)
         {
             var azureMaps = new AzureMapsToolkit.AzureMapsServices(GetMapKey());
             var distanceRequest = new GreatCircleDistanceRequest
             {
-                Query = $"{pointA.Item1},{pointA.Item2}:{pointB.Item1},{pointB.Item2}",
-                Start = new Coordinate { Lat = pointA.Item1, Lon = pointA.Item2 },
-                End = new Coordinate { Lat = pointB.Item1, Lon = pointB.Item2 },
+                Query = $"{pointA.Lat},{pointA.Lon}:{pointB.Lat},{pointB.Lon}",
+                Start = new Coordinate { Lat = pointA.Lat, Lon = pointA.Lon },
+                End = new Coordinate { Lat = pointB.Lat, Lon = pointB.Lon },
             };
 
             logger.LogInformation("Getting distance between two points: {0}",
@@ -120,7 +120,7 @@ namespace TrashMob.Shared.Managers
         }
 
         /// <inheritdoc />
-        public async Task<string> GetTimeForPointAsync(Tuple<double, double> pointA, DateTimeOffset dateTimeOffset)
+        public async Task<string> GetTimeForPointAsync((double Lat, double Lon) pointA, DateTimeOffset dateTimeOffset)
         {
             var azureMaps = new AzureMapsToolkit.AzureMapsServices(GetMapKey());
 
@@ -132,7 +132,7 @@ namespace TrashMob.Shared.Managers
 
             var timezoneRequest = new TimeZoneRequest
             {
-                Query = $"{pointA.Item1},{pointA.Item2}",
+                Query = $"{pointA.Lat},{pointA.Lon}",
                 TimeStamp = dateTimeOffset.UtcDateTime.ToString("O"),
             };
 

--- a/TrashMob/Controllers/EventLitterReportController.cs
+++ b/TrashMob/Controllers/EventLitterReportController.cs
@@ -145,7 +145,7 @@ namespace TrashMob.Controllers
 
         private async Task<IEnumerable<FullEventLitterReport>> ToFullEventLitterReports(IEnumerable<EventLitterReport> eventLitterReports, CancellationToken cancellationToken)
         {
-            var fullEventLitterReports = new List<FullEventLitterReport>();
+            List<FullEventLitterReport> fullEventLitterReports = [];
 
             foreach (var eventLitterReport in eventLitterReports)
             {

--- a/TrashMob/Controllers/IFTTT/IftttTrigger.cs
+++ b/TrashMob/Controllers/IFTTT/IftttTrigger.cs
@@ -4,45 +4,32 @@
 
     public class IftttTrigger
     {
-        public IftttTrigger()
+        public Dictionary<string, string> any_new_event_created { get; set; } = [];
+
+        public Dictionary<string, string> new_event_created_by_country { get; set; } = new()
         {
-            any_new_event_created = new Dictionary<string, string>();
+            { "country", "United States" },
+        };
 
-            new_event_created_by_country = new Dictionary<string, string>
-            {
-                { "country", "United States" },
-            };
+        public Dictionary<string, string> new_event_created_by_region { get; set; } = new()
+        {
+            { "region", "Washington" },
+            { "country", "United States" },
+        };
 
-            new_event_created_by_region = new Dictionary<string, string>
-            {
-                { "region", "Washington" },
-                { "country", "United States" },
-            };
+        public Dictionary<string, string> new_event_created_by_city { get; set; } = new()
+        {
+            { "city", "Issaquah" },
+            { "region", "Washington" },
+            { "country", "United States" },
+        };
 
-            new_event_created_by_city = new Dictionary<string, string>
-            {
-                { "city", "Issaquah" },
-                { "region", "Washington" },
-                { "country", "United States" },
-            };
-
-            new_event_created_by_postal_code = new Dictionary<string, string>
-            {
-                { "city", "Issaquah" },
-                { "region", "Washington" },
-                { "country", "United States" },
-                { "postal_code", "98027" },
-            };
-        }
-
-        public Dictionary<string, string> any_new_event_created { get; set; }
-
-        public Dictionary<string, string> new_event_created_by_country { get; set; }
-
-        public Dictionary<string, string> new_event_created_by_region { get; set; }
-
-        public Dictionary<string, string> new_event_created_by_city { get; set; }
-
-        public Dictionary<string, string> new_event_created_by_postal_code { get; set; }
+        public Dictionary<string, string> new_event_created_by_postal_code { get; set; } = new()
+        {
+            { "city", "Issaquah" },
+            { "region", "Washington" },
+            { "country", "United States" },
+            { "postal_code", "98027" },
+        };
     }
 }

--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -331,7 +331,7 @@ namespace TrashMob.Controllers
         private async Task<IEnumerable<FullLitterReport>> ToFullLitterReport(IEnumerable<LitterReport> litterReports,
             CancellationToken cancellationToken)
         {
-            var fullLitterReports = new List<FullLitterReport>();
+            List<FullLitterReport> fullLitterReports = [];
 
             foreach (var litterReport in litterReports)
             {

--- a/TrashMob/Controllers/PartnerAdminsController.cs
+++ b/TrashMob/Controllers/PartnerAdminsController.cs
@@ -136,7 +136,7 @@ namespace TrashMob.Controllers
                 return NotFound();
             }
 
-            var users = new List<DisplayUser>();
+            List<DisplayUser> users = [];
 
             foreach (var pu in partnerAdmins)
             {

--- a/TrashMob/Controllers/RouteSimulationController.cs
+++ b/TrashMob/Controllers/RouteSimulationController.cs
@@ -98,7 +98,7 @@ namespace TrashMob.Controllers
         {
             var stepDistance = (double)totalDistanceMeters / pointCount;
             var bearing = Rng.NextDouble() * 360;
-            var coordinates = new List<Coordinate>();
+            List<Coordinate> coordinates = [];
 
             var currentLat = centerLat;
             var currentLon = centerLon;

--- a/TrashMob/Controllers/SponsorPortalController.cs
+++ b/TrashMob/Controllers/SponsorPortalController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetMySponsors(CancellationToken cancellationToken)
         {
             var partners = await partnerAdminManager.GetPartnersByUserIdAsync(UserId, cancellationToken);
-            var allSponsors = new List<Sponsor>();
+            List<Sponsor> allSponsors = [];
 
             foreach (var partner in partners)
             {


### PR DESCRIPTION
## Summary
- Convert `Tuple<double, double>` to `(double Lat, double Lon)` value tuples in `IMapManager`, `MapManager`, and all callers (engine files, extensions, tests)
- Convert `Tuple<string, string>` to `(string Date, string Time)` in `EventExtensions` and callers (`EventManager`, `NotificationEngineBase`)
- Replace `string.Format()` with string interpolation in `EmailManager`, `EventPartnerLocationServiceManager`, `ImageManager`
- Convert remaining `new List<T>()` to collection expressions in controllers and `IftttTrigger`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442 tests pass
- [ ] Verify no runtime regressions in API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)