### PR TITLE
Fix litter report images not displaying after upload

### DIFF
--- a/TrashMob/Controllers/LitterReportController.cs
+++ b/TrashMob/Controllers/LitterReportController.cs
@@ -268,6 +268,11 @@ namespace TrashMob.Controllers
 
             await imageManager.UploadImageAsync(imageUpload);
 
+            // Update the LitterImage record with the blob URL so the detail page can display it
+            var imageUrl = await imageManager.GetImageUrlAsync(litterImageId, ImageTypeEnum.LitterImage, ImageSizeEnum.Reduced, cancellationToken);
+            litterImage.AzureBlobURL = imageUrl;
+            await litterImageManager.UpdateAsync(litterImage, UserId, cancellationToken);
+
             return Ok();
         }
 


### PR DESCRIPTION
## Summary

- After uploading a litter image to blob storage, the `LitterImage.AzureBlobURL` was never updated in the database. The detail page reads this field (via `ToFullLitterImage()` → `ImageURL`) to render images, so it was always empty/null, showing a broken image placeholder.
- Fix: after `UploadImageAsync`, look up the blob URL via `GetImageUrlAsync` and save it to the `LitterImage` record.

## Test plan

- [ ] Create a new litter report with one or more photos
- [ ] After submission, verify the detail page shows the uploaded images (not broken placeholders)
- [ ] Edit an existing litter report — existing images still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)