### PR TITLE
Add concurrency controls to deployment workflows

### DIFF
--- a/.github/workflows/container_ca-authext-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-authext-tm-dev-westus2.yml
@@ -12,6 +12,12 @@ on:
       - 'Deploy/containerAppAuthExtension.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on main.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-dev-authext
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmdevwestus2
   CONTAINER_APP_NAME: ca-authext-tm-dev-westus2

--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -14,6 +14,12 @@ on:
       - 'Deploy/containerApp.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on main.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmdevwestus2
   CONTAINER_APP_NAME: ca-tm-dev-westus2

--- a/.github/workflows/container_caj-tm-dev-westus2-daily.yml
+++ b/.github/workflows/container_caj-tm-dev-westus2-daily.yml
@@ -14,6 +14,12 @@ on:
       - 'Deploy/containerAppJobDaily.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on main.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-dev-daily
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmdevwestus2
   CONTAINER_APP_JOB_NAME: caj-tm-dev-westus2-daily

--- a/.github/workflows/container_caj-tm-dev-westus2-hourly.yml
+++ b/.github/workflows/container_caj-tm-dev-westus2-hourly.yml
@@ -14,6 +14,12 @@ on:
       - 'Deploy/containerAppJobHourly.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on main.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-dev-hourly
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmdevwestus2
   CONTAINER_APP_JOB_NAME: caj-tm-dev-westus2-hourly

--- a/.github/workflows/container_mcp-tm-dev-westus2.yml
+++ b/.github/workflows/container_mcp-tm-dev-westus2.yml
@@ -14,6 +14,12 @@ on:
       - 'Deploy/containerAppMCP.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on main.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-dev-mcp
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmdevwestus2
   CONTAINER_APP_NAME: ca-mcp-tm-dev-westus2

--- a/.github/workflows/container_strapi-tm-dev-westus2.yml
+++ b/.github/workflows/container_strapi-tm-dev-westus2.yml
@@ -12,6 +12,12 @@ on:
       - 'Deploy/containerAppStrapi.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on main.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-dev-strapi
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmdevwestus2
   CONTAINER_APP_NAME: ca-strapi-tm-dev-westus2

--- a/.github/workflows/release_ca-tm-pr-westus2.yml
+++ b/.github/workflows/release_ca-tm-pr-westus2.yml
@@ -14,6 +14,12 @@ on:
       - 'Deploy/containerApp.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on release.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmprwestus2
   CONTAINER_APP_NAME: ca-tm-pr-westus2

--- a/.github/workflows/release_caj-tm-pr-westus2-daily.yml
+++ b/.github/workflows/release_caj-tm-pr-westus2-daily.yml
@@ -14,6 +14,12 @@ on:
       - 'Deploy/containerAppJobDaily.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on release.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-prod-daily
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmprwestus2
   CONTAINER_APP_JOB_NAME: caj-tm-pr-westus2-daily

--- a/.github/workflows/release_caj-tm-pr-westus2-hourly.yml
+++ b/.github/workflows/release_caj-tm-pr-westus2-hourly.yml
@@ -14,6 +14,12 @@ on:
       - 'Deploy/containerAppJobHourly.bicep'
   workflow_dispatch:
 
+# Cancel in-progress deployments when a newer commit lands on release.
+# Only the latest code matters — earlier runs deploy stale commits.
+concurrency:
+  group: deploy-prod-hourly
+  cancel-in-progress: true
+
 env:
   AZURE_CONTAINER_REGISTRY: acrtmprwestus2
   CONTAINER_APP_JOB_NAME: caj-tm-pr-westus2-hourly


### PR DESCRIPTION
## Summary
- Adds `concurrency` with `cancel-in-progress: true` to all 9 deployment workflows (dev + prod)
- Prevents ARM `DeploymentActive` errors when multiple PRs merge in quick succession
- Each workflow gets its own concurrency group so different services don't block each other

**Concurrency groups:**
| Group | Workflow | Branch |
|-------|----------|--------|
| `deploy-dev` | Container App (web) | main |
| `deploy-dev-daily` | Daily Jobs | main |
| `deploy-dev-hourly` | Hourly Jobs | main |
| `deploy-dev-mcp` | MCP Server | main |
| `deploy-dev-strapi` | Strapi CMS | main |
| `deploy-dev-authext` | Auth Extension | main |
| `deploy-prod` | Container App (web) | release |
| `deploy-prod-daily` | Daily Jobs | release |
| `deploy-prod-hourly` | Hourly Jobs | release |

**Root cause:** When multiple commits land on `main` (or `release`) in quick succession, Azure ARM rejects concurrent `az deployment group create` calls with `DeploymentActive` error. The `cancel-in-progress` strategy is preferred over queuing because only the latest commit matters for deployment — earlier runs deploy stale code.

## Test plan
- [ ] Verify workflows pass YAML linting
- [ ] Merge 2+ PRs in quick succession and confirm only the latest deployment runs complete
- [ ] Verify `workflow_dispatch` still works for manual triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)