### PR TITLE
Improve Event Details page layout and empty states

### DIFF
--- a/TrashMob/Controllers/RouteSimulationController.cs
+++ b/TrashMob/Controllers/RouteSimulationController.cs
@@ -7,11 +7,13 @@ namespace TrashMob.Controllers
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Hosting;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.Identity.Web.Resource;
     using NetTopologySuite.Geometries;
     using TrashMob.Models;
     using TrashMob.Models.Extensions;
     using TrashMob.Models.Poco;
+    using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Persistence.Interfaces;
@@ -19,6 +21,7 @@ namespace TrashMob.Controllers
     /// <summary>
     /// Generates simulated GPS routes for dev/QA testing. Not available in production.
     /// </summary>
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
     [Route("api/routes/simulate")]
     public class RouteSimulationController(
         IHostEnvironment env,

--- a/TrashMobMobile/Pages/ViewEventPage.xaml
+++ b/TrashMobMobile/Pages/ViewEventPage.xaml
@@ -10,68 +10,64 @@
              xmlns:tabs="http://sharpnado.com"
              xmlns:views="clr-namespace:TrashMobMobile.Views.ViewEvent"
              Title="Event Details">
-    <Grid>
-        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Margin="10">
-            <Label
-                    Text="{Binding EventViewModel.Name}"
-                    FontFamily="LexendSemibold"
-                    FontSize="Title"
-                    HorizontalOptions="Start"
-                    VerticalOptions="Center"
-                    Margin="4" />
+    <Grid RowDefinitions="Auto,Auto,*" Margin="10">
+        <Label Grid.Row="0"
+               Text="{Binding EventViewModel.Name}"
+               FontFamily="LexendSemibold"
+               FontSize="Title"
+               HorizontalOptions="Start"
+               VerticalOptions="Center"
+               Margin="4,4,4,8" />
 
-            <tabs:TabHostView Padding="0"
-                              Orientation="Horizontal"
-                              TabType="Fixed"
-                              SelectedIndex="{Binding Source={x:Reference Switcher},
-                                          Path=SelectedIndex, Mode=TwoWay}">
-                <tabs:BottomTabItem Label="Details"  SelectedTabColor="{StaticResource Primary}" />
+        <tabs:TabHostView Grid.Row="1"
+                          Padding="0"
+                          Orientation="Horizontal"
+                          TabType="Fixed"
+                          SelectedIndex="{Binding Source={x:Reference Switcher},
+                                      Path=SelectedIndex, Mode=TwoWay}">
+            <tabs:BottomTabItem Label="Details"  SelectedTabColor="{StaticResource Primary}" />
+            <tabs:BottomTabItem Label="Partners" SelectedTabColor="{StaticResource Primary}" />
+            <tabs:BottomTabItem Label="People" SelectedTabColor="{StaticResource Primary}" />
+            <tabs:BottomTabItem Label="Litter" SelectedTabColor="{StaticResource Primary}" />
+            <tabs:BottomTabItem Label="Photos" SelectedTabColor="{StaticResource Primary}" />
+            <tabs:BottomTabItem Label="Routes" SelectedTabColor="{StaticResource Primary}" />
+        </tabs:TabHostView>
 
-                <tabs:BottomTabItem Label="Partners" SelectedTabColor="{StaticResource Primary}" />
-
-                <tabs:BottomTabItem Label="People" SelectedTabColor="{StaticResource Primary}" />
-
-                <tabs:BottomTabItem Label="Litter" SelectedTabColor="{StaticResource Primary}" />
-
-                <tabs:BottomTabItem Label="Photos" SelectedTabColor="{StaticResource Primary}" />
-
-                <tabs:BottomTabItem Label="Routes" SelectedTabColor="{StaticResource Primary}" />
-
-            </tabs:TabHostView>
-
-            <tabs:ViewSwitcher x:Name="Switcher"
+        <tabs:ViewSwitcher Grid.Row="2"
+                           x:Name="Switcher"
                            Margin="0"
                            Animate="True">
