### PR TITLE
Fix mobile auth token refresh, UI consistency, and server-side auth bugs

### DIFF
--- a/TrashMob/Controllers/NewsletterPreferencesController.cs
+++ b/TrashMob/Controllers/NewsletterPreferencesController.cs
@@ -7,13 +7,14 @@ namespace TrashMob.Controllers
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.EntityFrameworkCore;
     using TrashMob.Models;
+    using TrashMob.Security;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Persistence.Interfaces;
 
     /// <summary>
     /// Controller for managing user newsletter preferences.
     /// </summary>
-    [Authorize]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
     [Route("api/newsletter-preferences")]
     public class NewsletterPreferencesController : SecureController
     {

--- a/TrashMob/Security/UserIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsAdminAuthHandler.cs
@@ -32,7 +32,7 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim.Value : emailAddressClaim.Value;
+                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 

--- a/TrashMob/Security/UserIsEventLeadAuthHandler.cs
+++ b/TrashMob/Security/UserIsEventLeadAuthHandler.cs
@@ -47,7 +47,7 @@ namespace TrashMob.Security
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim.Value : emailAddressClaim.Value;
+                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 

--- a/TrashMob/Security/UserIsEventLeadOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsEventLeadOrIsAdminAuthHandler.cs
@@ -43,7 +43,7 @@ namespace TrashMob.Security
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim.Value : emailAddressClaim.Value;
+                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 

--- a/TrashMob/Security/UserIsPartnerUserOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsPartnerUserOrIsAdminAuthHandler.cs
@@ -37,7 +37,7 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim.Value : emailAddressClaim.Value;
+                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 

--- a/TrashMob/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandler.cs
@@ -41,7 +41,7 @@ namespace TrashMob.Security
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim.Value : emailAddressClaim.Value;
+                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 

--- a/TrashMob/Security/UserOwnsEntityAuthHandler.cs
+++ b/TrashMob/Security/UserOwnsEntityAuthHandler.cs
@@ -33,7 +33,7 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim.Value : emailAddressClaim.Value;
+                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 

--- a/TrashMob/Security/UserOwnsEntityOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserOwnsEntityOrIsAdminAuthHandler.cs
@@ -34,7 +34,7 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim.Value : emailAddressClaim.Value;
+                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 

--- a/TrashMobMobile/Authentication/AuthService.cs
+++ b/TrashMobMobile/Authentication/AuthService.cs
@@ -220,15 +220,16 @@ public class AuthService : IAuthService
         var emailClaim = result.ClaimsPrincipal.Claims.FirstOrDefault(c => c.Type == "email");
         var context = GetUserContext(result);
 
+        // Set user context first so AuthHandler can use the token for the API call below
+        UserState.UserContext = context;
+
         if (emailClaim != null)
         {
             userEmail = emailClaim.Value;
-            var user = await userManager.GetUserByEmailAsync(context.EmailAddress, context);
+            var user = await userManager.GetUserByEmailAsync(context.EmailAddress);
 
             App.CurrentUser = user;
         }
-
-        UserState.UserContext = context;
     }
 
     private bool IsTokenExpired()

--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -65,10 +65,10 @@
              * Use your correct FairPlayTube API port
              * */
             //ngrok.exe http https://localhost:44373 -host-header="localhost:44373"
-            services.AddScoped<BaseAddressAuthorizationMessageHandler>();
+            services.AddScoped<AuthHandler>();
             services.AddHttpClient($"ServerAPI", client =>
                     client.BaseAddress = new Uri(Settings.ApiBaseUrl))
-                .AddHttpMessageHandler<BaseAddressAuthorizationMessageHandler>()
+                .AddHttpMessageHandler<AuthHandler>()
                 .AddHttpMessageHandler<SentryHttpMessageHandler>()
                 .SetHandlerLifetime(TimeSpan.FromMinutes(5)) //Set lifetime to five minutes
                 .AddPolicyHandler(GetRetryPolicy());

--- a/TrashMobMobile/Pages/CancelEventPage.xaml
+++ b/TrashMobMobile/Pages/CancelEventPage.xaml
@@ -11,43 +11,51 @@
              Title="Cancel Event">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto" Margin="10">
-                    <VerticalStackLayout Grid.Row="0">
-                        <Label Text="Event Name" Style="{StaticResource FieldLabel}" />
-                        <Border Style="{x:StaticResource RoundBorder}">
-                            <Label Text="{Binding EventViewModel.Name}" FontSize="Small" />
-                        </Border>
-                    </VerticalStackLayout>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                    <VerticalStackLayout Grid.Row="1">
-                        <Label Text="Event Date" Style="{StaticResource FieldLabel}" />
-                        <Border Style="{x:StaticResource RoundBorder}">
-                            <Label Text="{Binding EventViewModel.DisplayDate}" FontSize="Small" />
-                        </Border>
+                <!-- Event Details -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Event Details" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout Spacing="2">
+                            <Label Text="Event Name" Style="{StaticResource FieldLabel}" />
+                            <Label Text="{Binding EventViewModel.Name}" FontSize="Small"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                        <Grid ColumnDefinitions="*, *" ColumnSpacing="12">
+                            <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                <Label Text="Event Date" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding EventViewModel.DisplayDate}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Column="1" Spacing="2">
+                                <Label Text="Event Time" Style="{StaticResource FieldLabel}" />
+                                <Label Text="{Binding EventViewModel.DisplayTime}" FontSize="Small"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                        </Grid>
                     </VerticalStackLayout>
+                </Border>
 
-                    <VerticalStackLayout Grid.Row="2">
-                        <Label Text="Event Time" Style="{StaticResource FieldLabel}" />
-                        <Border Style="{x:StaticResource RoundBorder}">
-                            <Label Text="{Binding EventViewModel.DisplayTime}" FontSize="Small" />
-                        </Border>
-                    </VerticalStackLayout>
-
-                    <VerticalStackLayout Grid.Row="2">
-                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Cancellation Reason" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                        <Border Style="{x:StaticResource RoundBorder}">
+                <!-- Cancellation Reason -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Cancellation" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout>
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Cancellation Reason" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                             <controls:TMEditor Text="{Binding EventViewModel.CancellationReason}">
                                 <controls:TMEditor.Behaviors>
                                     <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"
                                                                     x:Name="cancellationReasonValidator" />
                                 </controls:TMEditor.Behaviors>
                             </controls:TMEditor>
-                        </Border>
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
-                </Grid>
+                </Border>
 
-                <Button Text="Cancel Event" Command="{Binding CancelEventCommand}" Margin="10">
+                <Button Text="Cancel Event" Command="{Binding CancelEventCommand}"
+                        Style="{StaticResource PrimaryLargeButton}"
+                        Margin="10,8,10,10">
                     <Button.Triggers>
                         <MultiTrigger TargetType="Button">
                             <MultiTrigger.Conditions>
@@ -65,7 +73,7 @@
                        HorizontalOptions="Center"
                        HorizontalTextAlignment="Center"
                        TextColor="Red"
-                       Margin="10">
+                       Margin="10,0">
                     <Label.Triggers>
                         <MultiTrigger TargetType="Label">
                             <MultiTrigger.Conditions>

--- a/TrashMobMobile/Pages/EditEventPartnerLocationServicesPage.xaml
+++ b/TrashMobMobile/Pages/EditEventPartnerLocationServicesPage.xaml
@@ -8,53 +8,57 @@
              Title="Partner Services">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                <Grid RowDefinitions="Auto, Auto">
-                    <Label Grid.Row="0"
-                           Text="Available Services"
-                           FontSize="Medium"
-                           VerticalOptions="Center"
-                           HorizontalOptions="Start"
-                           HorizontalTextAlignment="Center"
-                           Margin="10"/>
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,10">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Available Services"
+                               Style="{StaticResource SectionHeader}"
+                               Margin="0" />
+                        <CollectionView x:Name="PartnerLocationServices"
+                                        ItemsSource="{Binding EventPartnerLocationServices}"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:EventPartnerLocationServiceViewModel">
+                                    <Border Style="{StaticResource RoundBorder}" Margin="0,3">
+                                        <VerticalStackLayout Padding="10,8" Spacing="6">
+                                            <Label Text="{Binding PartnerLocationName}"
+                                                   FontFamily="LexendSemibold"
+                                                   FontSize="Small" />
+                                            <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto" ColumnSpacing="8" RowSpacing="4">
+                                                <Label Text="Service" Grid.Row="0" Grid.Column="0"
+                                                       Style="{StaticResource FieldLabel}" />
+                                                <Label Text="{Binding ServiceName}" Grid.Row="0" Grid.Column="1"
+                                                       FontSize="Small" />
+                                                <Label Text="Status" Grid.Row="1" Grid.Column="0"
+                                                       Style="{StaticResource FieldLabel}" />
+                                                <Label Text="{Binding ServiceStatus}" Grid.Row="1" Grid.Column="1"
+                                                       FontSize="Small"
+                                                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                            </Grid>
+                                            <Label Text="{Binding PartnerLocationNotes}"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <HorizontalStackLayout Spacing="8">
+                                                <Button Text="Request Service"
+                                                        Command="{Binding RequestServiceCommand}"
+                                                        IsEnabled="{Binding CanRequestService}"
+                                                        IsVisible="{Binding CanRequestService}"
+                                                        Style="{StaticResource PrimarySmallButton}" />
+                                                <Button Text="Cancel Request"
+                                                        Command="{Binding UnrequestServiceCommand}"
+                                                        IsEnabled="{Binding CanUnrequestService}"
+                                                        IsVisible="{Binding CanUnrequestService}"
+                                                        Style="{StaticResource SecondarySmallButton}" />
+                                            </HorizontalStackLayout>
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
 
-                    <CollectionView Grid.Row="1" x:Name="PartnerLocationServices"
-                                    ItemsSource="{Binding EventPartnerLocationServices}"
-                                    SelectionMode="None">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:EventPartnerLocationServiceViewModel">
-                                <Border Style="{StaticResource RoundBorder}" Margin="5">
-                                    <Grid ColumnDefinitions="*, *"
-                                          RowDefinitions="*, *, *, *, *"
-                                          x:Name="PartnerLocationServiceItem">
-                                        <Label Text="Partner Name" Grid.Row="0" Grid.Column="0" Style="{StaticResource FieldLabel}" />
-                                        <Label Text="{Binding PartnerLocationName}" Grid.Row="0" Grid.Column="1" />
-                                        <Label Text="Service" Grid.Row="1" Grid.Column="0" Style="{StaticResource FieldLabel}" />
-                                        <Label Text="{Binding ServiceName}" Grid.Row="1" Grid.Column="1" />
-                                        <Label Text="Status" Grid.Row="2" Grid.Column="0" Style="{StaticResource FieldLabel}" />
-                                        <Label Text="{Binding ServiceStatus}" Grid.Row="2" Grid.Column="2" />
-                                        <Label Text="Notes" Grid.Row="3" Grid.Column="0" Style="{StaticResource FieldLabel}" />
-                                        <Label Text="{Binding PartnerLocationNotes}" Grid.Row="3" Grid.Column="3" FontSize="Micro" /> 
-                                        <Button Text="Request Service" Command="{Binding RequestServiceCommand}"
-                                                IsEnabled="{Binding CanRequestService}"
-                                                IsVisible="{Binding CanRequestService}" 
-                                                Grid.Row="4"
-                                                Grid.Column="0"
-                                                Style="{StaticResource SecondarySmallButton}" />
-                                        <Button Text="Cancel Service Request"
-                                                Command="{Binding UnrequestServiceCommand}"
-                                                IsEnabled="{Binding CanUnrequestService}"
-                                                IsVisible="{Binding CanUnrequestService}"
-                                                Grid.Row="4"
-                                                Grid.Column="4"
-                                                Style="{StaticResource SecondarySmallButton}" />
-                                    </Grid>
-                                </Border>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </Grid>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/ImpactPage.xaml
+++ b/TrashMobMobile/Pages/ImpactPage.xaml
@@ -8,161 +8,214 @@
              Title="Impact">
 
     <ScrollView>
-        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+        <Grid>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-            <!-- Your Impact -->
-            <Label Text="Your Impact"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="5,10,5,0" />
+                <!-- Your Impact -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Your Impact" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="0" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconCalendarCheck}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding PersonalStats.TotalEvents}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Events" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="1" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconTrashCanOutline}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding PersonalStats.TotalBags}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Bags" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="2" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconWeight}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding PersonalStats.TotalWeightDisplay}" FontFamily="LexendSemibold" FontSize="Small" HorizontalTextAlignment="Center" />
+                                    <Label Text="Weight" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="0" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconClockOutline}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding PersonalStats.TotalHours}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Hours" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconClipboardText}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding PersonalStats.TotalLitterReportsSubmitted}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Litter Reports" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
 
