### PR TITLE
Fix litter report DB error and align image limit

### DIFF
--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -172,6 +172,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                     litterImage.LastUpdatedByUserId = userId;
                     litterImage.CreatedDate = DateTime.UtcNow;
                     litterImage.LastUpdatedDate = DateTime.UtcNow;
+                    litterImage.AzureBlobURL ??= string.Empty;
                 }
 
                 // Add litter report
@@ -422,6 +423,7 @@ namespace TrashMob.Shared.Managers.LitterReport
                     litterImage.LastUpdatedByUserId = userId;
                     litterImage.CreatedDate = DateTime.UtcNow;
                     litterImage.LastUpdatedDate = DateTime.UtcNow;
+                    litterImage.AzureBlobURL ??= string.Empty;
                 }
 
                 // Add litter report

--- a/TrashMob/client-app/src/components/litterreports/image-uploader.tsx
+++ b/TrashMob/client-app/src/components/litterreports/image-uploader.tsx
@@ -36,7 +36,7 @@ export const ImageUploader = ({
     images,
     onImagesChange,
     onEditLocation,
-    maxImages = 10,
+    maxImages = 5,
     maxSizeMB = 10,
 }: ImageUploaderProps) => {
     const fileInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Summary
- Default `AzureBlobURL` to empty string when null during litter report creation to prevent NOT NULL constraint violation (`DbUpdateException`). The image URL is set during the separate upload step after report creation, so it's expected to be null at creation time.
- Align web app max image limit from 10 to 5 to match the mobile app (`MaxImages = 5` in `CreateLitterReportViewModel` and `EditLitterReportViewModel`).

## Test plan
- [ ] Create a new litter report with photos — should no longer get "A database error occurred" 
- [ ] Verify web image uploader says "max 5 photos" instead of "max 10 photos"
- [ ] Verify existing litter reports still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)