### PR TITLE
Fix litter report creation 400 error

### DIFF
--- a/TrashMob/client-app/src/pages/litterreports/create.tsx
+++ b/TrashMob/client-app/src/pages/litterreports/create.tsx
@@ -124,6 +124,7 @@ const CreateLitterReportPageInner = () => {
             litterReport.description = formValues.description || '';
             litterReport.litterReportStatusId = 1; // New
             litterReport.createdByUserId = currentUser.id;
+            litterReport.lastUpdatedByUserId = currentUser.id;
 
             // Build litter image data array
             litterReport.litterImages = images.map((img) => {
@@ -138,6 +139,7 @@ const CreateLitterReportPageInner = () => {
                 litterImage.country = img.country;
                 litterImage.postalCode = img.postalCode;
                 litterImage.createdByUserId = currentUser.id;
+                litterImage.lastUpdatedByUserId = currentUser.id;
                 return litterImage;
             });
 


### PR DESCRIPTION
## Summary
- Fix 400 Bad Request when creating a new litter report
- The `lastUpdatedByUserId` field on both `LitterReportData` and `LitterImageData` defaulted to an empty string, which the backend couldn't deserialize as a `System.Guid`
- Set `lastUpdatedByUserId = currentUser.id` for both the report and each image during creation

## Test plan
- [ ] Create a new litter report with at least one photo — should succeed without error
- [ ] Verify the report appears in the litter reports list after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)