-                <tabs:DelayedView x:TypeArguments="views:TabDetails" x:Name="tabDetails"
-                        AccentColor="{StaticResource Primary}"
-                        Animate="True"
-                        UseActivityIndicator="True" />
-                <tabs:DelayedView x:TypeArguments="views:TabPartners" x:Name="tabPartners"
-                        AccentColor="{StaticResource Primary}"
-                        Animate="True"
-                        UseActivityIndicator="True" />
-                <tabs:DelayedView x:TypeArguments="views:TabAttendees"
-                        AccentColor="{StaticResource Primary}"
-                        Animate="True"
-                        UseActivityIndicator="True" />
-                <tabs:DelayedView x:TypeArguments="views:TabLitterReports"
-                        AccentColor="{StaticResource Primary}"
-                        Animate="True"
-                        UseActivityIndicator="True" />
-                <tabs:DelayedView x:TypeArguments="views:TabPhotos"
-                        AccentColor="{StaticResource Primary}"
-                        Animate="True"
-                        UseActivityIndicator="True" />
-                <tabs:DelayedView x:TypeArguments="views:TabRoutes"
-                        AccentColor="{StaticResource Primary}"
-                        Animate="True"
-                        UseActivityIndicator="True" />
-            </tabs:ViewSwitcher>
+            <tabs:DelayedView x:TypeArguments="views:TabDetails" x:Name="tabDetails"
+                    AccentColor="{StaticResource Primary}"
+                    Animate="True"
+                    UseActivityIndicator="True" />
+            <tabs:DelayedView x:TypeArguments="views:TabPartners" x:Name="tabPartners"
+                    AccentColor="{StaticResource Primary}"
+                    Animate="True"
+                    UseActivityIndicator="True" />
+            <tabs:DelayedView x:TypeArguments="views:TabAttendees"
+                    AccentColor="{StaticResource Primary}"
+                    Animate="True"
+                    UseActivityIndicator="True" />
+            <tabs:DelayedView x:TypeArguments="views:TabLitterReports"
+                    AccentColor="{StaticResource Primary}"
+                    Animate="True"
+                    UseActivityIndicator="True" />
+            <tabs:DelayedView x:TypeArguments="views:TabPhotos"
+                    AccentColor="{StaticResource Primary}"
+                    Animate="True"
+                    UseActivityIndicator="True" />
+            <tabs:DelayedView x:TypeArguments="views:TabRoutes"
+                    AccentColor="{StaticResource Primary}"
+                    Animate="True"
+                    UseActivityIndicator="True" />
+        </tabs:ViewSwitcher>
 
-        </VerticalStackLayout>
-        <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
-                     VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />
-        <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" VerticalOptions="Center"
-                               HorizontalOptions="Center" />
+        <BoxView Grid.RowSpan="3"
+                 BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
+                 VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />
+        <ActivityIndicator Grid.RowSpan="3"
+                           IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" VerticalOptions="Center"
+                           HorizontalOptions="Center" />
     </Grid>
 </ContentPage>

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -18,7 +18,7 @@
     <!-- <x:String x:Key="IconAccountKey">&#xf000b;</x:String> -->
     <!-- <x:String x:Key="IconTooltipAccount">&#xf000c;</x:String> -->
     <!-- <x:String x:Key="IconAccountMinus">&#xf000d;</x:String> -->
-    <!-- <x:String x:Key="IconAccountMultiple">&#xf000e;</x:String> -->
+    <x:String x:Key="IconAccountMultiple">&#xf000e;</x:String>
     <!-- <x:String x:Key="IconAccountMultipleOutline">&#xf000f;</x:String> -->
     <!-- <x:String x:Key="IconAccountMultiplePlus">&#xf0010;</x:String> -->
     <!-- <x:String x:Key="IconAccountNetwork">&#xf0011;</x:String> -->
@@ -4623,7 +4623,7 @@
     <!-- <x:String x:Key="IconEmoticonLolOutline">&#xf1215;</x:String> -->
     <!-- <x:String x:Key="IconFileSync">&#xf1216;</x:String> -->
     <!-- <x:String x:Key="IconFileSyncOutline">&#xf1217;</x:String> -->
-    <!-- <x:String x:Key="IconHandshake">&#xf1218;</x:String> -->
+    <x:String x:Key="IconHandshake">&#xf1218;</x:String>
     <!-- <x:String x:Key="IconLanguageKotlin">&#xf1219;</x:String> -->
     <!-- <x:String x:Key="IconLanguageFortran">&#xf121a;</x:String> -->
     <!-- <x:String x:Key="IconOffer">&#xf121b;</x:String> -->

