### PR TITLE
Replace == null / != null with is null / is not null in Controllers, Security, and DailyJobs

### DIFF
--- a/TrashMob/Controllers/AdoptableAreasController.cs
+++ b/TrashMob/Controllers/AdoptableAreasController.cs
@@ -39,7 +39,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetAreas(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -59,7 +59,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetAvailableAreas(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -80,7 +80,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetArea(Guid partnerId, Guid areaId, CancellationToken cancellationToken)
         {
             var area = await areaManager.GetAsync(areaId, cancellationToken);
-            if (area == null || area.PartnerId != partnerId)
+            if (area is null || area.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -131,7 +131,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -169,7 +169,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -226,7 +226,7 @@ namespace TrashMob.Controllers
             }
 
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -238,7 +238,7 @@ namespace TrashMob.Controllers
             }
 
             var existingArea = await areaManager.GetAsync(areaId, cancellationToken);
-            if (existingArea == null || existingArea.PartnerId != partnerId)
+            if (existingArea is null || existingArea.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -295,7 +295,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -305,7 +305,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            if (file == null || file.Length == 0)
+            if (file is null || file.Length == 0)
             {
                 return BadRequest("A file is required.");
             }
@@ -342,7 +342,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -352,7 +352,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            if (areas == null || areas.Count == 0)
+            if (areas is null || areas.Count == 0)
             {
                 return BadRequest("At least one area is required.");
             }
@@ -384,7 +384,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -396,7 +396,7 @@ namespace TrashMob.Controllers
             }
 
             var existingArea = await areaManager.GetAsync(areaId, cancellationToken);
-            if (existingArea == null || existingArea.PartnerId != partnerId)
+            if (existingArea is null || existingArea.PartnerId != partnerId)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/AdoptionEventsController.cs
+++ b/TrashMob/Controllers/AdoptionEventsController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetLinkedEvents(Guid adoptionId, CancellationToken cancellationToken)
         {
             var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return NotFound();
             }
@@ -75,7 +75,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return NotFound();
             }
@@ -121,7 +121,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/CommunitiesController.cs
+++ b/TrashMob/Controllers/CommunitiesController.cs
@@ -56,7 +56,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetCommunityBySlug(string slug, CancellationToken cancellationToken)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -101,7 +101,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -125,7 +125,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -147,7 +147,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -169,7 +169,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -222,7 +222,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var community = await communityManager.GetByIdAsync(communityId, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -253,7 +253,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var community = await communityManager.GetByIdAsync(communityId, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -285,13 +285,13 @@ namespace TrashMob.Controllers
             [FromBody] Partner community,
             CancellationToken cancellationToken = default)
         {
-            if (community == null || community.Id != communityId)
+            if (community is null || community.Id != communityId)
             {
                 return BadRequest("Community ID in URL must match the body.");
             }
 
             var existing = await communityManager.GetByIdAsync(communityId, cancellationToken);
-            if (existing == null)
+            if (existing is null)
             {
                 return NotFound();
             }
@@ -325,7 +325,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetCommunityPhotos(string slug, CancellationToken cancellationToken)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -353,7 +353,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -405,7 +405,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -417,7 +417,7 @@ namespace TrashMob.Controllers
             }
 
             var photo = await partnerPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.PartnerId != community.Id)
+            if (photo is null || photo.PartnerId != community.Id)
             {
                 return NotFound();
             }
@@ -448,7 +448,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
-            if (community == null)
+            if (community is null)
             {
                 return NotFound();
             }
@@ -460,7 +460,7 @@ namespace TrashMob.Controllers
             }
 
             var photo = await partnerPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.PartnerId != community.Id)
