### PR TITLE
Convert logger format placeholders to structured logging

### DIFF
--- a/TrashMob.Shared/Engine/EventSummaryAttendeeNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryAttendeeNotifier.cs
@@ -36,13 +36,13 @@
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)
         {
-            Logger.LogInformation("Generating Notifications for {0}", NotificationType);
+            Logger.LogInformation("Generating Notifications for {NotificationType}", NotificationType);
 
             // Get list of users who have notifications turned on for locations
             var users = await UserManager.GetAsync(cancellationToken).ConfigureAwait(false);
             var notificationCounter = 0;
 
-            Logger.LogInformation("Generating {0} Notifications for {1} total users", NotificationType, users.Count());
+            Logger.LogInformation("Generating {NotificationType} Notifications for {UserCount} total users", NotificationType, users.Count());
 
             // for each user
             foreach (var user in users)
@@ -80,7 +80,7 @@
                     .ConfigureAwait(false);
             }
 
-            Logger.LogInformation("Generating {0} Total {1} Notifications", notificationCounter, NotificationType);
+            Logger.LogInformation("Generating {NotificationCount} Total {NotificationType} Notifications", notificationCounter, NotificationType);
         }
     }
 }

--- a/TrashMob.Shared/Engine/EventSummaryHostReminderNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryHostReminderNotifier.cs
@@ -37,13 +37,13 @@
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)
         {
-            Logger.LogInformation("Generating Notifications for {0}", NotificationType);
+            Logger.LogInformation("Generating Notifications for {NotificationType}", NotificationType);
 
             // Get list of users who have notifications turned on for locations
             var users = await UserManager.GetAsync(cancellationToken).ConfigureAwait(false);
             var notificationCounter = 0;
 
-            Logger.LogInformation("Generating {0} Notifications for {1} total users", NotificationType, users.Count());
+            Logger.LogInformation("Generating {NotificationType} Notifications for {UserCount} total users", NotificationType, users.Count());
 
             // for each user
             foreach (var user in users)
@@ -69,7 +69,7 @@
                     .ConfigureAwait(false);
             }
 
-            Logger.LogInformation("Generating {0} Total {1} Notifications", notificationCounter, NotificationType);
+            Logger.LogInformation("Generating {NotificationCount} Total {NotificationType} Notifications", notificationCounter, NotificationType);
         }
     }
 }

--- a/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
@@ -39,13 +39,13 @@
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)
         {
-            Logger.LogInformation("Generating Notifications for {0}", NotificationType);
+            Logger.LogInformation("Generating Notifications for {NotificationType}", NotificationType);
 
             // Get list of users who have notifications turned on for locations
             var users = await UserManager.GetAsync(cancellationToken).ConfigureAwait(false);
             var notificationCounter = 0;
 
-            Logger.LogInformation("Generating {0} Notifications for {1} total users", NotificationType, users.Count());
+            Logger.LogInformation("Generating {NotificationType} Notifications for {UserCount} total users", NotificationType, users.Count());
 
             // for each user
             foreach (var user in users)
@@ -84,7 +84,7 @@
                     .ConfigureAwait(false);
             }
 
-            Logger.LogInformation("Generating {0} Total {1} Notifications", notificationCounter, NotificationType);
+            Logger.LogInformation("Generating {NotificationCount} Total {NotificationType} Notifications", notificationCounter, NotificationType);
         }
     }
 }

--- a/TrashMob.Shared/Engine/NotificationEngineBase.cs
+++ b/TrashMob.Shared/Engine/NotificationEngineBase.cs
@@ -186,7 +186,7 @@
                         new() { Name = user.UserName, Email = user.Email },
                     ];
 
-                    Logger.LogInformation("Sending email to {0}, Subject {0}", user.Email, EmailSubject);
+                    Logger.LogInformation("Sending email to {Email}, Subject {Subject}", user.Email, EmailSubject);
 
                     await EmailManager.SendTemplatedEmailAsync(EmailSubject, SendGridEmailTemplateId.EventEmail,
                             SendGridEmailGroupId.EventRelated, dynamicTemplateData, recipients, CancellationToken.None)
@@ -232,7 +232,7 @@
                 new() { Name = user.UserName, Email = user.Email },
             ];
 
-            Logger.LogInformation("Sending email to {0}, Subject {0}", user.Email, EmailSubject);
+            Logger.LogInformation("Sending email to {Email}, Subject {Subject}", user.Email, EmailSubject);
 
             await EmailManager.SendTemplatedEmailAsync(EmailSubject, SendGridEmailTemplateId.GenericEmail,
                     SendGridEmailGroupId.General, dynamicTemplateData, recipients, CancellationToken.None)

