### PR TITLE
Improve Create Event UX: map-first location picker

### DIFF
--- a/TrashMob/client-app/src/pages/events/create.tsx
+++ b/TrashMob/client-app/src/pages/events/create.tsx
@@ -340,9 +340,7 @@ export const CreateEventPage = () => {
                                     <GoogleMap
                                         id='locationPicker'
                                         defaultCenter={
-                                            latitude && longitude
-                                                ? { lat: latitude, lng: longitude }
-                                                : undefined
+                                            latitude && longitude ? { lat: latitude, lng: longitude } : undefined
                                         }
                                         defaultZoom={latitude && longitude ? 16 : undefined}
                                         style={{ width: '100%', height: '300px' }}


### PR DESCRIPTION
## Summary
- Show the map immediately on Step 1 so users can click directly on the map to set a location (previously the map only appeared after a text search)
- Map centers on user's geolocation via existing `useGetDefaultMapCenter` hook; clicking places a marker and triggers reverse geocode to populate address fields
- Add required-field asterisks (red `*`) on Event Name, Event Type, Date, Start/End Time, Max Attendees using `EnhancedFormLabel`
- Replace inline character count logic with reusable `CharacterCounter` component (matches litter report create page pattern)
- Always show Next button on Step 1 (disabled until location is set) for clearer affordance
- Dynamic help text: "Search or click the map" before location set, "Drag marker to fine-tune" after

## Test plan
- [ ] Navigate to `/createvent` — map appears immediately on Step 1 centered on user location
- [ ] Click anywhere on the map — marker appears, address auto-populates
- [ ] Search for an address — map pans, marker appears
- [ ] Drag marker — address updates via reverse geocode
- [ ] Next button is disabled until location is set, then enabled
- [ ] Required fields show red asterisks on Step 2
- [ ] Character counters display correctly for Event Name and Description
- [ ] Full flow: pick location → edit details → review → create event works end-to-end
- [ ] Creating from a litter report still skips Step 1 and pre-populates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)