### PR TITLE
Fix adoptable area create 400 bad request

### DIFF
--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/create.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/create.tsx
@@ -119,7 +119,7 @@ export const PartnerCommunityAreaCreate = () => {
             if (!partnerId) return;
 
             const area: AdoptableAreaData = {
-                id: '',
+                id: '00000000-0000-0000-0000-000000000000',
                 partnerId,
                 name: formValues.name,
                 description: formValues.description,
@@ -135,9 +135,9 @@ export const PartnerCommunityAreaCreate = () => {
                 safetyRequirements: formValues.safetyRequirements,
                 allowCoAdoption: formValues.allowCoAdoption,
                 isActive: true,
-                createdByUserId: '',
+                createdByUserId: '00000000-0000-0000-0000-000000000000',
                 createdDate: new Date(),
-                lastUpdatedByUserId: '',
+                lastUpdatedByUserId: '00000000-0000-0000-0000-000000000000',
                 lastUpdatedDate: new Date(),
             };
 


### PR DESCRIPTION
## Summary

- Fix 400 Bad Request when creating a new adoptable area — `id`, `createdByUserId`, and `lastUpdatedByUserId` were set to empty strings (`''`) which fail .NET `System.Guid` deserialization. Changed to empty GUID format (`00000000-0000-0000-0000-000000000000`).

## Test plan

- [ ] Navigate to Partner Dashboard > Adoptable Areas > Create Area
- [ ] Fill in required fields, draw a polygon, click Create Area
- [ ] Area saves successfully (no 400 error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)