### PR TITLE
Mobile: multi-waiver flow, styled popup, thumbnails, and UI fixes

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -41,6 +41,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(ViewPickupLocationPage), typeof(ViewPickupLocationPage));
         Routing.RegisterRoute(nameof(ViewCommunityPage), typeof(ViewCommunityPage));
         Routing.RegisterRoute(nameof(ViewTeamPage), typeof(ViewTeamPage));
+        Routing.RegisterRoute(nameof(WaiverListPage), typeof(WaiverListPage));
         Routing.RegisterRoute(nameof(WaiverPage), typeof(WaiverPage));
         Routing.RegisterRoute(nameof(WelcomePage), typeof(WelcomePage));
         Routing.RegisterRoute(nameof(AgeGatePage), typeof(AgeGatePage));

--- a/TrashMobMobile/Config/Settings.cs
+++ b/TrashMobMobile/Config/Settings.cs
@@ -1,7 +1,5 @@
 ﻿namespace TrashMobMobile.Config;
 
-using TrashMobMobile.Models;
-
 public static class Settings
 {
 #if USETEST
@@ -13,12 +11,6 @@ public static class Settings
 
     public const string SiteBaseUrl = "https://www.trashmob.eco";
 #endif
-
-    public static WaiverVersion CurrentTrashMobWaiverVersion => new()
-    {
-        VersionId = "1.0",
-        VersionDate = "2023-07-01 00:00:00",
-    };
 
     public const int DefaultTravelDistance = 20;
     public const float DefaultLatitude = 39.0919879f;

--- a/TrashMobMobile/Controls/QuickActionPopup.xaml.cs
+++ b/TrashMobMobile/Controls/QuickActionPopup.xaml.cs
@@ -1,5 +1,7 @@
 namespace TrashMobMobile.Controls;
 
+using CommunityToolkit.Maui.Extensions;
+
 public partial class QuickActionPopup : ContentView
 {
     public const string CreateEvent = "CreateEvent";
@@ -7,27 +9,25 @@ public partial class QuickActionPopup : ContentView
 
     public string? SelectedAction { get; private set; }
 
-    public event EventHandler? ActionSelected;
-
     public QuickActionPopup()
     {
         InitializeComponent();
     }
 
-    private void OnCreateEventClicked(object? sender, EventArgs e)
+    private async void OnCreateEventClicked(object? sender, EventArgs e)
     {
         SelectedAction = CreateEvent;
-        ActionSelected?.Invoke(this, EventArgs.Empty);
+        await Shell.Current.ClosePopupAsync(SelectedAction);
     }
 
-    private void OnReportLitterClicked(object? sender, EventArgs e)
+    private async void OnReportLitterClicked(object? sender, EventArgs e)
     {
         SelectedAction = ReportLitter;
-        ActionSelected?.Invoke(this, EventArgs.Empty);
+        await Shell.Current.ClosePopupAsync(SelectedAction);
     }
 
-    private void OnCancelClicked(object? sender, EventArgs e)
+    private async void OnCancelClicked(object? sender, EventArgs e)
     {
-        ActionSelected?.Invoke(this, EventArgs.Empty);
+        await Shell.Current.ClosePopupAsync();
     }
 }

--- a/TrashMobMobile/Extensions/UserExtensions.cs
+++ b/TrashMobMobile/Extensions/UserExtensions.cs
@@ -1,40 +1,20 @@
-﻿namespace TrashMobMobile.Extensions
+namespace TrashMobMobile.Extensions;
+
+using TrashMob.Models;
+
+public static class UserExtensions
 {
-    using TrashMob.Models;
-    using TrashMobMobile.Models;
-
-    public static class UserExtensions
+    public static AddressViewModel GetAddress(this User user)
     {
-        public static bool HasUserSignedWaiver(this User user, Waiver waiver, TrashMobMobile.Models.WaiverVersion waiverVersion)
+        return new AddressViewModel
         {
-            // If there is no waiver, skip it
-            if (waiver == null)
-            {
-                return true;
-            }
-
-            if (waiver.IsWaiverEnabled &&
-                (user.DateAgreedToTrashMobWaiver == null ||
-                 user.DateAgreedToTrashMobWaiver < DateTime.Parse(waiverVersion.VersionDate)))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        public static AddressViewModel GetAddress(this User user)
-        {
-            return new AddressViewModel
-            {
-                City = user.City,
-                Country = user.Country,
-                Latitude = user.Latitude,
-                Longitude = user.Longitude,
-                PostalCode = user.PostalCode,
-                Region = user.Region,
-                Location = new Location(user.Latitude ?? Config.Settings.DefaultLatitude, user.Longitude ?? Config.Settings.DefaultLongitude),
-            };
-        }
+            City = user.City,
+            Country = user.Country,
+            Latitude = user.Latitude,
+            Longitude = user.Longitude,
+            PostalCode = user.PostalCode,
+            Region = user.Region,
+            Location = new Location(user.Latitude ?? Config.Settings.DefaultLatitude, user.Longitude ?? Config.Settings.DefaultLongitude),
+        };
     }
 }

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -93,6 +93,7 @@ public static class MauiProgram
         builder.Services.AddTransient<ViewPickupLocationPage>();
         builder.Services.AddTransient<ViewCommunityPage>();
         builder.Services.AddTransient<ViewTeamPage>();
+        builder.Services.AddTransient<WaiverListPage>();
         builder.Services.AddTransient<WaiverPage>();
         builder.Services.AddTransient<WelcomePage>();
         builder.Services.AddTransient<AgeGatePage>();
@@ -132,6 +133,7 @@ public static class MauiProgram
         builder.Services.AddTransient<ViewPickupLocationViewModel>();
         builder.Services.AddTransient<ViewCommunityViewModel>();
         builder.Services.AddTransient<ViewTeamViewModel>();
+        builder.Services.AddTransient<WaiverListViewModel>();
         builder.Services.AddTransient<WaiverViewModel>();
         builder.Services.AddTransient<WelcomeViewModel>();
         builder.Services.AddTransient<AgeGateViewModel>();

--- a/TrashMobMobile/Models/AcceptWaiverApiRequest.cs
+++ b/TrashMobMobile/Models/AcceptWaiverApiRequest.cs
@@ -1,0 +1,16 @@
+namespace TrashMobMobile.Models;
+
+public class AcceptWaiverApiRequest
+{
+    public Guid WaiverVersionId { get; set; }
+
+    public string TypedLegalName { get; set; } = string.Empty;
+
+    public bool IsMinor { get; set; }
+
+    public Guid? GuardianUserId { get; set; }
+
+    public string? GuardianName { get; set; }
+
+    public string? GuardianRelationship { get; set; }
+}

--- a/TrashMobMobile/Models/WaiverVersion.cs
+++ b/TrashMobMobile/Models/WaiverVersion.cs
@@ -1,9 +1,0 @@
-﻿namespace TrashMobMobile.Models
-{
-    public class WaiverVersion
-    {
-        public string VersionId { get; set; } = string.Empty;
-
-        public string VersionDate { get; set; } = string.Empty;
-    }
-}

--- a/TrashMobMobile/Pages/ExplorePage.xaml
+++ b/TrashMobMobile/Pages/ExplorePage.xaml
@@ -176,13 +176,25 @@
                         <CollectionView.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:LitterReportViewModel">
                                 <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
-                                    <VerticalStackLayout Padding="10,8" Spacing="2">
-                                        <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
-                                        <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
-                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                        <Label Text="{Binding Description}" FontSize="Micro" MaxLines="2"
-                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                    </VerticalStackLayout>
+                                    <Grid ColumnDefinitions="*, Auto" Padding="10,8">
+                                        <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                            <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                            <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </VerticalStackLayout>
+                                        <Border Grid.Column="1"
+                                                StrokeShape="RoundRectangle 6"
+                                                StrokeThickness="0"
+                                                IsVisible="{Binding HasThumbnail}"
+                                                WidthRequest="56"
+                                                HeightRequest="56"
+                                                VerticalOptions="Center">
+                                            <Image Source="{Binding ThumbnailUrl}"
+                                                   Aspect="AspectFill"
+                                                   WidthRequest="56"
+                                                   HeightRequest="56" />
+                                        </Border>
+                                    </Grid>
                                     <Border.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ExploreViewModel}}, Path=ViewLitterReportCommand}"

