### PR TITLE
Add event visibility support to mobile app (Project 47 Phase 3)

### DIFF
--- a/TrashMobMobile/Extensions/EventExtensions.cs
+++ b/TrashMobMobile/Extensions/EventExtensions.cs
@@ -41,10 +41,14 @@
             return localDateTime.ToShortTimeString();
         }
 
-        public static string GetPublicEventText(this Event mobEvent)
+        public static string GetVisibilityText(this Event mobEvent)
         {
-            //TODO: move hard code string to resource file
-            return mobEvent.IsEventPublic ? "Yes" : "No";
+            return mobEvent.EventVisibilityId switch
+            {
+                (int)EventVisibilityEnum.TeamOnly => "Team Only",
+                (int)EventVisibilityEnum.Private => "Private",
+                _ => "Public",
+            };
         }
 
         public static string GetEventStatusText(this Event mobEvent)
@@ -127,7 +131,8 @@
                 EventDate = mobEvent.EventDate,
                 EventStatusId = mobEvent.EventStatusId,
                 EventTypeId = mobEvent.EventTypeId,
-                IsEventPublic = mobEvent.IsEventPublic,
+                EventVisibilityId = mobEvent.EventVisibilityId,
+                TeamId = mobEvent.TeamId,
                 MaxNumberOfParticipants = mobEvent.MaxNumberOfParticipants,
                 Name = mobEvent.Name,
                 UserRoleForEvent = mobEvent.IsEventLead(userId) ? "Lead" : "Attendee",

--- a/TrashMobMobile/Pages/CreateEvent/Step1.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step1.xaml
@@ -20,7 +20,7 @@
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
                 <Grid ColumnDefinitions="*, *"
                       MaximumWidthRequest="400"
-                      RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto">
+                      RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto">
                     <VerticalStackLayout Grid.Row="0"
                                          Grid.ColumnSpan="2"
                                          Margin="0,10"
@@ -37,11 +37,22 @@
                                            ItemsSource="{Binding ETypes}"
                                            SelectedItem="{Binding SelectedEventType, Mode=TwoWay}" />
                     </VerticalStackLayout>
-                    <HorizontalStackLayout Grid.Row="1" Grid.Column="1" Padding="10,10,0,0">
-                        <Label Text="Is Event Public?" Style="{StaticResource FieldLabel}" />
-                        <CheckBox IsChecked="{Binding EventViewModel.IsEventPublic}" />
-                    </HorizontalStackLayout>
-                    <VerticalStackLayout Grid.Row="2"
+                    <VerticalStackLayout Grid.Row="1" Grid.Column="1" Margin="0,10">
+                        <Label Text="Visibility" Style="{StaticResource FieldLabel}" />
+                        <controls:TMPicker Title="Visibility"
+                                           HeightRequest="40"
+                                           ItemsSource="{Binding VisibilityOptions}"
+                                           SelectedItem="{Binding SelectedVisibility, Mode=TwoWay}" />
+                    </VerticalStackLayout>
+                    <VerticalStackLayout Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5,0,10"
+                                         IsVisible="{Binding IsTeamPickerVisible}">
+                        <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Team" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                        <controls:TMPicker Title="Select Team"
+                                           HeightRequest="40"
+                                           ItemsSource="{Binding TeamNames}"
+                                           SelectedItem="{Binding SelectedTeam, Mode=TwoWay}" />
+                    </VerticalStackLayout>
+                    <VerticalStackLayout Grid.Row="3"
                                          Grid.Column="0"
                                          Margin="0,5,0,10"
                                          Spacing="5">
@@ -49,7 +60,7 @@
                         <controls:TMDatePicker HeightRequest="45" Margin="0,0,5,0"
                                    Date="{Binding EventViewModel.EventDateOnly}" />
                     </VerticalStackLayout>
-                    <Grid Grid.Row="2" Grid.Column="1"
+                    <Grid Grid.Row="3" Grid.Column="1"
                           Margin="0,10"
                           ColumnDefinitions="*,*"
                           RowDefinitions="Auto,Auto,Auto">
@@ -63,29 +74,29 @@
                                Text="{Binding EventDurationError}">
                         </Label>
                     </Grid>