-            <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
-                <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *, *, *">
-                    <Image Grid.Row="0" Grid.Column="0" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconCalendarCheck}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="0" Text="{Binding PersonalStats.TotalEvents}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="0" Text="Events"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                <!-- Community Impact -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Community Impact" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="0" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconCalendarCheck}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding CommunityStats.TotalEvents}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Events" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="1" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconAccount}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding CommunityStats.TotalAttendees}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Volunteers" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="2" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconTrashCanOutline}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding CommunityStats.TotalBags}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Bags" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="0" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconWeight}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding CommunityStats.TotalWeightDisplay}" FontFamily="LexendSemibold" FontSize="Small" HorizontalTextAlignment="Center" />
+                                    <Label Text="Weight" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="1" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconClockOutline}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding CommunityStats.TotalHours}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Hours" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="2" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center" Spacing="2">
+                                    <Image WidthRequest="28" HeightRequest="28" HorizontalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconClipboardText}"
+                                                             Size="28"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Label Text="{Binding CommunityStats.TotalLitterReportsSubmitted}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Litter Reports" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
 
-                    <Image Grid.Row="0" Grid.Column="1" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconTrashCanOutline}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="1" Text="{Binding PersonalStats.TotalBags}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="1" Text="Bags"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
+                <!-- Explore More -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0,10,10">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Explore More" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Button Text="Leaderboards"
+                                Command="{Binding ViewLeaderboardsCommand}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                ContentLayout="Left, 12"
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconTrophy}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                        <Button Text="Achievements"
+                                Command="{Binding ViewAchievementsCommand}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                ContentLayout="Left, 12"
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMedal}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                    </VerticalStackLayout>
+                </Border>
 
-                    <Image Grid.Row="0" Grid.Column="2" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconClockOutline}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="2" Text="{Binding PersonalStats.TotalHours}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="2" Text="Hours"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-
-                    <Image Grid.Row="0" Grid.Column="3" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconClipboardText}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="3" Text="{Binding PersonalStats.TotalLitterReportsSubmitted}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="3" Text="Litter Reports"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                </Grid>
-            </Border>
-
-            <!-- Community Impact -->
-            <Label Text="Community Impact"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="5,15,5,0" />
-
-            <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
-                <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *, *, *, *">
-                    <Image Grid.Row="0" Grid.Column="0" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconCalendarCheck}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="0" Text="{Binding CommunityStats.TotalEvents}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="0" Text="Events"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-
-                    <Image Grid.Row="0" Grid.Column="1" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconAccount}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="1" Text="{Binding CommunityStats.TotalAttendees}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="1" Text="Participants"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-
-                    <Image Grid.Row="0" Grid.Column="2" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconTrashCanOutline}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="2" Text="{Binding CommunityStats.TotalBags}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="2" Text="Bags"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-
-                    <Image Grid.Row="0" Grid.Column="3" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconClockOutline}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="3" Text="{Binding CommunityStats.TotalHours}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="3" Text="Hours"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-
-                    <Image Grid.Row="0" Grid.Column="4" MaximumWidthRequest="40">
-                        <Image.Source>
-                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                             Glyph="{StaticResource IconClipboardText}"
-                                             Size="50"
-                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                        </Image.Source>
-                    </Image>
-                    <Label Grid.Row="1" Grid.Column="4" Text="{Binding CommunityStats.TotalLitterReportsSubmitted}"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                    <Label Grid.Row="2" Grid.Column="4" Text="Litter Reports"
-                           FontSize="Micro" HorizontalTextAlignment="Center" />
-                </Grid>
-            </Border>
-
-            <!-- Explore More -->
-            <Label Text="Explore More"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="5,15,5,5" />
-
-            <VerticalStackLayout Spacing="8" Margin="5,0,5,20">
-                <Button Text="Leaderboards"
-                        Command="{Binding ViewLeaderboardsCommand}"
-                        Style="{StaticResource SecondaryLargeButton}"
-                        ContentLayout="Left, 12"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconTrophy}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
-                <Button Text="Achievements"
-                        Command="{Binding ViewAchievementsCommand}"
-                        Style="{StaticResource SecondaryLargeButton}"
-                        ContentLayout="Left, 12"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMedal}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
             </VerticalStackLayout>
-
-        </VerticalStackLayout>
+            <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
+                     VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" VerticalOptions="Center"
+                               HorizontalOptions="Center" />
+        </Grid>
     </ScrollView>
 </ContentPage>

--- a/TrashMobMobile/Pages/ManageEventPartnersPage.xaml
+++ b/TrashMobMobile/Pages/ManageEventPartnersPage.xaml
@@ -8,34 +8,38 @@
              Title="Manage Event Partners">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Grid RowDefinitions="Auto, Auto">
-                    <Label Grid.Row="0"
-                           Text="Available Event Partners"
-                           FontSize="Micro"
-                           VerticalOptions="Center"
-                           HorizontalOptions="Start"
-                           HorizontalTextAlignment="Center" />
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                    <CollectionView Grid.Row="1" x:Name="AvailableEventPartners"
-                                    ItemsSource="{Binding AvailablePartners}"
-                                    SelectedItem="{Binding SelectedEventPartnerLocation}"
-                                    SelectionMode="Single">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:EventPartnerLocationViewModel">
-                                <Border Style="{StaticResource RoundBorder}">
-                                    <Grid ColumnDefinitions="*, *, *"
-                                          RowDefinitions="Auto"
-                                          x:Name="PartnerLocationItem">
-                                        <Label Text="{Binding PartnerLocationName}" Grid.Column="0" />
-                                        <Label Text="{Binding PartnerLocationNotes}" Grid.Column="1" />
-                                        <Label Text="{Binding PartnerServicesEngaged}" Grid.Column="2" />
-                                    </Grid>
-                                </Border>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </Grid>
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,10">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Available Event Partners"
+                               Style="{StaticResource SectionHeader}"
+                               Margin="0" />
+                        <CollectionView x:Name="AvailableEventPartners"
+                                        ItemsSource="{Binding AvailablePartners}"
+                                        SelectedItem="{Binding SelectedEventPartnerLocation}"
+                                        SelectionMode="Single">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:EventPartnerLocationViewModel">
+                                    <Border Style="{StaticResource RoundBorder}" Margin="0,3">
+                                        <VerticalStackLayout Padding="10,8" Spacing="4">
+                                            <Label Text="{Binding PartnerLocationName}"
+                                                   FontFamily="LexendSemibold"
+                                                   FontSize="Small" />
+                                            <Label Text="{Binding PartnerLocationNotes}"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding PartnerServicesEngaged}"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/ProfilePage.xaml
+++ b/TrashMobMobile/Pages/ProfilePage.xaml
@@ -8,253 +8,263 @@
              Title="Profile">
 
     <ScrollView>
-        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+        <Grid>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-            <!-- User Header -->
-            <Border Style="{x:StaticResource RoundBorder}" Margin="5,10,5,5">
-                <VerticalStackLayout Spacing="4" Padding="5">
-                    <Label Text="{Binding UserName}"
-                           AutomationId="UserNameLabel"
-                           FontFamily="LexendSemibold"
-                           FontSize="Large" />
-                    <Label Text="{Binding UserEmail}"
-                           FontSize="Small"
-                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    <Label Text="{Binding MemberSince}"
-                           FontSize="Micro"
-                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                </VerticalStackLayout>
-            </Border>
-
-            <!-- Location Preference -->
-            <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
-                <Grid ColumnDefinitions="*, Auto" Padding="5">
-                    <VerticalStackLayout Grid.Column="0" Spacing="2">
-                        <Label Text="Location Preference"
+                <!-- User Header -->
+                <Border Style="{x:StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="4" Padding="12,10">
+                        <Label Text="{Binding UserName}"
+                               AutomationId="UserNameLabel"
                                FontFamily="LexendSemibold"
-                               FontSize="Small" />
-                        <Label Text="{Binding LocationSummary}"
+                               FontSize="Large" />
+                        <Label Text="{Binding UserEmail}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding MemberSince}"
                                FontSize="Micro"
                                TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                     </VerticalStackLayout>
-                    <Button Grid.Column="1"
-                            Text="Edit"
-                            Command="{Binding EditLocationCommand}"
-                            Style="{StaticResource SecondarySmallButton}" />
-                </Grid>
-            </Border>
+                </Border>
+
+                <!-- Location Preference -->
+                <Border Style="{x:StaticResource RoundBorder}" Margin="10,0">
+                    <Grid ColumnDefinitions="*, Auto" Padding="12,10">
+                        <VerticalStackLayout Grid.Column="0" Spacing="2">
+                            <Label Text="Location Preference"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Small" />
+                            <Label Text="{Binding LocationSummary}"
+                                   FontSize="Micro"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                        <Button Grid.Column="1"
+                                Text="Edit"
+                                Command="{Binding EditLocationCommand}"
+                                Style="{StaticResource SecondarySmallButton}" />
+                    </Grid>
+                </Border>
 
             <!-- My Events Section -->
-            <Label Text="My Events"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="5,15,5,5" />
+            <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="My Events" Style="{StaticResource SectionHeader}" Margin="0" />
+                    <HorizontalStackLayout Spacing="8">
+                        <Button Text="Upcoming"
+                                Command="{Binding ShowUpcomingEventsCommand}"
+                                Style="{StaticResource SecondarySmallButton}">
+                            <Button.Triggers>
+                                <DataTrigger TargetType="Button" Binding="{Binding ShowUpcoming}" Value="true">
+                                    <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
+                                </DataTrigger>
+                                <DataTrigger TargetType="Button" Binding="{Binding ShowUpcoming}" Value="false">
+                                    <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
+                                </DataTrigger>
+                            </Button.Triggers>
+                        </Button>
+                        <Button Text="Completed"
+                                Command="{Binding ShowCompletedEventsCommand}"
+                                Style="{StaticResource SecondarySmallButton}">
+                            <Button.Triggers>
+                                <DataTrigger TargetType="Button" Binding="{Binding ShowCompleted}" Value="true">
+                                    <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
+                                </DataTrigger>
+                                <DataTrigger TargetType="Button" Binding="{Binding ShowCompleted}" Value="false">
+                                    <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
+                                </DataTrigger>
+                            </Button.Triggers>
+                        </Button>
+                    </HorizontalStackLayout>
 
-            <HorizontalStackLayout Spacing="8" Margin="5,0">
-                <Button Text="Upcoming"
-                        Command="{Binding ShowUpcomingEventsCommand}"
-                        Style="{StaticResource PrimarySmallButton}" />
-                <Button Text="Completed"
-                        Command="{Binding ShowCompletedEventsCommand}"
-                        Style="{StaticResource SecondarySmallButton}" />
-            </HorizontalStackLayout>
+                    <!-- Upcoming Events List -->
+                    <VerticalStackLayout IsVisible="{Binding ShowUpcoming}">
+                        <Label Text="No upcoming events"
+                               IsVisible="{Binding AreNoUpcomingEventsFound}"
+                               FontSize="Small"
+                               Margin="0,4"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <CollectionView ItemsSource="{Binding UpcomingEvents}"
+                                        SelectionMode="None"
+                                        IsVisible="{Binding AreUpcomingEventsFound}"
+                                        MaximumHeightRequest="300">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:EventViewModel">
+                                    <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                        <VerticalStackLayout Padding="10,8" Spacing="2">
+                                            <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                            <Label Text="{Binding DisplayDate}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </VerticalStackLayout>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewEventCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
 
-            <!-- Upcoming Events List -->
-            <VerticalStackLayout IsVisible="{Binding ShowUpcoming}">
-                <Label Text="No upcoming events"
-                       IsVisible="{Binding AreNoUpcomingEventsFound}"
-                       FontSize="Small"
-                       Margin="10,10"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                <CollectionView ItemsSource="{Binding UpcomingEvents}"
-                                SelectionMode="None"
-                                IsVisible="{Binding AreUpcomingEventsFound}"
-                                MaximumHeightRequest="300">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="viewModels:EventViewModel">
-                            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                                <VerticalStackLayout Padding="10,8" Spacing="2">
-                                    <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
-                                    <Label Text="{Binding DisplayDate}" FontSize="Micro"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                    <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                </VerticalStackLayout>
-                                <Border.GestureRecognizers>
-                                    <TapGestureRecognizer
-                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewEventCommand}"
-                                        CommandParameter="{Binding .}" />
-                                </Border.GestureRecognizers>
-                            </Border>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-            </VerticalStackLayout>
-
-            <!-- Completed Events List -->
-            <VerticalStackLayout IsVisible="{Binding ShowCompleted}">
-                <Label Text="No completed events"
-                       IsVisible="{Binding AreNoCompletedEventsFound}"
-                       FontSize="Small"
-                       Margin="10,10"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                <CollectionView ItemsSource="{Binding CompletedEvents}"
-                                SelectionMode="None"
-                                IsVisible="{Binding AreCompletedEventsFound}"
-                                MaximumHeightRequest="300">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="viewModels:EventViewModel">
-                            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                                <VerticalStackLayout Padding="10,8" Spacing="2">
-                                    <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
-                                    <Label Text="{Binding DisplayDate}" FontSize="Micro"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                    <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                </VerticalStackLayout>
-                                <Border.GestureRecognizers>
-                                    <TapGestureRecognizer
-                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewEventCommand}"
-                                        CommandParameter="{Binding .}" />
-                                </Border.GestureRecognizers>
-                            </Border>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-            </VerticalStackLayout>
+                    <!-- Completed Events List -->
+                    <VerticalStackLayout IsVisible="{Binding ShowCompleted}">
+                        <Label Text="No completed events"
+                               IsVisible="{Binding AreNoCompletedEventsFound}"
+                               FontSize="Small"
+                               Margin="0,4"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <CollectionView ItemsSource="{Binding CompletedEvents}"
+                                        SelectionMode="None"
+                                        IsVisible="{Binding AreCompletedEventsFound}"
+                                        MaximumHeightRequest="300">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:EventViewModel">
+                                    <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                        <VerticalStackLayout Padding="10,8" Spacing="2">
+                                            <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                            <Label Text="{Binding DisplayDate}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </VerticalStackLayout>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewEventCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </Border>
 
             <!-- My Litter Reports Section -->