--- a/TrashMobMobile/Views/ViewEvent/TabAttendees.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabAttendees.xaml
@@ -13,6 +13,24 @@
         <CollectionView x:Name="EventAttendeesCollection" Grid.Row="1"
                                     ItemsSource="{Binding EventAttendees}"
                                     SelectionMode="None">
+            <CollectionView.EmptyView>
+                <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center"
+                                     Spacing="8" Margin="20">
+                    <Image MaximumWidthRequest="32" MaximumHeightRequest="32"
+                           HorizontalOptions="Center">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconAccountMultiple}"
+                                             Size="32"
+                                             Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Text="No attendees yet"
+                           FontSize="Small"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+            </CollectionView.EmptyView>
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:EventAttendeeViewModel">
                     <Border Style="{StaticResource RoundBorder}" Margin="5,3">

--- a/TrashMobMobile/Views/ViewEvent/TabLitterReports.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabLitterReports.xaml
@@ -5,23 +5,43 @@
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:Class="TrashMobMobile.Views.ViewEvent.TabLitterReports">
-    <Grid RowDefinitions="*, *, *">
-        <Label Text="There are currently no litter reports assigned to this event." IsVisible="{Binding AreNoLitterReportsAvailable}" Margin="10" Grid.Row="1" />
+    <Grid RowDefinitions="*">
+        <!-- Empty state -->
+        <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center"
+                             Spacing="8" Margin="20"
+                             IsVisible="{Binding AreNoLitterReportsAvailable}">
+            <Image MaximumWidthRequest="32" MaximumHeightRequest="32"
+                   HorizontalOptions="Center">
+                <Image.Source>
+                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                     Glyph="{StaticResource IconTrashCanOutline}"
+                                     Size="32"
+                                     Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </Image.Source>
+            </Image>
+            <Label Text="No litter reports for this event"
+                   FontSize="Small"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+        </VerticalStackLayout>
 
-        <Grid RowDefinitions="*, *, *, *" IsVisible="{Binding AreLitterReportsAvailable}" Grid.Row="2">
+        <!-- Content when litter reports exist -->
+        <Grid RowDefinitions="Auto, *" IsVisible="{Binding AreLitterReportsAvailable}">
+            <!-- Map/List toggle toolbar -->
             <Grid Margin="5" Grid.Row="0"
-                      ColumnDefinitions="6*, *, *"
-                      RowDefinitions="Auto">
+                  ColumnDefinitions="6*, *, *"
+                  RowDefinitions="Auto">
                 <ImageButton Grid.Column="1"
                              HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
+                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
                              Command="{Binding MapSelectedCommand}" />
-                <ImageButton Grid.Column="2" 
+                <ImageButton Grid.Column="2"
                              HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
+                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}"
                              Command="{Binding ListSelectedCommand}" />
             </Grid>
 
+            <!-- Map view -->
             <controls:CustomMap x:Name="litterImagesMap"
                               Grid.Row="1"
                               ItemsSource="{Binding LitterImages}"
@@ -37,6 +57,7 @@
                 </maps:Map.ItemTemplate>
             </controls:CustomMap>
 
+            <!-- List view -->
             <CollectionView x:Name="LitterReportsCollection" Grid.Row="1"
                                     ItemsSource="{Binding EventLitterReports}"
                                     IsVisible="{Binding IsLitterReportListSelected}"
@@ -78,5 +99,4 @@
             </CollectionView>
         </Grid>
     </Grid>
-
 </ContentView>

--- a/TrashMobMobile/Views/ViewEvent/TabPartners.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabPartners.xaml
@@ -3,13 +3,31 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:Class="TrashMobMobile.Views.ViewEvent.TabPartners">
-    <Grid RowDefinitions="Auto, Auto">
-        <Label Grid.Row="1" Text="We're sorry. There are currently no partners assigned to this event." IsVisible="{Binding AreNoPartnersAvailable}" />
+    <Grid RowDefinitions="*">
+        <!-- Empty state -->
+        <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center"
+                             Spacing="8" Margin="20"
+                             IsVisible="{Binding AreNoPartnersAvailable}">
+            <Image MaximumWidthRequest="32" MaximumHeightRequest="32"
+                   HorizontalOptions="Center">
+                <Image.Source>
+                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                     Glyph="{StaticResource IconHandshake}"
+                                     Size="32"
+                                     Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </Image.Source>
+            </Image>
+            <Label Text="No partners assigned to this event"
+                   FontSize="Small"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+        </VerticalStackLayout>
 