-                    <VerticalStackLayout Grid.Row="4" 
+                    <VerticalStackLayout Grid.Row="5"
                                          Grid.Column="0"
                                          Margin="0,5,0,10"
                                          Spacing="5">
                         <Label Text="Max Attendees" Style="{StaticResource FieldLabel}" />
                         <controls:TMEntry Keyboard="Numeric"
                               WidthRequest="35"
-                              HeightRequest="40"                              
+                              HeightRequest="40"
                               Text="{Binding EventViewModel.MaxNumberOfParticipants}">
                             <controls:TMEntry.Behaviors>
                                 <toolkit:NumericValidationBehavior Flags="ValidateOnValueChanged"
                                                        x:Name="maxNumberOfParticipantsValidator"
-                                                       MinimumValue="0" 
+                                                       MinimumValue="0"
                                                        MaximumDecimalPlaces="0" />
                             </controls:TMEntry.Behaviors>
                         </controls:TMEntry>
                     </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="4" Grid.Column="1" Margin="0,10">
+                    <VerticalStackLayout Grid.Row="5" Grid.Column="1" Margin="0,10">
                         <Label Text="Duration" Style="{StaticResource FieldLabel}"></Label>
                         <Label Text="{Binding FormattedEventDuration}" FontSize="Small">
                         </Label>
                     </VerticalStackLayout>
-                    <VerticalStackLayout Grid.Row="5" Grid.ColumnSpan="2" Margin="0,10">
+                    <VerticalStackLayout Grid.Row="6" Grid.ColumnSpan="2" Margin="0,10">
                         <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                         <controls:TMEditor
                             Placeholder="Describe your event here"

--- a/TrashMobMobile/Pages/ExplorePage.xaml
+++ b/TrashMobMobile/Pages/ExplorePage.xaml
@@ -211,7 +211,18 @@
                             <DataTemplate x:DataType="viewModels:EventViewModel">
                                 <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
                                     <VerticalStackLayout Padding="10,8" Spacing="2">
-                                        <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                        <HorizontalStackLayout Spacing="6">
+                                            <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                            <Label Text="{Binding EventVisibilityText}" FontSize="Micro"
+                                                   TextColor="{StaticResource Primary}"
+                                                   VerticalOptions="Center">
+                                                <Label.Triggers>
+                                                    <DataTrigger TargetType="Label" Binding="{Binding EventVisibilityText}" Value="Public">
+                                                        <Setter Property="IsVisible" Value="False" />
+                                                    </DataTrigger>
+                                                </Label.Triggers>
+                                            </Label>
+                                        </HorizontalStackLayout>
                                         <Label Text="{Binding DisplayDate}" FontSize="Micro"
                                                TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                                         <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro"

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -524,7 +524,7 @@
     <!-- <x:String x:Key="IconExclamation">&#xf0205;</x:String> -->
     <!-- <x:String x:Key="IconExitToApp">&#xf0206;</x:String> -->
     <!-- <x:String x:Key="IconExport">&#xf0207;</x:String> -->
-    <!-- <x:String x:Key="IconEye">&#xf0208;</x:String> -->
+    <x:String x:Key="IconEye">&#xf0208;</x:String>
     <!-- <x:String x:Key="IconEyeOff">&#xf0209;</x:String> -->
     <!-- <x:String x:Key="IconEyedropper">&#xf020a;</x:String> -->
     <!-- <x:String x:Key="IconEyedropperVariant">&#xf020b;</x:String> -->

--- a/TrashMobMobile/ViewModels/EventViewModel.cs
+++ b/TrashMobMobile/ViewModels/EventViewModel.cs
@@ -37,7 +37,10 @@ public partial class EventViewModel : ObservableObject
     private Guid id;
 
     [ObservableProperty]
-    private bool isEventPublic;
+    private int eventVisibilityId = (int)EventVisibilityEnum.Public;
+
+    [ObservableProperty]
+    private Guid? teamId;
 
     private bool isUserAttending;
 
@@ -134,6 +137,13 @@ public partial class EventViewModel : ObservableObject
         return true;
     }
 