-            <Label Text="My Litter Reports"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="5,15,5,5" />
-
-            <Label Text="No litter reports"
-                   IsVisible="{Binding AreNoLitterReportsFound}"
-                   FontSize="Small"
-                   Margin="10,5"
-                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-            <CollectionView ItemsSource="{Binding LitterReports}"
-                            SelectionMode="None"
-                            IsVisible="{Binding AreLitterReportsFound}"
-                            MaximumHeightRequest="250">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:LitterReportViewModel">
-                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                            <VerticalStackLayout Padding="10,8" Spacing="2">
-                                <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
-                                <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                <Label Text="{Binding Description}" FontSize="Micro" MaxLines="2"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                            </VerticalStackLayout>
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewLitterReportCommand}"
-                                    CommandParameter="{Binding .}" />
-                            </Border.GestureRecognizers>
-                        </Border>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+            <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="My Litter Reports" Style="{StaticResource SectionHeader}" Margin="0" />
+                    <Label Text="No litter reports"
+                           IsVisible="{Binding AreNoLitterReportsFound}"
+                           FontSize="Small"
+                           Margin="0,4"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <CollectionView ItemsSource="{Binding LitterReports}"
+                                    SelectionMode="None"
+                                    IsVisible="{Binding AreLitterReportsFound}"
+                                    MaximumHeightRequest="250">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterReportViewModel">
+                                <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                    <VerticalStackLayout Padding="10,8" Spacing="2">
+                                        <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                        <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding Description}" FontSize="Micro" MaxLines="2"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewLitterReportCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    </Border.GestureRecognizers>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Border>
 
             <!-- My Teams Section -->
-            <Grid ColumnDefinitions="*, Auto" Margin="5,15,5,5">
-                <Label Text="My Teams"
-                       FontFamily="LexendSemibold"
-                       FontSize="Medium"
-                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                       Grid.Column="0" />
-                <Button Text="Browse Teams"
-                        Command="{Binding BrowseTeamsCommand}"
-                        Style="{StaticResource SecondarySmallButton}"
-                        Grid.Column="1" />
-            </Grid>
-
-            <Label Text="You haven't joined any teams yet"
-                   IsVisible="{Binding AreNoTeamsFound}"
-                   FontSize="Small"
-                   Margin="10,5"
-                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-            <CollectionView ItemsSource="{Binding MyTeams}"
-                            SelectionMode="None"
-                            IsVisible="{Binding AreTeamsFound}"
-                            MaximumHeightRequest="250">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:TeamViewModel">
-                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                            <VerticalStackLayout Padding="10,8" Spacing="2">
-                                <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
-                                <Label Text="{Binding Location}" FontSize="Micro"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                <Label Text="{Binding MemberCountDisplay}" FontSize="Micro"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                            </VerticalStackLayout>
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewTeamCommand}"
-                                    CommandParameter="{Binding .}" />
-                            </Border.GestureRecognizers>
-                        </Border>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+            <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                <VerticalStackLayout Spacing="8">
+                    <Grid ColumnDefinitions="*, Auto">
+                        <Label Text="My Teams" Style="{StaticResource SectionHeader}" Margin="0"
+                               Grid.Column="0" />
+                        <Button Text="Browse Teams"
+                                Command="{Binding BrowseTeamsCommand}"
+                                Style="{StaticResource SecondarySmallButton}"
+                                Grid.Column="1" />
+                    </Grid>
+                    <Label Text="You haven't joined any teams yet"
+                           IsVisible="{Binding AreNoTeamsFound}"
+                           FontSize="Small"
+                           Margin="0,4"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <CollectionView ItemsSource="{Binding MyTeams}"
+                                    SelectionMode="None"
+                                    IsVisible="{Binding AreTeamsFound}"
+                                    MaximumHeightRequest="250">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:TeamViewModel">
+                                <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                    <VerticalStackLayout Padding="10,8" Spacing="2">
+                                        <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                        <Label Text="{Binding Location}" FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding MemberCountDisplay}" FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewTeamCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    </Border.GestureRecognizers>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Border>
 
             <!-- Settings Section -->
-            <Label Text="Settings"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="5,15,5,5" />
-
-            <VerticalStackLayout Spacing="8" Margin="5,0">
-                <Button Text="Privacy Policy"
-                        Command="{Binding OpenPrivacyPolicyCommand}"
-                        Style="{StaticResource SecondaryLargeButton}"
-                        ContentLayout="Left, 12"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconBinoculars}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
-                <Button Text="Terms of Service"
-                        Command="{Binding OpenTermsOfServiceCommand}"
-                        Style="{StaticResource SecondaryLargeButton}"
-                        ContentLayout="Left, 12"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconFileDocument}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
-                <Button Text="Sign Waiver"
-                        Command="{Binding SignWaiverCommand}"
-                        Style="{StaticResource SecondaryLargeButton}"
-                        ContentLayout="Left, 12"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconSignatureText}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
-                <Button Text="Contact Us"
-                        Command="{Binding ContactUsCommand}"
-                        Style="{StaticResource SecondaryLargeButton}"
-                        ContentLayout="Left, 12"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmail}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
-                <Button Text="Newsletter Preferences"
-                        Command="{Binding ManageNewsletterPreferencesCommand}"
-                        Style="{StaticResource SecondaryLargeButton}"
-                        ContentLayout="Left, 12"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmailNewsletter}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
-            </VerticalStackLayout>
+            <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Settings" Style="{StaticResource SectionHeader}" Margin="0" />
+                    <Button Text="Privacy Policy"
+                            Command="{Binding OpenPrivacyPolicyCommand}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            ContentLayout="Left, 12"
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconBinoculars}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                    <Button Text="Terms of Service"
+                            Command="{Binding OpenTermsOfServiceCommand}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            ContentLayout="Left, 12"
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconFileDocument}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                    <Button Text="Contact Us"
+                            Command="{Binding ContactUsCommand}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            ContentLayout="Left, 12"
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmail}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                    <Button Text="Newsletter Preferences"
+                            Command="{Binding ManageNewsletterPreferencesCommand}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            ContentLayout="Left, 12"
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmailNewsletter}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                </VerticalStackLayout>
+            </Border>
 
             <!-- Sign Out -->
             <Button Text="Sign Out"
                     AutomationId="SignOutButton"
                     Command="{Binding SignOutCommand}"
                     Style="{StaticResource PrimaryLargeButton}"
-                    Margin="5,20,5,5" />
+                    Margin="10,8,10,10" />
 
             <!-- Version -->
             <Label x:Name="VersionLabel"
                    FontSize="Micro"
                    HorizontalTextAlignment="Center"
-                   Margin="0,5,0,20"
+                   Margin="0,0,0,20"
                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
 
-            <!-- Loading Overlay -->
-            <BoxView BackgroundColor="{StaticResource TransparentBlack}"
-                     IsVisible="{Binding IsBusy}"
-                     VerticalOptions="Fill"
-                     HorizontalOptions="Fill" />
-            <ActivityIndicator IsRunning="{Binding IsBusy}"
-                               IsVisible="{Binding IsBusy}"
-                               VerticalOptions="Center"
+            </VerticalStackLayout>
+            <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
+                     VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" VerticalOptions="Center"
                                HorizontalOptions="Center" />
-
-        </VerticalStackLayout>
+        </Grid>
     </ScrollView>
 </ContentPage>

--- a/TrashMobMobile/Pages/SearchEventsPage.xaml
+++ b/TrashMobMobile/Pages/SearchEventsPage.xaml
@@ -9,129 +9,138 @@
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
              Title="Search Events">
     <Grid>
-        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-            <Grid RowDefinitions="Auto, Auto, *">
-                <Grid RowDefinitions="Auto" ColumnDefinitions="*, *, *, *" Grid.Row="0">
-                    <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="0" 
-                            Style="{StaticResource SecondarySmallButton}"
-                            Command="{Binding ViewUpcomingCommand}"                                 
-                            Text="Upcoming">
-                        <Button.Triggers>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsUpcomingSelected}" Value="true">
-                                <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
-                            </DataTrigger>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsUpcomingSelected}" Value="false">
-                                <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
-                            </DataTrigger>
-                        </Button.Triggers>
-                    </Button>
-                    <Button Margin="10"
-                            Grid.Row="0" 
-                            Grid.Column="1" 
-                            Style="{StaticResource SecondarySmallButton}"
-                            Command="{Binding ViewCompletedCommand}" 
-                            Text="Completed">
-                        <Button.Triggers>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsCompletedSelected}" Value="true">
-                                <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
-                            </DataTrigger>
-                            <DataTrigger TargetType="Button" Binding="{Binding IsCompletedSelected}" Value="false">
-                                <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
-                            </DataTrigger>
-                        </Button.Triggers>
-                    </Button>
-                    <controls:TMPicker Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2"
-                                           IsVisible="{Binding IsUpcomingSelected}"
-                                           Title="Upcoming Date Range"
-                                           HeightRequest="40"
-                                           Margin="0, 0, 10, 0"
-                                           ItemsSource="{Binding UpcomingDateRanges}"
-                                           SelectedItem="{Binding SelectedUpcomingDateRange, Mode=TwoWay}" />
-                    <controls:TMPicker Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2"
-                                           IsVisible="{Binding IsCompletedSelected}"
-                                           Title="Completed Date Range"
-                                           HeightRequest="40"
-                                           Margin="0, 0, 10, 0"
-                                           ItemsSource="{Binding CompletedDateRanges}"
-                                           SelectedItem="{Binding SelectedCompletedDateRange, Mode=TwoWay}" />
-                </Grid>
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
+            <Grid RowDefinitions="Auto, Auto, Auto, *">
+                <!-- Status Filters -->
+                <Border Grid.Row="0" Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Filters" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*, *, *, *" ColumnSpacing="4">
+                            <Button Grid.Column="0"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    Command="{Binding ViewUpcomingCommand}"
+                                    Text="Upcoming">
+                                <Button.Triggers>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsUpcomingSelected}" Value="true">
+                                        <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
+                                    </DataTrigger>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsUpcomingSelected}" Value="false">
+                                        <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
+                                    </DataTrigger>
+                                </Button.Triggers>
+                            </Button>
+                            <Button Grid.Column="1"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    Command="{Binding ViewCompletedCommand}"
+                                    Text="Completed">
+                                <Button.Triggers>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsCompletedSelected}" Value="true">
+                                        <Setter Property="Style" Value="{StaticResource PrimarySmallButton}" />
+                                    </DataTrigger>
+                                    <DataTrigger TargetType="Button" Binding="{Binding IsCompletedSelected}" Value="false">
+                                        <Setter Property="Style" Value="{StaticResource SecondarySmallButton}" />
+                                    </DataTrigger>
+                                </Button.Triggers>
+                            </Button>
+                            <controls:TMPicker Grid.Column="2" Grid.ColumnSpan="2"
+                                               IsVisible="{Binding IsUpcomingSelected}"
+                                               Title="Date Range"
+                                               HeightRequest="40"
+                                               ItemsSource="{Binding UpcomingDateRanges}"
+                                               SelectedItem="{Binding SelectedUpcomingDateRange, Mode=TwoWay}" />
+                            <controls:TMPicker Grid.Column="2" Grid.ColumnSpan="2"
+                                               IsVisible="{Binding IsCompletedSelected}"
+                                               Title="Date Range"
+                                               HeightRequest="40"
+                                               ItemsSource="{Binding CompletedDateRanges}"
+                                               SelectedItem="{Binding SelectedCompletedDateRange, Mode=TwoWay}" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
 
