### PR TITLE
Add event visibility badges to web UI

### DIFF
--- a/Planning/Projects/Project_47_Team_Private_Events.md
+++ b/Planning/Projects/Project_47_Team_Private_Events.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | Not Started |
+| **Status** | In Progress (Phase 1 + 1b complete) |
 | **Priority** | Medium |
 | **Risk** | Medium |
 | **Size** | Medium |
@@ -265,5 +265,5 @@ if (evt is null || evt.EventVisibilityId != (int)EventVisibilityEnum.Public)
 
 **Last Updated:** February 14, 2026
 **Owner:** Product & Engineering
-**Status:** Not Started
+**Status:** In Progress — Phase 1 (data model, API, web create/edit) and Phase 1b (MCP security fixes) complete. Phases 2-4 remaining.
 **Next Review:** When prioritized

--- a/TrashMob/client-app/src/components/Map/EventInfoWindowContent/EventDetailInfoWindowContent.tsx
+++ b/TrashMob/client-app/src/components/Map/EventInfoWindowContent/EventDetailInfoWindowContent.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { EventVisibilityBadge } from '@/components/ui/badge';
 import { useGetEventType } from '../../../hooks/useGetEventType';
 import { RegisterBtn } from '../../Customization/RegisterBtn';
 import EventData from '../../Models/EventData';
@@ -52,7 +53,10 @@ export const EventDetailInfoWindowContent = (props: EventDetailInfoWindowContent
         <div style={{ width: 500, overflowX: 'auto' }}>
             <div>
                 {!hideTitle && <h5 className='mt-1 font-bold'>{name}</h5>}
-                <p className='my-3 event-list-event-type p-2 rounded'>{eventType?.name}</p>
+                <div className='my-3 flex gap-2 items-center'>
+                    <p className='event-list-event-type p-2 rounded m-0'>{eventType?.name}</p>
+                    <EventVisibilityBadge eventVisibilityId={event.eventVisibilityId} />
+                </div>
                 <p className='m-0'>
                     {date},{time}
                 </p>

--- a/TrashMob/client-app/src/components/events/event-list.tsx
+++ b/TrashMob/client-app/src/components/events/event-list.tsx
@@ -5,7 +5,7 @@ import compact from 'lodash/compact';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { AttendingBadge, Badge, HostingBadge } from '@/components/ui/badge';
+import { AttendingBadge, Badge, EventVisibilityBadge, HostingBadge } from '@/components/ui/badge';
 import EventData from '@/components/Models/EventData';
 import UserData from '@/components/Models/UserData';
 import { RegisterBtn } from '@/components/Customization/RegisterBtn';
@@ -57,6 +57,7 @@ export const EventListItem = (props: EventListItemProps) => {
                             <CalendarRange /> {eventType.name}
                         </Badge>
                     ) : null}
+                    <EventVisibilityBadge eventVisibilityId={event.eventVisibilityId} />
                     {event.isAttending ? <AttendingBadge /> : null}
                     {event.createdByUserId === currentUser.id ? <HostingBadge /> : null}
                 </div>

--- a/TrashMob/client-app/src/components/ui/badge.tsx
+++ b/TrashMob/client-app/src/components/ui/badge.tsx
@@ -60,4 +60,40 @@ function HostingBadge(props: BadgeProps) {
     );
 }
 
-export { Badge, AttendingBadge, HostingBadge, badgeVariants };
+function TeamOnlyBadge(props: BadgeProps) {
+    return (
+        <Badge variant='outline' className='bg-blue-100 text-blue-800 border-blue-300' {...props}>
+            <svg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'>
+                <path
+                    d='M7 1.75C5.067 1.75 3.5 3.317 3.5 5.25C3.5 7.183 5.067 8.75 7 8.75C8.933 8.75 10.5 7.183 10.5 5.25C10.5 3.317 8.933 1.75 7 1.75ZM5.25 5.25C5.25 4.284 6.034 3.5 7 3.5C7.966 3.5 8.75 4.284 8.75 5.25C8.75 6.216 7.966 7 7 7C6.034 7 5.25 6.216 5.25 5.25ZM3.5 10.5C2.534 10.5 1.75 11.284 1.75 12.25H12.25C12.25 11.284 11.466 10.5 10.5 10.5H3.5Z'
+                    fill='#1e40af'
+                />
+            </svg>
+            Team Only
+        </Badge>
+    );
+}
+
+function PrivateBadge(props: BadgeProps) {
+    return (
+        <Badge variant='outline' className='bg-gray-100 text-gray-800 border-gray-300' {...props}>
+            <svg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'>
+                <path
+                    fill-rule='evenodd'
+                    clip-rule='evenodd'
+                    d='M3.5 5.25V4.375C3.5 2.441 5.067 0.875 7 0.875C8.933 0.875 10.5 2.441 10.5 4.375V5.25C11.19 5.25 11.75 5.81 11.75 6.5V11.375C11.75 12.065 11.19 12.625 10.5 12.625H3.5C2.81 12.625 2.25 12.065 2.25 11.375V6.5C2.25 5.81 2.81 5.25 3.5 5.25ZM5.25 4.375C5.25 3.409 6.034 2.625 7 2.625C7.966 2.625 8.75 3.409 8.75 4.375V5.25H5.25V4.375Z'
+                    fill='#4b5563'
+                />
+            </svg>
+            Private
+        </Badge>
+    );
+}
+
+function EventVisibilityBadge({ eventVisibilityId, ...props }: BadgeProps & { eventVisibilityId: number }) {
+    if (eventVisibilityId === 2) return <TeamOnlyBadge {...props} />;
+    if (eventVisibilityId === 3) return <PrivateBadge {...props} />;
+    return null;
+}
+
+export { Badge, AttendingBadge, HostingBadge, TeamOnlyBadge, PrivateBadge, EventVisibilityBadge, badgeVariants };

