### PR TITLE
Redesign waiver signing flow with hub/list view

### DIFF
--- a/TrashMob/client-app/src/components/Waivers/WaiverSigningFlow.tsx
+++ b/TrashMob/client-app/src/components/Waivers/WaiverSigningFlow.tsx
@@ -85,7 +85,7 @@ export const WaiverSigningFlow: React.FC<WaiverSigningFlowProps> = ({ waivers, o
         return (
             <WaiverSigningDialog
                 waiver={waivers[0]}
-                open={open && selectedWaiver === null && signedWaiverIds.size === 0}
+                open={open && selectedWaiver === null ? signedWaiverIds.size === 0 : null}
                 onClose={handleSigningCancelled}
                 onSigned={handleWaiverSigned}
             />
@@ -159,7 +159,7 @@ export const WaiverSigningFlow: React.FC<WaiverSigningFlowProps> = ({ waivers, o
             {selectedWaiver ? (
                 <WaiverSigningDialog
                     waiver={selectedWaiver}
-                    open={true}
+                    open
                     onClose={handleSigningCancelled}
                     onSigned={handleWaiverSigned}
                 />


### PR DESCRIPTION
## Summary
- Redesigns `WaiverSigningFlow` to show a hub/list dialog when multiple waivers are required
- Users see all waivers with signed/unsigned status and choose which to sign
- After signing a waiver, returns to the hub with that waiver marked as signed
- When all waivers are signed, a "Continue" button completes the flow
- Single-waiver case unchanged (opens signing dialog directly)
- No changes to callers (RegisterBtn, MyWaiversCard, LitterReportDetailPage) — same props interface

## Test plan
- [ ] With 2+ required waivers: hub shows list, sign one, returns to hub with it marked signed, sign remaining, "Continue" appears
- [ ] With 1 required waiver: goes directly to signing dialog (no hub)
- [ ] Cancel from hub closes flow (`onComplete(false)`)
- [ ] Cancel from signing dialog returns to hub (does not exit flow)
- [ ] RegisterBtn: attend event needing waivers → hub → sign all → registers
- [ ] MyWaiversCard: "Sign Required Waivers" → hub → sign all → lists refresh
- [ ] Litter report: "Create Event" with pending waivers → hub → sign all → navigates

🤖 Generated with [Claude Code](https://claude.com/claude-code)