-                <Border Grid.Row="1" Style="{StaticResource RoundBorder}">
-                    <Grid ColumnDefinitions="*, *, *, *">
-                        <Picker x:Name="CountryPicker" Title="Select a country"
+                <!-- Location Filters -->
+                <Border Grid.Row="1" Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Location" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*, *, *, Auto" ColumnSpacing="4">
+                            <Picker x:Name="CountryPicker" Title="Country"
                                     ItemsSource="{Binding CountryCollection}" SelectedItem="{Binding SelectedCountry}"
                                     FontSize="Micro" Grid.Column="0" />
-                        <Picker x:Name="RegionPicker" Title="Select a state"
+                            <Picker x:Name="RegionPicker" Title="State"
                                     ItemsSource="{Binding RegionCollection}" SelectedItem="{Binding SelectedRegion}"
                                     FontSize="Micro" Grid.Column="1" />
-                        <Picker x:Name="CityPicker" Title="Select a city" ItemsSource="{Binding CityCollection}"
+                            <Picker x:Name="CityPicker" Title="City" ItemsSource="{Binding CityCollection}"
                                     SelectedItem="{Binding SelectedCity}" FontSize="Micro" Grid.Column="2" />
-                        <Button Text="Clear Selections" Command="{Binding ClearSelectionsCommand}" Margin="10" Style="{StaticResource SecondarySmallButton}"
-                                    Grid.Column="3" />
-                    </Grid>
+                            <Button Text="Clear" Command="{Binding ClearSelectionsCommand}"
+                                    FontSize="Micro" Grid.Column="3" />
+                        </Grid>
+                    </VerticalStackLayout>
                 </Border>
-                <Grid Margin="5" Grid.Row="2"
+
+                <Grid Margin="10,4" Grid.Row="2"
                       ColumnDefinitions="6*, *, *"
                       RowDefinitions="Auto">
                     <ImageButton Grid.Column="1"
                              HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
+                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
                              Command="{Binding MapSelectedCommand}" />
-                    <ImageButton Grid.Column="2" 
+                    <ImageButton Grid.Column="2"
                              HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
+                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
                              Command="{Binding ListSelectedCommand}" />
                 </Grid>
-            </Grid>
 
-            <controls:CustomMap x:Name="eventsMap"
-                          ItemsSource="{Binding Events}"
-                          IsVisible="{Binding IsMapSelected}">
-                <maps:Map.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:EventViewModel">
-                        <controls:CustomPin Location="{Binding Address.Location}"
-                                      Address="{Binding Address.StreetAddress}"
-                                      Label="{Binding Name}"
-                                      AutomationId="{Binding Id}"
-                                      ImageSource="{Binding Address.IconFile}"
-                                      InfoWindowClicked="Pin_InfoWindowClicked" />
-                    </DataTemplate>
-                </maps:Map.ItemTemplate>
-            </controls:CustomMap>
+                <controls:CustomMap x:Name="eventsMap"
+                              Grid.Row="3"
+                              ItemsSource="{Binding Events}"
+                              IsVisible="{Binding IsMapSelected}">
+                    <maps:Map.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
+                            <controls:CustomPin Location="{Binding Address.Location}"
+                                          Address="{Binding Address.StreetAddress}"
+                                          Label="{Binding Name}"
+                                          AutomationId="{Binding Id}"
+                                          ImageSource="{Binding Address.IconFile}"
+                                          InfoWindowClicked="Pin_InfoWindowClicked" />
+                        </DataTemplate>
+                    </maps:Map.ItemTemplate>
+                </controls:CustomMap>
 
-            <Grid RowDefinitions="Auto" IsVisible="{Binding IsListSelected}" Margin="10">
-                <Label Text="There are no events matching the selected criteria." IsVisible="{Binding AreNoEventsFound}" Grid.Row="0" />
-                <CollectionView x:Name="EventsCollection"
-                                ItemsSource="{Binding Events}"
-                                SelectedItem="{Binding SelectedEvent}"
-                                IsVisible="{Binding AreEventsFound}"
-                                SelectionMode="Single"
-                                Grid.Row="0"
-                                MaximumHeightRequest="400">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:EventViewModel">
-                        <StackLayout Margin="5">
-                            <Border Style="{StaticResource RoundBorder}">
-                                <Grid ColumnDefinitions="*, *"
-                                          RowDefinitions="Auto, Auto, Auto, Auto"
-                                          x:Name="EventItem">
-
-                                    <Label Text="{Binding Name}" Grid.Row="0" Grid.ColumnSpan="2" FontSize="Small" />
-                                    <Label Text="{Binding DisplayDate}" Grid.Row="1" Grid.ColumnSpan="2"
-                                               FontSize="Micro" />
-                                    <Label Text="{Binding DisplayTime}" Grid.Row="1" Grid.Column="1"
-                                               FontSize="Micro" />
-                                    <Label Text="{Binding Address.DisplayAddress}" Grid.Row="2" Grid.ColumnSpan="2"
-                                               FontSize="Micro" />
-                                    <Label Text="{Binding UserRoleForEvent}" Grid.Row="3" FontSize="Micro" />
-                                </Grid>
-                            </Border>
-                        </StackLayout>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+                <Grid Grid.Row="3" IsVisible="{Binding IsListSelected}">
+                    <Label Text="There are no events matching the selected criteria." IsVisible="{Binding AreNoEventsFound}" Margin="10" />
+                    <CollectionView x:Name="EventsCollection"
+                                    ItemsSource="{Binding Events}"
+                                    SelectedItem="{Binding SelectedEvent}"
+                                    IsVisible="{Binding AreEventsFound}"
+                                    SelectionMode="Single"
+                                    MaximumHeightRequest="400">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:EventViewModel">
+                                <StackLayout Margin="5">
+                                    <Border Style="{StaticResource RoundBorder}">
+                                        <Grid ColumnDefinitions="*, *"
+                                              RowDefinitions="Auto, Auto, Auto, Auto"
+                                              x:Name="EventItem">
+                                            <Label Text="{Binding Name}" Grid.Row="0" Grid.ColumnSpan="2" FontSize="Small"
+                                                   FontFamily="LexendSemibold" />
+                                            <Label Text="{Binding DisplayDate}" Grid.Row="1" Grid.ColumnSpan="2"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding DisplayTime}" Grid.Row="1" Grid.Column="1"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding Address.DisplayAddress}" Grid.Row="2" Grid.ColumnSpan="2"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding UserRoleForEvent}" Grid.Row="3" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Grid>
+                                    </Border>
+                                </StackLayout>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </Grid>
             </Grid>
         </VerticalStackLayout>
         <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"

--- a/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml.cs
+++ b/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml.cs
@@ -1,5 +1,6 @@
 namespace TrashMobMobile.Pages;
 
+using System.ComponentModel;
 using Microsoft.Maui.Controls.Maps;
 using Microsoft.Maui.Maps;
 
@@ -13,6 +14,8 @@ public partial class SetUserLocationPreferencePage : ContentPage
         this.viewModel = viewModel;
         this.viewModel.Navigation = Navigation;
         BindingContext = this.viewModel;
+
+        viewModel.PropertyChanged += OnViewModelPropertyChanged;
     }
 
     protected override async void OnNavigatedTo(NavigatedToEventArgs args)
@@ -23,16 +26,59 @@ public partial class SetUserLocationPreferencePage : ContentPage
 
         if (viewModel?.Address?.Latitude != null && viewModel?.Address?.Longitude != null)
         {
-            var mapSpan =
-                new MapSpan(new Location(viewModel.Address.Latitude.Value, viewModel.Address.Longitude.Value), 0.01,
-                    0.01);
+            var center = new Location(viewModel.Address.Latitude.Value, viewModel.Address.Longitude.Value);
+            var mapSpan = MapSpan.FromCenterAndRadius(center, GetTravelRadius());
             userLocationMap.InitialMapSpanAndroid = mapSpan;
             userLocationMap.MoveToRegion(mapSpan);
+            UpdateRadiusCircle();
         }
     }
 
     private async void OnMapClicked(object sender, MapClickedEventArgs e)
     {
         await viewModel.ChangeLocation(e.Location);
+        UpdateRadiusCircle();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(viewModel.TravelDistance) or nameof(viewModel.Units))
+        {
+            UpdateRadiusCircle();
+        }
+    }
+
+    private void UpdateRadiusCircle()
+    {
+        if (viewModel?.Address?.Latitude == null || viewModel?.Address?.Longitude == null)
+            return;
+
+        userLocationMap.MapElements.Clear();
+
+        var center = new Location(viewModel.Address.Latitude.Value, viewModel.Address.Longitude.Value);
+        var radius = GetTravelRadius();
+
+        var circle = new Circle
+        {
+            Center = center,
+            Radius = radius,
+            StrokeColor = Color.FromArgb("#80005B4C"),
+            StrokeWidth = 2,
+            FillColor = Color.FromArgb("#20005B4C"),
+        };
+
+        userLocationMap.MapElements.Add(circle);
+
+        // Zoom map to fit the circle
+        var mapSpan = MapSpan.FromCenterAndRadius(center, radius);
+        userLocationMap.MoveToRegion(mapSpan);
+    }
+
+    private Distance GetTravelRadius()
+    {
+        var distance = viewModel.TravelDistance > 0 ? viewModel.TravelDistance : 1;
+        return viewModel.Units == "Miles"
+            ? Distance.FromMiles(distance)
+            : Distance.FromKilometers(distance);
     }
 }

--- a/TrashMobMobile/Pages/ViewCommunityPage.xaml
+++ b/TrashMobMobile/Pages/ViewCommunityPage.xaml
@@ -8,202 +8,206 @@
              Title="Community Details">
 
     <ScrollView>
-        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+        <Grid>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-            <!-- Community Header -->
-            <VerticalStackLayout Padding="10,15" Spacing="4">
-                <Label Text="{Binding CommunityName}"
-                       FontFamily="LexendSemibold"
-                       FontSize="Title" />
-                <Label Text="{Binding Tagline}"
-                       FontSize="Small"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                <Label Text="{Binding Location}"
-                       FontSize="Micro"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                <!-- Community Header -->
+                <Border Style="{x:StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="{Binding CommunityName}"
+                               FontFamily="LexendSemibold"
+                               FontSize="Title" />
+                        <Label Text="{Binding Tagline}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding Location}"
+                               FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- About Section -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0" IsVisible="{Binding HasPublicNotes}">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="About" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Label Text="{Binding PublicNotes}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Impact Stats -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Community Impact" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="0" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center">
+                                    <Label Text="{Binding Stats.TotalEvents}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Events" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="1" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center">
+                                    <Label Text="{Binding Stats.TotalAttendees}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Volunteers" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="2" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center">
+                                    <Label Text="{Binding Stats.TotalBags}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Bags" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="0" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center">
+                                    <Label Text="{Binding Stats.TotalHours}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Hours" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="1" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center">
+                                    <Label Text="{Binding Stats.TotalLitterReportsSubmitted}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Reports" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                            <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="2" Padding="8">
+                                <VerticalStackLayout HorizontalOptions="Center">
+                                    <Label Text="{Binding Stats.TotalLitterReportsClosed}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
+                                    <Label Text="Resolved" FontSize="Micro" HorizontalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </Border>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Upcoming Events Section -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Upcoming Events" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Label Text="No upcoming events"
+                               IsVisible="{Binding AreNoEventsFound}"
+                               FontSize="Small"
+                               Margin="0,4"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <CollectionView ItemsSource="{Binding UpcomingEvents}"
+                                        SelectionMode="None"
+                                        IsVisible="{Binding AreEventsFound}">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:EventViewModel">
+                                    <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                        <VerticalStackLayout Padding="10,10" Spacing="4">
+                                            <Label Text="{Binding Name}"
+                                                   FontFamily="LexendSemibold"
+                                                   FontSize="Small" />
+                                            <Label Text="{Binding DisplayDate}"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding Address.DisplayAddress}"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </VerticalStackLayout>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewCommunityViewModel}}, Path=ViewEventCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Nearby Teams Section -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Nearby Teams" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Label Text="No nearby teams"
+                               IsVisible="{Binding AreNoTeamsFound}"
+                               FontSize="Small"
+                               Margin="0,4"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <CollectionView ItemsSource="{Binding NearbyTeams}"
+                                        SelectionMode="None"
+                                        IsVisible="{Binding AreTeamsFound}">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:TeamViewModel">
+                                    <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                        <VerticalStackLayout Padding="10,10" Spacing="4">
+                                            <Label Text="{Binding Name}"
+                                                   FontFamily="LexendSemibold"
+                                                   FontSize="Small" />
+                                            <Label Text="{Binding Location}"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding MemberCountDisplay}"
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </VerticalStackLayout>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewCommunityViewModel}}, Path=ViewTeamCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Contact Info Section -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0,10,10">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Contact" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <VerticalStackLayout Spacing="2" IsVisible="{Binding HasWebsite}">
+                            <Label Text="Website" FontSize="Micro"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding Website}" FontSize="Small"
+                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                   TextDecorations="Underline">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding OpenWebsiteCommand}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="2" IsVisible="{Binding HasContactEmail}">
+                            <Label Text="Email" FontSize="Micro"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding ContactEmail}" FontSize="Small"
+                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                   TextDecorations="Underline">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding SendEmailCommand}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="2" IsVisible="{Binding HasContactPhone}">
+                            <Label Text="Phone" FontSize="Micro"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding ContactPhone}" FontSize="Small"
+                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                   TextDecorations="Underline">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding CallPhoneCommand}" />
+                                </Label.GestureRecognizers>
+                            </Label>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
             </VerticalStackLayout>