+    public string EventVisibilityText => EventVisibilityId switch
+    {
+        (int)EventVisibilityEnum.TeamOnly => "Team Only",
+        (int)EventVisibilityEnum.Private => "Private",
+        _ => "Public",
+    };
+
     public Event ToEvent()
     {
         return new Event
@@ -148,7 +158,8 @@ public partial class EventViewModel : ObservableObject
             DurationHours = DurationHours,
             DurationMinutes = DurationMinutes,
             EventTypeId = EventTypeId,
-            EventVisibilityId = IsEventPublic ? (int)EventVisibilityEnum.Public : (int)EventVisibilityEnum.Private,
+            EventVisibilityId = EventVisibilityId,
+            TeamId = TeamId,
             Latitude = Address.Latitude,
             Longitude = Address.Longitude,
             MaxNumberOfParticipants = MaxNumberOfParticipants,

--- a/TrashMobMobile/Views/EditEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/EditEvent/TabDetails.xaml
@@ -4,12 +4,11 @@
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
              x:Class="TrashMobMobile.Views.EditEvent.TabDetails">
-    <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *, *" MaximumWidthRequest="400">
+    <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *, *" MaximumWidthRequest="400">
 
         <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="4">
             <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMEntry Text="{Binding EventViewModel.Name}" />
-
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2">
@@ -37,7 +36,6 @@
             <controls:TMEditor Text="{Binding EventViewModel.Description}" />
         </VerticalStackLayout>
 
-
         <VerticalStackLayout Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2">
             <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Type" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
             <controls:TMPicker Title="Event Type" ItemsSource="{Binding ETypes}"
@@ -50,8 +48,18 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="4" Grid.Column="3">
-            <Label Text="Is Event Public?" Style="{StaticResource FieldLabel}" />
-            <CheckBox IsChecked="{Binding EventViewModel.IsEventPublic}" />
+            <Label Text="Visibility" Style="{StaticResource FieldLabel}" />
+            <controls:TMPicker Title="Visibility"
+                               ItemsSource="{Binding VisibilityOptions}"
+                               SelectedItem="{Binding SelectedVisibility, Mode=TwoWay}" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Grid.Row="5" Grid.ColumnSpan="4"
+                             IsVisible="{Binding IsTeamPickerVisible}">
+            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Team" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+            <controls:TMPicker Title="Select Team"
+                               ItemsSource="{Binding TeamNames}"
+                               SelectedItem="{Binding SelectedTeam, Mode=TwoWay}" />
         </VerticalStackLayout>
     </Grid>
 </ContentView>

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
@@ -96,6 +96,21 @@
                                VerticalOptions="Center" />
                     </HorizontalStackLayout>
 
+                    <!-- Visibility -->
+                    <HorizontalStackLayout Spacing="10">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconEye}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="{Binding EventViewModel.EventVisibilityText}"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+
                 </VerticalStackLayout>
             </Border>
 


### PR DESCRIPTION
## Summary
- Replaces the boolean `IsEventPublic` checkbox with a three-option visibility picker (Public / Team Only / Private) in mobile event creation and editing forms
- When "Team Only" is selected, a team picker appears allowing users to scope the event to one of their teams
- Adds visibility display to the View Event details page (eye icon + text) and Explore page event list (badge for non-public events)
- Adds validation requiring team selection for Team Only events

## Changes
- **EventViewModel**: Replace `IsEventPublic` (bool) with `EventVisibilityId` (int) + `TeamId` (Guid?), add `EventVisibilityText` computed property
- **EventExtensions**: Map `EventVisibilityId`/`TeamId` instead of `IsEventPublic` in `ToEventViewModel()`
- **CreateEventViewModel / EditEventViewModel**: Add `ITeamManager` dependency, visibility picker properties, team picker properties, validation
- **Step1.xaml / TabDetails.xaml (Edit)**: Replace checkbox with `TMPicker` for visibility + conditional team picker row
- **ViewEvent/TabDetails.xaml**: Add visibility row with eye icon
- **ExplorePage.xaml**: Show visibility text badge on non-public event cards
- **GoogleMaterialIcons.xaml**: Uncomment `IconEye` glyph

## Test plan
- [ ] Create event with each visibility option (Public, Team Only, Private)
- [ ] Verify team picker appears only when "Team Only" is selected
- [ ] Verify validation prevents saving Team Only events without a team
- [ ] Edit an existing event and change visibility
- [ ] Verify View Event details page shows correct visibility text
- [ ] Verify Explore page shows visibility badge for non-public events
- [ ] Verify public events work exactly as before (no visual badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)