--- a/TrashMobMobile/Pages/ImpactPage.xaml
+++ b/TrashMobMobile/Pages/ImpactPage.xaml
@@ -202,12 +202,12 @@
                                 Command="{Binding ViewLeaderboardsCommand}"
                                 Style="{StaticResource SecondaryLargeButton}"
                                 ContentLayout="Left, 12"
-                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconTrophy}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconTrophy}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                         <Button Text="Achievements"
                                 Command="{Binding ViewAchievementsCommand}"
                                 Style="{StaticResource SecondaryLargeButton}"
                                 ContentLayout="Left, 12"
-                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMedal}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMedal}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                     </VerticalStackLayout>
                 </Border>
 

--- a/TrashMobMobile/Pages/ProfilePage.xaml
+++ b/TrashMobMobile/Pages/ProfilePage.xaml
@@ -160,13 +160,25 @@
                         <CollectionView.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:LitterReportViewModel">
                                 <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
-                                    <VerticalStackLayout Padding="10,8" Spacing="2">
-                                        <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
-                                        <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
-                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                        <Label Text="{Binding Description}" FontSize="Micro" MaxLines="2"
-                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                                    </VerticalStackLayout>
+                                    <Grid ColumnDefinitions="*, Auto" Padding="10,8">
+                                        <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                            <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                            <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </VerticalStackLayout>
+                                        <Border Grid.Column="1"
+                                                StrokeShape="RoundRectangle 6"
+                                                StrokeThickness="0"
+                                                IsVisible="{Binding HasThumbnail}"
+                                                WidthRequest="56"
+                                                HeightRequest="56"
+                                                VerticalOptions="Center">
+                                            <Image Source="{Binding ThumbnailUrl}"
+                                                   Aspect="AspectFill"
+                                                   WidthRequest="56"
+                                                   HeightRequest="56" />
+                                        </Border>
+                                    </Grid>
                                     <Border.GestureRecognizers>
                                         <TapGestureRecognizer
                                             Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ProfileViewModel}}, Path=ViewLitterReportCommand}"

--- a/TrashMobMobile/Pages/SearchLitterReportsPage.xaml
+++ b/TrashMobMobile/Pages/SearchLitterReportsPage.xaml
@@ -126,29 +126,29 @@
                                     MaximumHeightRequest="400">
                         <CollectionView.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:LitterReportViewModel">
