### PR TITLE
Fix litter report create/update and improve mobile error handling

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -121,7 +121,7 @@ jobs:
       # Note: Azure AD B2C configuration is now set via environment variables in containerApp.bicep
       # The B2C settings are public configuration values (not secrets) determined by the 'environment' parameter
 
-      - name: Grant Key Vault Access via RBAC
+      - name: Grant Key Vault and Storage Access via RBAC
         run: |
           echo "Getting Container App managed identity..."
           PRINCIPAL_ID=$(az containerapp show \
@@ -130,6 +130,7 @@ jobs:
             --query identity.principalId \
             -o tsv)
           echo "Principal ID: $PRINCIPAL_ID"
+          PERMISSIONS_ADDED=false
 
           # Get Key Vault resource ID for role assignment scope
           KEY_VAULT_ID=$(az keyvault show --name ${{ env.KEY_VAULT_NAME }} --query id -o tsv)
@@ -148,10 +149,32 @@ jobs:
               --assignee $PRINCIPAL_ID \
               --role "Key Vault Secrets User" \
               --scope $KEY_VAULT_ID
-            echo "Waiting 30 seconds for permissions to propagate..."
-            sleep 30
+            PERMISSIONS_ADDED=true
           else
             echo "Key Vault Secrets User role already assigned to principal $PRINCIPAL_ID"
+          fi
+
+          echo "Checking if Storage Blob Data Contributor role already assigned..."
+          EXISTING_STORAGE_ROLE=$(az role assignment list \
+            --assignee $PRINCIPAL_ID \
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.Storage/storageAccounts/${{ env.STORAGE_ACCOUNT_NAME }} \
+            --query "[?roleDefinitionName=='Storage Blob Data Contributor'].roleDefinitionName" \
+            -o tsv)
+
+          if [ -z "$EXISTING_STORAGE_ROLE" ]; then
+            echo "Storage role assignment not found. Granting Storage Blob Data Contributor role..."
+            az role assignment create \
+              --assignee $PRINCIPAL_ID \
+              --role "Storage Blob Data Contributor" \
+              --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.Storage/storageAccounts/${{ env.STORAGE_ACCOUNT_NAME }}
+            PERMISSIONS_ADDED=true
+          else
+            echo "Storage Blob Data Contributor role already assigned"
+          fi
+
+          if [ "$PERMISSIONS_ADDED" = true ]; then
+            echo "Waiting 30 seconds for permissions to propagate..."
+            sleep 30
           fi
 
       - name: Grant Azure Maps Access via RBAC

--- a/.github/workflows/release_ca-tm-pr-westus2.yml
+++ b/.github/workflows/release_ca-tm-pr-westus2.yml
@@ -96,7 +96,7 @@ jobs:
       # Note: Azure AD B2C configuration is now set via environment variables in containerApp.bicep
       # The B2C settings are public configuration values (not secrets) determined by the 'environment' parameter
 
-      - name: Grant Key Vault Access via RBAC
+      - name: Grant Key Vault and Storage Access via RBAC
         run: |
           echo "Getting Container App managed identity..."
           PRINCIPAL_ID=$(az containerapp show \
@@ -105,6 +105,7 @@ jobs:
             --query identity.principalId \
             -o tsv)
           echo "Principal ID: $PRINCIPAL_ID"
+          PERMISSIONS_ADDED=false
 
           # Get Key Vault resource ID for role assignment scope
           KEY_VAULT_ID=$(az keyvault show --name ${{ env.KEY_VAULT_NAME }} --query id -o tsv)
@@ -123,10 +124,32 @@ jobs:
               --assignee $PRINCIPAL_ID \
               --role "Key Vault Secrets User" \
               --scope $KEY_VAULT_ID
-            echo "Waiting 30 seconds for permissions to propagate..."
-            sleep 30
+            PERMISSIONS_ADDED=true
           else
             echo "Key Vault Secrets User role already assigned to principal $PRINCIPAL_ID"