-        <CollectionView Grid.Row="1" x:Name="AvailableEventPartners"
-                                    ItemsSource="{Binding AvailablePartners}"
-                                    SelectionMode="None" 
-                                    IsVisible="{Binding ArePartnersAvailable}">
+        <!-- Partner list -->
+        <CollectionView x:Name="AvailableEventPartners"
+                        ItemsSource="{Binding AvailablePartners}"
+                        SelectionMode="None"
+                        IsVisible="{Binding ArePartnersAvailable}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:EventPartnerLocationViewModel">
                     <Border Style="{StaticResource RoundBorder}" Margin="5,3">

--- a/TrashMobMobile/Views/ViewEvent/TabPhotos.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabPhotos.xaml
@@ -18,12 +18,24 @@
         </Grid>
 
         <!-- Empty state -->
-        <Label Grid.Row="1"
-               Text="No photos yet. Be the first to share!"
-               IsVisible="{Binding AreNoPhotosFound}"
-               FontSize="Small"
-               Margin="10,10"
-               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+        <VerticalStackLayout Grid.Row="1"
+                             VerticalOptions="Center" HorizontalOptions="Center"
+                             Spacing="8" Margin="20"
+                             IsVisible="{Binding AreNoPhotosFound}">
+            <Image MaximumWidthRequest="32" MaximumHeightRequest="32"
+                   HorizontalOptions="Center">
+                <Image.Source>
+                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                     Glyph="{StaticResource IconPlusCircle}"
+                                     Size="32"
+                                     Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </Image.Source>
+            </Image>
+            <Label Text="No photos yet. Be the first to share!"
+                   FontSize="Small"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+        </VerticalStackLayout>
 
         <!-- Photo grid -->
         <CollectionView Grid.Row="2"

--- a/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml
@@ -54,12 +54,24 @@
                             Margin="10,4" />
 
         <!-- Empty state -->
-        <Label Grid.Row="3"
-               Text="No routes recorded yet."
-               IsVisible="{Binding AreNoRoutesFound}"
-               FontSize="Small"
-               Margin="10,10"
-               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+        <VerticalStackLayout Grid.Row="3"
+                             VerticalOptions="Center" HorizontalOptions="Center"
+                             Spacing="8" Margin="20"
+                             IsVisible="{Binding AreNoRoutesFound}">
+            <Image MaximumWidthRequest="32" MaximumHeightRequest="32"
+                   HorizontalOptions="Center">
+                <Image.Source>
+                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                     Glyph="{StaticResource IconCompass}"
+                                     Size="32"
+                                     Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </Image.Source>
+            </Image>
+            <Label Text="No routes recorded yet."
+                   FontSize="Small"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+        </VerticalStackLayout>
 
         <!-- Route list -->
         <CollectionView Grid.Row="4"


### PR DESCRIPTION
## Summary
- **Styled empty states** across all Event Details tabs (Partners, Attendees, Litter Reports, Photos, Routes) with consistent centered icon + muted text pattern
- **Fixed broken layouts**: TabPartners had both children on row 1 with row 0 unused; TabLitterReports had wasteful `*, *, *` grid sizing
- **Added missing empty state** for TabAttendees (previously showed blank when no attendees)
- **Fixed RouteSimulationController auth bug**: Controller extends `SecureController` and uses `UserId` but was missing `[Authorize(Policy = "ValidUser")]`, causing NullReferenceException when simulating routes

## Test plan
- [ ] Navigate to Event Details page and verify each tab shows styled empty state (icon + muted text) when no data
- [ ] Verify Partners tab layout is correct when partners exist
- [ ] Verify Litter Reports tab map/list toggle works properly
- [ ] Click Simulate Route on Routes tab and verify it no longer errors (requires auth)
- [ ] Verify light and dark mode both render muted colors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)