-                                <StackLayout Margin="5">
-                                    <Border Style="{StaticResource RoundBorder}">
-                                        <Grid ColumnDefinitions="*, *"
-                                              RowDefinitions="Auto, Auto, Auto"
-                                              x:Name="LitterReportItem">
-                                            <Label Text="{Binding Name}" Grid.Row="0" Grid.ColumnSpan="1"
-                                                   FontSize="Small" />
-                                            <Label Text="{Binding CreatedDate}" Grid.Row="0" Grid.ColumnSpan="1"
-                                                   Grid.Column="1" FontSize="Micro" />
-                                            <Label Text="{Binding Description}" Grid.Row="1" Grid.ColumnSpan="2"
-                                                   FontSize="Micro" />
-                                            <Label Text="Locations" Grid.Row="2" FontSize="Micro" FontAttributes="Bold" />
-                                            <CollectionView ItemsSource="{Binding LitterImageViewModels}" Grid.Row="2"
-                                                            Grid.Column="1">
-                                                <CollectionView.ItemTemplate>
-                                                    <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                                        <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro" />
-                                                    </DataTemplate>
-                                                </CollectionView.ItemTemplate>
-                                            </CollectionView>
-                                        </Grid>
-                                    </Border>
-                                </StackLayout>
+                                <Border Style="{x:StaticResource RoundBorder}" Margin="5,3">
+                                    <Grid ColumnDefinitions="*, Auto" Padding="10,8">
+                                        <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                            <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                            <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding CreatedDate}" FontSize="Micro"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </VerticalStackLayout>
+                                        <Border Grid.Column="1"
+                                                StrokeShape="RoundRectangle 6"
+                                                StrokeThickness="0"
+                                                IsVisible="{Binding HasThumbnail}"
+                                                WidthRequest="56"
+                                                HeightRequest="56"
+                                                VerticalOptions="Center">
+                                            <Image Source="{Binding ThumbnailUrl}"
+                                                   Aspect="AspectFill"
+                                                   WidthRequest="56"
+                                                   HeightRequest="56" />
+                                        </Border>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </CollectionView.ItemTemplate>
                     </CollectionView>

--- a/TrashMobMobile/Pages/WaiverListPage.xaml
+++ b/TrashMobMobile/Pages/WaiverListPage.xaml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             xmlns:models="clr-namespace:TrashMob.Models;assembly=TrashMob.Models"
+             x:DataType="viewModels:WaiverListViewModel"
+             x:Class="TrashMobMobile.Pages.WaiverListPage"
+             Shell.BackButtonBehavior="{BackButtonBehavior IsVisible=False}"
+             Title="Required Waivers">
+    <ScrollView>
+        <Grid>
+            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
+
+                <!-- Intro -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="The following waivers must be signed before you can create or participate in events."
+                               FontSize="Small" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Pending Waivers -->
+                <Label Text="Pending"
+                       FontFamily="LexendSemibold"
+                       FontSize="Small"
+                       Margin="14,8,14,0"
+                       IsVisible="{Binding HasPendingWaivers}" />
+
+                <CollectionView ItemsSource="{Binding PendingWaivers}"
+                                SelectionMode="None"
+                                IsVisible="{Binding HasPendingWaivers}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:WaiverVersion">
+                            <Border Style="{StaticResource RoundBorder}" Margin="10,3">
+                                <Grid ColumnDefinitions="Auto, *, Auto" Padding="12,10" ColumnSpacing="12">
+                                    <Image Grid.Column="0" WidthRequest="24" HeightRequest="24" VerticalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconFileDocument}"
+                                                             Size="24"
+                                                             Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
+                                        <Label Text="{Binding Name}"
+                                               FontFamily="LexendSemibold"
+                                               FontSize="Small" />
+                                        <Label Text="Tap to review and sign"
+                                               FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                    <Image Grid.Column="2" WidthRequest="20" HeightRequest="20" VerticalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconChevronRight}"
+                                                             Size="20"
+                                                             Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:WaiverListViewModel}}, Path=SelectWaiverCommand}"
+                                        CommandParameter="{Binding .}" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <!-- Signed Waivers -->
+                <Label Text="Signed"
+                       FontFamily="LexendSemibold"
+                       FontSize="Small"
+                       Margin="14,8,14,0"
+                       IsVisible="{Binding HasSignedWaivers}" />
+
+                <CollectionView ItemsSource="{Binding SignedWaivers}"
+                                SelectionMode="None"
+                                IsVisible="{Binding HasSignedWaivers}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:UserWaiver">
+                            <Border Style="{StaticResource RoundBorder}" Margin="10,3">
+                                <Grid ColumnDefinitions="Auto, *" Padding="12,10" ColumnSpacing="12">
+                                    <Image Grid.Column="0" WidthRequest="24" HeightRequest="24" VerticalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconCheckCircle}"
+                                                             Size="24"
+                                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
+                                        <Label Text="{Binding WaiverVersion.Name}"
+                                               FontFamily="LexendSemibold"
+                                               FontSize="Small" />
+                                        <Label Text="{Binding AcceptedDate, StringFormat='Signed {0:MMM d, yyyy}'}"
+                                               FontSize="Micro"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <!-- All Signed Message -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,4"
+                        IsVisible="{Binding AllWaiversSigned}">
+                    <HorizontalStackLayout Spacing="8" Padding="4">
+                        <Image WidthRequest="20" HeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconCheckCircle}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="All waivers signed! You may continue."
+                               FontSize="Small"
+                               VerticalOptions="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                    </HorizontalStackLayout>
+                </Border>
+
+                <!-- Buttons -->
+                <VerticalStackLayout Spacing="8" Margin="10,8,10,10">
+                    <Button Text="Continue"
+                            Command="{Binding ContinueCommand}"
+                            Style="{StaticResource PrimaryLargeButton}" />
+                    <Button Text="Cancel"
+                            Clicked="OnCancelClicked"
+                            Style="{StaticResource SecondaryLargeButton}" />
+                </VerticalStackLayout>
+
+            </VerticalStackLayout>
+            <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
+                     VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" VerticalOptions="Center"
+                               HorizontalOptions="Center" />
+        </Grid>
+    </ScrollView>
+</ContentPage>

