### PR TITLE
Fix 500 error on event edit due to EF Core tracking conflict

### DIFF
--- a/TrashMob.Shared/Managers/Interfaces/IKeyedManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IKeyedManager.cs
@@ -18,5 +18,14 @@
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The entity or null if not found.</returns>
         Task<T> GetAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves an entity by its unique identifier without change tracking.
+        /// Use this when you only need to read entity data and won't be updating it.
+        /// </summary>
+        /// <param name="id">The entity ID.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The entity or null if not found.</returns>
+        Task<T> GetWithNoTrackingAsync(Guid id, CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMob.Shared/Managers/KeyedManager.cs
+++ b/TrashMob.Shared/Managers/KeyedManager.cs
@@ -52,5 +52,11 @@
         {
             return Repo.GetAsync(id, cancellationToken);
         }
+
+        /// <inheritdoc />
+        public virtual Task<T> GetWithNoTrackingAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            return Repo.GetWithNoTrackingAsync(id, cancellationToken);
+        }
     }
 }

--- a/TrashMob/Security/UserIsEventLeadAuthHandler.cs
+++ b/TrashMob/Security/UserIsEventLeadAuthHandler.cs
@@ -75,7 +75,8 @@ namespace TrashMob.Security
 
                 // Look up the actual event from the database to verify ownership
                 // SECURITY: Do not trust CreatedByUserId from the request body
-                var actualEvent = await eventManager.GetAsync(eventId.Value, CancellationToken.None);
+                // Use no-tracking to avoid EF Core conflicts when the entity is later updated
+                var actualEvent = await eventManager.GetWithNoTrackingAsync(eventId.Value, CancellationToken.None);
 
                 if (actualEvent is null)
                 {


### PR DESCRIPTION
## Summary
- The `UserIsEventLeadAuthHandler` was loading the Event entity **with change tracking** to verify ownership (security fix from a prior PR)
- When `EventManager.UpdateAsync` later tried to attach the incoming Event entity with the same ID, EF Core threw `InvalidOperationException: The instance of entity type 'Event' cannot be tracked because another instance with the same key value for {'Id'} is already being tracked`
- Fixed by using `GetWithNoTrackingAsync` in the auth handler, since it only reads the entity to check `CreatedByUserId`
- Added `GetWithNoTrackingAsync` to `IKeyedManager<T>` interface and `KeyedManager<T>` implementation (the repository layer already had it)

## Test plan
- [ ] Edit an existing event and save — should succeed without 500 error
- [ ] Verify event lead authorization still works (non-lead users should be rejected)
- [ ] Verify co-lead users can still edit events

🤖 Generated with [Claude Code](https://claude.com/claude-code)