+          fi
+
+          echo "Checking if Storage Blob Data Contributor role already assigned..."
+          EXISTING_STORAGE_ROLE=$(az role assignment list \
+            --assignee $PRINCIPAL_ID \
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.Storage/storageAccounts/${{ env.STORAGE_ACCOUNT_NAME }} \
+            --query "[?roleDefinitionName=='Storage Blob Data Contributor'].roleDefinitionName" \
+            -o tsv)
+
+          if [ -z "$EXISTING_STORAGE_ROLE" ]; then
+            echo "Storage role assignment not found. Granting Storage Blob Data Contributor role..."
+            az role assignment create \
+              --assignee $PRINCIPAL_ID \
+              --role "Storage Blob Data Contributor" \
+              --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.Storage/storageAccounts/${{ env.STORAGE_ACCOUNT_NAME }}
+            PERMISSIONS_ADDED=true
+          else
+            echo "Storage Blob Data Contributor role already assigned"
+          fi
+
+          if [ "$PERMISSIONS_ADDED" = true ]; then
+            echo "Waiting 30 seconds for permissions to propagate..."
+            sleep 30
           fi
 
       - name: Grant Azure Maps Access via RBAC

--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -42,7 +42,7 @@ namespace TrashMob.Shared.Managers.LitterReport
 
                 logger.LogInformation("Updating litter report");
 
-                var existingInstance = Repo.Get().Where(l => l.Id == litterReport.Id)
+                var existingInstance = Repo.Get(l => l.Id == litterReport.Id, withNoTracking: false)
                     .Include(l => l.LitterImages)
                     .FirstOrDefault();
 
@@ -98,7 +98,7 @@ namespace TrashMob.Shared.Managers.LitterReport
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error adding litter report");
+                logger.LogError(ex, "Error updating litter report");
                 return null;
             }
         }

--- a/TrashMobMobile/Pages/CreateLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/CreateLitterReportPage.xaml
@@ -61,7 +61,9 @@
                                         <Grid ColumnDefinitions="Auto, *, Auto">
                                             <Image Grid.Column="0"
                                                    Margin="5"
-                                                   MaximumWidthRequest="100"
+                                                   WidthRequest="80" HeightRequest="80"
+                                                   MaximumWidthRequest="80" MaximumHeightRequest="80"
+                                                   Aspect="AspectFill"
                                                    Source="{Binding FilePath}" />
                                             <Label Grid.Column="1"
                                                    Margin="5"

--- a/TrashMobMobile/Pages/CreateLitterReportPage.xaml.cs
+++ b/TrashMobMobile/Pages/CreateLitterReportPage.xaml.cs
@@ -23,8 +23,6 @@ public partial class CreateLitterReportPage : ContentPage
 
             if (photo != null)
             {
-                await DisplayAlertAsync("Photo Ok", "The photo was successful.", "Ok");
-
                 // save the file into local storage
                 viewModel.LocalFilePath = Path.Combine(FileSystem.CacheDirectory, photo.FileName);
 
@@ -32,13 +30,8 @@ public partial class CreateLitterReportPage : ContentPage
                 using var localFileStream = File.OpenWrite(viewModel.LocalFilePath);
 
                 await sourceStream.CopyToAsync(localFileStream);
-                await DisplayAlertAsync("Photo Ok", "Adding photo to collection.", "Ok");
                 await viewModel.AddImageToCollection();
                 viewModel.ValidateReport();
-            }
-            else
-            {
-                await DisplayAlertAsync("Photo Error", "The photo did not work.", "Ok");
             }
         }
     }

--- a/TrashMobMobile/Pages/EditLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/EditLitterReportPage.xaml
@@ -78,7 +78,10 @@
                                     <Border Style="{StaticResource RoundBorder}" Margin="0,4">
                                         <Grid ColumnDefinitions="Auto, *, Auto"
                                               x:Name="LitterImageItem">