-
-            <!-- About Section -->
-            <VerticalStackLayout Padding="10,0" IsVisible="{Binding HasPublicNotes}">
-                <Label Text="About"
-                       Style="{StaticResource SectionHeader}"
-                       Margin="0,5,0,5" />
-                <Label Text="{Binding PublicNotes}"
-                       FontSize="Small"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-            </VerticalStackLayout>
-
-            <!-- Impact Stats -->
-            <Label Text="Community Impact"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="10,15,10,5" />
-
-            <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto" Padding="10,0" ColumnSpacing="8" RowSpacing="8">
-                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="0" Padding="8">
-                    <VerticalStackLayout HorizontalOptions="Center">
-                        <Label Text="{Binding Stats.TotalEvents}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
-                        <Label Text="Events" FontSize="Micro" HorizontalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    </VerticalStackLayout>
-                </Border>
-                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="1" Padding="8">
-                    <VerticalStackLayout HorizontalOptions="Center">
-                        <Label Text="{Binding Stats.TotalAttendees}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
-                        <Label Text="Volunteers" FontSize="Micro" HorizontalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    </VerticalStackLayout>
-                </Border>
-                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="0" Grid.Column="2" Padding="8">
-                    <VerticalStackLayout HorizontalOptions="Center">
-                        <Label Text="{Binding Stats.TotalBags}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
-                        <Label Text="Bags" FontSize="Micro" HorizontalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    </VerticalStackLayout>
-                </Border>
-                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="0" Padding="8">
-                    <VerticalStackLayout HorizontalOptions="Center">
-                        <Label Text="{Binding Stats.TotalHours}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
-                        <Label Text="Hours" FontSize="Micro" HorizontalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    </VerticalStackLayout>
-                </Border>
-                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="1" Padding="8">
-                    <VerticalStackLayout HorizontalOptions="Center">
-                        <Label Text="{Binding Stats.TotalLitterReportsSubmitted}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
-                        <Label Text="Reports" FontSize="Micro" HorizontalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    </VerticalStackLayout>
-                </Border>
-                <Border Style="{x:StaticResource RoundBorder}" Grid.Row="1" Grid.Column="2" Padding="8">
-                    <VerticalStackLayout HorizontalOptions="Center">
-                        <Label Text="{Binding Stats.TotalLitterReportsClosed}" FontFamily="LexendSemibold" FontSize="Medium" HorizontalTextAlignment="Center" />
-                        <Label Text="Resolved" FontSize="Micro" HorizontalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    </VerticalStackLayout>
-                </Border>
-            </Grid>
-
-            <!-- Upcoming Events Section -->
-            <Label Text="Upcoming Events"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="10,15,10,5" />
-
-            <Label Text="No upcoming events"
-                   IsVisible="{Binding AreNoEventsFound}"
-                   FontSize="Small"
-                   Margin="10,5"
-                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-
-            <CollectionView ItemsSource="{Binding UpcomingEvents}"
-                            SelectionMode="None"
-                            IsVisible="{Binding AreEventsFound}">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:EventViewModel">
-                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                            <VerticalStackLayout Padding="10,10" Spacing="4">
-                                <Label Text="{Binding Name}"
-                                       FontFamily="LexendSemibold"
-                                       FontSize="Small" />
-                                <Label Text="{Binding DisplayDate}"
-                                       FontSize="Micro"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                <Label Text="{Binding Address.DisplayAddress}"
-                                       FontSize="Micro"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                            </VerticalStackLayout>
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewCommunityViewModel}}, Path=ViewEventCommand}"
-                                    CommandParameter="{Binding .}" />
-                            </Border.GestureRecognizers>
-                        </Border>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-
-            <!-- Nearby Teams Section -->
-            <Label Text="Nearby Teams"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="10,15,10,5" />
-
-            <Label Text="No nearby teams"
-                   IsVisible="{Binding AreNoTeamsFound}"
-                   FontSize="Small"
-                   Margin="10,5"
-                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-
-            <CollectionView ItemsSource="{Binding NearbyTeams}"
-                            SelectionMode="None"
-                            IsVisible="{Binding AreTeamsFound}">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:TeamViewModel">
-                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                            <VerticalStackLayout Padding="10,10" Spacing="4">
-                                <Label Text="{Binding Name}"
-                                       FontFamily="LexendSemibold"
-                                       FontSize="Small" />
-                                <Label Text="{Binding Location}"
-                                       FontSize="Micro"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                <Label Text="{Binding MemberCountDisplay}"
-                                       FontSize="Micro"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                            </VerticalStackLayout>
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewCommunityViewModel}}, Path=ViewTeamCommand}"
-                                    CommandParameter="{Binding .}" />
-                            </Border.GestureRecognizers>
-                        </Border>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-
-            <!-- Contact Info Section -->
-            <Label Text="Contact"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="10,15,10,5" />
-
-            <Border Style="{x:StaticResource RoundBorder}" Margin="5,3" Padding="10,10">
-                <VerticalStackLayout Spacing="8">
-                    <VerticalStackLayout Spacing="2" IsVisible="{Binding HasWebsite}">
-                        <Label Text="Website" FontSize="Micro"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                        <Label Text="{Binding Website}" FontSize="Small"
-                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                               TextDecorations="Underline">
-                            <Label.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding OpenWebsiteCommand}" />
-                            </Label.GestureRecognizers>
-                        </Label>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Spacing="2" IsVisible="{Binding HasContactEmail}">
-                        <Label Text="Email" FontSize="Micro"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                        <Label Text="{Binding ContactEmail}" FontSize="Small"
-                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                               TextDecorations="Underline">
-                            <Label.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding SendEmailCommand}" />
-                            </Label.GestureRecognizers>
-                        </Label>
-                    </VerticalStackLayout>
-                    <VerticalStackLayout Spacing="2" IsVisible="{Binding HasContactPhone}">
-                        <Label Text="Phone" FontSize="Micro"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                        <Label Text="{Binding ContactPhone}" FontSize="Small"
-                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                               TextDecorations="Underline">
-                            <Label.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding CallPhoneCommand}" />
-                            </Label.GestureRecognizers>
-                        </Label>
-                    </VerticalStackLayout>
-                </VerticalStackLayout>
-            </Border>
-
-            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" Margin="0,20" />
-
-        </VerticalStackLayout>
+            <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
+                     VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" VerticalOptions="Center"
+                               HorizontalOptions="Center" />
+        </Grid>
     </ScrollView>
 </ContentPage>

--- a/TrashMobMobile/Pages/ViewEventSummaryPage.xaml
+++ b/TrashMobMobile/Pages/ViewEventSummaryPage.xaml
@@ -10,92 +10,99 @@
              Title="Event Summary">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" >
-                <Grid RowDefinitions="*" ColumnDefinitions="*, *">
-                    <Button Text="Add Pickup Location" 
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
+
+                <!-- Action Buttons -->
+                <Grid ColumnDefinitions="*, *" ColumnSpacing="8" Margin="10,8,10,0">
+                    <Button Text="Add Pickup Location"
                             Command="{Binding AddPickupLocationCommand}"
-                            IsVisible="{Binding EnableAddPickupLocation}" 
-                            Grid.Row="0" 
+                            IsVisible="{Binding EnableAddPickupLocation}"
                             Grid.Column="0"
                             Style="{StaticResource PrimarySmallButton}" />
-                    <Button Text="Edit Event Summary" 
+                    <Button Text="Edit Event Summary"
                             Command="{Binding EditEventSummaryCommand}"
-                            IsVisible="{Binding EnableEditEventSummary}" 
-                            Grid.Row="0" 
-                            Grid.Column="1" 
-                            Style="{StaticResource SecondarySmallButton}"/>
+                            IsVisible="{Binding EnableEditEventSummary}"
+                            Grid.Column="1"
+                            Style="{StaticResource SecondarySmallButton}" />
                 </Grid>
-                <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*, *">
-                    <Border Style="{x:StaticResource RoundBorder}" Margin="5,0" Grid.Row="0" Grid.ColumnSpan="2">
-                        <Grid RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *, *">
-                            <Label Text="Here's what TrashMob volunteers accomplished at this event!" Grid.Row="0"
-                                   Grid.Column="0" Grid.ColumnSpan="4" FontSize="Micro" Margin="0, 0, 0, 10" />
-                            <Image Grid.Row="1" Grid.Column="0" Source="person" MaximumWidthRequest="25" />
-                            <Label Grid.Row="2" Grid.Column="0"
+
+                <!-- Event Metrics -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Event Metrics" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Label Text="Here's what TrashMob volunteers accomplished at this event!"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                               HorizontalTextAlignment="Center" />
+                        <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *, *, *" ColumnSpacing="8">
+                            <Image Grid.Row="0" Grid.Column="0" Source="person" MaximumWidthRequest="25" />
+                            <Label Grid.Row="1" Grid.Column="0"
                                    Text="{ Binding EventSummaryViewModel.ActualNumberOfAttendees }" FontSize="Micro"
                                    HorizontalTextAlignment="Center" />
-                            <Label Grid.Row="3" Grid.Column="0" Text="Attendees" FontSize="Micro"
+                            <Label Grid.Row="2" Grid.Column="0" Text="Attendees" FontSize="Micro"
                                    HorizontalTextAlignment="Center" />
-                            <Image Grid.Row="1" Grid.Column="1" Source="trashbag" WidthRequest="25" />
-                            <Label Grid.Row="2" Grid.Column="1" Text="{ Binding EventSummaryViewModel.NumberOfBags }"
+                            <Image Grid.Row="0" Grid.Column="1" Source="trashbag" WidthRequest="25" />
+                            <Label Grid.Row="1" Grid.Column="1" Text="{ Binding EventSummaryViewModel.NumberOfBags }"
                                    FontSize="Micro" HorizontalTextAlignment="Center" />
-                            <Label Grid.Row="3" Grid.Column="1" Text="Bags Collected" FontSize="Micro"
+                            <Label Grid.Row="2" Grid.Column="1" Text="Bags Collected" FontSize="Micro"
                                    HorizontalTextAlignment="Center" />
-                            <Image Grid.Row="1" Grid.Column="2" Source="clock" WidthRequest="25" />
-                            <Label Grid.Row="2" Grid.Column="2"
+                            <Image Grid.Row="0" Grid.Column="2" Source="clock" WidthRequest="25" />
+                            <Label Grid.Row="1" Grid.Column="2"
                                    Text="{ Binding EventSummaryViewModel.DurationInMinutes }" FontSize="Micro"
                                    HorizontalTextAlignment="Center" />
-                            <Label Grid.Row="3" Grid.Column="2" Text="Duration (min)" FontSize="Micro"
+                            <Label Grid.Row="2" Grid.Column="2" Text="Duration (min)" FontSize="Micro"
                                    HorizontalTextAlignment="Center" />
-                            <Image Grid.Row="1" Grid.Column="3" Source="scale" WidthRequest="25" />
-                            <Label Grid.Row="2" Grid.Column="3"
+                            <Image Grid.Row="0" Grid.Column="3" Source="scale" WidthRequest="25" />
+                            <Label Grid.Row="1" Grid.Column="3"
                                    Text="{ Binding EventSummaryViewModel.WeightDisplay }" FontSize="Micro"
                                    HorizontalTextAlignment="Center" />
-                            <Label Grid.Row="3" Grid.Column="3" Text="Weight" FontSize="Micro"
+                            <Label Grid.Row="2" Grid.Column="3" Text="Weight" FontSize="Micro"
                                    HorizontalTextAlignment="Center" />
                         </Grid>
-                    </Border>
-
-                    <VerticalStackLayout Grid.Row="1" Grid.ColumnSpan="2">
-                        <Label Text="Notes" Style="{StaticResource FieldLabel}" />
-                        <Label Text="{Binding EventSummaryViewModel.Notes}"
-                               VerticalOptions="Center"
-                               HorizontalOptions="Start"
-                               HorizontalTextAlignment="Center" />
                     </VerticalStackLayout>
+                </Border>
 
-                    <Label Text="Pickup Locations" Grid.Row="2" Style="{StaticResource FieldLabel}" />
+                <!-- Notes -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Notes" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Label Text="{Binding EventSummaryViewModel.Notes}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
 