--- a/TrashMobMobile/Pages/WaiverListPage.xaml.cs
+++ b/TrashMobMobile/Pages/WaiverListPage.xaml.cs
@@ -1,0 +1,26 @@
+namespace TrashMobMobile.Pages;
+
+using TrashMobMobile.ViewModels;
+
+public partial class WaiverListPage : ContentPage
+{
+    private readonly WaiverListViewModel viewModel;
+
+    public WaiverListPage(WaiverListViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        BindingContext = this.viewModel;
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init();
+    }
+
+    private void OnCancelClicked(object? sender, EventArgs e)
+    {
+        Shell.Current.SendBackButtonPressed();
+    }
+}

--- a/TrashMobMobile/Pages/WaiverPage.xaml
+++ b/TrashMobMobile/Pages/WaiverPage.xaml
@@ -2,12 +2,10 @@
 
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:DataType="viewModels:WaiverViewModel"
              x:Class="TrashMobMobile.Pages.WaiverPage"
-             Shell.BackButtonBehavior="{BackButtonBehavior IsVisible=False}"
-             Title="TrashMob.eco Waiver">
+             Title="{Binding WaiverName}">
     <ScrollView>
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="8">
@@ -15,48 +13,16 @@
                 <!-- Intro -->
                 <Border Style="{StaticResource RoundBorder}" Margin="10,8,10,0">
                     <VerticalStackLayout Spacing="8">
-                        <Label Text="In order to create or participate in TrashMob.eco events, you must agree to a liability waiver. Please click the Sign Waiver button below."
+                        <Label Text="Please review the waiver below, then check the box and enter your full legal name to sign."
                                FontSize="Small" />
-                        <Label Text="You will only need to sign this waiver once unless we have to change the legalese."
-                               FontSize="Micro"
-                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                     </VerticalStackLayout>
                 </Border>
 
-                <!-- Waiver Text -->
+                <!-- Waiver Text (loaded from API) -->
                 <Border Style="{StaticResource RoundBorder}" Margin="10,0">
-                    <VerticalStackLayout Spacing="8">
-                        <Label Text="TrashMob.eco Volunteer Release"
-                               FontFamily="LexendSemibold"
-                               FontSize="Medium"
-                               HorizontalTextAlignment="Center"
-                               HorizontalOptions="Center" />
-                        <Label Text="and Waiver of Liability Form"
-                               FontFamily="LexendSemibold"
-                               FontSize="Medium"
-                               HorizontalTextAlignment="Center"
-                               HorizontalOptions="Center" />
-                        <Label Text="THE VOLUNTEER RELEASE AND WAIVER OF LIABILITY FORM (&quot;RELEASE&quot;)"
-                               FontSize="Small"
-                               FontAttributes="Bold" />
-                        <Label Text="(&quot;VOLUNTEER&quot;) HEREBY RELEASES TRASHMOB.ECO, ITS OFFICERS AND DIRECTORS, ANY LAND OWNERS AND MANAGERS, AND ALL RELATED SPONSORS (&quot;PARTIES&quot;) JOINTLY AND SEVERALLY, AND INDIVIDUALLY."
-                               FontSize="Small"
-                               FontAttributes="Bold" />
-                        <Label Text="The Volunteer desires to provide volunteer services and to participate in activities related to serving as a volunteer for events facilitated by TrashMob.eco.  Volunteer services (&quot;Services&quot;) will be broadly defined as picking up trash at TrashMob.eco facilitated events (&quot;Events&quot;). The above Volunteer hereby agrees as follows: "
-                               FontSize="Small" />
-                        <Label Text="1.	WAIVER AND RELEASE:  I, the Volunteer, release and forever discharge and hold harmless the Parties from any and all liability, claims, and demands of whatever kind or nature, either in law or in equity, which arise or may hereafter arise as result of my participation in such Events.  I understand and acknowledge that this Release discharges from any liability or claim that I may have with respect to bodily injury, personal injury, illness, death, or property damage that may result from the Services I am providing by participating in the Event."
-                               FontSize="Small" />
-                        <Label Text="2.	INSURANCE:  I, the Volunteer, understand that none of the Parties assume any responsibility for or obligation to provide me with financial or other assistance, including but not limited to medical, health, or disability benefits or insurance of any nature in the event of my injury, illness, death or damage to my property.  I expressly waive any such claim for compensation or liability from the Parties."
-                               FontSize="Small" />
-                        <Label Text="3.	MEDICAL TREATMENT:  I, the Volunteer, do hereby release and forever discharge the Parties from any claim whatsoever which arises or may hereafter arise on account of any first aid, treatment, or service rendered by any person in connection with an emergency during my tenure as a volunteer during the course of an Event."
-                               FontSize="Small" />
-                        <Label Text="4.	ASSUMPTION OF THE RISK:  I, the Volunteer, acknowledge that there are potential hazards (&quot;Hazards&quot;), known and unknown, involved in the Event. The term &quot;Hazards&quot; is intended to be used in its broadest sense and includes, but is not limited to natural hazards (land, weather, etc.) and man-made hazards (concrete, steel, etc.). I understand and acknowledge that participation may include Hazards that could harm me, and that such Hazards may or may not always be obvious.  I hereby expressly and specifically assume the risk of injury or harm for all such Hazards."
-                               FontSize="Small" />
-                        <Label Text="5.	PHOTOGRAPHIC RELEASE: I, the Volunteer, grant and convey to the Parties all right, title, and interest in any and all photographs, images, video, and audio in connection with my providing volunteer services at Events."
-                               FontSize="Small" />
-                        <Label Text="6.	OTHER:  I, the Volunteer, expressly agrees that this Release is intended to be as broad and inclusive as permitted by law. I agree that in the event that any clause or provision of this Release shall be held to be invalid by any court of competent jurisdiction, the validity of the remaining provisions of this Release shall continue to be enforceable."
-                               FontSize="Small" />
-                    </VerticalStackLayout>
+                    <Label Text="{Binding WaiverText}"
+                           TextType="Html"
+                           FontSize="Small" />
                 </Border>
 
                 <!-- Agreement -->