-                                            <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="100"
+                                            <Image Source="{Binding DisplayImageSource}"
+                                                   WidthRequest="80" HeightRequest="80"
+                                                   MaximumWidthRequest="80" MaximumHeightRequest="80"
+                                                   Aspect="AspectFill"
                                                    Grid.Column="0" />
                                             <Label Grid.Column="1" Margin="5"
                                                    FontSize="Small"

--- a/TrashMobMobile/Pages/ViewLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/ViewLitterReportPage.xaml
@@ -49,7 +49,10 @@
                                 <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                                     <Border Style="{StaticResource RoundBorder}" Margin="0,3">
                                         <Grid ColumnDefinitions="Auto, *" Padding="8,6" ColumnSpacing="10">
-                                            <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="80" Aspect="AspectFill" Grid.Column="0" />
+                                            <Image Source="{Binding AzureBlobUrl}"
+                                                   WidthRequest="80" HeightRequest="80"
+                                                   MaximumWidthRequest="80" MaximumHeightRequest="80"
+                                                   Aspect="AspectFill" Grid.Column="0" />
                                             <Label Text="{Binding Address.DisplayAddress}" Grid.Column="1"
                                                    LineBreakMode="WordWrap" FontSize="Small" VerticalOptions="Center"
                                                    TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />

--- a/TrashMobMobile/Services/LitterReportRestService.cs
+++ b/TrashMobMobile/Services/LitterReportRestService.cs
@@ -54,7 +54,13 @@
 
             using (var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken))
             {
-                response.EnsureSuccessStatusCode();
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                    throw new HttpRequestException(
+                        $"Server returned {(int)response.StatusCode} ({response.StatusCode}): {errorBody}");
+                }
+
                 var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 var result = JsonConvert.DeserializeObject<LitterReport>(responseContent);
 
@@ -79,7 +85,12 @@
 
             using (var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken))
             {
-                response.EnsureSuccessStatusCode();
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                    throw new HttpRequestException(
+                        $"Server returned {(int)response.StatusCode} ({response.StatusCode}): {errorBody}");
+                }
 
                 var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 var result = JsonConvert.DeserializeObject<LitterReport>(responseContent);
@@ -191,7 +202,12 @@
 
                     using (var response = await AuthorizedHttpClient.SendAsync(request, cancellationToken))
                     {
-                        response.EnsureSuccessStatusCode();
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                            throw new HttpRequestException(
+                                $"Image upload failed with {(int)response.StatusCode} ({response.StatusCode}): {errorBody}");
+                        }
                     }
                 }
         }