-                    <Grid Margin="5" Grid.Row="2" Grid.Column="1"
-                      ColumnDefinitions="4*, *, *"
-                      RowDefinitions="Auto">
-                        <ImageButton Grid.Column="1"
-                             HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
-                             Command="{Binding MapSelectedCommand}" />
-                        <ImageButton Grid.Column="2" 
-                             HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
-                             Command="{Binding ListSelectedCommand}" />
-                    </Grid>
+                <!-- Pickup Locations -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Grid ColumnDefinitions="*, Auto, Auto" ColumnSpacing="8">
+                            <Label Text="Pickup Locations" Style="{StaticResource SectionHeader}" Margin="0"
+                                   Grid.Column="0" />
+                            <ImageButton Grid.Column="1"
+                                     HeightRequest="24"
+                                     Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
+                                     Command="{Binding MapSelectedCommand}" />
+                            <ImageButton Grid.Column="2"
+                                     HeightRequest="24"
+                                     Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
+                                     Command="{Binding ListSelectedCommand}" />
+                        </Grid>
 
-                    <CollectionView x:Name="PickupLocationCollection"
-                                    ItemsSource="{Binding PickupLocations}"
-                                    SelectedItem="{Binding SelectedPickupLocation}"
-                                    IsVisible="{Binding IsListSelected}"
-                                    SelectionMode="Single"
-                                    Grid.Row="4"
-                                    Grid.ColumnSpan="2">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
-                                <StackLayout Margin="5">
-                                    <Border Style="{StaticResource RoundBorder}">
+                        <CollectionView x:Name="PickupLocationCollection"
+                                        ItemsSource="{Binding PickupLocations}"
+                                        SelectedItem="{Binding SelectedPickupLocation}"
+                                        IsVisible="{Binding IsListSelected}"
+                                        SelectionMode="Single">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
+                                    <Border Style="{StaticResource RoundBorder}" Margin="0,3">
                                         <Grid ColumnDefinitions="*, *, *, *"
                                               RowDefinitions="Auto"
                                               x:Name="LitterReportItem">
                                             <Image Source="{Binding ImageUrl}" Grid.Column="0" Margin="5" />
                                             <Label Text="{Binding Address.DisplayAddress}" Grid.Column="1" Margin="5"
-                                                   FontSize="Micro" />
+                                                   FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                                             <Button Text="Edit Location" Grid.Column="2"
                                                     Command="{Binding EditPickupLocationCommand}"
                                                     IsEnabled="{Binding CanEditPickupLocation}"
@@ -108,28 +115,26 @@
                                                     HeightRequest="40" FontSize="Micro" />
                                         </Grid>
                                     </Border>
-                                </StackLayout>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
 
-                    <controls:CustomMap x:Name="pickupLocationsMap"
-                              ItemsSource="{Binding PickupLocations}"
-                              IsVisible="{Binding IsMapSelected}"
-                              Grid.Row="4"
-                              Grid.ColumnSpan="2">
-                        <maps:Map.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
-                                <controls:CustomPin Location="{Binding Address.Location}"
-                                          Address="{Binding Address.StreetAddress}"
-                                          Label="{Binding Id}"
-                                          AutomationId="{Binding Id}"
-                                          ImageSource="{Binding Address.IconFile}"
-                                          InfoWindowClicked="Pin_InfoWindowClicked" />
-                            </DataTemplate>
-                        </maps:Map.ItemTemplate>
-                    </controls:CustomMap>
-                </Grid>
+                        <controls:CustomMap x:Name="pickupLocationsMap"
+                                  ItemsSource="{Binding PickupLocations}"
+                                  IsVisible="{Binding IsMapSelected}">
+                            <maps:Map.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
+                                    <controls:CustomPin Location="{Binding Address.Location}"
+                                              Address="{Binding Address.StreetAddress}"
+                                              Label="{Binding Id}"
+                                              AutomationId="{Binding Id}"
+                                              ImageSource="{Binding Address.IconFile}"
+                                              InfoWindowClicked="Pin_InfoWindowClicked" />
+                                </DataTemplate>
+                            </maps:Map.ItemTemplate>
+                        </controls:CustomMap>
+                    </VerticalStackLayout>
+                </Border>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/ViewLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/ViewLitterReportPage.xaml
@@ -10,11 +10,11 @@
              Title="Litter Report">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
                 <!-- Report Info Card -->
-                <Border Style="{x:StaticResource RoundBorder}" Margin="5,10,5,5">
-                    <VerticalStackLayout Spacing="4" Padding="10,10">
+                <Border Style="{x:StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="4">
                         <Label Text="{Binding LitterReportViewModel.Name}"
                                FontFamily="LexendSemibold"
                                FontSize="Large" />
@@ -28,70 +28,70 @@
                 </Border>
 
                 <!-- Action Buttons -->
-                <VerticalStackLayout Spacing="8" Margin="5,5">
-                    <Button Command="{Binding EditLitterReportCommand}"
-                            Text="Edit Report"
-                            IsEnabled="{Binding CanEditLitterReport}"
-                            IsVisible="{Binding CanEditLitterReport}"
-                            Style="{StaticResource PrimaryLargeButton}" />
-                    <Button Command="{Binding MarkLitterReportCleanedCommand}"
-                            IsEnabled="{Binding CanMarkLitterReportCleaned}"
-                            IsVisible="{Binding CanMarkLitterReportCleaned}"
-                            Style="{StaticResource SecondaryLargeButton}"
-                            Text="Mark as Cleaned" />
-                    <Button Command="{Binding DeleteLitterReportCommand}"
-                            IsEnabled="{Binding CanDeleteLitterReport}"
-                            IsVisible="{Binding CanDeleteLitterReport}"
-                            Style="{StaticResource SecondaryLargeButton}"
-                            Text="Delete Report" />
-                    <Button Command="{Binding ViewEventCommand}"
-                            IsEnabled="{Binding IsAssignedToEvent}"
-                            IsVisible="{Binding IsAssignedToEvent}"
-                            Style="{StaticResource SecondaryLargeButton}"
-                            Text="View Event" />
-                    <Button Command="{Binding CreateEventCommand}"
-                            IsEnabled="{Binding IsNotAssignedToEvent}"
-                            IsVisible="{Binding IsNotAssignedToEvent}"
-                            Style="{StaticResource SecondaryLargeButton}"
-                            Text="Create Event" />
-                </VerticalStackLayout>
-
-                <!-- Map -->
-                <Label Text="Locations"
-                       Style="{StaticResource SectionHeader}"
-                       Margin="5,10,5,5" />
-
-                <Border Style="{x:StaticResource RoundBorder}" Margin="5,0">
-                    <controls:CustomMap x:Name="litterReportLocationMap" ItemsSource="{Binding LitterImageViewModels}">
-                        <maps:Map.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                <controls:CustomPin Location="{Binding Address.Location}"
-                                          Address="{Binding Address.StreetAddress}"
-                                          ImageSource="{Binding Address.IconFile}"
-                                          Label="Litter Image" />
-                            </DataTemplate>
-                        </maps:Map.ItemTemplate>
-                    </controls:CustomMap>
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Actions" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Button Command="{Binding EditLitterReportCommand}"
+                                Text="Edit Report"
+                                IsEnabled="{Binding CanEditLitterReport}"
+                                IsVisible="{Binding CanEditLitterReport}"
+                                Style="{StaticResource PrimaryLargeButton}" />
+                        <Button Command="{Binding MarkLitterReportCleanedCommand}"
+                                IsEnabled="{Binding CanMarkLitterReportCleaned}"
+                                IsVisible="{Binding CanMarkLitterReportCleaned}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="Mark as Cleaned" />
+                        <Button Command="{Binding DeleteLitterReportCommand}"
+                                IsEnabled="{Binding CanDeleteLitterReport}"
+                                IsVisible="{Binding CanDeleteLitterReport}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="Delete Report" />
+                        <Button Command="{Binding ViewEventCommand}"
+                                IsEnabled="{Binding IsAssignedToEvent}"
+                                IsVisible="{Binding IsAssignedToEvent}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="View Event" />
+                        <Button Command="{Binding CreateEventCommand}"
+                                IsEnabled="{Binding IsNotAssignedToEvent}"
+                                IsVisible="{Binding IsNotAssignedToEvent}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="Create Event" />
+                    </VerticalStackLayout>
                 </Border>
 
-                <!-- Litter Images -->
-                <CollectionView x:Name="LitterImagesCollection"
-                                ItemsSource="{Binding LitterImageViewModels}"
-                                SelectionMode="None"
-                                Margin="0,5">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                            <Border Style="{StaticResource RoundBorder}" Margin="5,3">
-                                <Grid ColumnDefinitions="Auto, *" Padding="8,6" ColumnSpacing="10">
-                                    <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="80" Aspect="AspectFill" Grid.Column="0" />
-                                    <Label Text="{Binding Address.DisplayAddress}" Grid.Column="1"
-                                           LineBreakMode="WordWrap" FontSize="Small" VerticalOptions="Center"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                </Grid>
-                            </Border>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
+                <!-- Locations -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Locations" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <controls:CustomMap x:Name="litterReportLocationMap" ItemsSource="{Binding LitterImageViewModels}">
+                            <maps:Map.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                    <controls:CustomPin Location="{Binding Address.Location}"
+                                              Address="{Binding Address.StreetAddress}"
+                                              ImageSource="{Binding Address.IconFile}"
+                                              Label="Litter Image" />
+                                </DataTemplate>
+                            </maps:Map.ItemTemplate>
+                        </controls:CustomMap>
+
+                        <CollectionView x:Name="LitterImagesCollection"
+                                        ItemsSource="{Binding LitterImageViewModels}"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                    <Border Style="{StaticResource RoundBorder}" Margin="0,3">
+                                        <Grid ColumnDefinitions="Auto, *" Padding="8,6" ColumnSpacing="10">
+                                            <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="80" Aspect="AspectFill" Grid.Column="0" />
+                                            <Label Text="{Binding Address.DisplayAddress}" Grid.Column="1"
+                                                   LineBreakMode="WordWrap" FontSize="Small" VerticalOptions="Center"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/ViewTeamPage.xaml
+++ b/TrashMobMobile/Pages/ViewTeamPage.xaml
@@ -8,147 +8,151 @@
              Title="Team Details">
 
     <ScrollView>
-        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+        <Grid>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-            <!-- Team Header -->
-            <VerticalStackLayout Padding="10,15" Spacing="4">
-                <Label Text="{Binding Team.Name}"
-                       FontFamily="LexendSemibold"
-                       FontSize="Title" />
-                <Label Text="{Binding Team.Description}"
-                       FontSize="Small"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                <Label Text="{Binding Team.Location}"
-                       FontSize="Micro"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                <Label Text="{Binding Team.MemberCountDisplay}"
-                       FontSize="Micro"
-                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                <!-- Team Header -->
+                <Border Style="{x:StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="{Binding Team.Name}"
+                               FontFamily="LexendSemibold"
+                               FontSize="Title" />
+                        <Label Text="{Binding Team.Description}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding Team.Location}"
+                               FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding Team.MemberCountDisplay}"
+                               FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                        <!-- Join Button -->
+                        <Button Text="{Binding JoinButtonText}"
+                                Command="{Binding JoinTeamCommand}"
+                                IsVisible="{Binding CanJoin}"
+                                Style="{StaticResource PrimarySmallButton}"
+                                Margin="0,4,0,0" />
+
+                        <HorizontalStackLayout IsVisible="{Binding IsUserMember}" Spacing="6" Margin="0,4,0,0">
+                            <Image WidthRequest="18" HeightRequest="18">
+                                <Image.Source>
+                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                     Glyph="{StaticResource IconCheckCircle}"
+                                                     Size="18"
+                                                     Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                </Image.Source>
+                            </Image>
+                            <Label Text="You are a member of this team"
+                                   FontSize="Small"
+                                   FontAttributes="Bold"
+                                   VerticalOptions="Center"
+                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </HorizontalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Members Section -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Members" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Label Text="No members found"
+                               IsVisible="{Binding AreNoMembersFound}"
+                               FontSize="Small"
+                               Margin="0,4"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <CollectionView ItemsSource="{Binding Members}"
+                                        SelectionMode="None"
+                                        IsVisible="{Binding AreMembersFound}">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:TeamMemberViewModel">
+                                    <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                        <HorizontalStackLayout Padding="10,8" Spacing="8">
+                                            <Label Text="{Binding UserName}"
+                                                   FontFamily="LexendSemibold"
+                                                   FontSize="Small"
+                                                   VerticalOptions="Center" />
+                                            <Label Text="{Binding Role}"
+                                                   FontSize="Micro"
+                                                   VerticalOptions="Center"
+                                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                            <Label Text="{Binding JoinedDate, StringFormat='Joined {0}'}"
+                                                   FontSize="Micro"
+                                                   VerticalOptions="Center"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </HorizontalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Upcoming Events Section -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Grid ColumnDefinitions="*, Auto">
+                            <Label Grid.Column="0" Text="Upcoming Events"
+                                   Style="{StaticResource SectionHeader}" Margin="0" />
+                            <Button Grid.Column="1"
+                                    Text="Link Event"
+                                    Command="{Binding LinkEventCommand}"
+                                    IsVisible="{Binding IsTeamLead}"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    FontSize="Micro"
+                                    HeightRequest="32"
+                                    Padding="10,0" />
+                        </Grid>
+                        <Label Text="No upcoming events"
+                               IsVisible="{Binding AreNoUpcomingEventsFound}"
+                               FontSize="Small"
+                               Margin="0,4"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <CollectionView ItemsSource="{Binding UpcomingEvents}"
+                                        SelectionMode="None"
+                                        IsVisible="{Binding AreUpcomingEventsFound}">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:EventViewModel">
+                                    <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                                        <Grid ColumnDefinitions="*, Auto" Padding="10,10">
+                                            <VerticalStackLayout Grid.Column="0" Spacing="4">
+                                                <Label Text="{Binding Name}"
+                                                       FontFamily="LexendSemibold"
+                                                       FontSize="Small" />
+                                                <Label Text="{Binding DisplayDate}"
+                                                       FontSize="Micro"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                <Label Text="{Binding Address.DisplayAddress}"
+                                                       FontSize="Micro"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            </VerticalStackLayout>
+                                            <Button Grid.Column="1"
+                                                    Text="Unlink"
+                                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewTeamViewModel}}, Path=UnlinkEventCommand}"
+                                                    CommandParameter="{Binding .}"
+                                                    IsVisible="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewTeamViewModel}}, Path=IsTeamLead}"
+                                                    Style="{StaticResource SecondarySmallButton}"
+                                                    FontSize="Micro"
+                                                    HeightRequest="30"
+                                                    Padding="8,0"
+                                                    VerticalOptions="Center" />
+                                        </Grid>
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewTeamViewModel}}, Path=ViewEventCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
             </VerticalStackLayout>