--- a/TrashMob/client-app/src/pages/MyDashboard/events-table/columns.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/events-table/columns.tsx
@@ -4,6 +4,7 @@ import type EventData from '@/components/Models/EventData';
 import type UserData from '@/components/Models/UserData';
 import moment from 'moment';
 import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { EventVisibilityBadge } from '@/components/ui/badge';
 import { EventActions } from './actions';
 
 interface GetColumnsProps {
@@ -20,6 +21,11 @@ export const getColumns = ({
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+    },
+    {
+        accessorKey: 'eventVisibilityId',
+        header: 'Visibility',
+        cell: ({ row }) => <EventVisibilityBadge eventVisibilityId={row.original.eventVisibilityId} />,
     },
     {
         accessorKey: 'role',

--- a/TrashMob/client-app/src/pages/eventdetails/$eventId/page.tsx
+++ b/TrashMob/client-app/src/pages/eventdetails/$eventId/page.tsx
@@ -12,7 +12,7 @@ import { GetAllEventsBeingAttendedByUser, GetEventAttendees, GetEventLeads } fro
 import { useGetEvent } from '@/hooks/useGetEvent';
 import { useGetEventType } from '@/hooks/useGetEventType';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { Badge, EventVisibilityBadge } from '@/components/ui/badge';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -175,7 +175,10 @@ export const EventDetails: FC<EventDetailsProps> = () => {
                                 </Button>
                             </div>
                         </div>
-                        <Badge>{eventType?.name}</Badge>
+                        <div className='flex gap-2'>
+                            <Badge>{eventType?.name}</Badge>
+                            {event ? <EventVisibilityBadge eventVisibilityId={event.eventVisibilityId} /> : null}
+                        </div>
                         <p className='mt-4 mb-8 text-foreground'>{description}</p>
                         <div className='mb-8!'>
                             <EventPlaceAndLocation {...event} />

--- a/TrashMob/client-app/src/pages/teams/$teamId/index.tsx
+++ b/TrashMob/client-app/src/pages/teams/$teamId/index.tsx
@@ -19,7 +19,7 @@ import {
 
 import { HeroSection } from '@/components/Customization/HeroSection';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Badge, EventVisibilityBadge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
 import TeamData from '@/components/Models/TeamData';
@@ -181,9 +181,12 @@ export const TeamDetailPage = () => {
             accessorKey: 'name',
             header: ({ column }) => <DataTableColumnHeader column={column} title='Event' />,
             cell: ({ row }) => (
-                <Link to={`/eventdetails/${row.original.id}`} className='text-primary hover:underline font-medium'>
-                    {row.original.name}
-                </Link>
+                <div className='flex items-center gap-2'>
+                    <Link to={`/eventdetails/${row.original.id}`} className='text-primary hover:underline font-medium'>
+                        {row.original.name}
+                    </Link>
+                    <EventVisibilityBadge eventVisibilityId={row.original.eventVisibilityId} />
+                </div>
             ),
         },
         {


### PR DESCRIPTION
## Summary
- New `TeamOnlyBadge` (blue, people icon) and `PrivateBadge` (gray, lock icon) components in badge.tsx
- `EventVisibilityBadge` wrapper renders the correct badge based on `eventVisibilityId` (returns null for public events)
- Badge shown in 5 locations: event list cards, event detail page, dashboard events table, team detail events table, and map info windows

This is Phase 2 of Project 47 (Team-Visible Private Events) — adding visual indicators so users can distinguish event visibility at a glance.

## Test plan
- [ ] Create a Team Only event and verify blue "Team Only" badge appears on event card, detail page, dashboard, and map popup
- [ ] Create a Private event and verify gray "Private" badge appears in the same locations
- [ ] Verify Public events show no visibility badge (clean, no visual clutter)
- [ ] Verify dashboard Visibility column renders correctly for all three types
- [ ] `npm run build` — clean
- [ ] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)