--- a/TrashMobMobile/Pages/WaiverPage.xaml.cs
+++ b/TrashMobMobile/Pages/WaiverPage.xaml.cs
@@ -1,8 +1,6 @@
 namespace TrashMobMobile.Pages;
 
-using CommunityToolkit.Maui.Alerts;
-using CommunityToolkit.Maui.Core;
-
+[QueryProperty(nameof(WaiverVersionId), nameof(WaiverVersionId))]
 public partial class WaiverPage : ContentPage
 {
     private readonly WaiverViewModel viewModel;
@@ -11,7 +9,18 @@ public partial class WaiverPage : ContentPage
     {
         InitializeComponent();
         this.viewModel = viewModel;
-        this.viewModel.Navigation = Navigation;
         BindingContext = this.viewModel;
+    }
+
+    public string WaiverVersionId { get; set; } = string.Empty;
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+
+        if (Guid.TryParse(WaiverVersionId, out var versionId) && versionId != Guid.Empty)
+        {
+            await viewModel.Init(versionId);
+        }
     }
 }

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -326,7 +326,7 @@
     <!-- <x:String x:Key="IconChevronDoubleUp">&#xf013f;</x:String> -->
     <!-- <x:String x:Key="IconChevronDown">&#xf0140;</x:String> -->
     <!-- <x:String x:Key="IconChevronLeft">&#xf0141;</x:String> -->
-    <!-- <x:String x:Key="IconChevronRight">&#xf0142;</x:String> -->
+    <x:String x:Key="IconChevronRight">&#xf0142;</x:String>
     <!-- <x:String x:Key="IconChevronUp">&#xf0143;</x:String> -->
     <!-- <x:String x:Key="IconChurch">&#xf0144;</x:String> -->
     <!-- <x:String x:Key="IconRollerSkateOff">&#xf0145;</x:String> -->

--- a/TrashMobMobile/Services/IWaiverManager.cs
+++ b/TrashMobMobile/Services/IWaiverManager.cs
@@ -1,7 +1,15 @@
-﻿namespace TrashMobMobile.Services
+namespace TrashMobMobile.Services;
+
+using TrashMob.Models;
+using TrashMobMobile.Models;
+
+public interface IWaiverManager
 {
-    public interface IWaiverManager
-    {
-        public Task<bool> HasUserSignedTrashMobWaiverAsync(CancellationToken cancellationToken = default);
-    }
+    Task<bool> HasUserSignedAllRequiredWaiversAsync(CancellationToken cancellationToken = default);
+
+    Task<List<WaiverVersion>> GetRequiredWaiversAsync(CancellationToken cancellationToken = default);
+
+    Task<List<UserWaiver>> GetMyWaiversAsync(CancellationToken cancellationToken = default);
+
+    Task<UserWaiver> AcceptWaiverAsync(AcceptWaiverApiRequest request, CancellationToken cancellationToken = default);
 }