-
-            <!-- Join Button -->
-            <Button Text="{Binding JoinButtonText}"
-                    Command="{Binding JoinTeamCommand}"
-                    IsVisible="{Binding CanJoin}"
-                    Style="{StaticResource PrimarySmallButton}"
-                    Margin="10,5" />
-
-            <HorizontalStackLayout IsVisible="{Binding IsUserMember}" Spacing="6" Margin="10,5">
-                <Image WidthRequest="18" HeightRequest="18">
-                    <Image.Source>
-                        <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
-                                         Glyph="{StaticResource IconCheckCircle}"
-                                         Size="18"
-                                         Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                    </Image.Source>
-                </Image>
-                <Label Text="You are a member of this team"
-                       FontSize="Small"
-                       FontAttributes="Bold"
-                       VerticalOptions="Center"
-                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-            </HorizontalStackLayout>
-
-            <!-- Members Section -->
-            <Label Text="Members"
-                   Style="{StaticResource SectionHeader}"
-                   Margin="10,15,10,5" />
-
-            <Label Text="No members found"
-                   IsVisible="{Binding AreNoMembersFound}"
-                   FontSize="Small"
-                   Margin="10,5"
-                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-
-            <CollectionView ItemsSource="{Binding Members}"
-                            SelectionMode="None"
-                            IsVisible="{Binding AreMembersFound}">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:TeamMemberViewModel">
-                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                            <HorizontalStackLayout Padding="10,8" Spacing="8">
-                                <Label Text="{Binding UserName}"
-                                       FontFamily="LexendSemibold"
-                                       FontSize="Small"
-                                       VerticalOptions="Center" />
-                                <Label Text="{Binding Role}"
-                                       FontSize="Micro"
-                                       VerticalOptions="Center"
-                                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                                <Label Text="{Binding JoinedDate, StringFormat='Joined {0}'}"
-                                       FontSize="Micro"
-                                       VerticalOptions="Center"
-                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                            </HorizontalStackLayout>
-                        </Border>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-
-            <!-- Upcoming Events Section -->
-            <Grid ColumnDefinitions="*, Auto" Margin="10,15,10,5">
-                <Label Grid.Column="0"
-                       Text="Upcoming Events"
-                       FontFamily="LexendSemibold"
-                       FontSize="Medium"
-                       TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                <Button Grid.Column="1"
-                        Text="Link Event"
-                        Command="{Binding LinkEventCommand}"
-                        IsVisible="{Binding IsTeamLead}"
-                        Style="{StaticResource SecondarySmallButton}"
-                        FontSize="Micro"
-                        HeightRequest="32"
-                        Padding="10,0" />
-            </Grid>
-
-            <Label Text="No upcoming events"
-                   IsVisible="{Binding AreNoUpcomingEventsFound}"
-                   FontSize="Small"
-                   Margin="10,5"
-                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-
-            <CollectionView ItemsSource="{Binding UpcomingEvents}"
-                            SelectionMode="None"
-                            IsVisible="{Binding AreUpcomingEventsFound}">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:EventViewModel">
-                        <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                            <Grid ColumnDefinitions="*, Auto" Padding="10,10">
-                                <VerticalStackLayout Grid.Column="0" Spacing="4">
-                                    <Label Text="{Binding Name}"
-                                           FontFamily="LexendSemibold"
-                                           FontSize="Small" />
-                                    <Label Text="{Binding DisplayDate}"
-                                           FontSize="Micro"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                    <Label Text="{Binding Address.DisplayAddress}"
-                                           FontSize="Micro"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                </VerticalStackLayout>
-                                <Button Grid.Column="1"
-                                        Text="Unlink"
-                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewTeamViewModel}}, Path=UnlinkEventCommand}"
-                                        CommandParameter="{Binding .}"
-                                        IsVisible="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewTeamViewModel}}, Path=IsTeamLead}"
-                                        Style="{StaticResource SecondarySmallButton}"
-                                        FontSize="Micro"
-                                        HeightRequest="30"
-                                        Padding="8,0"
-                                        VerticalOptions="Center" />
-                            </Grid>
-                            <Border.GestureRecognizers>
-                                <TapGestureRecognizer
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewTeamViewModel}}, Path=ViewEventCommand}"
-                                    CommandParameter="{Binding .}" />
-                            </Border.GestureRecognizers>
-                        </Border>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-
-            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" Margin="0,20" />
-
-        </VerticalStackLayout>
+            <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
+                     VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" VerticalOptions="Center"
+                               HorizontalOptions="Center" />
+        </Grid>
     </ScrollView>
 </ContentPage>

--- a/TrashMobMobile/Pages/WaiverPage.xaml
+++ b/TrashMobMobile/Pages/WaiverPage.xaml
@@ -9,46 +9,71 @@
              Title="TrashMob.eco Waiver">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Label Margin="10"
-                    Text="In order to create or participate in TrashMob.eco events, you must agree to a liability waiver. Please click the Sign Waiver button below."
-                    FontSize="Micro"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Start"
-                    HorizontalTextAlignment="Start" />
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                <Label
-                    Text="You will only need to sign this waiver once unless we have to change the legalese."
-                    FontSize="Small"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Center"
-                    HorizontalTextAlignment="Center" />
-                
-                <Label 
-                    Text="TrashMob.eco Volunteer Release" FontSize="Large" HorizontalTextAlignment="Center" HorizontalOptions="Center" />
-                <Label Text="and Waiver of Liability Form" FontSize="Large" HorizontalTextAlignment="Center" HorizontalOptions="Center" />
-                <Label Text="THE VOLUNTEER RELEASE AND WAIVER OF LIABILITY FORM (“RELEASE”)" FontSize="Medium" Margin="5, 5, 5, 5" />
-                <Label Text="(“VOLUNTEER”) HEREBY RELEASES TRASHMOB.ECO, ITS OFFICERS AND DIRECTORS, ANY LAND OWNERS AND MANAGERS, AND ALL RELATED SPONSORS (“PARTIES”) JOINTLY AND SEVERALLY, AND INDIVIDUALLY." FontSize="Medium" Margin="5, 5, 5, 5" />
-                <Label Text="The Volunteer desires to provide volunteer services and to participate in activities related to serving as a volunteer for events facilitated by TrashMob.eco.  Volunteer services (“Services”) will be broadly defined as picking up trash at TrashMob.eco facilitated events (“Events”). The above Volunteer hereby agrees as follows: " FontSize="Body" Margin="5, 5, 5, 5" />
-                <Label Text="1.	WAIVER AND RELEASE:  I, the Volunteer, release and forever discharge and hold harmless the Parties from any and all liability, claims, and demands of whatever kind or nature, either in law or in equity, which arise or may hereafter arise as result of my participation in such Events.  I understand and acknowledge that this Release discharges from any liability or claim that I may have with respect to bodily injury, personal injury, illness, death, or property damage that may result from the Services I am providing by participating in the Event." FontSize="Body" Margin="5, 5, 5, 5" />
-                <Label Text="2.	INSURANCE:  I, the Volunteer, understand that none of the Parties assume any responsibility for or obligation to provide me with financial or other assistance, including but not limited to medical, health, or disability benefits or insurance of any nature in the event of my injury, illness, death or damage to my property.  I expressly waive any such claim for compensation or liability from the Parties." FontSize="Body" Margin="5, 5, 5, 5" />
-                <Label Text="3.	MEDICAL TREATMENT:  I, the Volunteer, do hereby release and forever discharge the Parties from any claim whatsoever which arises or may hereafter arise on account of any first aid, treatment, or service rendered by any person in connection with an emergency during my tenure as a volunteer during the course of an Event." FontSize="Body" Margin="5, 5, 5, 5" />
-                <Label Text="4.	ASSUMPTION OF THE RISK:  I, the Volunteer, acknowledge that there are potential hazards (“Hazards”), known and unknown, involved in the Event. The term “Hazards” is intended to be used in its broadest sense and includes, but is not limited to natural hazards (land, weather, etc.) and man-made hazards (concrete, steel, etc.). I understand and acknowledge that participation may include Hazards that could harm me, and that such Hazards may or may not always be obvious.  I hereby expressly and specifically assume the risk of injury or harm for all such Hazards." FontSize="Body" Margin="5, 5, 5, 5" />
-                <Label Text="5.	PHOTOGRAPHIC RELEASE: I, the Volunteer, grant and convey to the Parties all right, title, and interest in any and all photographs, images, video, and audio in connection with my providing volunteer services at Events." FontSize="Body" />
-                <Label Text="6.	OTHER:  I, the Volunteer, expressly agrees that this Release is intended to be as broad and inclusive as permitted by law. I agree that in the event that any clause or provision of this Release shall be held to be invalid by any court of competent jurisdiction, the validity of the remaining provisions of this Release shall continue to be enforceable." FontSize="Body" Margin="5, 5, 5, 5" />
+                <!-- Intro -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="In order to create or participate in TrashMob.eco events, you must agree to a liability waiver. Please click the Sign Waiver button below."
+                               FontSize="Small" />
+                        <Label Text="You will only need to sign this waiver once unless we have to change the legalese."
+                               FontSize="Micro"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
 
