### PR TITLE
Mark Project 47 complete in planning docs

### DIFF
--- a/Planning/Projects/Project_47_Team_Private_Events.md
+++ b/Planning/Projects/Project_47_Team_Private_Events.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 1, 1b, 2, 3 complete; Phase 4 PR #2734 pending) |
+| **Status** | Complete |
 | **Priority** | Medium |
 | **Risk** | Medium |
 | **Size** | Medium |
@@ -265,5 +265,5 @@ if (evt is null || evt.EventVisibilityId != (int)EventVisibilityEnum.Public)
 
 **Last Updated:** February 14, 2026
 **Owner:** Product & Engineering
-**Status:** In Progress — Phases 1, 1b, 2, 3 complete. Phase 4 (Notifications & Polish) in PR #2734.
+**Status:** Complete — All phases (1, 1b, 2, 3, 4) merged.
 **Next Review:** When prioritized

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -68,7 +68,7 @@
 | [Project 39 - Regional Communities](./Projects/Project_39_Regional_Communities.md) | County/state community pages and adoption programs | ✅ Complete |
 | [Project 41 - Sponsored Adoptions](./Projects/Project_41_Sponsored_Adoptions.md) | Sponsor-funded professional cleanup tracking | In Progress (Phases 1-4 Complete) |
 | [Project 42 - Partner Document Management](./Projects/Project_42_Partner_Document_Management.md) | File upload & storage for partner documents | ✅ Complete |
-| [Project 47 - Team-Visible Private Events](./Projects/Project_47_Team_Private_Events.md) | Team-scoped event visibility for member-only events | Not Started |
+| [Project 47 - Team-Visible Private Events](./Projects/Project_47_Team_Private_Events.md) | Team-scoped event visibility for member-only events | ✅ Complete |
 
 #### High Priority (Marketing & Growth)
 
@@ -109,7 +109,7 @@
 - [Project 42 - Partner Document Management](./Projects/Project_42_Partner_Document_Management.md)
 - [Project 43 - Sign Management](./Projects/Project_43_Sign_Management.md)
 - [Project 44 - Area Map Editor](./Projects/Project_44_Area_Map_Editor.md)
-- [Project 47 - Team-Visible Private Events](./Projects/Project_47_Team_Private_Events.md)
+- [Project 47 - Team-Visible Private Events](./Projects/Project_47_Team_Private_Events.md) ✅
 
 ### Impact Tracking
 - [Project 7 - Event Weights](./Projects/Project_07_Event_Weights.md) ✅
@@ -149,11 +149,11 @@
 
 | Status | Count | Projects |
 |--------|-------|----------|
-| ✅ **Complete** | 24 | Projects 3, 7, 9, 10, 11, 13, 14, 16, 17, 18, 19, 20, 21, 26, 27, 28, 29, 32, 34, 35, 37, 39, 40, 42 |
+| ✅ **Complete** | 25 | Projects 3, 7, 9, 10, 11, 13, 14, 16, 17, 18, 19, 20, 21, 26, 27, 28, 29, 32, 34, 35, 37, 39, 40, 42, 47 |
 | **In Progress** | 12 | Projects 1 (Phase 2 Complete, Phase 3 next), 4 (Phases 1-2 Complete), 6, 8 (Phase 1-4 Complete), 15 (Backend & Website Complete), 22 (Phase 1-3 Complete), 25 (Phase 1 Complete), 30, 38 (Phases 1-4, 6-7 Complete), 41 (Phases 1-4 Complete), 44 (Phases 1-4 Complete), 45 (Phases 1-4 Complete) |
 | **Ready for Review** | 2 | Projects 2, 5 |
 | **Planning** | 1 | Project 23 (combined with Project 1) |
-| **Not Started** | 7 | Projects 12, 24, 31, 36, 43, 46, 47 |
+| **Not Started** | 6 | Projects 12, 24, 31, 36, 43, 46 |
 | **Deprioritized** | 1 | Project 33 |
 
 **Total:** 47 project specifications documented


### PR DESCRIPTION
## Summary
- Updated Planning/README.md: Project 47 status → ✅ Complete, moved from "Not Started" (6) to "Complete" (25), added ✅ in Quick Links
- Updated Project_47_Team_Private_Events.md: Status → Complete

## Test plan
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)