--- a/TrashMobMobile/Services/IWaiverRestService.cs
+++ b/TrashMobMobile/Services/IWaiverRestService.cs
@@ -1,9 +1,13 @@
-﻿namespace TrashMobMobile.Services
-{
-    using TrashMob.Models;
+namespace TrashMobMobile.Services;
 
-    public interface IWaiverRestService
-    {
-        public Task<Waiver> GetWaiver(string waiverName, CancellationToken cancellationToken = default);
-    }
+using TrashMob.Models;
+using TrashMobMobile.Models;
+
+public interface IWaiverRestService
+{
+    Task<List<WaiverVersion>> GetRequiredWaiversAsync(Guid? communityId = null, CancellationToken cancellationToken = default);
+
+    Task<List<UserWaiver>> GetMyWaiversAsync(CancellationToken cancellationToken = default);
+
+    Task<UserWaiver> AcceptWaiverAsync(AcceptWaiverApiRequest request, CancellationToken cancellationToken = default);
 }

--- a/TrashMobMobile/Services/WaiverManager.cs
+++ b/TrashMobMobile/Services/WaiverManager.cs
@@ -1,24 +1,28 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
-using TrashMobMobile.Config;
-using TrashMobMobile.Extensions;
+using TrashMob.Models;
+using TrashMobMobile.Models;
 
-public class WaiverManager : IWaiverManager
+public class WaiverManager(IWaiverRestService waiverRestService) : IWaiverManager
 {
-    private const string TrashMobWaiverName = "trashmob";
-
-    private readonly IWaiverRestService waiverRestService;
-    private readonly IUserManager userManager;
-
-    public WaiverManager(IWaiverRestService service, IUserManager userManager)
+    public async Task<bool> HasUserSignedAllRequiredWaiversAsync(CancellationToken cancellationToken = default)
     {
-        waiverRestService = service;
-        this.userManager = userManager;
+        var required = await waiverRestService.GetRequiredWaiversAsync(null, cancellationToken);
+        return required.Count == 0;
     }
 
-    public async Task<bool> HasUserSignedTrashMobWaiverAsync(CancellationToken cancellationToken = default)
+    public Task<List<WaiverVersion>> GetRequiredWaiversAsync(CancellationToken cancellationToken = default)
     {
-        var waiver = await waiverRestService.GetWaiver(TrashMobWaiverName, cancellationToken);
-        return userManager.CurrentUser.HasUserSignedWaiver(waiver, Settings.CurrentTrashMobWaiverVersion);
+        return waiverRestService.GetRequiredWaiversAsync(null, cancellationToken);
+    }
+
+    public Task<List<UserWaiver>> GetMyWaiversAsync(CancellationToken cancellationToken = default)
+    {
+        return waiverRestService.GetMyWaiversAsync(cancellationToken);
+    }
+
+    public Task<UserWaiver> AcceptWaiverAsync(AcceptWaiverApiRequest request, CancellationToken cancellationToken = default)
+    {
+        return waiverRestService.AcceptWaiverAsync(request, cancellationToken);
     }
 }

--- a/TrashMobMobile/Services/WaiverRestService.cs
+++ b/TrashMobMobile/Services/WaiverRestService.cs
@@ -1,22 +1,39 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
-using System.Diagnostics;
-using Newtonsoft.Json;
+using System.Net.Http.Json;
 using TrashMob.Models;
+using TrashMobMobile.Models;
 
 public class WaiverRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IWaiverRestService
 {
     protected override string Controller => "waivers";
 
-    public async Task<Waiver> GetWaiver(string waiverName, CancellationToken cancellationToken)
+    public async Task<List<WaiverVersion>> GetRequiredWaiversAsync(Guid? communityId = null, CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + "/" + waiverName;
-        using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
-        {
-            response.EnsureSuccessStatusCode();
-            var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
+        var requestUri = communityId.HasValue
+            ? $"{Controller}/required?communityId={communityId.Value}"
+            : $"{Controller}/required";
 
-            return JsonConvert.DeserializeObject<Waiver>(responseString)!;
-        }
+        var result = await AuthorizedHttpClient.GetFromJsonAsync<List<WaiverVersion>>(requestUri, SerializerOptions, cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<List<UserWaiver>> GetMyWaiversAsync(CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{Controller}/my";
+        var result = await AuthorizedHttpClient.GetFromJsonAsync<List<UserWaiver>>(requestUri, SerializerOptions, cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<UserWaiver> AcceptWaiverAsync(AcceptWaiverApiRequest request, CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{Controller}/accept";
+        var content = JsonContent.Create(request, typeof(AcceptWaiverApiRequest), null, SerializerOptions);
+
+        using var response = await AuthorizedHttpClient.PostAsync(requestUri, content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<UserWaiver>(SerializerOptions, cancellationToken);
+        return result!;
     }
 }

--- a/TrashMobMobile/ViewModels/CreateEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/CreateEventViewModel.cs
@@ -21,7 +21,6 @@ public partial class CreateEventViewModel : BaseViewModel
     private readonly IMapRestService mapRestService;
 
     private readonly IMobEventManager mobEventManager;
-    private readonly IWaiverManager waiverManager;
     private readonly IEventPartnerLocationServiceRestService eventPartnerLocationServiceRestService;
     private readonly ILitterReportManager litterReportManager;
     private readonly IEventLitterReportManager eventLitterReportManager;
@@ -191,7 +190,6 @@ public partial class CreateEventViewModel : BaseViewModel
     public CreateEventViewModel(IMobEventManager mobEventManager,
         IEventTypeRestService eventTypeRestService,
         IMapRestService mapRestService,
-        IWaiverManager waiverManager,
         INotificationService notificationService,
         IEventPartnerLocationServiceRestService eventPartnerLocationServiceRestService,
         ILitterReportManager litterReportManager,
@@ -203,7 +201,6 @@ public partial class CreateEventViewModel : BaseViewModel
         this.mobEventManager = mobEventManager;
         this.eventTypeRestService = eventTypeRestService;
         this.mapRestService = mapRestService;
-        this.waiverManager = waiverManager;
         this.notificationService = notificationService;
         this.eventPartnerLocationServiceRestService = eventPartnerLocationServiceRestService;
         this.litterReportManager = litterReportManager;

--- a/TrashMobMobile/ViewModels/MainViewModel.cs
+++ b/TrashMobMobile/ViewModels/MainViewModel.cs
@@ -242,9 +242,9 @@ public partial class MainViewModel(IAuthService authService,
     [RelayCommand]
     private async Task CreateEvent()
     {
-        if (!await waiverManager.HasUserSignedTrashMobWaiverAsync())
+        if (!await waiverManager.HasUserSignedAllRequiredWaiversAsync())
         {
-            await Shell.Current.GoToAsync(nameof(WaiverPage));
+            await Shell.Current.GoToAsync(nameof(WaiverListPage));
             return;
         }
 

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -328,9 +328,9 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
     [RelayCommand]
     private async Task CreateEvent()
     {
-        if (!await waiverManager.HasUserSignedTrashMobWaiverAsync())
+        if (!await waiverManager.HasUserSignedAllRequiredWaiversAsync())
         {
-            await Shell.Current.GoToAsync(nameof(WaiverPage));
+            await Shell.Current.GoToAsync(nameof(WaiverListPage));
             return;
         }
 

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -435,9 +435,9 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     {
         await ExecuteAsync(async () =>
         {
-            if (!await waiverManager.HasUserSignedTrashMobWaiverAsync())
+            if (!await waiverManager.HasUserSignedAllRequiredWaiversAsync())
             {
-                await Shell.Current.GoToAsync($"{nameof(WaiverPage)}");
+                await Shell.Current.GoToAsync($"{nameof(WaiverListPage)}");
                 return;
             }
 

--- a/TrashMobMobile/ViewModels/ViewLitterReportViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewLitterReportViewModel.cs
@@ -132,9 +132,9 @@ public partial class ViewLitterReportViewModel(ILitterReportManager litterReport
     [RelayCommand]
     private async Task CreateEvent()
     {
-        if (!await waiverManager.HasUserSignedTrashMobWaiverAsync())
+        if (!await waiverManager.HasUserSignedAllRequiredWaiversAsync())
         {
-            await Shell.Current.GoToAsync(nameof(WaiverPage));
+            await Shell.Current.GoToAsync(nameof(WaiverListPage));
             return;
         }
 

--- a/TrashMobMobile/ViewModels/WaiverListViewModel.cs
+++ b/TrashMobMobile/ViewModels/WaiverListViewModel.cs
@@ -1,0 +1,54 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMob.Models;
+using TrashMobMobile.Services;
+
+public partial class WaiverListViewModel(IWaiverManager waiverManager, INotificationService notificationService) : BaseViewModel(notificationService)
+{
+    [ObservableProperty]
+    private ObservableCollection<WaiverVersion> pendingWaivers = [];
+
+    [ObservableProperty]
+    private ObservableCollection<UserWaiver> signedWaivers = [];
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ContinueCommand))]
+    private bool allWaiversSigned;
+
+    [ObservableProperty]
+    private bool hasPendingWaivers;
+
+    [ObservableProperty]
+    private bool hasSignedWaivers;
+
+    public async Task Init()
+    {
+        await ExecuteAsync(async () =>
+        {
+            var pending = await waiverManager.GetRequiredWaiversAsync();
+            var signed = await waiverManager.GetMyWaiversAsync();
+
+            PendingWaivers = new ObservableCollection<WaiverVersion>(pending);
+            SignedWaivers = new ObservableCollection<UserWaiver>(signed);
+
+            HasPendingWaivers = PendingWaivers.Count > 0;
+            HasSignedWaivers = SignedWaivers.Count > 0;
+            AllWaiversSigned = PendingWaivers.Count == 0;
+        }, "Failed to load waivers. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task SelectWaiver(WaiverVersion waiver)
+    {
+        await Shell.Current.GoToAsync($"{nameof(WaiverPage)}?WaiverVersionId={waiver.Id}");
+    }
+
+    [RelayCommand(CanExecute = nameof(AllWaiversSigned))]
+    private void Continue()
+    {
+        Shell.Current.SendBackButtonPressed();
+    }
+}

--- a/TrashMobMobile/ViewModels/WaiverViewModel.cs
+++ b/TrashMobMobile/ViewModels/WaiverViewModel.cs
@@ -1,13 +1,20 @@
-﻿namespace TrashMobMobile.ViewModels;
+namespace TrashMobMobile.ViewModels;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using TrashMobMobile.Config;
+using TrashMob.Models;
+using TrashMobMobile.Models;
 using TrashMobMobile.Services;
 
-public partial class WaiverViewModel(INotificationService notificationService, IUserManager userManager) : BaseViewModel(notificationService)
+public partial class WaiverViewModel(INotificationService notificationService, IWaiverManager waiverManager) : BaseViewModel(notificationService)
 {
-    private readonly IUserManager userManager = userManager;
+    private Guid waiverVersionId;
+
+    [ObservableProperty]
+    private string waiverName = string.Empty;
+
+    [ObservableProperty]
+    private string waiverText = string.Empty;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SignWaiverCommand))]
@@ -19,29 +26,44 @@ public partial class WaiverViewModel(INotificationService notificationService, I
 
     private bool CanSignWaiver => HasAgreed && TypedLegalName.Trim().Length >= 2;
 
+    public async Task Init(Guid versionId)
+    {
+        waiverVersionId = versionId;
+        TypedLegalName = string.Empty;
+        HasAgreed = false;
+
+        await ExecuteAsync(async () =>
+        {
+            var requiredWaivers = await waiverManager.GetRequiredWaiversAsync();
+            var waiver = requiredWaivers.Find(w => w.Id == versionId);
+
+            if (waiver != null)
+            {
+                WaiverName = waiver.Name;
+                WaiverText = waiver.WaiverText ?? string.Empty;
+            }
+        }, "Failed to load waiver details. Please try again.");
+    }
+
     [RelayCommand(CanExecute = nameof(CanSignWaiver))]
     private async Task SignWaiver()
     {
         await ExecuteAsync(async () =>
         {
-            var user = await userManager.GetUserAsync(userManager.CurrentUser.Id.ToString());
-            if (user == null)
+            var request = new AcceptWaiverApiRequest
             {
-                throw new Exception("User not found.");
-            }
+                WaiverVersionId = waiverVersionId,
+                TypedLegalName = TypedLegalName.Trim(),
+            };
 
-            user.DateAgreedToTrashMobWaiver = DateTime.UtcNow;
-            user.TrashMobWaiverVersion = Settings.CurrentTrashMobWaiverVersion.VersionId;
-
-            await userManager.UpdateUserAsync(user);
-            userManager.CurrentUser = user;
-            await Navigation.PopAsync();
+            await waiverManager.AcceptWaiverAsync(request);
+            await Shell.Current.GoToAsync("..");
         }, "An error occurred while signing the waiver. Please try again.");
     }
 
     [RelayCommand]
     private async Task Cancel()
     {
-        await Shell.Current.GoToAsync($"//{nameof(MainTabsPage)}");
+        await Shell.Current.GoToAsync("..");
     }
 }

--- a/TrashMobMobile/Views/MyDashboard/TabLitterReports.xaml
+++ b/TrashMobMobile/Views/MyDashboard/TabLitterReports.xaml
@@ -22,17 +22,27 @@
                                 IsVisible="{Binding AreLitterReportsFound}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:LitterReportViewModel">
-                    <Border Style="{StaticResource RoundBorder}" Margin="5">
-                        <Grid ColumnDefinitions="*, *"
-                                      RowDefinitions="Auto, Auto, Auto, Auto"
-                                      x:Name="LitterReportItem" RowSpacing="3">
-
-                            <Label Text="{Binding Name}" Grid.Row="0" Grid.ColumnSpan="2" FontSize="Small" />
-                            <Label Text="{Binding LitterReportStatus}" Grid.Row="0" Grid.Column="1"
-                                           FontSize="Micro" />
-                            <Label Text="{Binding CreatedDate}" Grid.Row="1" Grid.Column="0"
-                                           Grid.ColumnSpan="1" FontSize="Micro" />
-                            <Label Text="{Binding Description}" Grid.Row="1" Grid.Column="1" FontSize="Micro" />
+                    <Border Style="{x:StaticResource RoundBorder}" Margin="0,3">
+                        <Grid ColumnDefinitions="*, Auto" Padding="10,8">
+                            <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                <Label Text="{Binding Name}" FontFamily="LexendSemibold" FontSize="Small" />
+                                <Label Text="{Binding LitterReportStatus}" FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding CreatedDate}" FontSize="Micro"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </VerticalStackLayout>
+                            <Border Grid.Column="1"
+                                    StrokeShape="RoundRectangle 6"
+                                    StrokeThickness="0"
+                                    IsVisible="{Binding HasThumbnail}"
+                                    WidthRequest="56"
+                                    HeightRequest="56"
+                                    VerticalOptions="Center">
+                                <Image Source="{Binding ThumbnailUrl}"
+                                       Aspect="AspectFill"
+                                       WidthRequest="56"
+                                       HeightRequest="56" />
+                            </Border>
                         </Grid>
                     </Border>
                 </DataTemplate>


### PR DESCRIPTION
## Summary

- **Multi-waiver flow**: New `WaiverListPage` shows all required waivers with signing progress, replaces single-waiver redirect loop. Waiver check moved from page load to navigation source (Quick Actions popup) for smoother UX.
- **Styled Quick Actions popup**: Replaced native `DisplayActionSheet` with custom styled popup using CommunityToolkit.Maui v13 popup API (`ShowPopupAsync<T>`/`ClosePopupAsync`).
- **Litter report thumbnails**: All litter report list views (Explore, Profile, Search, MyDashboard) now show a 56x56 thumbnail of the first litter image, matching the existing HomeFeed pattern.
- **UI fixes**: Fixed invisible icons on Impact page Leaderboards/Achievements buttons (icon color matched background), fixed Cancel button navigation on WaiverListPage using `SendBackButtonPressed()`.
- **Waiver service simplification**: Removed duplicate `WaiverVersion` model, using shared `TrashMob.Models` types throughout.

## Test plan

- [ ] Quick Actions popup appears styled with icons when tapping the center tab
- [ ] Create Event from popup navigates to WaiverListPage if waivers unsigned, then to CreateEventPage after signing
- [ ] Cancel button on WaiverListPage navigates back correctly
- [ ] Continue button enables only after all waivers are signed
- [ ] Litter report thumbnails appear in Explore list view, Profile page, Search Litter Reports, and MyDashboard Litter Reports tab
- [ ] Litter reports without images render normally (no broken placeholder)
- [ ] Impact page Leaderboards and Achievements buttons show white icons
- [ ] Report Litter from popup navigates directly to CreateLitterReportPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)