--- a/TrashMob.Shared/Engine/UpcomingEventAttendingBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventAttendingBaseNotifier.cs
@@ -29,13 +29,13 @@
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)
         {
-            Logger.LogInformation("Generating Notifications for {0}", NotificationType);
+            Logger.LogInformation("Generating Notifications for {NotificationType}", NotificationType);
 
             // Get list of users who have notifications turned on for locations
             var users = await UserManager.GetAsync(cancellationToken).ConfigureAwait(false);
             var notificationCounter = 0;
 
-            Logger.LogInformation("Generating {0} Notifications for {1} total users", NotificationType, users.Count());
+            Logger.LogInformation("Generating {NotificationType} Notifications for {UserCount} total users", NotificationType, users.Count());
 
             // for each user
             foreach (var user in users)
@@ -76,7 +76,7 @@
                     .ConfigureAwait(false);
             }
 
-            Logger.LogInformation("Generating {0} Total {1} Notifications", notificationCounter, NotificationType);
+            Logger.LogInformation("Generating {NotificationCount} Total {NotificationType} Notifications", notificationCounter, NotificationType);
         }
     }
 }

--- a/TrashMob.Shared/Engine/UpcomingEventHostingBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventHostingBaseNotifier.cs
@@ -29,13 +29,13 @@
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)
         {
-            Logger.LogInformation("Generating Notifications for {0}", NotificationType);
+            Logger.LogInformation("Generating Notifications for {NotificationType}", NotificationType);
 
             // Get list of users who have notifications turned on for locations
             var users = await UserManager.GetAsync(cancellationToken).ConfigureAwait(false);
             var notificationCounter = 0;
 
-            Logger.LogInformation("Generating {0} Notifications for {1} total users", NotificationType, users.Count());
+            Logger.LogInformation("Generating {NotificationType} Notifications for {UserCount} total users", NotificationType, users.Count());
 
             // for each user
             foreach (var user in users)
@@ -66,7 +66,7 @@
                     .ConfigureAwait(false);
             }
 
-            Logger.LogInformation("Generating {0} Total {1} Notifications", notificationCounter, NotificationType);
+            Logger.LogInformation("Generating {NotificationCount} Total {NotificationType} Notifications", notificationCounter, NotificationType);
         }
     }
 }

--- a/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingEventsInYourAreaBaseNotifier.cs
@@ -29,13 +29,13 @@
         /// <inheritdoc />
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)
         {
-            Logger.LogInformation("Generating Notifications for {0}", NotificationType);
+            Logger.LogInformation("Generating Notifications for {NotificationType}", NotificationType);
 
             // Get list of users who have notifications turned on for locations
             var users = await UserManager.GetAsync(cancellationToken).ConfigureAwait(false);
             var notificationCounter = 0;
 
-            Logger.LogInformation("Generating {0} Notifications for {1} total users", NotificationType, users.Count());
+            Logger.LogInformation("Generating {NotificationType} Notifications for {UserCount} total users", NotificationType, users.Count());
 
             // for each user
             foreach (var user in users)
@@ -107,7 +107,7 @@
                     .ConfigureAwait(false);
             }
 
-            Logger.LogInformation("Generating {0} Total {1} Notifications", notificationCounter, NotificationType);
+            Logger.LogInformation("Generating {NotificationCount} Total {NotificationType} Notifications", notificationCounter, NotificationType);
         }
     }
 }

--- a/TrashMob.Shared/Engine/UserProfileLocationNotifier.cs
+++ b/TrashMob.Shared/Engine/UserProfileLocationNotifier.cs
@@ -44,21 +44,21 @@
         /// <returns>A task representing the asynchronous operation.</returns>
         public async Task GenerateNotificationsAsync(CancellationToken cancellationToken = default)
         {
-            Logger.LogInformation("Generating Notifications for {0}", NotificationType);
+            Logger.LogInformation("Generating Notifications for {NotificationType}", NotificationType);
 
             // Get list of all users
             var users = await UserManager.GetAsync(cancellationToken).ConfigureAwait(false);
 
             var notificationCounter = 0;
 
-            Logger.LogInformation("Generating {0} Notifications for {1} total users", NotificationType, users.Count());
+            Logger.LogInformation("Generating {NotificationType} Notifications for {UserCount} total users", NotificationType, users.Count());
 
             // for each user
             foreach (var user in users)
             {
                 if (await UserHasAlreadyReceivedNotification(user, cancellationToken).ConfigureAwait(false))
                 {
-                    Logger.LogInformation("User {0} has already received notification {1}. Skipping.", user.Id,
+                    Logger.LogInformation("User {UserId} has already received notification {NotificationType}. Skipping.", user.Id,
                         NotificationType);
                     continue;
                 }
@@ -68,18 +68,18 @@
                 {
                     if (user.Id.ToString() == "2A648BA2-854C-4949-BB36-64D90E15B8CA")
                     {
-                        Logger.LogInformation("User {0} has not set their location. Notifying.", user.Id);
+                        Logger.LogInformation("User {UserId} has not set their location. Notifying.", user.Id);
                         notificationCounter += await SendNotification(user, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        Logger.LogInformation("User {0} has not set their location. We're in debug mode so skipping.",
+                        Logger.LogInformation("User {UserId} has not set their location. We're in debug mode so skipping.",
                             user.Id);
                     }
                 }
             }
 
-            Logger.LogInformation("Generating {0} Total {1} Notifications", notificationCounter, NotificationType);
+            Logger.LogInformation("Generating {NotificationCount} Total {NotificationType} Notifications", notificationCounter, NotificationType);
         }
     }
 }

--- a/TrashMob.Shared/Managers/MapManager.cs
+++ b/TrashMob.Shared/Managers/MapManager.cs
@@ -80,12 +80,12 @@ namespace TrashMob.Shared.Managers
                 End = new Coordinate { Lat = pointB.Lat, Lon = pointB.Lon },
             };
 
