### PR TITLE
Fix 400 error when saving location preferences

### DIFF
--- a/TrashMob/client-app/src/pages/locationpreference/index.tsx
+++ b/TrashMob/client-app/src/pages/locationpreference/index.tsx
@@ -119,6 +119,11 @@ export const LocationPreference = () => {
             body.longitude = values.longitude;
             body.prefersMetric = values.prefersMetric;
             body.travelLimitForLocalEvents = values.travelLimitForLocalEvents;
+            body.givenName = currentUser.givenName ?? '';
+            body.surname = currentUser.surname ?? '';
+            body.dateOfBirth = currentUser.dateOfBirth;
+            body.isSiteAdmin = currentUser.isSiteAdmin;
+            body.profilePhotoUrl = currentUser.profilePhotoUrl ?? '';
 
             updateUser.mutateAsync(body);
         },


### PR DESCRIPTION
## Summary
- The location preference page was not passing through `dateOfBirth`, `givenName`, `surname`, `isSiteAdmin`, or `profilePhotoUrl` when updating the user
- `dateOfBirth` defaulted to `""` (empty string) in the `UserData` model, which the backend rejects because it can't parse `""` as `DateTimeOffset?`
- Now passes through all existing user fields (matching the myprofile page pattern) to prevent both the 400 error and silent data loss

## Test plan
- [ ] Go to Location Preferences page, change travel distance, click Save — should succeed without 400 error
- [ ] Verify user's givenName, surname, dateOfBirth, and profilePhotoUrl are preserved after saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)