### PR TITLE
Replace == null / != null with is null / is not null pattern matching

### DIFF
--- a/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
+++ b/TrashMob.Shared/Engine/EventSummaryHostReminderWeekNotifier.cs
@@ -73,7 +73,7 @@
                         .GetAsync(es => es.EventId == mobEvent.Id, cancellationToken).ConfigureAwait(false);
 
                     // Only send an email if the summary has not been completed.
-                    if (eventSummary?.FirstOrDefault() == null)
+                    if (eventSummary?.FirstOrDefault() is null)
                     {
                         // Add to the event list to be sent
                         eventsToNotifyUserFor.Add(mobEvent);

--- a/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
+++ b/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
@@ -74,7 +74,7 @@ namespace TrashMob.Shared.Engine
                 foreach (var report in recentReports)
                 {
                     var firstImage = report.LitterImages?.FirstOrDefault();
-                    if (firstImage == null || !firstImage.Latitude.HasValue || !firstImage.Longitude.HasValue)
+                    if (firstImage is null || !firstImage.Latitude.HasValue || !firstImage.Longitude.HasValue)
                     {
                         continue;
                     }
@@ -130,7 +130,7 @@ namespace TrashMob.Shared.Engine
                 var reportListHtml = string.Join("", reports.Take(5).Select(r =>
                 {
                     var firstImage = r.LitterImages?.FirstOrDefault();
-                    var location = firstImage != null
+                    var location = firstImage is not null
                         ? $"{firstImage.City}, {firstImage.Region}"
                         : "Unknown location";
                     var url = $"{baseUrl}/litterreports/{r.Id}";

--- a/TrashMob.Shared/Managers/ActiveDirectoryManager.cs
+++ b/TrashMob.Shared/Managers/ActiveDirectoryManager.cs
@@ -44,7 +44,7 @@ namespace TrashMob.Shared.Managers
             var response = await DoesUserExist(activeDirectoryNewUserRequest.userName,
                 activeDirectoryNewUserRequest.email, cancellationToken);
 
-            if (response != null)
+            if (response is not null)
             {
                 return response;
             }
@@ -69,7 +69,7 @@ namespace TrashMob.Shared.Managers
         {
             var user = await userManager.GetUserByObjectIdAsync(objectId, cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 var response = new ActiveDirectoryValidationFailedResponse
                 {
@@ -124,7 +124,7 @@ namespace TrashMob.Shared.Managers
             var response = await DoesUserExist(activeDirectoryValidateNewUserRequest.userName,
                 activeDirectoryValidateNewUserRequest.email, cancellationToken);
 
-            if (response != null)
+            if (response is not null)
             {
                 return response;
             }
@@ -158,7 +158,7 @@ namespace TrashMob.Shared.Managers
             var originalUser = await userManager
                 .GetUserByObjectIdAsync(activeDirectoryUpdateUserProfileRequest.objectId, cancellationToken);
 
-            if (originalUser == null)
+            if (originalUser is null)
             {
                 var response = new ActiveDirectoryValidationFailedResponse
                 {
@@ -173,7 +173,7 @@ namespace TrashMob.Shared.Managers
             var checkUser = await userManager
                 .GetUserByUserNameAsync(activeDirectoryUpdateUserProfileRequest.userName, CancellationToken.None);
 
-            if (checkUser != null && checkUser.ObjectId != activeDirectoryUpdateUserProfileRequest.objectId)
+            if (checkUser is not null && checkUser.ObjectId != activeDirectoryUpdateUserProfileRequest.objectId)
             {
                 var response = new ActiveDirectoryValidationFailedResponse
                 {
@@ -214,7 +214,7 @@ namespace TrashMob.Shared.Managers
             var originalUser = await userManager
                 .GetUserByObjectIdAsync(activeDirectoryUpdateUserProfileRequest.objectId, cancellationToken);
 
-            if (originalUser == null)
+            if (originalUser is null)
             {
                 var response = new ActiveDirectoryValidationFailedResponse
                 {
@@ -244,7 +244,7 @@ namespace TrashMob.Shared.Managers
         {
             var originalUser = await userManager.GetUserByEmailAsync(email, cancellationToken);
 
-            if (originalUser != null)
+            if (originalUser is not null)
             {
                 var response = new ActiveDirectoryValidationFailedResponse
                 {
@@ -258,7 +258,7 @@ namespace TrashMob.Shared.Managers
 
             var checkUser = await userManager.GetUserByUserNameAsync(userName, CancellationToken.None);
 
-            if (checkUser != null)
+            if (checkUser is not null)
             {
                 var response = new ActiveDirectoryValidationFailedResponse
                 {

--- a/TrashMob.Shared/Managers/Adoptions/TeamAdoptionEventManager.cs
+++ b/TrashMob.Shared/Managers/Adoptions/TeamAdoptionEventManager.cs
@@ -32,7 +32,7 @@ namespace TrashMob.Shared.Managers.Adoptions
         {
             // Validate adoption exists and is approved
             var adoption = await adoptionManager.GetAsync(teamAdoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return ServiceResult<TeamAdoptionEvent>.Failure("Adoption not found.");
             }
@@ -44,7 +44,7 @@ namespace TrashMob.Shared.Managers.Adoptions
 
             // Validate event exists
             var evt = await eventManager.GetAsync(eventId, cancellationToken);
-            if (evt == null)
+            if (evt is null)
             {
                 return ServiceResult<TeamAdoptionEvent>.Failure("Event not found.");
             }
@@ -83,7 +83,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             CancellationToken cancellationToken = default)
         {
             var adoptionEvent = await GetAsync(teamAdoptionEventId, cancellationToken);
-            if (adoptionEvent == null)
+            if (adoptionEvent is null)
             {
                 return ServiceResult<bool>.Failure("Adoption event link not found.");
             }
@@ -152,7 +152,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             CancellationToken cancellationToken = default)
         {
             var adoption = await adoptionManager.GetAsync(teamAdoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return;
             }
@@ -164,7 +164,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             // Update tracking fields
             adoption.EventCount = eventsList.Count;
             adoption.LastEventDate = eventsList
-                .Where(ae => ae.Event != null)
+                .Where(ae => ae.Event is not null)
                 .Select(ae => ae.Event.EventDate)
                 .OrderByDescending(d => d)
                 .FirstOrDefault();

--- a/TrashMob.Shared/Managers/Adoptions/TeamAdoptionManager.cs
+++ b/TrashMob.Shared/Managers/Adoptions/TeamAdoptionManager.cs
@@ -36,14 +36,14 @@ namespace TrashMob.Shared.Managers.Adoptions
         {
             // Validate team exists and is active
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return ServiceResult<TeamAdoption>.Failure("Team not found or is inactive.");
             }
 
             // Validate area exists, is active, and is available
             var area = await adoptableAreaManager.GetAsync(adoptableAreaId, cancellationToken);
-            if (area == null || !area.IsActive)
+            if (area is null || !area.IsActive)
             {
                 return ServiceResult<TeamAdoption>.Failure("Adoptable area not found or is inactive.");
             }
@@ -89,7 +89,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             CancellationToken cancellationToken = default)
         {
             var adoption = await Repo.GetAsync(adoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return ServiceResult<TeamAdoption>.Failure("Adoption application not found.");
             }
@@ -109,7 +109,7 @@ namespace TrashMob.Shared.Managers.Adoptions
 
             // Update area status if not allowing co-adoption
             var area = await adoptableAreaManager.GetAsync(adoption.AdoptableAreaId, cancellationToken);
-            if (area != null && !area.AllowCoAdoption)
+            if (area is not null && !area.AllowCoAdoption)
             {
                 area.Status = "Adopted";
                 area.LastUpdatedByUserId = reviewedByUserId;
@@ -132,7 +132,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             CancellationToken cancellationToken = default)
         {
             var adoption = await Repo.GetAsync(adoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return ServiceResult<TeamAdoption>.Failure("Adoption application not found.");
             }
@@ -393,7 +393,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             var subject = $"Adoption Approved: {area.Name}";
 
             var recipients = leadList
-                .Where(l => l.User != null && !string.IsNullOrWhiteSpace(l.User.Email))
+                .Where(l => l.User is not null && !string.IsNullOrWhiteSpace(l.User.Email))
                 .Select(l => new EmailAddress { Name = l.User.UserName ?? l.User.Email, Email = l.User.Email })
                 .ToList();
 
@@ -443,7 +443,7 @@ namespace TrashMob.Shared.Managers.Adoptions
             var subject = $"Adoption Application Update: {area.Name}";
 
             var recipients = leadList
-                .Where(l => l.User != null && !string.IsNullOrWhiteSpace(l.User.Email))
+                .Where(l => l.User is not null && !string.IsNullOrWhiteSpace(l.User.Email))
                 .Select(l => new EmailAddress { Name = l.User.UserName ?? l.User.Email, Email = l.User.Email })
                 .ToList();
 

--- a/TrashMob.Shared/Managers/Areas/AreaFileParser.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaFileParser.cs
@@ -210,7 +210,7 @@ namespace TrashMob.Shared.Managers.Areas
 
                 // Extract ExtendedData
                 var extData = placemark.Element(ns + "ExtendedData");
-                if (extData != null)
+                if (extData is not null)
                 {
                     foreach (var data in extData.Elements(ns + "Data"))
                     {
@@ -240,7 +240,7 @@ namespace TrashMob.Shared.Managers.Areas
                 var polygon = placemark.Descendants(ns + "Polygon").FirstOrDefault();
                 var lineString = placemark.Descendants(ns + "LineString").FirstOrDefault();
 
-                if (polygon != null)
+                if (polygon is not null)
                 {
                     var coords = ParseKmlCoordinates(
                         polygon.Descendants(ns + "coordinates").FirstOrDefault()?.Value);
@@ -257,7 +257,7 @@ namespace TrashMob.Shared.Managers.Areas
                             $"Feature '{name ?? "unnamed"}' skipped: polygon has fewer than 3 coordinates.");
                     }
                 }
-                else if (lineString != null)
+                else if (lineString is not null)
                 {
                     var coords = ParseKmlCoordinates(
                         lineString.Descendants(ns + "coordinates").FirstOrDefault()?.Value);
@@ -278,7 +278,7 @@ namespace TrashMob.Shared.Managers.Areas
                 {
                     // Check for Point — we skip these with a warning
                     var point = placemark.Descendants(ns + "Point").FirstOrDefault();
-                    if (point != null)
+                    if (point is not null)
                     {
                         feature.IsValid = false;
                         feature.ValidationErrors.Add(
@@ -304,7 +304,7 @@ namespace TrashMob.Shared.Managers.Areas
             var kmlEntry = archive.Entries
                 .FirstOrDefault(e => e.FullName.EndsWith(".kml", StringComparison.OrdinalIgnoreCase));
 
-            if (kmlEntry == null)
+            if (kmlEntry is null)
             {
                 result.Error = "KMZ file does not contain a .kml file.";
                 return;
@@ -352,7 +352,7 @@ namespace TrashMob.Shared.Managers.Areas
                     var feature = new AreaImportFeature();
 
                     // Extract attributes as properties
-                    if (ntsFeature.Attributes != null)
+                    if (ntsFeature.Attributes is not null)
                     {
                         foreach (var attrName in ntsFeature.Attributes.GetNames())
                         {
@@ -362,7 +362,7 @@ namespace TrashMob.Shared.Managers.Areas
                     }
 
                     // Convert geometry to GeoJSON
-                    if (ntsFeature.Geometry != null)
+                    if (ntsFeature.Geometry is not null)
                     {
                         var geomType = ntsFeature.Geometry.GeometryType;
 

--- a/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
@@ -69,7 +69,7 @@ namespace TrashMob.Shared.Managers.Areas
             {
                 // Step 1: Ask Claude to interpret the description
                 var claudeResponse = await GetClaudeInterpretation(apiKey, request, cancellationToken);
-                if (claudeResponse == null)
+                if (claudeResponse is null)
                 {
                     return new AreaSuggestionResult { Message = "Could not interpret the area description. Try being more specific." };
                 }
@@ -192,7 +192,7 @@ namespace TrashMob.Shared.Managers.Areas
         {
             List<(double Lat, double Lon)> coordinates = [];
 
-            if (queries == null || queries.Count == 0)
+            if (queries is null || queries.Count == 0)
             {
                 return coordinates;
             }
@@ -204,7 +204,7 @@ namespace TrashMob.Shared.Managers.Areas
                     var rawJson = await mapManager.SearchAddressAsync(query.Address);
                     var searchResult = JsonSerializer.Deserialize<AzureMapsSearchResponse>(rawJson, JsonOptions);
 
-                    if (searchResult?.Results != null && searchResult.Results.Count > 0)
+                    if (searchResult?.Results is not null && searchResult.Results.Count > 0)
                     {
                         var topResult = searchResult.Results[0];
                         coordinates.Add((topResult.Position.Lat, topResult.Position.Lon));

--- a/TrashMob.Shared/Managers/Communities/CommunityManager.cs
+++ b/TrashMob.Shared/Managers/Communities/CommunityManager.cs
@@ -130,7 +130,7 @@ namespace TrashMob.Shared.Managers.Communities
         public async Task<IEnumerable<Event>> GetCommunityEventsAsync(string slug, bool upcomingOnly = true, CancellationToken cancellationToken = default)
         {
             var community = await GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return Enumerable.Empty<Event>();
             }
@@ -173,7 +173,7 @@ namespace TrashMob.Shared.Managers.Communities
         public async Task<IEnumerable<Team>> GetCommunityTeamsAsync(string slug, double radiusMiles = 50, CancellationToken cancellationToken = default)
         {
             var community = await GetBySlugAsync(slug, cancellationToken);
-            if (community == null || !community.Latitude.HasValue || !community.Longitude.HasValue)
+            if (community is null || !community.Latitude.HasValue || !community.Longitude.HasValue)
             {
                 return Enumerable.Empty<Team>();
             }
@@ -191,7 +191,7 @@ namespace TrashMob.Shared.Managers.Communities
         public async Task<IEnumerable<LitterReport>> GetCommunityLitterReportsAsync(string slug, CancellationToken cancellationToken = default)
         {
             var community = await GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return Enumerable.Empty<LitterReport>();
             }
@@ -220,7 +220,7 @@ namespace TrashMob.Shared.Managers.Communities
 
             // Get unique litter reports from the images
             var litterReportIds = litterImages
-                .Where(li => li.LitterReport != null)
+                .Where(li => li.LitterReport is not null)
                 .Select(li => li.LitterReportId)
                 .Distinct()
                 .ToList();
@@ -237,7 +237,7 @@ namespace TrashMob.Shared.Managers.Communities
             var stats = new Stats();
 
             var community = await GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return stats;
             }
@@ -344,7 +344,7 @@ namespace TrashMob.Shared.Managers.Communities
         public async Task<Partner> UpdateCommunityContentAsync(Partner community, Guid userId, CancellationToken cancellationToken = default)
         {
             var existing = await partnerRepository.GetAsync(community.Id, cancellationToken);
-            if (existing == null)
+            if (existing is null)
             {
                 return null;
             }
@@ -380,7 +380,7 @@ namespace TrashMob.Shared.Managers.Communities
         public async Task<CommunityDashboard> GetCommunityDashboardAsync(Guid partnerId, CancellationToken cancellationToken = default)
         {
             var community = await partnerRepository.GetAsync(partnerId, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return null;
             }
@@ -497,7 +497,7 @@ namespace TrashMob.Shared.Managers.Communities
                 var litterImages = await litterQuery.ToListAsync(cancellationToken);
 
                 var openLitterReportIds = litterImages
-                    .Where(li => li.LitterReport != null && li.LitterReport.LitterReportStatusId == (int)LitterReportStatusEnum.New)
+                    .Where(li => li.LitterReport is not null && li.LitterReport.LitterReportStatusId == (int)LitterReportStatusEnum.New)
                     .Select(li => li.LitterReportId)
                     .Distinct()
                     .ToList();

--- a/TrashMob.Shared/Managers/EmailInviteManager.cs
+++ b/TrashMob.Shared/Managers/EmailInviteManager.cs
@@ -88,7 +88,7 @@ namespace TrashMob.Shared.Managers
                 .Include(b => b.Invites)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (batch == null)
+            if (batch is null)
             {
                 throw new ArgumentException("Batch not found.", nameof(batchId));
             }

--- a/TrashMob.Shared/Managers/EventPhotoManager.cs
+++ b/TrashMob.Shared/Managers/EventPhotoManager.cs
@@ -116,7 +116,7 @@ namespace TrashMob.Shared.Managers
             CancellationToken cancellationToken = default)
         {
             var photo = await GetAsync(photoId, cancellationToken);
-            if (photo == null)
+            if (photo is null)
             {
                 return null;
             }
@@ -134,7 +134,7 @@ namespace TrashMob.Shared.Managers
             CancellationToken cancellationToken = default)
         {
             var photo = await GetAsync(photoId, cancellationToken);
-            if (photo == null)
+            if (photo is null)
             {
                 return false;
             }
@@ -157,7 +157,7 @@ namespace TrashMob.Shared.Managers
             CancellationToken cancellationToken = default)
         {
             var photo = await GetAsync(photoId, cancellationToken);
-            if (photo == null)
+            if (photo is null)
             {
                 return false;
             }
@@ -213,7 +213,7 @@ namespace TrashMob.Shared.Managers
             CancellationToken cancellationToken = default)
         {
             var photo = await GetAsync(photoId, cancellationToken);
-            if (photo == null)
+            if (photo is null)
             {
                 return null;
             }
@@ -242,7 +242,7 @@ namespace TrashMob.Shared.Managers
             CancellationToken cancellationToken = default)
         {
             var photo = await GetAsync(photoId, cancellationToken);
-            if (photo == null)
+            if (photo is null)
             {
                 return null;
             }

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -100,14 +100,14 @@ namespace TrashMob.Shared.Managers.Events
             var attendee = await Repository.Get(ea => ea.EventId == eventId && ea.UserId == userId)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (attendee != null && attendee.IsEventLead)
+            if (attendee is not null && attendee.IsEventLead)
             {
                 return true;
             }
 
             // Also check if user is the event creator (they're always considered a lead)
             var evt = await eventRepository.GetAsync(eventId, cancellationToken);
-            return evt != null && evt.CreatedByUserId == userId;
+            return evt is not null && evt.CreatedByUserId == userId;
         }
 
         /// <inheritdoc />
@@ -134,7 +134,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Include(ea => ea.User)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (attendee == null)
+            if (attendee is null)
             {
                 throw new InvalidOperationException("User is not an attendee of this event.");
             }
@@ -172,7 +172,7 @@ namespace TrashMob.Shared.Managers.Events
                 .Include(ea => ea.User)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (attendee == null)
+            if (attendee is null)
             {
                 throw new InvalidOperationException("User is not an attendee of this event.");
             }
@@ -202,7 +202,7 @@ namespace TrashMob.Shared.Managers.Events
             }
 
             var evt = await eventRepository.GetAsync(eventId, cancellationToken);
-            if (evt == null)
+            if (evt is null)
             {
                 return;
             }

--- a/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
@@ -33,7 +33,7 @@ namespace TrashMob.Shared.Managers.Events
         {
             // Validate event exists
             var eventEntity = await eventManager.GetAsync(eventId, cancellationToken);
-            if (eventEntity == null)
+            if (eventEntity is null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Event not found.");
             }
@@ -50,7 +50,7 @@ namespace TrashMob.Shared.Managers.Events
             // Check for existing submission
             var existingMetrics = await GetMyMetricsAsync(eventId, userId, cancellationToken);
 
-            if (existingMetrics != null)
+            if (existingMetrics is not null)
             {
                 // Update existing submission if still pending
                 if (existingMetrics.Status != EventAttendeeMetricsStatus.Pending)
@@ -138,7 +138,7 @@ namespace TrashMob.Shared.Managers.Events
             CancellationToken cancellationToken = default)
         {
             var metrics = await Repo.GetAsync(metricsId, cancellationToken);
-            if (metrics == null)
+            if (metrics is null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Metrics submission not found.");
             }
@@ -166,7 +166,7 @@ namespace TrashMob.Shared.Managers.Events
             CancellationToken cancellationToken = default)
         {
             var metrics = await Repo.GetAsync(metricsId, cancellationToken);
-            if (metrics == null)
+            if (metrics is null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Metrics submission not found.");
             }
@@ -196,7 +196,7 @@ namespace TrashMob.Shared.Managers.Events
             CancellationToken cancellationToken = default)
         {
             var metrics = await Repo.GetAsync(metricsId, cancellationToken);
-            if (metrics == null)
+            if (metrics is null)
             {
                 return ServiceResult<EventAttendeeMetrics>.Failure("Metrics submission not found.");
             }
@@ -390,7 +390,7 @@ namespace TrashMob.Shared.Managers.Events
                 }
 
                 // Add to contributors list (all approved metrics are public by default)
-                if (metrics.User != null)
+                if (metrics.User is not null)
                 {
                     summary.Contributors.Add(new PublicAttendeeMetrics
                     {
@@ -475,7 +475,7 @@ namespace TrashMob.Shared.Managers.Events
                 }
 
                 // Add event breakdown
-                if (metrics.Event != null)
+                if (metrics.Event is not null)
                 {
                     stats.EventBreakdown.Add(new UserEventMetricsSummary
                     {

--- a/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
@@ -124,7 +124,7 @@ namespace TrashMob.Shared.Managers.Events
         {
             var route = await Repo.GetAsync(routeId, cancellationToken);
 
-            if (route == null)
+            if (route is null)
             {
                 return ServiceResult<EventAttendeeRoute>.Failure("Route not found.");
             }
@@ -151,7 +151,7 @@ namespace TrashMob.Shared.Managers.Events
             route.BagsCollected = request.BagsCollected;
             route.WeightCollected = request.WeightCollected;
 
-            if (route.PrivacyLevel == "Public" && route.ExpiresDate == null)
+            if (route.PrivacyLevel == "Public" && route.ExpiresDate is null)
             {
                 route.ExpiresDate = DateTimeOffset.UtcNow.AddYears(2);
             }

--- a/TrashMob.Shared/Managers/Events/EventSummaryManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventSummaryManager.cs
@@ -48,7 +48,7 @@ namespace TrashMob.Shared.Managers.Events
                 })
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (aggregates != null)
+            if (aggregates is not null)
             {
                 stats.TotalBags = aggregates.TotalBags + aggregates.TotalBuckets / 3;
                 stats.TotalHours = aggregates.TotalHoursMinutes / 60;
@@ -92,7 +92,7 @@ namespace TrashMob.Shared.Managers.Events
                 elr => eventIdsList.Contains(elr.EventId), cancellationToken);
 
             stats.TotalLitterReportsClosed = eventLitterReports.Count(elr =>
-                elr.LitterReport != null &&
+                elr.LitterReport is not null &&
                 elr.LitterReport.LitterReportStatusId == (int)LitterReportStatusEnum.Cleaned);
 
             stats.TotalLitterReportsSubmitted = await litterReportManager.GetUserLitterReportCountAsync(userId, cancellationToken);
@@ -195,7 +195,7 @@ namespace TrashMob.Shared.Managers.Events
 
             foreach (var eventLitterReport in eventLitterReports)
             {
-                if (eventLitterReport.LitterReport != null &&
+                if (eventLitterReport.LitterReport is not null &&
                     eventLitterReport.LitterReport.LitterReportStatusId != (int)LitterReportStatusEnum.Cleaned)
                 {
                     // Update the litter report status to Cleaned

--- a/TrashMob.Shared/Managers/Gamification/AchievementManager.cs
+++ b/TrashMob.Shared/Managers/Gamification/AchievementManager.cs
@@ -134,7 +134,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .Where(ua => ua.UserId == userId && ua.AchievementTypeId == achievementTypeId)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (existingAchievement != null)
+            if (existingAchievement is not null)
             {
                 return false; // Already earned
             }

--- a/TrashMob.Shared/Managers/Gamification/LeaderboardManager.cs
+++ b/TrashMob.Shared/Managers/Gamification/LeaderboardManager.cs
@@ -126,7 +126,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .Select(u => new { u.ShowOnLeaderboards })
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 return new UserRankResponse
                 {
@@ -167,7 +167,7 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.LocationScope == "Global")
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (userEntry == null)
+            if (userEntry is null)
             {
                 // User not ranked - check why
                 var eventCount = await GetUserEventCountAsync(userId, timeRange, cancellationToken);
@@ -354,7 +354,7 @@ namespace TrashMob.Shared.Managers.Gamification
                 .Select(t => new { t.Name, t.IsActive })
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (team == null)
+            if (team is null)
             {
                 return new TeamRankResponse
                 {
@@ -398,7 +398,7 @@ namespace TrashMob.Shared.Managers.Gamification
                     && l.LocationScope == "Global")
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (teamEntry == null)
+            if (teamEntry is null)
             {
                 // Team not ranked - check why
                 var eventCount = await GetTeamEventCountAsync(teamId, timeRange, cancellationToken);

--- a/TrashMob.Shared/Managers/IFTTT/QueriesManager.cs
+++ b/TrashMob.Shared/Managers/IFTTT/QueriesManager.cs
@@ -22,7 +22,7 @@
         public async Task<List<IftttEventResponse>> GetEventsQueryDataAsync(QueriesRequest queryRequest, Guid userId,
             CancellationToken cancellationToken)
         {
-            if (queryRequest == null)
+            if (queryRequest is null)
             {
                 throw new ArgumentNullException(nameof(queryRequest));
             }
@@ -31,7 +31,7 @@
             var trigger = Repository.Get(t => t.TriggerId == queryRequest.trigger_identity).FirstOrDefault();
 
             // Store Trigger in database if it does not exist
-            if (trigger == null)
+            if (trigger is null)
             {
                 trigger = new IftttTrigger
                 {
@@ -55,7 +55,7 @@
             IQueryable<Event> events;
 
             // Return all events
-            if (eventFields == null)
+            if (eventFields is null)
             {
                 events = eventRepository.Get();
             }

--- a/TrashMob.Shared/Managers/IFTTT/TriggersManager.cs
+++ b/TrashMob.Shared/Managers/IFTTT/TriggersManager.cs
@@ -24,7 +24,7 @@
         public async Task<List<IftttEventResponse>> GetEventsTriggerDataAsync(TriggersRequest triggersRequest,
             Guid userId, CancellationToken cancellationToken)
         {
-            if (triggersRequest == null)
+            if (triggersRequest is null)
             {
                 throw new ArgumentNullException(nameof(triggersRequest));
             }
@@ -33,7 +33,7 @@
             var trigger = Repository.Get(t => t.TriggerId == triggersRequest.trigger_identity).FirstOrDefault();
 
             // Store Trigger in database if it does not exist
-            if (trigger == null)
+            if (trigger is null)
             {
                 trigger = new IftttTrigger
                 {
@@ -57,7 +57,7 @@
             IQueryable<Event> events;
 
             // Return all events
-            if (eventFields == null)
+            if (eventFields is null)
             {
                 events = eventRepository.Get();
             }
@@ -103,7 +103,7 @@
         /// <inheritdoc />
         public object ValidateRequest(TriggersRequest triggersRequest, EventRequestType eventRequestType)
         {
-            if (triggersRequest?.triggerFields == null)
+            if (triggersRequest?.triggerFields is null)
             {
                 var error = new
                 {
@@ -121,7 +121,7 @@
 
             var eventFields = JsonSerializer.Deserialize<IftttEventRequest>(triggersRequest.triggerFields.ToString());
 
-            if (eventRequestType >= EventRequestType.ByCountry && eventFields.country == null)
+            if (eventRequestType >= EventRequestType.ByCountry && eventFields.country is null)
             {
                 var error = new
                 {
@@ -137,7 +137,7 @@
                 return error;
             }
 
-            if (eventRequestType >= EventRequestType.ByRegion && eventFields.region == null)
+            if (eventRequestType >= EventRequestType.ByRegion && eventFields.region is null)
             {
                 var error = new
                 {
@@ -153,7 +153,7 @@
                 return error;
             }
 
-            if (eventRequestType >= EventRequestType.ByCity && eventFields.city == null)
+            if (eventRequestType >= EventRequestType.ByCity && eventFields.city is null)
             {
                 var error = new
                 {
@@ -169,7 +169,7 @@
                 return error;
             }
 
-            if (eventRequestType >= EventRequestType.ByPostalCode && eventFields.postal_code == null)
+            if (eventRequestType >= EventRequestType.ByPostalCode && eventFields.postal_code is null)
             {
                 var error = new
                 {

--- a/TrashMob.Shared/Managers/ImageManager.cs
+++ b/TrashMob.Shared/Managers/ImageManager.cs
@@ -44,7 +44,7 @@ namespace TrashMob.Shared.Managers
         /// <inheritdoc />
         public async Task UploadImageAsync(ImageUpload imageUpload)
         {
-            if (imageUpload?.FormFile == null)
+            if (imageUpload?.FormFile is null)
             {
                 throw new ArgumentNullException(nameof(imageUpload));
             }
@@ -65,7 +65,7 @@ namespace TrashMob.Shared.Managers
             var fileName = $"{imageUpload.ParentId}-{imageUpload.ImageType}-{ImageSizeEnum.Raw}-{fileTime}{Path.GetExtension(imageUpload.FormFile?.FileName)}".ToLower();
 
             // Upload the raw file
-            if (imageUpload.FormFile == null)
+            if (imageUpload.FormFile is null)
             {
                 throw new ArgumentException("ImageUpload FormFile cannot be null");
             }
@@ -115,7 +115,7 @@ namespace TrashMob.Shared.Managers
         {
             var imageName = await GetImageNameAsync(parentId, imageType);
 
-            if (imageName == null)
+            if (imageName is null)
             {
                 return false;
             }

--- a/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterImageManager.cs
@@ -36,7 +36,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         public override async Task<LitterImage> UpdateAsync(LitterImage instance, Guid userId,
             CancellationToken cancellationToken = default)
         {
-            if (instance == null)
+            if (instance is null)
             {
                 return null;
             }
@@ -49,7 +49,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             var litterImage = await GetAsync(id, cancellationToken);
 
-            if (litterImage == null)
+            if (litterImage is null)
             {
                 return -1;
             }

--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -35,7 +35,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             try
             {
-                if (litterReport.LitterImages == null || litterReport.LitterImages.Count == 0)
+                if (litterReport.LitterImages is null || litterReport.LitterImages.Count == 0)
                 {
                     return null;
                 }
@@ -46,7 +46,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                     .Include(l => l.LitterImages)
                     .FirstOrDefault();
 
-                if (existingInstance == null)
+                if (existingInstance is null)
                 {
                     return null;
                 }
@@ -89,7 +89,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                 var resultLitterReport = await base.UpdateAsync(existingInstance, userId, cancellationToken);
 
                 // Send notification to creator if status changed to Cleaned
-                if (statusChangedToCleaned && resultLitterReport != null)
+                if (statusChangedToCleaned && resultLitterReport is not null)
                 {
                     await SendLitterReportCleanedNotificationAsync(resultLitterReport, cancellationToken);
                 }
@@ -108,7 +108,7 @@ namespace TrashMob.Shared.Managers.LitterReport
             try
             {
                 var creator = await userManager.GetUserByInternalIdAsync(litterReport.CreatedByUserId, cancellationToken);
-                if (creator == null || string.IsNullOrWhiteSpace(creator.Email))
+                if (creator is null || string.IsNullOrWhiteSpace(creator.Email))
                 {
                     logger.LogWarning("Could not find creator for litter report {LitterReportId} to send cleaned notification", litterReport.Id);
                     return;
@@ -156,7 +156,7 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             try
             {
-                if (litterReport.LitterImages == null || litterReport.LitterImages.Count == 0)
+                if (litterReport.LitterImages is null || litterReport.LitterImages.Count == 0)
                 {
                     return null;
                 }
@@ -177,7 +177,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                 // Add litter report
                 var newLitterReport = await base.AddAsync(litterReport, userId, cancellationToken);
 
-                if (newLitterReport == null)
+                if (newLitterReport is null)
                 {
                     return null;
                 }
@@ -225,7 +225,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                 await dbTransaction.BeginTransactionAsync();
 
                 var instance = await Repo.GetAsync(id, cancellationToken);
-                if (instance == null)
+                if (instance is null)
                 {
                     return -1;
                 }
@@ -361,7 +361,7 @@ namespace TrashMob.Shared.Managers.LitterReport
             var existingInstance =
                 await Repo.GetWithNoTrackingAsync(instance.Id, cancellationToken);
 
-            if (existingInstance == null)
+            if (existingInstance is null)
             {
                 return null;
             }
@@ -394,12 +394,12 @@ namespace TrashMob.Shared.Managers.LitterReport
         public async Task<ServiceResult<LitterReport>> AddWithResultAsync(LitterReport litterReport, Guid userId,
             CancellationToken cancellationToken = default)
         {
-            if (litterReport == null)
+            if (litterReport is null)
             {
                 return ServiceResult<LitterReport>.Failure("Litter report cannot be null.");
             }
 
-            if (litterReport.LitterImages == null || litterReport.LitterImages.Count == 0)
+            if (litterReport.LitterImages is null || litterReport.LitterImages.Count == 0)
             {
                 return ServiceResult<LitterReport>.Failure("Litter report must include at least one image.");
             }
@@ -427,7 +427,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                 // Add litter report
                 var newLitterReport = await base.AddAsync(litterReport, userId, cancellationToken);
 
-                if (newLitterReport == null)
+                if (newLitterReport is null)
                 {
                     await dbTransaction.RollbackTransactionAsync();
                     return ServiceResult<LitterReport>.Failure("Failed to save litter report to the database.");

--- a/TrashMob.Shared/Managers/MapManager.cs
+++ b/TrashMob.Shared/Managers/MapManager.cs
@@ -124,7 +124,7 @@ namespace TrashMob.Shared.Managers
         {
             var azureMaps = new AzureMapsToolkit.AzureMapsServices(GetMapKey());
 
-            if (azureMaps == null)
+            if (azureMaps is null)
             {
                 logger.LogError("Failed to get instance of azuremaps.");
                 throw new Exception("Failed to get instance of azuremaps");
@@ -156,7 +156,7 @@ namespace TrashMob.Shared.Managers
         {
             var azureMaps = new AzureMapsToolkit.AzureMapsServices(GetMapKey());
 
-            if (azureMaps == null)
+            if (azureMaps is null)
             {
                 logger.LogError("Failed to get instance of azuremaps.");
                 throw new Exception("Failed to get instance of azuremaps");

--- a/TrashMob.Shared/Managers/NewsletterManager.cs
+++ b/TrashMob.Shared/Managers/NewsletterManager.cs
@@ -57,7 +57,7 @@ namespace TrashMob.Shared.Managers
         public async Task<Newsletter> ScheduleNewsletterAsync(Guid newsletterId, DateTimeOffset scheduledDate, Guid userId, CancellationToken cancellationToken = default)
         {
             var newsletter = await GetAsync(newsletterId, cancellationToken);
-            if (newsletter == null)
+            if (newsletter is null)
             {
                 throw new InvalidOperationException($"Newsletter {newsletterId} not found.");
             }
@@ -83,7 +83,7 @@ namespace TrashMob.Shared.Managers
                 .Include(n => n.Category)
                 .FirstOrDefaultAsync(n => n.Id == newsletterId, cancellationToken);
 
-            if (newsletter == null)
+            if (newsletter is null)
             {
                 throw new InvalidOperationException($"Newsletter {newsletterId} not found.");
             }
@@ -132,7 +132,7 @@ namespace TrashMob.Shared.Managers
                     var community = await dbContext.Partners
                         .FirstOrDefaultAsync(p => p.Id == newsletter.TargetId.Value, cancellationToken);
 
-                    if (community == null)
+                    if (community is null)
                     {
                         return Enumerable.Empty<User>();
                     }
@@ -159,7 +159,7 @@ namespace TrashMob.Shared.Managers
         public async Task UpdateStatisticsAsync(Guid newsletterId, int deliveredCount, int openCount, int clickCount, int bounceCount, int unsubscribeCount, CancellationToken cancellationToken = default)
         {
             var newsletter = await dbContext.Newsletters.FindAsync(new object[] { newsletterId }, cancellationToken);
-            if (newsletter == null)
+            if (newsletter is null)
             {
                 return;
             }
@@ -180,7 +180,7 @@ namespace TrashMob.Shared.Managers
                 .Include(n => n.Category)
                 .FirstOrDefaultAsync(n => n.Id == newsletterId, cancellationToken);
 
-            if (newsletter == null)
+            if (newsletter is null)
             {
                 throw new InvalidOperationException($"Newsletter {newsletterId} not found.");
             }

--- a/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerAdminInvitationManager.cs
@@ -53,7 +53,7 @@ namespace TrashMob.Shared.Managers.Partners
             var existingUser = await userManager.GetUserByEmailAsync(instance.Email, cancellationToken);
             var partner = await partnerManager.GetAsync(instance.PartnerId, cancellationToken);
 
-            if (existingInvitation != null)
+            if (existingInvitation is not null)
             {
                 if (existingInvitation.InvitationStatusId == (int)InvitationStatusEnum.Accepted)
                 {
@@ -67,7 +67,7 @@ namespace TrashMob.Shared.Managers.Partners
             {
                 instance.InvitationStatusId = (int)InvitationStatusEnum.New;
 
-                if (existingUser != null)
+                if (existingUser is not null)
                 {
                     // Check to see if this Admin already exists in the system (without an invite since they were created prior to invites).
                     var partners =
@@ -83,7 +83,7 @@ namespace TrashMob.Shared.Managers.Partners
                 await base.AddAsync(instance, userId, cancellationToken);
             }
 
-            if (existingUser == null)
+            if (existingUser is null)
             {
                 var welcomeMessage =
                     emailManager.GetHtmlEmailCopy(NotificationTypeEnum.InviteNewUserToBePartnerAdmin.ToString());
@@ -147,7 +147,7 @@ namespace TrashMob.Shared.Managers.Partners
             var partnerAdminInvitation = await Repository.Get(pa => pa.Id == partnerAdminInviationId)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (partnerAdminInvitation == null)
+            if (partnerAdminInvitation is null)
             {
                 return;
             }
@@ -170,7 +170,7 @@ namespace TrashMob.Shared.Managers.Partners
             var partnerAdminInvitation = await Repository.Get(pa => pa.Id == partnerAdminInviationId)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (partnerAdminInvitation == null)
+            if (partnerAdminInvitation is null)
             {
                 return;
             }
@@ -188,7 +188,7 @@ namespace TrashMob.Shared.Managers.Partners
             var existingUser = await userManager.GetUserByEmailAsync(instance.Email, cancellationToken);
             var partner = await partnerManager.GetAsync(instance.PartnerId, cancellationToken);
 
-            if (existingUser == null)
+            if (existingUser is null)
             {
                 var welcomeMessage =
                     emailManager.GetHtmlEmailCopy(NotificationTypeEnum.InviteNewUserToBePartnerAdmin.ToString());

--- a/TrashMob.Shared/Managers/PhotoModerationManager.cs
+++ b/TrashMob.Shared/Managers/PhotoModerationManager.cs
@@ -582,7 +582,7 @@ namespace TrashMob.Shared.Managers
                     .Include(i => i.CreatedByUser)
                     .FirstOrDefaultAsync(i => i.Id == photoId, cancellationToken);
 
-                if (image != null)
+                if (image is not null)
                 {
                     uploaderName = image.CreatedByUser?.UserName ?? "Unknown";
                     uploaderEmail = image.CreatedByUser?.Email ?? "Unknown";
@@ -596,7 +596,7 @@ namespace TrashMob.Shared.Managers
                     .Include(p => p.UploadedByUser)
                     .FirstOrDefaultAsync(p => p.Id == photoId, cancellationToken);
 
-                if (photo != null)
+                if (photo is not null)
                 {
                     uploaderName = photo.UploadedByUser?.UserName ?? "Unknown";
                     uploaderEmail = photo.UploadedByUser?.Email ?? "Unknown";
@@ -610,7 +610,7 @@ namespace TrashMob.Shared.Managers
                     .Include(p => p.UploadedByUser)
                     .FirstOrDefaultAsync(p => p.Id == photoId, cancellationToken);
 
-                if (photo != null)
+                if (photo is not null)
                 {
                     uploaderName = photo.UploadedByUser?.UserName ?? "Unknown";
                     uploaderEmail = photo.UploadedByUser?.Email ?? "Unknown";
@@ -624,7 +624,7 @@ namespace TrashMob.Shared.Managers
                     .Include(p => p.UploadedByUser)
                     .FirstOrDefaultAsync(p => p.Id == photoId, cancellationToken);
 
-                if (photo != null)
+                if (photo is not null)
                 {
                     uploaderName = photo.UploadedByUser?.UserName ?? "Unknown";
                     uploaderEmail = photo.UploadedByUser?.Email ?? "Unknown";

--- a/TrashMob.Shared/Managers/PickupLocationManager.cs
+++ b/TrashMob.Shared/Managers/PickupLocationManager.cs
@@ -90,7 +90,7 @@ namespace TrashMob.Shared.Managers
             var partnerLocation =
                 await eventPartnerLocationServiceManager.GetHaulingPartnerLocationForEvent(eventId, cancellationToken);
 
-            if (partnerLocation == null)
+            if (partnerLocation is null)
             {
                 // Todo add error handling for this
                 return;

--- a/TrashMob.Shared/Managers/Prospects/CommunityProspectManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/CommunityProspectManager.cs
@@ -40,7 +40,7 @@ namespace TrashMob.Shared.Managers.Prospects
         {
             var prospect = await Repo.GetAsync(id, cancellationToken);
 
-            if (prospect == null)
+            if (prospect is null)
             {
                 return null;
             }

--- a/TrashMob.Shared/Managers/Prospects/CsvImportManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/CsvImportManager.cs
@@ -119,7 +119,7 @@ namespace TrashMob.Shared.Managers.Prospects
 
                     // Calculate and persist FitScore
                     var breakdown = await scoringManager.CalculateFitScoreAsync(added.Id, cancellationToken);
-                    if (breakdown != null && breakdown.TotalScore != 0)
+                    if (breakdown is not null && breakdown.TotalScore != 0)
                     {
                         added.FitScore = breakdown.TotalScore;
                         added.LastUpdatedByUserId = userId;

--- a/TrashMob.Shared/Managers/Prospects/ProspectActivityManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectActivityManager.cs
@@ -40,7 +40,7 @@ namespace TrashMob.Shared.Managers.Prospects
             if (string.Equals(instance.ActivityType, "Reply", StringComparison.OrdinalIgnoreCase))
             {
                 var prospect = await prospectRepository.GetAsync(instance.ProspectId, cancellationToken);
-                if (prospect != null)
+                if (prospect is not null)
                 {
                     var advanced = false;
 

--- a/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
@@ -30,7 +30,7 @@ namespace TrashMob.Shared.Managers.Prospects
             CancellationToken cancellationToken = default)
         {
             var prospect = await prospectRepository.GetAsync(request.ProspectId, cancellationToken);
-            if (prospect == null)
+            if (prospect is null)
             {
                 return new ProspectConversionResult { Success = false, ErrorMessage = "Prospect not found." };
             }

--- a/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
@@ -35,7 +35,7 @@ namespace TrashMob.Shared.Managers.Prospects
             CancellationToken cancellationToken = default)
         {
             var prospect = await prospectRepository.GetAsync(prospectId, cancellationToken);
-            if (prospect == null)
+            if (prospect is null)
             {
                 return new OutreachPreview { ProspectId = prospectId, Subject = "Prospect not found" };
             }
@@ -70,7 +70,7 @@ namespace TrashMob.Shared.Managers.Prospects
             }
 
             var prospect = await prospectRepository.GetAsync(prospectId, cancellationToken);
-            if (prospect == null)
+            if (prospect is null)
             {
                 return new OutreachSendResult { Success = false, ErrorMessage = "Prospect not found." };
             }

--- a/TrashMob.Shared/Managers/Prospects/ProspectScoringManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectScoringManager.cs
@@ -30,7 +30,7 @@ namespace TrashMob.Shared.Managers.Prospects
         {
             var prospect = await prospectRepository.GetAsync(prospectId, cancellationToken);
 
-            if (prospect == null)
+            if (prospect is null)
             {
                 return null;
             }

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCleanupLogManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCleanupLogManager.cs
@@ -66,7 +66,7 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
         {
             // Validate the sponsored adoption exists and is active
             var adoption = await sponsoredAdoptionRepository.GetAsync(log.SponsoredAdoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return ServiceResult<ProfessionalCleanupLog>.Failure("Sponsored adoption not found.");
             }

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCompanyUserManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/ProfessionalCompanyUserManager.cs
@@ -68,7 +68,7 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
             var entity = await Repository.Get(cu => cu.ProfessionalCompanyId == companyId && cu.UserId == userId, false)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (entity == null)
+            if (entity is null)
             {
                 return 0;
             }

--- a/TrashMob.Shared/Managers/SponsoredAdoptions/SponsoredAdoptionManager.cs
+++ b/TrashMob.Shared/Managers/SponsoredAdoptions/SponsoredAdoptionManager.cs
@@ -85,7 +85,7 @@ namespace TrashMob.Shared.Managers.SponsoredAdoptions
                     .OrderByDescending(l => l.CleanupDate)
                     .FirstOrDefault();
 
-                if (lastCleanup != null &&
+                if (lastCleanup is not null &&
                     (now - lastCleanup.CleanupDate).TotalDays <= adoption.CleanupFrequencyDays)
                 {
                     stats.AdoptionsOnSchedule++;

--- a/TrashMob.Shared/Managers/Teams/TeamMemberManager.cs
+++ b/TrashMob.Shared/Managers/Teams/TeamMemberManager.cs
@@ -79,7 +79,7 @@ namespace TrashMob.Shared.Managers.Teams
         public async Task<int> RemoveMemberAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default)
         {
             var member = await GetByTeamAndUserAsync(teamId, userId, cancellationToken);
-            if (member == null)
+            if (member is null)
             {
                 return 0;
             }
@@ -91,7 +91,7 @@ namespace TrashMob.Shared.Managers.Teams
         public async Task<TeamMember> PromoteToLeadAsync(Guid teamId, Guid userId, Guid promotedByUserId, CancellationToken cancellationToken = default)
         {
             var member = await GetByTeamAndUserAsync(teamId, userId, cancellationToken);
-            if (member == null)
+            if (member is null)
             {
                 throw new InvalidOperationException($"User {userId} is not a member of team {teamId}");
             }
@@ -107,7 +107,7 @@ namespace TrashMob.Shared.Managers.Teams
         public async Task<TeamMember> DemoteFromLeadAsync(Guid teamId, Guid userId, Guid demotedByUserId, CancellationToken cancellationToken = default)
         {
             var member = await GetByTeamAndUserAsync(teamId, userId, cancellationToken);
-            if (member == null)
+            if (member is null)
             {
                 throw new InvalidOperationException($"User {userId} is not a member of team {teamId}");
             }

--- a/TrashMob.Shared/Managers/UserFeedbackManager.cs
+++ b/TrashMob.Shared/Managers/UserFeedbackManager.cs
@@ -66,7 +66,7 @@ namespace TrashMob.Shared.Managers
         public async Task<UserFeedback> UpdateStatusAsync(Guid id, string status, string internalNotes, Guid reviewedByUserId, CancellationToken cancellationToken = default)
         {
             var feedback = await Repo.GetAsync(id, cancellationToken);
-            if (feedback == null)
+            if (feedback is null)
             {
                 return null;
             }

--- a/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
+++ b/TrashMob.Shared/Managers/UserNewsletterPreferenceManager.cs
@@ -34,7 +34,7 @@ namespace TrashMob.Shared.Managers
             var preference = await dbContext.UserNewsletterPreferences
                 .FirstOrDefaultAsync(p => p.UserId == userId && p.CategoryId == categoryId, cancellationToken);
 
-            if (preference == null)
+            if (preference is null)
             {
                 preference = new UserNewsletterPreference
                 {
@@ -152,7 +152,7 @@ namespace TrashMob.Shared.Managers
 
                 // Verify user exists
                 var user = await dbContext.Users.FindAsync(new object[] { userId }, cancellationToken);
-                if (user == null)
+                if (user is null)
                 {
                     return new UnsubscribeResult { Success = false, ErrorMessage = "User not found." };
                 }
@@ -177,7 +177,7 @@ namespace TrashMob.Shared.Managers
                     }
 
                     var category = await dbContext.NewsletterCategories.FindAsync(new object[] { categoryId }, cancellationToken);
-                    if (category == null)
+                    if (category is null)
                     {
                         return new UnsubscribeResult { Success = false, ErrorMessage = "Category not found." };
                     }

--- a/TrashMob.Shared/Managers/UserWaiverManager.cs
+++ b/TrashMob.Shared/Managers/UserWaiverManager.cs
@@ -85,7 +85,7 @@ namespace TrashMob.Shared.Managers
             // Combine and filter out already signed waivers
             List<WaiverVersion> requiredWaivers = [];
 
-            if (globalWaiver != null && !signedWaiverVersionIds.Contains(globalWaiver.Id))
+            if (globalWaiver is not null && !signedWaiverVersionIds.Contains(globalWaiver.Id))
             {
                 requiredWaivers.Add(globalWaiver);
             }
@@ -120,7 +120,7 @@ namespace TrashMob.Shared.Managers
 
             List<WaiverVersion> requiredWaivers = [];
 
-            if (globalWaiver != null && !signedWaiverVersionIds.Contains(globalWaiver.Id))
+            if (globalWaiver is not null && !signedWaiverVersionIds.Contains(globalWaiver.Id))
             {
                 requiredWaivers.Add(globalWaiver);
             }
@@ -166,7 +166,7 @@ namespace TrashMob.Shared.Managers
 
             // Get the waiver version
             var waiverVersion = await waiverVersionRepository.GetAsync(request.WaiverVersionId, cancellationToken);
-            if (waiverVersion == null)
+            if (waiverVersion is null)
             {
                 return ServiceResult<UserWaiver>.Failure("Waiver version not found.");
             }
@@ -194,7 +194,7 @@ namespace TrashMob.Shared.Managers
                     uw.ExpiryDate >= now)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (existingWaiver != null)
+            if (existingWaiver is not null)
             {
                 return ServiceResult<UserWaiver>.Failure("You have already signed this waiver version.");
             }
@@ -273,7 +273,7 @@ namespace TrashMob.Shared.Managers
             CancellationToken cancellationToken = default)
         {
             // Validate file
-            if (request.FormFile == null || request.FormFile.Length == 0)
+            if (request.FormFile is null || request.FormFile.Length == 0)
             {
                 return ServiceResult<UserWaiver>.Failure("No file was uploaded.");
             }
@@ -296,14 +296,14 @@ namespace TrashMob.Shared.Managers
 
             // Validate user exists
             var user = await userRepository.GetAsync(request.UserId, cancellationToken);
-            if (user == null)
+            if (user is null)
             {
                 return ServiceResult<UserWaiver>.Failure("User not found.");
             }
 
             // Validate waiver version exists and is active
             var waiverVersion = await waiverVersionRepository.GetAsync(request.WaiverVersionId, cancellationToken);
-            if (waiverVersion == null)
+            if (waiverVersion is null)
             {
                 return ServiceResult<UserWaiver>.Failure("Waiver version not found.");
             }
@@ -322,7 +322,7 @@ namespace TrashMob.Shared.Managers
                     uw.ExpiryDate >= now)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (existingWaiver != null)
+            if (existingWaiver is not null)
             {
                 return ServiceResult<UserWaiver>.Failure("User has already signed this waiver version.");
             }

--- a/TrashMob.Shared/Managers/WaiverDocumentManager.cs
+++ b/TrashMob.Shared/Managers/WaiverDocumentManager.cs
@@ -377,7 +377,7 @@ namespace TrashMob.Shared.Managers
         /// </summary>
         private static void RenderInlines(TextDescriptor text, ContainerInline container)
         {
-            if (container == null) return;
+            if (container is null) return;
 
             foreach (var inline in container)
             {

--- a/TrashMob.Shared/Managers/WaiverVersionManager.cs
+++ b/TrashMob.Shared/Managers/WaiverVersionManager.cs
@@ -85,7 +85,7 @@ namespace TrashMob.Shared.Managers
                 .Get(cw => cw.WaiverVersionId == waiverId && cw.CommunityId == communityId)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (existing != null)
+            if (existing is not null)
             {
                 throw new InvalidOperationException("This waiver is already assigned to this community.");
             }
@@ -112,7 +112,7 @@ namespace TrashMob.Shared.Managers
                 .Get(cw => cw.WaiverVersionId == waiverId && cw.CommunityId == communityId)
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (communityWaiver != null)
+            if (communityWaiver is not null)
             {
                 await communityWaiverRepository.DeleteAsync(communityWaiver);
             }
@@ -131,7 +131,7 @@ namespace TrashMob.Shared.Managers
         public async Task DeactivateAsync(Guid waiverId, Guid userId, CancellationToken cancellationToken = default)
         {
             var waiver = await Repo.GetAsync(waiverId, cancellationToken);
-            if (waiver == null)
+            if (waiver is null)
             {
                 throw new InvalidOperationException("Waiver not found.");
             }


### PR DESCRIPTION
## Summary
- Modernize null checks in Engine (2 files) and Managers (39 files) to use C# pattern matching: `is null` / `is not null`
- Expression tree lambdas (EF Core LINQ queries) retain `== null` / `!= null` as required by the C# compiler (`CS8122`)
- Purely mechanical replacement — 143 lines changed with identical logic

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442 tests pass
- [ ] Verify no runtime regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)