+            if (photo is null || photo.PartnerId != community.Id)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/CommunityAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunityAdoptionsController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetPendingApplications(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -66,7 +66,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetApprovedAdoptions(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -99,7 +99,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -140,7 +140,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -178,7 +178,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetDelinquentAdoptions(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -206,7 +206,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetComplianceStats(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -234,7 +234,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> ExportAdoptions(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/CommunityInvitesController.cs
+++ b/TrashMob/Controllers/CommunityInvitesController.cs
@@ -72,7 +72,7 @@ namespace TrashMob.Controllers
 
             var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
-            if (result == null || result.CommunityId != communityId)
+            if (result is null || result.CommunityId != communityId)
             {
                 return NotFound();
             }
@@ -105,7 +105,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            if (request == null || request.Emails == null || !request.Emails.Any())
+            if (request is null || request.Emails is null || !request.Emails.Any())
             {
                 return BadRequest("Email list is required.");
             }

--- a/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
+++ b/TrashMob/Controllers/CommunityProfessionalCompaniesController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetCompanies(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -67,7 +67,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetCompany(Guid partnerId, Guid companyId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -78,7 +78,7 @@ namespace TrashMob.Controllers
             }
 
             var company = await companyManager.GetAsync(companyId, cancellationToken);
-            if (company == null || company.PartnerId != partnerId)
+            if (company is null || company.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -105,7 +105,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -144,7 +144,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -155,7 +155,7 @@ namespace TrashMob.Controllers
             }
 
             var existing = await companyManager.GetAsync(companyId, cancellationToken);
-            if (existing == null || existing.PartnerId != partnerId)
+            if (existing is null || existing.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -189,7 +189,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -200,7 +200,7 @@ namespace TrashMob.Controllers
             }
 
             var company = await companyManager.GetAsync(companyId, cancellationToken);
-            if (company == null || company.PartnerId != partnerId)
+            if (company is null || company.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -233,7 +233,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -244,7 +244,7 @@ namespace TrashMob.Controllers
             }
 
             var company = await companyManager.GetAsync(companyId, cancellationToken);
-            if (company == null || company.PartnerId != partnerId)
+            if (company is null || company.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -268,7 +268,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetUsers(Guid partnerId, Guid companyId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -279,7 +279,7 @@ namespace TrashMob.Controllers
             }
 
             var company = await companyManager.GetAsync(companyId, cancellationToken);
-            if (company == null || company.PartnerId != partnerId)
+            if (company is null || company.PartnerId != partnerId)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/CommunityProspectsController.cs
+++ b/TrashMob/Controllers/CommunityProspectsController.cs
@@ -75,7 +75,7 @@ namespace TrashMob.Controllers
         {
             var prospect = await communityProspectManager.GetAsync(id, cancellationToken);
 
-            if (prospect == null)
+            if (prospect is null)
             {
                 return NotFound();
             }
@@ -136,7 +136,7 @@ namespace TrashMob.Controllers
         {
             var result = await communityProspectManager.UpdatePipelineStageAsync(id, request.Stage, UserId, cancellationToken);
 
-            if (result == null)
+            if (result is null)
             {
                 return NotFound();
             }
@@ -197,7 +197,7 @@ namespace TrashMob.Controllers
         {
             var breakdown = await prospectScoringManager.CalculateFitScoreAsync(id, cancellationToken);
 
-            if (breakdown == null)
+            if (breakdown is null)
             {
                 return NotFound();
             }
@@ -239,7 +239,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> ImportCsv(IFormFile file, CancellationToken cancellationToken)
         {
-            if (file == null || file.Length == 0)
+            if (file is null || file.Length == 0)
             {
                 return BadRequest("No file provided.");
             }

--- a/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
+++ b/TrashMob/Controllers/CommunitySponsoredAdoptionsController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetSponsoredAdoptions(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -67,7 +67,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetSponsoredAdoption(Guid partnerId, Guid id, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -78,7 +78,7 @@ namespace TrashMob.Controllers
             }
 
             var adoption = await adoptionManager.GetAsync(id, cancellationToken);
-            if (adoption == null)
+            if (adoption is null)
             {
                 return NotFound();
             }
@@ -105,7 +105,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -143,7 +143,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -154,7 +154,7 @@ namespace TrashMob.Controllers
             }
 
             var existing = await adoptionManager.GetAsync(id, cancellationToken);
-            if (existing == null)
+            if (existing is null)
             {
                 return NotFound();
             }
@@ -180,7 +180,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetComplianceStats(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/CommunitySponsorsController.cs
+++ b/TrashMob/Controllers/CommunitySponsorsController.cs
@@ -37,7 +37,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetSponsors(Guid partnerId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -66,7 +66,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetSponsor(Guid partnerId, Guid sponsorId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -77,7 +77,7 @@ namespace TrashMob.Controllers
             }
 
             var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
-            if (sponsor == null || sponsor.PartnerId != partnerId)
+            if (sponsor is null || sponsor.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -101,7 +101,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> CreateSponsor(Guid partnerId, [FromBody] Sponsor sponsor, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -140,7 +140,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -151,7 +151,7 @@ namespace TrashMob.Controllers
             }
 
             var existing = await sponsorManager.GetAsync(sponsorId, cancellationToken);
-            if (existing == null || existing.PartnerId != partnerId)
+            if (existing is null || existing.PartnerId != partnerId)
             {
                 return NotFound();
             }
@@ -179,7 +179,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> DeactivateSponsor(Guid partnerId, Guid sponsorId, CancellationToken cancellationToken)
         {
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -190,7 +190,7 @@ namespace TrashMob.Controllers
             }
 
             var existing = await sponsorManager.GetAsync(sponsorId, cancellationToken);
-            if (existing == null || existing.PartnerId != partnerId)
+            if (existing is null || existing.PartnerId != partnerId)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/ConfigController.cs
+++ b/TrashMob/Controllers/ConfigController.cs
@@ -91,7 +91,7 @@ namespace TrashMob.Controllers
                         deleteUser = deleteUserAuthority,
                         profileEdit = profileEditAuthority,
                     },
-                    scopes = b2cDomain != null
+                    scopes = b2cDomain is not null
                         ? new[]
                         {
                             $"https://{b2cDomain}/api/TrashMob.Read",
@@ -133,7 +133,7 @@ namespace TrashMob.Controllers
                     clientId = entraFrontendClientId,
                     authorityDomain,
                     authority,
-                    scopes = entraDomain != null
+                    scopes = entraDomain is not null
                         ? new[]
                         {
                             $"https://{entraDomain}/api/TrashMob.Read",

--- a/TrashMob/Controllers/EmailInvitesController.cs
+++ b/TrashMob/Controllers/EmailInvitesController.cs
@@ -55,7 +55,7 @@ namespace TrashMob.Controllers
         {
             var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
-            if (result == null)
+            if (result is null)
             {
                 return NotFound();
             }
@@ -80,7 +80,7 @@ namespace TrashMob.Controllers
             [FromBody] CreateEmailInviteBatchRequest request,
             CancellationToken cancellationToken = default)
         {
-            if (request == null || request.Emails == null || !request.Emails.Any())
+            if (request is null || request.Emails is null || !request.Emails.Any())
             {
                 return BadRequest("Email list is required.");
             }

--- a/TrashMob/Controllers/EventAttendeeMetricsController.cs
+++ b/TrashMob/Controllers/EventAttendeeMetricsController.cs
@@ -37,7 +37,7 @@ namespace TrashMob.Controllers
         {
             var metrics = await metricsManager.GetMyMetricsAsync(eventId, UserId, cancellationToken);
 
-            if (metrics == null)
+            if (metrics is null)
             {
                 return NotFound();
             }
@@ -86,7 +86,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetAllMetrics(Guid eventId, CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -114,7 +114,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetPendingMetrics(Guid eventId, CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -147,7 +147,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -188,7 +188,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -229,7 +229,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -276,7 +276,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> ApproveAllPending(Guid eventId, CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -310,7 +310,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetTotals(Guid eventId, CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -337,7 +337,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetPublicMetrics(Guid eventId, CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/EventAttendeeRoutesController.cs
+++ b/TrashMob/Controllers/EventAttendeeRoutesController.cs
@@ -85,7 +85,7 @@ namespace TrashMob.Controllers
         {
             var result = await eventAttendeeRouteManager.GetAsync(x => x.Id == id, cancellationToken);
 
-            if (result == null || result.Count() == 0)
+            if (result is null || result.Count() == 0)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/EventAttendeesController.cs
+++ b/TrashMob/Controllers/EventAttendeesController.cs
@@ -262,7 +262,7 @@ namespace TrashMob.Controllers
             var attendee = await eventAttendeeManager
                 .GetAsync(ea => ea.EventId == eventId && ea.UserId == userId, cancellationToken);
 
-            return attendee?.FirstOrDefault() != null;
+            return attendee?.FirstOrDefault() is not null;
         }
     }
 

--- a/TrashMob/Controllers/EventLitterReportController.cs
+++ b/TrashMob/Controllers/EventLitterReportController.cs
@@ -140,7 +140,7 @@ namespace TrashMob.Controllers
             var litterReport = await eventLitterReportManager
                 .GetAsync(ea => ea.EventId == eventId && ea.LitterReportId == litterReportId, cancellationToken);
 
-            return litterReport?.FirstOrDefault() != null;
+            return litterReport?.FirstOrDefault() is not null;
         }
 
         private async Task<IEnumerable<FullEventLitterReport>> ToFullEventLitterReports(IEnumerable<EventLitterReport> eventLitterReports, CancellationToken cancellationToken)

--- a/TrashMob/Controllers/EventPartnerLocationServicesController.cs
+++ b/TrashMob/Controllers/EventPartnerLocationServicesController.cs
@@ -89,7 +89,7 @@ namespace TrashMob.Controllers
         {
             var mobEvent = await eventManager.GetAsync(eventPartnerLocationService.EventId, cancellationToken);
 
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -126,7 +126,7 @@ namespace TrashMob.Controllers
         {
             var partner = await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationId, cancellationToken);
 
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -134,7 +134,7 @@ namespace TrashMob.Controllers
             var eventPartnerLocationServices =
                 await eventPartnerLocationServiceManager.GetCurrentPartnersAsync(eventId, cancellationToken);
 
-            if (eventPartnerLocationServices == null || !eventPartnerLocationServices.Any(epls =>
+            if (eventPartnerLocationServices is null || !eventPartnerLocationServices.Any(epls =>
                     epls.ServiceTypeId == serviceId && epls.PartnerLocationId == partnerLocationId))
             {
                 return NotFound();
@@ -177,7 +177,7 @@ namespace TrashMob.Controllers
         {
             var partner = await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationId, cancellationToken);
 
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -185,7 +185,7 @@ namespace TrashMob.Controllers
             var eventPartnerLocationServices =
                 await eventPartnerLocationServiceManager.GetCurrentPartnersAsync(eventId, cancellationToken);
 
-            if (eventPartnerLocationServices == null || !eventPartnerLocationServices.Any(epls =>
+            if (eventPartnerLocationServices is null || !eventPartnerLocationServices.Any(epls =>
                     epls.ServiceTypeId == serviceId && epls.PartnerLocationId == partnerLocationId))
             {
                 return NotFound();
@@ -226,7 +226,7 @@ namespace TrashMob.Controllers
         {
             var mobEvent = await eventManager.GetAsync(eventPartnerLocationService.EventId, cancellationToken);
 
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -263,7 +263,7 @@ namespace TrashMob.Controllers
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
 
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/EventPhotosController.cs
+++ b/TrashMob/Controllers/EventPhotosController.cs
@@ -40,7 +40,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound("Event not found");
             }
@@ -70,7 +70,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetPhoto(Guid eventId, Guid photoId, CancellationToken cancellationToken)
         {
             var photo = await eventPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.EventId != eventId)
+            if (photo is null || photo.EventId != eventId)
             {
                 return NotFound("Photo not found");
             }
@@ -97,14 +97,14 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound("Event not found");
             }
 
             // Check if user is event lead or attendee
             var isLead = mobEvent.CreatedByUserId == UserId;
-            var isAttendee = await eventAttendeeManager.GetAsync(eventId, UserId, cancellationToken) != null;
+            var isAttendee = await eventAttendeeManager.GetAsync(eventId, UserId, cancellationToken) is not null;
 
             if (!isLead && !isAttendee)
             {
@@ -163,7 +163,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var photo = await eventPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.EventId != eventId)
+            if (photo is null || photo.EventId != eventId)
             {
                 return NotFound("Photo not found");
             }
@@ -206,7 +206,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var photo = await eventPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.EventId != eventId)
+            if (photo is null || photo.EventId != eventId)
             {
                 return NotFound("Photo not found");
             }
@@ -247,7 +247,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var photo = await eventPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.EventId != eventId)
+            if (photo is null || photo.EventId != eventId)
             {
                 return NotFound("Photo not found");
             }

--- a/TrashMob/Controllers/EventSummariesController.cs
+++ b/TrashMob/Controllers/EventSummariesController.cs
@@ -32,7 +32,7 @@ namespace TrashMob.Controllers
             var eventSummary =
                 (await eventSummaryManager.GetAsync(es => es.EventId == eventId, cancellationToken)).FirstOrDefault();
 
-            if (eventSummary != null)
+            if (eventSummary is not null)
             {
                 return Ok(eventSummary);
             }
@@ -52,7 +52,7 @@ namespace TrashMob.Controllers
             var eventSummary =
                 (await eventSummaryManager.GetAsync(es => es.EventId == eventId, cancellationToken)).FirstOrDefault();
 
-            if (eventSummary == null)
+            if (eventSummary is null)
             {
                 eventSummary = new EventSummary
                 {

--- a/TrashMob/Controllers/EventsController.cs
+++ b/TrashMob/Controllers/EventsController.cs
@@ -165,7 +165,7 @@ namespace TrashMob.Controllers
         {
             var mobEvent = await eventManager.GetAsync(id, cancellationToken);
 
-            if (mobEvent == null)
+            if (mobEvent is null)
             {
                 return NotFound();
             }
@@ -186,7 +186,7 @@ namespace TrashMob.Controllers
         {
             var result = await eventManager.GetFilteredEventsAsync(filter, cancellationToken);
 
-            if (filter.PageSize != null)
+            if (filter.PageSize is not null)
             {
                 var pagedResults = result.OrderByDescending(e => e.EventDate).Skip(filter.PageIndex.GetValueOrDefault(0) * filter.PageSize.GetValueOrDefault(10))
                     .Take(filter.PageSize.GetValueOrDefault(10)).ToList();
@@ -214,7 +214,7 @@ namespace TrashMob.Controllers
 
             var allResults = result1.Union(result2, new EventComparer());
 
-            if (filter.PageSize != null)
+            if (filter.PageSize is not null)
             {
                 var pagedResults = PaginatedList<Event>.Create(allResults.OrderByDescending(e => e.EventDate).AsQueryable(),
                                        filter.PageIndex.GetValueOrDefault(0), filter.PageSize.GetValueOrDefault(10));
@@ -237,7 +237,7 @@ namespace TrashMob.Controllers
         {
             var result = await eventManager.GetFilteredEventsAsync(filter, cancellationToken);
 
-            if (filter.PageSize != null)
+            if (filter.PageSize is not null)
             {
                 var pagedResults = PaginatedList<Event>.Create(result.OrderByDescending(e => e.EventDate).AsQueryable(),
                                        filter.PageIndex.GetValueOrDefault(0), filter.PageSize.GetValueOrDefault(10));
@@ -357,7 +357,7 @@ namespace TrashMob.Controllers
         {
             var mobEvent = await eventManager.GetAsync(id, cancellationToken);
 
-            return mobEvent != null;
+            return mobEvent is not null;
         }
     }
 }

--- a/TrashMob/Controllers/IFTTT/v1/TriggersController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/TriggersController.cs
@@ -31,7 +31,7 @@ namespace TrashMob.Controllers.IFTTT
         {
             var error = triggersManager.ValidateRequest(triggersRequest, EventRequestType.All);
 
-            if (error != null)
+            if (error is not null)
             {
                 return BadRequest(error);
             }
@@ -59,7 +59,7 @@ namespace TrashMob.Controllers.IFTTT
         {
             var error = triggersManager.ValidateRequest(triggersRequest, EventRequestType.ByCountry);
 
-            if (error != null)
+            if (error is not null)
             {
                 return BadRequest(error);
             }
@@ -87,7 +87,7 @@ namespace TrashMob.Controllers.IFTTT
         {
             var error = triggersManager.ValidateRequest(triggersRequest, EventRequestType.ByRegion);
 
-            if (error != null)
+            if (error is not null)
             {
                 return BadRequest(error);
             }
@@ -114,7 +114,7 @@ namespace TrashMob.Controllers.IFTTT
         {
             var error = triggersManager.ValidateRequest(triggersRequest, EventRequestType.ByCity);
 
-            if (error != null)
+            if (error is not null)
             {
                 return BadRequest(error);
             }
@@ -142,7 +142,7 @@ namespace TrashMob.Controllers.IFTTT
         {
             var error = triggersManager.ValidateRequest(triggersRequest, EventRequestType.ByPostalCode);
 
-            if (error != null)
+            if (error is not null)
             {
                 return BadRequest(error);
             }

--- a/TrashMob/Controllers/IFTTT/v1/UserController.cs
+++ b/TrashMob/Controllers/IFTTT/v1/UserController.cs
@@ -26,7 +26,7 @@ namespace TrashMob.Controllers.IFTTT
         {
             var user = await userManager.GetAsync(UserId, cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -163,7 +163,7 @@ namespace TrashMob.Controllers
         {
             var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken);
 
-            if (filter.PageSize != null)
+            if (filter.PageSize is not null)
             {
                 var pagedResults = result.OrderByDescending(e => e.CreatedDate).Skip(filter.PageIndex.GetValueOrDefault(0) * filter.PageSize.GetValueOrDefault(10))
                     .Take(filter.PageSize.GetValueOrDefault(10)).ToList();
@@ -189,7 +189,7 @@ namespace TrashMob.Controllers
         {
             var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken);
 
-            if (filter.PageSize != null)
+            if (filter.PageSize is not null)
             {
                 var pagedResults = PaginatedList<LitterReport>.Create(result.OrderByDescending(e => e.CreatedDate).AsQueryable(),
                     filter.PageIndex.GetValueOrDefault(0), filter.PageSize.GetValueOrDefault(10));
@@ -228,7 +228,7 @@ namespace TrashMob.Controllers
         [RequiredScope(Constants.TrashMobWriteScope)]
         public async Task<IActionResult> AddLitterReport(LitterReport litterReport, CancellationToken cancellationToken)
         {
-            if (litterReport == null)
+            if (litterReport is null)
             {
                 return BadRequest("Litter report cannot be null.");
             }
@@ -290,7 +290,7 @@ namespace TrashMob.Controllers
 
             var updatedLitterReport = await litterReportManager.UpdateAsync(litterReport, UserId, cancellationToken);
 
-            if (updatedLitterReport != null)
+            if (updatedLitterReport is not null)
             {
                 TrackEvent(nameof(UpdateLitterReport));
                 return Ok(updatedLitterReport);

--- a/TrashMob/Controllers/NewsletterWebhooksController.cs
+++ b/TrashMob/Controllers/NewsletterWebhooksController.cs
@@ -31,7 +31,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> ProcessNewsletterEvents([FromBody] List<SendGridEvent> events, CancellationToken cancellationToken = default)
         {
-            if (events == null || !events.Any())
+            if (events is null || !events.Any())
             {
                 return Ok();
             }

--- a/TrashMob/Controllers/NewslettersController.cs
+++ b/TrashMob/Controllers/NewslettersController.cs
@@ -87,7 +87,7 @@ namespace TrashMob.Controllers
             }
 
             var newsletter = await newsletterManager.GetAsync(id, cancellationToken);
-            if (newsletter == null)
+            if (newsletter is null)
             {
                 return NotFound();
             }
@@ -155,7 +155,7 @@ namespace TrashMob.Controllers
             }
 
             var newsletter = await newsletterManager.GetAsync(id, cancellationToken);
-            if (newsletter == null)
+            if (newsletter is null)
             {
                 return NotFound();
             }
@@ -259,7 +259,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            if (request.Emails == null || !request.Emails.Any())
+            if (request.Emails is null || !request.Emails.Any())
             {
                 return BadRequest("At least one email address is required.");
             }
@@ -295,7 +295,7 @@ namespace TrashMob.Controllers
             }
 
             var newsletter = await newsletterManager.GetAsync(id, cancellationToken);
-            if (newsletter == null)
+            if (newsletter is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/PartnerAdminInvitationsController.cs
+++ b/TrashMob/Controllers/PartnerAdminInvitationsController.cs
@@ -75,7 +75,7 @@ namespace TrashMob.Controllers
                 (await partnerAdminInvitationManager.GetByParentIdAsync(partnerId, cancellationToken)).FirstOrDefault(
                     pu => pu.Email == email);
 
-            if (partnerInvite == null)
+            if (partnerInvite is null)
             {
                 return NotFound();
             }
@@ -112,7 +112,7 @@ namespace TrashMob.Controllers
 
             var addUser = await userManager.GetAsync(p => p.Email == partnerAdminInvitation.Email, cancellationToken);
 
-            if (addUser == null) 
+            if (addUser is null) 
             {
                 return NotFound($"User with Email {partnerAdminInvitation.Email} not found.");
             }

--- a/TrashMob/Controllers/PartnerAdminsController.cs
+++ b/TrashMob/Controllers/PartnerAdminsController.cs
@@ -99,7 +99,7 @@ namespace TrashMob.Controllers
                 (await partnerAdminManager.GetByParentIdAsync(partnerId, cancellationToken)).FirstOrDefault(pu =>
                     pu.UserId == userId);
 
-            if (partnerUser == null)
+            if (partnerUser is null)
             {
                 return NotFound();
             }
@@ -131,7 +131,7 @@ namespace TrashMob.Controllers
 
             var partnerAdmins = await partnerAdminManager.GetByParentIdAsync(partnerId, cancellationToken);
 
-            if (partnerAdmins == null || !partnerAdmins.Any())
+            if (partnerAdmins is null || !partnerAdmins.Any())
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/PartnerContactsController.cs
+++ b/TrashMob/Controllers/PartnerContactsController.cs
@@ -62,7 +62,7 @@ namespace TrashMob.Controllers
         {
             var partner = await partnerManager.GetAsync(partnerContact.PartnerId, cancellationToken);
 
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/PartnerDocumentsController.cs
+++ b/TrashMob/Controllers/PartnerDocumentsController.cs
@@ -117,7 +117,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            if (formFile == null || formFile.Length == 0)
+            if (formFile is null || formFile.Length == 0)
             {
                 return BadRequest("No file provided.");
             }

--- a/TrashMob/Controllers/PartnerLocationContactsController.cs
+++ b/TrashMob/Controllers/PartnerLocationContactsController.cs
@@ -67,7 +67,7 @@ namespace TrashMob.Controllers
                 await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationContact.PartnerLocationId,
                     cancellationToken);
 
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/PartnerLocationsController.cs
+++ b/TrashMob/Controllers/PartnerLocationsController.cs
@@ -50,7 +50,7 @@ namespace TrashMob.Controllers
                 (await partnerLocationManager.GetAsync(pl => pl.Id == partnerLocationId, cancellationToken))
                 .FirstOrDefault();
 
-            if (partnerLocation == null)
+            if (partnerLocation is null)
             {
                 return NotFound();
             }
@@ -68,7 +68,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> AddPartnerLocation(PartnerLocation partnerLocation,
             CancellationToken cancellationToken)
         {
-            if (partnerLocation == null)
+            if (partnerLocation is null)
             {
                 return BadRequest("PartnerLocation cannot be null.");
             }

--- a/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
+++ b/TrashMob/Controllers/ProfessionalCleanupLogsController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetLogs(Guid companyId, CancellationToken cancellationToken)
         {
             var company = await companyManager.GetAsync(companyId, cancellationToken);
-            if (company == null)
+            if (company is null)
             {
                 return NotFound();
             }
@@ -71,7 +71,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var company = await companyManager.GetAsync(companyId, cancellationToken);
-            if (company == null)
+            if (company is null)
             {
                 return NotFound();
             }
@@ -109,7 +109,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetAssignments(Guid companyId, CancellationToken cancellationToken)
         {
             var company = await companyManager.GetAsync(companyId, cancellationToken);
-            if (company == null)
+            if (company is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/RouteSimulationController.cs
+++ b/TrashMob/Controllers/RouteSimulationController.cs
@@ -56,7 +56,7 @@ namespace TrashMob.Controllers
             }
 
             var eventData = await eventRepository.GetAsync(eventId, cancellationToken);
-            if (eventData == null)
+            if (eventData is null)
             {
                 return NotFound($"Event {eventId} not found");
             }

--- a/TrashMob/Controllers/SponsorPortalController.cs
+++ b/TrashMob/Controllers/SponsorPortalController.cs
@@ -63,13 +63,13 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetSponsorCleanupLogs(Guid sponsorId, CancellationToken cancellationToken)
         {
             var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
-            if (sponsor == null)
+            if (sponsor is null)
             {
                 return NotFound();
             }
 
             var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -97,13 +97,13 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> ExportCleanupLogs(Guid sponsorId, CancellationToken cancellationToken)
         {
             var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
-            if (sponsor == null)
+            if (sponsor is null)
             {
                 return NotFound();
             }
 
             var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/SponsorReportsController.cs
+++ b/TrashMob/Controllers/SponsorReportsController.cs
@@ -39,13 +39,13 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetAdoptions(Guid sponsorId, CancellationToken cancellationToken)
         {
             var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
-            if (sponsor == null)
+            if (sponsor is null)
             {
                 return NotFound();
             }
 
             var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -77,13 +77,13 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
-            if (sponsor == null)
+            if (sponsor is null)
             {
                 return NotFound();
             }
 
             var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
-            if (partner == null)
+            if (partner is null)
             {
                 return NotFound();
             }
@@ -94,7 +94,7 @@ namespace TrashMob.Controllers
             }
 
             var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
-            if (adoption == null || adoption.SponsorId != sponsorId)
+            if (adoption is null || adoption.SponsorId != sponsorId)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/TeamAdminController.cs
+++ b/TrashMob/Controllers/TeamAdminController.cs
@@ -46,7 +46,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> DeleteTeam(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -67,7 +67,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> ReactivateTeam(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/TeamAdoptionsController.cs
+++ b/TrashMob/Controllers/TeamAdoptionsController.cs
@@ -39,7 +39,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetTeamAdoptions(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -74,7 +74,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -116,7 +116,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetActiveAdoptions(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/TeamEventsController.cs
+++ b/TrashMob/Controllers/TeamEventsController.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetTeamEvents(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -78,7 +78,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetUpcomingTeamEvents(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -121,7 +121,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetPastTeamEvents(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -169,7 +169,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> LinkEventToTeam(Guid teamId, Guid eventId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound("Team not found.");
             }
@@ -183,7 +183,7 @@ namespace TrashMob.Controllers
 
             // Check if event exists
             var eventEntity = await eventManager.GetAsync(eventId, cancellationToken);
-            if (eventEntity == null)
+            if (eventEntity is null)
             {
                 return NotFound("Event not found.");
             }
@@ -192,7 +192,7 @@ namespace TrashMob.Controllers
             var existingLink = await teamEventRepository.Get()
                 .FirstOrDefaultAsync(te => te.TeamId == teamId && te.EventId == eventId, cancellationToken);
 
-            if (existingLink != null)
+            if (existingLink is not null)
             {
                 return BadRequest("Event is already linked to this team.");
             }
@@ -227,7 +227,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> UnlinkEventFromTeam(Guid teamId, Guid eventId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound("Team not found.");
             }
@@ -242,7 +242,7 @@ namespace TrashMob.Controllers
             var teamEvent = await teamEventRepository.Get()
                 .FirstOrDefaultAsync(te => te.TeamId == teamId && te.EventId == eventId, cancellationToken);
 
-            if (teamEvent == null)
+            if (teamEvent is null)
             {
                 return NotFound("Event is not linked to this team.");
             }

--- a/TrashMob/Controllers/TeamInvitesController.cs
+++ b/TrashMob/Controllers/TeamInvitesController.cs
@@ -41,7 +41,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetBatches(Guid teamId, CancellationToken cancellationToken = default)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -74,7 +74,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetBatch(Guid teamId, Guid id, CancellationToken cancellationToken = default)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -88,7 +88,7 @@ namespace TrashMob.Controllers
 
             var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
-            if (result == null || result.TeamId != teamId)
+            if (result is null || result.TeamId != teamId)
             {
                 return NotFound();
             }
@@ -117,7 +117,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken = default)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -129,7 +129,7 @@ namespace TrashMob.Controllers
                 return Forbid();
             }
 
-            if (request == null || request.Emails == null || !request.Emails.Any())
+            if (request is null || request.Emails is null || !request.Emails.Any())
             {
                 return BadRequest("Email list is required.");
             }

--- a/TrashMob/Controllers/TeamMembersController.cs
+++ b/TrashMob/Controllers/TeamMembersController.cs
@@ -33,7 +33,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetMembers(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -68,7 +68,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetLeads(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -91,14 +91,14 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> JoinTeam(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
 
             // Check if already a member
             var existingMember = await teamMemberManager.GetByTeamAndUserAsync(teamId, UserId, cancellationToken);
-            if (existingMember != null)
+            if (existingMember is not null)
             {
                 return BadRequest("You are already a member of this team.");
             }
@@ -138,7 +138,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> AddMember(Guid teamId, Guid userId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -152,7 +152,7 @@ namespace TrashMob.Controllers
 
             // Check if user is already a member
             var existingMember = await teamMemberManager.GetByTeamAndUserAsync(teamId, userId, cancellationToken);
-            if (existingMember != null)
+            if (existingMember is not null)
             {
                 return BadRequest("User is already a member of this team.");
             }
@@ -177,13 +177,13 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> RemoveMember(Guid teamId, Guid userId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
 
             var member = await teamMemberManager.GetByTeamAndUserAsync(teamId, userId, cancellationToken);
-            if (member == null)
+            if (member is null)
             {
                 return NotFound();
             }
@@ -225,7 +225,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> PromoteToLead(Guid teamId, Guid userId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -238,7 +238,7 @@ namespace TrashMob.Controllers
             }
 
             var member = await teamMemberManager.GetByTeamAndUserAsync(teamId, userId, cancellationToken);
-            if (member == null)
+            if (member is null)
             {
                 return NotFound("User is not a member of this team.");
             }
@@ -268,7 +268,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> DemoteFromLead(Guid teamId, Guid userId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null || !team.IsActive)
+            if (team is null || !team.IsActive)
             {
                 return NotFound();
             }
@@ -281,7 +281,7 @@ namespace TrashMob.Controllers
             }
 
             var member = await teamMemberManager.GetByTeamAndUserAsync(teamId, userId, cancellationToken);
-            if (member == null)
+            if (member is null)
             {
                 return NotFound("User is not a member of this team.");
             }

--- a/TrashMob/Controllers/TeamsController.cs
+++ b/TrashMob/Controllers/TeamsController.cs
@@ -56,7 +56,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetTeam(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -150,7 +150,7 @@ namespace TrashMob.Controllers
 
             // Verify the user is an adult (18+) to create a team
             var user = await userManager.GetAsync(UserId, cancellationToken);
-            if (user == null)
+            if (user is null)
             {
                 return BadRequest("User not found.");
             }
@@ -192,7 +192,7 @@ namespace TrashMob.Controllers
             }
 
             var existingTeam = await teamManager.GetAsync(teamId, cancellationToken);
-            if (existingTeam == null)
+            if (existingTeam is null)
             {
                 return NotFound();
             }
@@ -247,7 +247,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> DeactivateTeam(Guid teamId, CancellationToken cancellationToken)
         {
             var existingTeam = await teamManager.GetAsync(teamId, cancellationToken);
-            if (existingTeam == null)
+            if (existingTeam is null)
             {
                 return NotFound();
             }
@@ -281,7 +281,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> GetTeamPhotos(Guid teamId, CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -324,7 +324,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -376,7 +376,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -389,7 +389,7 @@ namespace TrashMob.Controllers
             }
 
             var photo = await teamPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.TeamId != teamId)
+            if (photo is null || photo.TeamId != teamId)
             {
                 return NotFound();
             }
@@ -419,7 +419,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -432,7 +432,7 @@ namespace TrashMob.Controllers
             }
 
             var photo = await teamPhotoManager.GetAsync(photoId, cancellationToken);
-            if (photo == null || photo.TeamId != teamId)
+            if (photo is null || photo.TeamId != teamId)
             {
                 return NotFound();
             }
@@ -468,7 +468,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }
@@ -517,7 +517,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var team = await teamManager.GetAsync(teamId, cancellationToken);
-            if (team == null)
+            if (team is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/UserFeedbackController.cs
+++ b/TrashMob/Controllers/UserFeedbackController.cs
@@ -33,7 +33,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> SubmitFeedback([FromBody] UserFeedback feedback, CancellationToken cancellationToken)
         {
-            if (feedback == null)
+            if (feedback is null)
             {
                 return BadRequest("Feedback cannot be null.");
             }
@@ -58,7 +58,7 @@ namespace TrashMob.Controllers
             // Try to get UserId if authenticated
             try
             {
-                if (HttpContext.Items.ContainsKey("UserId") && HttpContext.Items["UserId"] != null)
+                if (HttpContext.Items.ContainsKey("UserId") && HttpContext.Items["UserId"] is not null)
                 {
                     feedback.UserId = new Guid(HttpContext.Items["UserId"].ToString());
                 }
@@ -90,7 +90,7 @@ namespace TrashMob.Controllers
         {
             var feedback = await feedbackManager.GetAsync(id, cancellationToken);
 
-            if (feedback == null)
+            if (feedback is null)
             {
                 return NotFound();
             }
@@ -132,7 +132,7 @@ namespace TrashMob.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> UpdateFeedback(Guid id, [FromBody] UpdateFeedbackRequest request, CancellationToken cancellationToken)
         {
-            if (request == null)
+            if (request is null)
             {
                 return BadRequest("Request body is required.");
             }
@@ -146,7 +146,7 @@ namespace TrashMob.Controllers
 
             var feedback = await feedbackManager.UpdateStatusAsync(id, request.Status, request.InternalNotes, UserId, cancellationToken);
 
-            if (feedback == null)
+            if (feedback is null)
             {
                 return NotFound();
             }
@@ -170,7 +170,7 @@ namespace TrashMob.Controllers
         public async Task<IActionResult> DeleteFeedback(Guid id, CancellationToken cancellationToken)
         {
             var existing = await feedbackManager.GetAsync(id, cancellationToken);
-            if (existing == null)
+            if (existing is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/UserInvitesController.cs
+++ b/TrashMob/Controllers/UserInvitesController.cs
@@ -63,7 +63,7 @@ namespace TrashMob.Controllers
         {
             var result = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
 
-            if (result == null)
+            if (result is null)
             {
                 return NotFound();
             }
@@ -121,7 +121,7 @@ namespace TrashMob.Controllers
             [FromBody] CreateEmailInviteBatchRequest request,
             CancellationToken cancellationToken = default)
         {
-            if (request == null || request.Emails == null || !request.Emails.Any())
+            if (request is null || request.Emails is null || !request.Emails.Any())
             {
                 return BadRequest("Email list is required.");
             }

--- a/TrashMob/Controllers/UserWaiverController.cs
+++ b/TrashMob/Controllers/UserWaiverController.cs
@@ -104,7 +104,7 @@ namespace TrashMob.Controllers
             [FromBody] AcceptWaiverApiRequest request,
             CancellationToken cancellationToken = default)
         {
-            if (request == null)
+            if (request is null)
             {
                 return BadRequest("Request is required.");
             }
@@ -191,7 +191,7 @@ namespace TrashMob.Controllers
             var waiver = await userWaiverManager
                 .GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken);
 
-            if (waiver == null)
+            if (waiver is null)
             {
                 return NotFound();
             }
@@ -226,7 +226,7 @@ namespace TrashMob.Controllers
             var waiver = await userWaiverManager
                 .GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken);
 
-            if (waiver == null)
+            if (waiver is null)
             {
                 return NotFound();
             }
@@ -293,12 +293,12 @@ namespace TrashMob.Controllers
             [FromForm] PaperWaiverUploadApiRequest request,
             CancellationToken cancellationToken = default)
         {
-            if (request == null)
+            if (request is null)
             {
                 return BadRequest("Request is required.");
             }
 
-            if (request.FormFile == null || request.FormFile.Length == 0)
+            if (request.FormFile is null || request.FormFile.Length == 0)
             {
                 return BadRequest("File is required.");
             }

--- a/TrashMob/Controllers/UsersController.cs
+++ b/TrashMob/Controllers/UsersController.cs
@@ -44,7 +44,7 @@ namespace TrashMob.Controllers
         {
             var user = await userManager.GetUserByUserNameAsync(userName, cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 return NotFound();
             }
@@ -64,7 +64,7 @@ namespace TrashMob.Controllers
         {
             var user = await userManager.GetUserByEmailAsync(email, cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 return NotFound();
             }
@@ -85,7 +85,7 @@ namespace TrashMob.Controllers
         {
             var user = await userManager.GetUserByUserNameAsync(userName, cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 return Ok();
             }
@@ -110,7 +110,7 @@ namespace TrashMob.Controllers
         {
             var user = await userManager.GetUserByInternalIdAsync(id, cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 return NotFound();
             }
@@ -133,7 +133,7 @@ namespace TrashMob.Controllers
             // Users can only update themselves unless they are a site admin
             var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
 
-            if (currentUser == null)
+            if (currentUser is null)
             {
                 return NotFound();
             }
@@ -174,7 +174,7 @@ namespace TrashMob.Controllers
             // Users can only delete themselves unless they are a site admin
             var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
 
-            if (currentUser == null)
+            if (currentUser is null)
             {
                 return NotFound();
             }
@@ -203,7 +203,7 @@ namespace TrashMob.Controllers
         {
             var user = await userManager.GetUserByInternalIdAsync(userId, cancellationToken);
 
-            if (user == null)
+            if (user is null)
             {
                 return NotFound();
             }
@@ -226,7 +226,7 @@ namespace TrashMob.Controllers
             CancellationToken cancellationToken)
         {
             var user = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
-            if (user == null)
+            if (user is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Controllers/WaiverAdminController.cs
+++ b/TrashMob/Controllers/WaiverAdminController.cs
@@ -71,7 +71,7 @@ namespace TrashMob.Controllers
         {
             var result = await waiverVersionManager.GetAsync(id, cancellationToken);
 
-            if (result == null)
+            if (result is null)
             {
                 return NotFound();
             }
@@ -96,7 +96,7 @@ namespace TrashMob.Controllers
             [FromBody] WaiverVersion waiverVersion,
             CancellationToken cancellationToken = default)
         {
-            if (waiverVersion == null)
+            if (waiverVersion is null)
             {
                 return BadRequest("Waiver version is required.");
             }
@@ -140,13 +140,13 @@ namespace TrashMob.Controllers
             [FromBody] WaiverVersion waiverVersion,
             CancellationToken cancellationToken = default)
         {
-            if (waiverVersion == null || waiverVersion.Id != id)
+            if (waiverVersion is null || waiverVersion.Id != id)
             {
                 return BadRequest("Waiver version ID mismatch.");
             }
 
             var existing = await waiverVersionManager.GetAsync(id, cancellationToken);
-            if (existing == null)
+            if (existing is null)
             {
                 return NotFound();
             }
@@ -233,7 +233,7 @@ namespace TrashMob.Controllers
             [FromBody] AssignWaiverRequest request,
             CancellationToken cancellationToken = default)
         {
-            if (request == null || request.WaiverId == Guid.Empty)
+            if (request is null || request.WaiverId == Guid.Empty)
             {
                 return BadRequest("Waiver ID is required.");
             }

--- a/TrashMob/Controllers/WaiverComplianceController.cs
+++ b/TrashMob/Controllers/WaiverComplianceController.cs
@@ -136,7 +136,7 @@ namespace TrashMob.Controllers
         {
             var result = await userWaiverManager.GetUserWaiverWithDetailsAsync(userWaiverId, cancellationToken);
 
-            if (result == null)
+            if (result is null)
             {
                 return NotFound();
             }

--- a/TrashMob/Security/ChannelKeyAuthenticationFilter.cs
+++ b/TrashMob/Security/ChannelKeyAuthenticationFilter.cs
@@ -27,7 +27,7 @@
 
         public Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
-            if (context == null)
+            if (context is null)
             {
                 throw new ArgumentNullException(nameof(context));
             }

--- a/TrashMob/Security/UserIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsAdminAuthHandler.cs
@@ -32,11 +32,11 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"User with email '{email}' not found.") });

--- a/TrashMob/Security/UserIsEventLeadAuthHandler.cs
+++ b/TrashMob/Security/UserIsEventLeadAuthHandler.cs
@@ -47,11 +47,11 @@ namespace TrashMob.Security
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"User with email '{email}' not found.") });
@@ -77,7 +77,7 @@ namespace TrashMob.Security
                 // SECURITY: Do not trust CreatedByUserId from the request body
                 var actualEvent = await eventManager.GetAsync(eventId.Value, CancellationToken.None);
 
-                if (actualEvent == null)
+                if (actualEvent is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"Event with ID '{eventId.Value}' not found.") });
@@ -142,7 +142,7 @@ namespace TrashMob.Security
         private static Guid? TryGetEventIdViaReflection(BaseModel resource)
         {
             var eventIdProperty = resource.GetType().GetProperty("EventId");
-            if (eventIdProperty != null && eventIdProperty.PropertyType == typeof(Guid))
+            if (eventIdProperty is not null && eventIdProperty.PropertyType == typeof(Guid))
             {
                 return (Guid)eventIdProperty.GetValue(resource);
             }

--- a/TrashMob/Security/UserIsEventLeadOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsEventLeadOrIsAdminAuthHandler.cs
@@ -43,11 +43,11 @@ namespace TrashMob.Security
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"User with email '{email}' not found.") });
@@ -133,7 +133,7 @@ namespace TrashMob.Security
         private static Guid? TryGetEventIdViaReflection(BaseModel resource)
         {
             var eventIdProperty = resource.GetType().GetProperty("EventId");
-            if (eventIdProperty != null && eventIdProperty.PropertyType == typeof(Guid))
+            if (eventIdProperty is not null && eventIdProperty.PropertyType == typeof(Guid))
             {
                 return (Guid)eventIdProperty.GetValue(resource);
             }

--- a/TrashMob/Security/UserIsPartnerUserOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsPartnerUserOrIsAdminAuthHandler.cs
@@ -37,11 +37,11 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"User with email '{email}' not found.") });
@@ -63,7 +63,7 @@
                         (await partnerUserManager.GetAsync(pu => pu.PartnerId == resource.Id && pu.UserId == user.Id,
                             CancellationToken.None)).FirstOrDefault();
 
-                    if (currentUserPartner != null)
+                    if (currentUserPartner is not null)
                     {
                         context.Succeed(requirement);
                     }

--- a/TrashMob/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandler.cs
@@ -41,11 +41,11 @@ namespace TrashMob.Security
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"User with email '{email}' not found.") });

--- a/TrashMob/Security/UserIsValidUserAuthHandler.cs
+++ b/TrashMob/Security/UserIsValidUserAuthHandler.cs
@@ -34,17 +34,17 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     // Auto-create user on first login (needed for Entra External ID which
                     // doesn't have B2C-style REST API callbacks during sign-up)
                     user = await TryAutoCreateUser(context, email);
 
-                    if (user == null)
+                    if (user is null)
                     {
                         AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                             { new(this, $"User with email '{email}' not found and could not be auto-created.") });
@@ -58,7 +58,7 @@
                 if (string.IsNullOrEmpty(user.ProfilePhotoUrl))
                 {
                     var pictureClaim = context.User.FindFirst("picture");
-                    if (pictureClaim != null)
+                    if (pictureClaim is not null)
                     {
                         user.ProfilePhotoUrl = pictureClaim.Value;
                         needsUpdate = true;
@@ -69,7 +69,7 @@
                 {
                     var givenNameClaim = context.User.FindFirst(ClaimTypes.GivenName)
                                       ?? context.User.FindFirst("given_name");
-                    if (givenNameClaim != null)
+                    if (givenNameClaim is not null)
                     {
                         user.GivenName = givenNameClaim.Value;
                         needsUpdate = true;
@@ -80,7 +80,7 @@
                 {
                     var surnameClaim = context.User.FindFirst(ClaimTypes.Surname)
                                     ?? context.User.FindFirst("family_name");
-                    if (surnameClaim != null)
+                    if (surnameClaim is not null)
                     {
                         user.Surname = surnameClaim.Value;
                         needsUpdate = true;
@@ -92,7 +92,7 @@
                     var dobClaim = context.User.FindFirst("dateOfBirth")
                                  ?? context.User.FindFirst(ClaimTypes.DateOfBirth)
                                  ?? context.User.Claims.FirstOrDefault(c => c.Type.Contains("dateOfBirth", StringComparison.OrdinalIgnoreCase));
-                    if (dobClaim != null && DateTimeOffset.TryParse(dobClaim.Value, out var parsedDob))
+                    if (dobClaim is not null && DateTimeOffset.TryParse(dobClaim.Value, out var parsedDob))
                     {
                         user.DateOfBirth = parsedDob;
                         needsUpdate = true;
@@ -130,7 +130,7 @@
                         ?? context.User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")
                         ?? context.User.FindFirst(ClaimTypes.NameIdentifier);
 
-            if (oidClaim == null || !Guid.TryParse(oidClaim.Value, out var objectId))
+            if (oidClaim is null || !Guid.TryParse(oidClaim.Value, out var objectId))
             {
                 logger.LogWarning("Cannot auto-create user: no valid object ID claim found for email {Email}", email);
                 return null;
@@ -151,13 +151,13 @@
 
             // Ensure username is unique
             var existingUser = await userManager.GetUserByUserNameAsync(userName, CancellationToken.None);
-            if (existingUser != null)
+            if (existingUser is not null)
             {
                 userName = $"{userName}_{objectId.ToString()[..8]}";
             }
 
             DateTimeOffset? dateOfBirth = null;
-            if (dobClaim != null && DateTimeOffset.TryParse(dobClaim.Value, out var parsedDob))
+            if (dobClaim is not null && DateTimeOffset.TryParse(dobClaim.Value, out var parsedDob))
             {
                 dateOfBirth = parsedDob;
             }

--- a/TrashMob/Security/UserOwnsEntityAuthHandler.cs
+++ b/TrashMob/Security/UserOwnsEntityAuthHandler.cs
@@ -33,11 +33,11 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"User with email '{email}' not found.") });

--- a/TrashMob/Security/UserOwnsEntityOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserOwnsEntityOrIsAdminAuthHandler.cs
@@ -34,11 +34,11 @@
                 var emailAddressClaim = context.User.FindFirst(ClaimTypes.Email);
                 var emailClaim = context.User.FindFirst("email");
 
-                var email = emailAddressClaim == null ? emailClaim?.Value : emailAddressClaim?.Value;
+                var email = emailAddressClaim is null ? emailClaim?.Value : emailAddressClaim?.Value;
 
                 var user = await userManager.GetUserByEmailAsync(email, CancellationToken.None);
 
-                if (user == null)
+                if (user is null)
                 {
                     AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
                         { new(this, $"User with email '{email}' not found.") });

--- a/TrashMobDailyJobs/StatGenerator.cs
+++ b/TrashMobDailyJobs/StatGenerator.cs
@@ -28,13 +28,13 @@ namespace TrashMobDailyJobs
             var sendGridApiKey = Environment.GetEnvironmentVariable("SendGridApiKey");
             var instanceName = Environment.GetEnvironmentVariable("InstanceName");
 
-            if (sendGridApiKey == null)
+            if (sendGridApiKey is null)
             {
                 logger.LogError("SendGrid API Key is not configured. Cannot send summary report email.");
                 return;
             }
 
-            if (instanceName == null)
+            if (instanceName is null)
             {
                 logger.LogError("Instance Name is not configured. Cannot send summary report email.");
                 return;


### PR DESCRIPTION
## Summary
- Modernize null checks in Controllers (46 files), Security handlers (9 files), and `StatGenerator` (1 file) to use C# pattern matching: `is null` / `is not null`
- Completes the `is null` / `is not null` modernization started in PR #2715 (which covered Engine + Managers)
- No expression tree concerns in these layers — Controllers and Security handlers don't contain EF Core LINQ queries
- Purely mechanical replacement — 245 lines changed with identical logic

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 442 tests pass
- [ ] Verify no runtime regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)