-            logger.LogInformation("Getting distance between two points: {0}",
+            logger.LogInformation("Getting distance between two points: {DistanceRequest}",
                 JsonSerializer.Serialize(distanceRequest));
 
             var response = await azureMaps.GetGreatCircleDistance(distanceRequest);
 
-            logger.LogInformation("Response from getting distance between two points: {0}",
+            logger.LogInformation("Response from getting distance between two points: {Response}",
                 JsonSerializer.Serialize(response));
 
             try
@@ -97,18 +97,18 @@ namespace TrashMob.Shared.Managers
 
                 var distanceInMeters = (long)response.Result.Result.DistanceInMeters;
 
-                logger.LogInformation("Distance in Meters: {0}", distanceInMeters);
+                logger.LogInformation("Distance in Meters: {DistanceInMeters}", distanceInMeters);
 
                 if (IsMetric)
                 {
                     var res = distanceInMeters / MetersPerKilometer;
-                    logger.LogInformation("Kilometers : {0}", res);
+                    logger.LogInformation("Kilometers : {Distance}", res);
                     return res;
                 }
                 else
                 {
                     var res = distanceInMeters / MetersPerMile;
-                    logger.LogInformation("Miles : {0}", res);
+                    logger.LogInformation("Miles : {Distance}", res);
                     return res;
                 }
             }
@@ -136,11 +136,11 @@ namespace TrashMob.Shared.Managers
                 TimeStamp = dateTimeOffset.UtcDateTime.ToString("O"),
             };
 
-            logger.LogInformation("Getting time for timezoneRequest: {0}", JsonSerializer.Serialize(timezoneRequest));
+            logger.LogInformation("Getting time for timezoneRequest: {TimezoneRequest}", JsonSerializer.Serialize(timezoneRequest));
 
             var response = await azureMaps.GetTimezoneByCoordinates(timezoneRequest);
 
-            logger.LogInformation("Response from getting time for timezoneRequest: {0}",
+            logger.LogInformation("Response from getting time for timezoneRequest: {Response}",
                 JsonSerializer.Serialize(response));
 
             if (response.HttpResponseCode != (int)HttpStatusCode.OK && response.HttpResponseCode != 0)
@@ -165,12 +165,12 @@ namespace TrashMob.Shared.Managers
             var searchAddressReverseRequest = new SearchAddressReverseRequest();
             searchAddressReverseRequest.Query = $"{latitude},{longitude}";
 
-            logger.LogInformation("Getting address for searchAddressReverseRequest: {0}",
+            logger.LogInformation("Getting address for searchAddressReverseRequest: {SearchRequest}",
                 JsonSerializer.Serialize(searchAddressReverseRequest));
 
             var response = await azureMaps.GetSearchAddressReverse(searchAddressReverseRequest);
 
-            logger.LogInformation("Response from getting address for searcAddressReverseRequest: {0}",
+            logger.LogInformation("Response from getting address for searchAddressReverseRequest: {Response}",
                 JsonSerializer.Serialize(response));
 
             if (response.HttpResponseCode != (int)HttpStatusCode.OK && response.HttpResponseCode != 0)


### PR DESCRIPTION
## Summary
- Replace `{0}`/`{1}` format-style placeholders with named placeholders (`{NotificationType}`, `{UserCount}`, `{Email}`, etc.) across 8 notification engine files and `MapManager`
- **Bug fix**: `NotificationEngineBase` had duplicate `{0}` placeholders in two log calls (`"Sending email to {0}, Subject {0}"`), causing the email address to be logged for both fields instead of the subject — now correctly uses `{Email}` and `{Subject}`
- Also fixes a typo in MapManager: `searcAddressReverseRequest` → `searchAddressReverseRequest`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442 tests pass
- [ ] Verify structured log output in Application Insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)