### PR TITLE
Move action buttons below content on mobile detail pages

### DIFF
--- a/TrashMobMobile/Pages/ViewEventSummaryPage.xaml
+++ b/TrashMobMobile/Pages/ViewEventSummaryPage.xaml
@@ -12,22 +12,8 @@
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
 
-                <!-- Action Buttons -->
-                <Grid ColumnDefinitions="*, *" ColumnSpacing="8" Margin="10,8,10,0">
-                    <Button Text="Add Pickup Location"
-                            Command="{Binding AddPickupLocationCommand}"
-                            IsVisible="{Binding EnableAddPickupLocation}"
-                            Grid.Column="0"
-                            Style="{StaticResource PrimarySmallButton}" />
-                    <Button Text="Edit Event Summary"
-                            Command="{Binding EditEventSummaryCommand}"
-                            IsVisible="{Binding EnableEditEventSummary}"
-                            Grid.Column="1"
-                            Style="{StaticResource SecondarySmallButton}" />
-                </Grid>
-
                 <!-- Event Metrics -->
-                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
                     <VerticalStackLayout Spacing="8">
                         <Label Text="Event Metrics" Style="{StaticResource SectionHeader}" Margin="0" />
                         <Label Text="Here's what TrashMob volunteers accomplished at this event!"
@@ -135,6 +121,20 @@
                         </controls:CustomMap>
                     </VerticalStackLayout>
                 </Border>
+
+                <!-- Action Buttons -->
+                <Grid ColumnDefinitions="*, *" ColumnSpacing="8" Margin="10,0">
+                    <Button Text="Add Pickup Location"
+                            Command="{Binding AddPickupLocationCommand}"
+                            IsVisible="{Binding EnableAddPickupLocation}"
+                            Grid.Column="0"
+                            Style="{StaticResource PrimarySmallButton}" />
+                    <Button Text="Edit Event Summary"
+                            Command="{Binding EditEventSummaryCommand}"
+                            IsVisible="{Binding EnableEditEventSummary}"
+                            Grid.Column="1"
+                            Style="{StaticResource SecondarySmallButton}" />
+                </Grid>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/ViewLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/ViewLitterReportPage.xaml
@@ -27,38 +27,6 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <!-- Action Buttons -->
-                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
-                    <VerticalStackLayout Spacing="8">
-                        <Label Text="Actions" Style="{StaticResource SectionHeader}" Margin="0" />
-                        <Button Command="{Binding EditLitterReportCommand}"
-                                Text="Edit Report"
-                                IsEnabled="{Binding CanEditLitterReport}"
-                                IsVisible="{Binding CanEditLitterReport}"
-                                Style="{StaticResource PrimaryLargeButton}" />
-                        <Button Command="{Binding MarkLitterReportCleanedCommand}"
-                                IsEnabled="{Binding CanMarkLitterReportCleaned}"
-                                IsVisible="{Binding CanMarkLitterReportCleaned}"
-                                Style="{StaticResource SecondaryLargeButton}"
-                                Text="Mark as Cleaned" />
-                        <Button Command="{Binding DeleteLitterReportCommand}"
-                                IsEnabled="{Binding CanDeleteLitterReport}"
-                                IsVisible="{Binding CanDeleteLitterReport}"
-                                Style="{StaticResource SecondaryLargeButton}"
-                                Text="Delete Report" />
-                        <Button Command="{Binding ViewEventCommand}"
-                                IsEnabled="{Binding IsAssignedToEvent}"
-                                IsVisible="{Binding IsAssignedToEvent}"
-                                Style="{StaticResource SecondaryLargeButton}"
-                                Text="View Event" />
-                        <Button Command="{Binding CreateEventCommand}"
-                                IsEnabled="{Binding IsNotAssignedToEvent}"
-                                IsVisible="{Binding IsNotAssignedToEvent}"
-                                Style="{StaticResource SecondaryLargeButton}"
-                                Text="Create Event" />
-                    </VerticalStackLayout>
-                </Border>
-
                 <!-- Locations -->
                 <Border Style="{StaticResource RoundBorder}" Margin="10,0">
                     <VerticalStackLayout Spacing="8">
@@ -90,6 +58,38 @@
                                 </DataTemplate>
                             </CollectionView.ItemTemplate>
                         </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Action Buttons -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Actions" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <Button Command="{Binding EditLitterReportCommand}"
+                                Text="Edit Report"
+                                IsEnabled="{Binding CanEditLitterReport}"
+                                IsVisible="{Binding CanEditLitterReport}"
+                                Style="{StaticResource PrimaryLargeButton}" />
+                        <Button Command="{Binding MarkLitterReportCleanedCommand}"
+                                IsEnabled="{Binding CanMarkLitterReportCleaned}"
+                                IsVisible="{Binding CanMarkLitterReportCleaned}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="Mark as Cleaned" />
+                        <Button Command="{Binding DeleteLitterReportCommand}"
+                                IsEnabled="{Binding CanDeleteLitterReport}"
+                                IsVisible="{Binding CanDeleteLitterReport}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="Delete Report" />
+                        <Button Command="{Binding ViewEventCommand}"
+                                IsEnabled="{Binding IsAssignedToEvent}"
+                                IsVisible="{Binding IsAssignedToEvent}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="View Event" />
+                        <Button Command="{Binding CreateEventCommand}"
+                                IsEnabled="{Binding IsNotAssignedToEvent}"
+                                IsVisible="{Binding IsNotAssignedToEvent}"
+                                Style="{StaticResource SecondaryLargeButton}"
+                                Text="Create Event" />
                     </VerticalStackLayout>
                 </Border>
             </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- Moved Actions section below Locations on ViewLitterReportPage so users see report details and photos before action buttons
- Moved action buttons (Add Pickup Location, Edit Event Summary) below Pickup Locations on ViewEventSummaryPage for the same reason

## Test plan
- [ ] Open a litter report detail on mobile — Actions section appears below the map and photo list
- [ ] Open an event summary on mobile — Add Pickup Location and Edit buttons appear below the pickup locations section

🤖 Generated with [Claude Code](https://claude.com/claude-code)