-                <HorizontalStackLayout Grid.Row="1" Grid.Column="1" Padding="10,10,0,0">
-                    <CheckBox x:Name="Agreed" IsChecked="False"  />
-                    <Label Text="I HAVE READ THIS RELEASE AND WAIVER FORM" Style="{StaticResource FieldLabel}" />
-                </HorizontalStackLayout>
+                <!-- Waiver Text -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="TrashMob.eco Volunteer Release"
+                               FontFamily="LexendSemibold"
+                               FontSize="Medium"
+                               HorizontalTextAlignment="Center"
+                               HorizontalOptions="Center" />
+                        <Label Text="and Waiver of Liability Form"
+                               FontFamily="LexendSemibold"
+                               FontSize="Medium"
+                               HorizontalTextAlignment="Center"
+                               HorizontalOptions="Center" />
+                        <Label Text="THE VOLUNTEER RELEASE AND WAIVER OF LIABILITY FORM (&quot;RELEASE&quot;)"
+                               FontSize="Small"
+                               FontAttributes="Bold" />
+                        <Label Text="(&quot;VOLUNTEER&quot;) HEREBY RELEASES TRASHMOB.ECO, ITS OFFICERS AND DIRECTORS, ANY LAND OWNERS AND MANAGERS, AND ALL RELATED SPONSORS (&quot;PARTIES&quot;) JOINTLY AND SEVERALLY, AND INDIVIDUALLY."
+                               FontSize="Small"
+                               FontAttributes="Bold" />
+                        <Label Text="The Volunteer desires to provide volunteer services and to participate in activities related to serving as a volunteer for events facilitated by TrashMob.eco.  Volunteer services (&quot;Services&quot;) will be broadly defined as picking up trash at TrashMob.eco facilitated events (&quot;Events&quot;). The above Volunteer hereby agrees as follows: "
+                               FontSize="Small" />
+                        <Label Text="1.	WAIVER AND RELEASE:  I, the Volunteer, release and forever discharge and hold harmless the Parties from any and all liability, claims, and demands of whatever kind or nature, either in law or in equity, which arise or may hereafter arise as result of my participation in such Events.  I understand and acknowledge that this Release discharges from any liability or claim that I may have with respect to bodily injury, personal injury, illness, death, or property damage that may result from the Services I am providing by participating in the Event."
+                               FontSize="Small" />
+                        <Label Text="2.	INSURANCE:  I, the Volunteer, understand that none of the Parties assume any responsibility for or obligation to provide me with financial or other assistance, including but not limited to medical, health, or disability benefits or insurance of any nature in the event of my injury, illness, death or damage to my property.  I expressly waive any such claim for compensation or liability from the Parties."
+                               FontSize="Small" />
+                        <Label Text="3.	MEDICAL TREATMENT:  I, the Volunteer, do hereby release and forever discharge the Parties from any claim whatsoever which arises or may hereafter arise on account of any first aid, treatment, or service rendered by any person in connection with an emergency during my tenure as a volunteer during the course of an Event."
+                               FontSize="Small" />
+                        <Label Text="4.	ASSUMPTION OF THE RISK:  I, the Volunteer, acknowledge that there are potential hazards (&quot;Hazards&quot;), known and unknown, involved in the Event. The term &quot;Hazards&quot; is intended to be used in its broadest sense and includes, but is not limited to natural hazards (land, weather, etc.) and man-made hazards (concrete, steel, etc.). I understand and acknowledge that participation may include Hazards that could harm me, and that such Hazards may or may not always be obvious.  I hereby expressly and specifically assume the risk of injury or harm for all such Hazards."
+                               FontSize="Small" />
+                        <Label Text="5.	PHOTOGRAPHIC RELEASE: I, the Volunteer, grant and convey to the Parties all right, title, and interest in any and all photographs, images, video, and audio in connection with my providing volunteer services at Events."
+                               FontSize="Small" />
+                        <Label Text="6.	OTHER:  I, the Volunteer, expressly agrees that this Release is intended to be as broad and inclusive as permitted by law. I agree that in the event that any clause or provision of this Release shall be held to be invalid by any court of competent jurisdiction, the validity of the remaining provisions of this Release shall continue to be enforceable."
+                               FontSize="Small" />
+                    </VerticalStackLayout>
+                </Border>
 
-                <Label
-                    Text="Thank you!" FontSize="Micro"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Center"
-                    HorizontalTextAlignment="Center" />
+                <!-- Agreement -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0,10,10">
+                    <VerticalStackLayout Spacing="8">
+                        <HorizontalStackLayout Spacing="4">
+                            <CheckBox x:Name="Agreed" IsChecked="False" />
+                            <Label Text="I HAVE READ THIS RELEASE AND WAIVER FORM"
+                                   Style="{StaticResource FieldLabel}"
+                                   VerticalOptions="Center" />
+                        </HorizontalStackLayout>
+                        <Button Text="Sign Waiver"
+                                Command="{Binding SignWaiverCommand}"
+                                IsEnabled="{Binding Source={x:Reference Agreed}, Path=IsChecked}"
+                                Style="{StaticResource PrimaryLargeButton}" />
+                    </VerticalStackLayout>
+                </Border>
 
-                <Button Text="Sign Waiver" Command="{Binding SignWaiverCommand}" IsEnabled="{Binding Source={x:Reference Agreed}, Path=IsChecked }" />
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Services/IUserManager.cs
+++ b/TrashMobMobile/Services/IUserManager.cs
@@ -1,7 +1,6 @@
 ﻿namespace TrashMobMobile.Services
 {
     using TrashMob.Models;
-    using TrashMobMobile.Authentication;
 
     public interface IUserManager
     {
@@ -9,7 +8,7 @@
 
         Task<User> GetUserAsync(string userId, CancellationToken cancellationToken = default);
 
-        Task<User> GetUserByEmailAsync(string email, UserContext userContext,
+        Task<User> GetUserByEmailAsync(string email,
             CancellationToken cancellationToken = default);
 
         Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default);

--- a/TrashMobMobile/Services/IUserRestService.cs
+++ b/TrashMobMobile/Services/IUserRestService.cs
@@ -1,13 +1,12 @@
 ﻿namespace TrashMobMobile.Services
 {
     using TrashMob.Models;
-    using TrashMobMobile.Authentication;
 
     public interface IUserRestService
     {
         Task<User> GetUserAsync(string userId, CancellationToken cancellationToken = default);
 
-        Task<User> GetUserByEmailAsync(string email, UserContext userContext,
+        Task<User> GetUserByEmailAsync(string email,
             CancellationToken cancellationToken = default);
 
         Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default);

--- a/TrashMobMobile/Services/RestServiceBase.cs
+++ b/TrashMobMobile/Services/RestServiceBase.cs
@@ -1,7 +1,6 @@
 ﻿namespace TrashMobMobile.Services
 {
     using System.Text.Json;
-    using TrashMobMobile.Authentication;
     using TrashMobMobile.Config;
 
     public abstract class RestServiceBase(IHttpClientFactory httpClientFactory)
@@ -23,8 +22,6 @@
                 var authorizedHttpClient = httpClientFactory.CreateClient("ServerAPI");
 
                 authorizedHttpClient.BaseAddress = new Uri(string.Concat(TrashMobApiAddress, Controller));
-                authorizedHttpClient.DefaultRequestHeaders.Add("Accept", "application/json, text/plain");
-                authorizedHttpClient.DefaultRequestHeaders.Authorization = GetAuthToken(UserState.UserContext);
 
                 return authorizedHttpClient;
             }
@@ -39,17 +36,6 @@
                 anonymousHttpClient.DefaultRequestHeaders.Add("Accept", "application/json, text/plain");
                 return anonymousHttpClient;
             }
-        }
-
-        protected virtual System.Net.Http.Headers.AuthenticationHeaderValue? GetAuthToken(UserContext userContext)
-        {
-            if (string.IsNullOrWhiteSpace(userContext.AccessToken))
-            {
-                return null;
-            }
-
-            return new System.Net.Http.Headers
-                .AuthenticationHeaderValue("bearer", userContext.AccessToken);
         }
     }
 }

--- a/TrashMobMobile/Services/UserManager.cs
+++ b/TrashMobMobile/Services/UserManager.cs
@@ -1,7 +1,6 @@
 ﻿namespace TrashMobMobile.Services
 {
     using TrashMob.Models;
-    using TrashMobMobile.Authentication;
 
     public class UserManager : IUserManager
     {
@@ -23,10 +22,10 @@
             return userRestService.GetUserAsync(userId, cancellationToken);
         }
 
-        public Task<User> GetUserByEmailAsync(string email, UserContext userContext,
+        public Task<User> GetUserByEmailAsync(string email,
             CancellationToken cancellationToken = default)
         {
-            return userRestService.GetUserByEmailAsync(email, userContext, cancellationToken);
+            return userRestService.GetUserByEmailAsync(email, cancellationToken);
         }
 
         public Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default)

--- a/TrashMobMobile/Services/UserRestService.cs
+++ b/TrashMobMobile/Services/UserRestService.cs
@@ -1,10 +1,8 @@
 ﻿namespace TrashMobMobile.Services;
 
-using System.Diagnostics;
 using System.Net.Http.Json;
 using Newtonsoft.Json;
 using TrashMob.Models;
-using TrashMobMobile.Authentication;
 
 public class UserRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IUserRestService
 {
@@ -23,20 +21,12 @@ public class UserRestService(IHttpClientFactory httpClientFactory) : RestService
         }
     }
 
-    public async Task<User> GetUserByEmailAsync(string email, UserContext userContext,
+    public async Task<User> GetUserByEmailAsync(string email,
         CancellationToken cancellationToken = default)
     {
-        var localHttpClient = new HttpClient
-        {
-            BaseAddress = new Uri(string.Concat(TrashMobApiAddress, Controller)),
-        };
-
-        localHttpClient.DefaultRequestHeaders.Authorization = GetAuthToken(userContext);
-        localHttpClient.DefaultRequestHeaders.Add("Accept", "application/json, text/plain");
-
         var requestUri = Controller + "/getuserbyemail/" + email;
 
-        using (var response = await localHttpClient.GetAsync(requestUri, cancellationToken))
+        using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/TrashMobMobile/ViewModels/ImpactViewModel.cs
+++ b/TrashMobMobile/ViewModels/ImpactViewModel.cs
@@ -34,6 +34,7 @@ public partial class ImpactViewModel(
             TotalEvents = stats.TotalEvents,
             TotalBags = stats.TotalBags,
             TotalHours = stats.TotalHours,
+            TotalWeightInPounds = stats.TotalWeightInPounds,
             TotalLitterReportsSubmitted = stats.TotalLitterReportsSubmitted,
             TotalLitterReportsClosed = stats.TotalLitterReportsClosed,
         };
@@ -61,6 +62,7 @@ public partial class ImpactViewModel(
             TotalEvents = stats.TotalEvents,
             TotalBags = stats.TotalBags,
             TotalHours = stats.TotalHours,
+            TotalWeightInPounds = stats.TotalWeightInPounds,
             TotalLitterReportsSubmitted = stats.TotalLitterReportsSubmitted,
             TotalLitterReportsClosed = stats.TotalLitterReportsClosed,
         };

--- a/TrashMobMobile/ViewModels/MainViewModel.cs
+++ b/TrashMobMobile/ViewModels/MainViewModel.cs
@@ -99,7 +99,7 @@ public partial class MainViewModel(IAuthService authService,
             if (signedIn.Succeeded)
             {
                 var email = authService.GetUserEmail();
-                var user = await userRestService.GetUserByEmailAsync(email, UserState.UserContext);
+                var user = await userRestService.GetUserByEmailAsync(email);
 
                 WelcomeMessage = $"Welcome, {user.UserName}!";
 

--- a/TrashMobMobile/ViewModels/ProfileViewModel.cs
+++ b/TrashMobMobile/ViewModels/ProfileViewModel.cs
@@ -253,6 +253,7 @@ public partial class ProfileViewModel(
         {
             StartDate = DateTimeOffset.UtcNow.AddYears(-1),
             EndDate = DateTimeOffset.UtcNow,
+            CreatedByUserId = userManager.CurrentUser.Id,
         };
 
         var reports = await litterReportManager.GetLitterReportsAsync(filter, ImageSizeEnum.Thumb, true);

--- a/TrashMobMobile/ViewModels/StatisticsViewModel.cs
+++ b/TrashMobMobile/ViewModels/StatisticsViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMobMobile.ViewModels;
+namespace TrashMobMobile.ViewModels;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -23,5 +23,14 @@ public partial class StatisticsViewModel : ObservableObject
     private int totalLitterReportsSubmitted;
 
     [ObservableProperty]
-    private int totalWeightInPounds;
+    private decimal totalWeightInPounds;
+
+    public string TotalWeightDisplay => TotalWeightInPounds > 0
+        ? $"{TotalWeightInPounds:N0} lbs"
+        : "0 lbs";
+
+    partial void OnTotalWeightInPoundsChanged(decimal value)
+    {
+        OnPropertyChanged(nameof(TotalWeightDisplay));
+    }
 }


### PR DESCRIPTION
## Summary

- **Fix mobile auth token refresh**: Replaced `BaseAddressAuthorizationMessageHandler` with `AuthHandler` in the HTTP pipeline so expired tokens are refreshed via MSAL instead of reusing the static login token. This was causing 401 errors on all authenticated API calls after ~1 hour.
- **Fix newsletter controller auth**: Added `ValidUser` policy to `NewsletterPreferencesController` (was using bare `[Authorize]` which skips the handler that sets `HttpContext.Items["UserId"]`, causing NullReferenceException / 500 errors).
- **Fix auth handler null-safety**: Added null-conditional operators in 7 of 8 auth handlers to prevent `NullReferenceException` when neither `ClaimTypes.Email` nor `"email"` claim is present in the token.
- **Continue mobile UI consistency**: Card styling for remaining pages (ViewCommunity, Waiver, ManageEventPartners, EditEventPartnerLocationServices, Profile, CancelEvent, ViewLitterReport, ViewEventSummary, SearchEvents, ViewTeam).
- **Impact page redesign**: Added weight stat with tile layout grid, consistent card styling.
- **Profile page fixes**: Fixed litter reports showing all users' reports (added `CreatedByUserId` filter), removed Sign Waiver button from settings, added travel radius circle on location preference map.

## Test plan

- [ ] Log into mobile app, navigate to Leaderboards page — should load without errors
- [ ] Navigate to Newsletter Preferences — should show categories (requires server deploy)
- [ ] Wait >1 hour and verify authenticated API calls still work (token refresh)
- [ ] Check all restyled pages for consistent card layout
- [ ] Verify Impact page shows weight stat with correct formatting
- [ ] Verify Profile page only shows user's own litter reports
- [ ] Verify waiver button is removed from profile settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)