--- a/TrashMobMobile/ViewModels/BaseViewModel.cs
+++ b/TrashMobMobile/ViewModels/BaseViewModel.cs
@@ -34,7 +34,7 @@ public abstract partial class BaseViewModel(INotificationService notificationSer
         {
             SentrySdk.CaptureException(ex);
             IsError = true;
-            await NotificationService.NotifyError(errorMessage);
+            await NotificationService.NotifyError(string.IsNullOrEmpty(ex.Message) ? errorMessage : ex.Message);
         }
         catch (TaskCanceledException ex)
         {
@@ -74,7 +74,7 @@ public abstract partial class BaseViewModel(INotificationService notificationSer
         {
             SentrySdk.CaptureException(ex);
             IsError = true;
-            await NotificationService.NotifyError(errorMessage);
+            await NotificationService.NotifyError(string.IsNullOrEmpty(ex.Message) ? errorMessage : ex.Message);
             return default;
         }
         catch (TaskCanceledException ex)

--- a/TrashMobMobile/ViewModels/CreateLitterReportViewModel.cs
+++ b/TrashMobMobile/ViewModels/CreateLitterReportViewModel.cs
@@ -152,6 +152,7 @@ public partial class CreateLitterReportViewModel : BaseViewModel
             }
 
             var litterReport = LitterReportViewModel.ToLitterReport();
+            litterReport.Id = Guid.NewGuid();
             litterReport.Name = Name;
             litterReport.Description = Description;
 
@@ -162,7 +163,7 @@ public partial class CreateLitterReportViewModel : BaseViewModel
                     Id = Guid.NewGuid(),
                     City = litterImageViewModel.Address.City,
                     Country = litterImageViewModel.Address.Country,
-                    LitterReportId = litterImageViewModel.LitterReportId,
+                    LitterReportId = litterReport.Id,
                     Latitude = litterImageViewModel.Address.Latitude,
                     Longitude = litterImageViewModel.Address.Longitude,
                     PostalCode = litterImageViewModel.Address.PostalCode,

--- a/TrashMobMobile/ViewModels/EditLitterReportViewModel.cs
+++ b/TrashMobMobile/ViewModels/EditLitterReportViewModel.cs
@@ -175,7 +175,7 @@ public partial class EditLitterReportViewModel(ILitterReportManager litterReport
             {
                 var litterImage = new LitterImage
                 {
-                    Id = Guid.NewGuid(),
+                    Id = litterImageViewModel.Id == Guid.Empty ? Guid.NewGuid() : litterImageViewModel.Id,
                     City = litterImageViewModel.Address.City,
                     Country = litterImageViewModel.Address.Country,
                     LitterReportId = litterImageViewModel.LitterReportId,

--- a/TrashMobMobile/ViewModels/LitterImageViewModel.cs
+++ b/TrashMobMobile/ViewModels/LitterImageViewModel.cs
@@ -9,6 +9,7 @@ public partial class LitterImageViewModel : BaseViewModel
     private AddressViewModel address;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DisplayImageSource))]
     private string azureBlobUrl;
 
     [ObservableProperty]
@@ -18,7 +19,13 @@ public partial class LitterImageViewModel : BaseViewModel
     private DateTimeOffset? createdDate;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DisplayImageSource))]
     private string filePath;
+
+    /// <summary>
+    /// Returns the local file path if available (new photo), otherwise the server URL.
+    /// </summary>
+    public string DisplayImageSource => !string.IsNullOrEmpty(FilePath) ? FilePath : AzureBlobUrl;
 
     [ObservableProperty]
     private Guid id;


### PR DESCRIPTION
## Summary

- **Fix 400 BadRequest on litter report update**: The server-side `LitterReportManager.UpdateAsync` loaded the existing entity with `AsNoTracking()`, causing a `DbUpdateConcurrencyException` when `dbSet.Update()` tried to save the detached entity graph. Changed to tracked query (`withNoTracking: false`) so EF Core properly tracks changes.
- **Fix 500 on litter report create**: Added `Storage Blob Data Contributor` RBAC role assignment in both dev and prod deployment workflows so the container app identity can upload images to blob storage.
- **Improve mobile error handling**: Read HTTP response body on errors instead of generic `EnsureSuccessStatusCode`; show actual server error messages to user via `BaseViewModel`.
- **Fix image thumbnails**: Constrain litter images to 80x80 with `MaximumWidthRequest`/`MaximumHeightRequest` on all litter report pages.
- **Fix edit flow**: Preserve existing image IDs on update (don't regenerate); add `DisplayImageSource` property to show local file vs Azure blob URL.
- **Remove debug alerts**: Remove leftover `DisplayAlertAsync` popups from CreateLitterReportPage.

## Test plan

- [ ] Create a new litter report with 1-3 images — should succeed (no 500 error)
- [ ] Edit an existing litter report (change name/description) — should succeed (no 400 error)
- [ ] Add new image to existing litter report — should succeed
- [ ] Delete image from existing litter report — should succeed
- [ ] Verify image thumbnails display at consistent 80x80 size on all litter report pages
- [ ] Verify no debug popup alerts appear when taking photos
- [ ] Verify error messages show actual server errors (not generic "An error has occurred")

🤖 Generated with [Claude Code](https://claude.com/claude-code)