### PR TITLE
Fix waiver timing, nav dropdown alignment, and litter report location filter

### DIFF
--- a/TrashMob/client-app/src/components/ui/navigation-menu.tsx
+++ b/TrashMob/client-app/src/components/ui/navigation-menu.tsx
@@ -77,7 +77,7 @@ const NavigationMenuViewport = React.forwardRef<
     React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
     React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
-    <div className='absolute left-0 top-full w-full flex justify-center pt-1'>
+    <div className='absolute left-0 top-full flex pt-1'>
         <NavigationMenuPrimitive.Viewport
             className={cn(
                 'origin-top-center relative h-[var(--radix-navigation-menu-viewport-height)] w-full rounded-md border bg-popover text-popover-foreground shadow md:w-[var(--radix-navigation-menu-viewport-width)]',


### PR DESCRIPTION
## Summary
- **Waiver on Create Event**: Show the waiver signing flow immediately when navigating to the Create Event page (not just on form submit). Users no longer fill in all event details only to be blocked by a waiver at the end.
- **Nav dropdown alignment**: Fix dropdown menus (Explore, Take Action, etc.) appearing centered on the nav bar instead of aligned near the trigger button. Removed `justify-center` from the NavigationMenu viewport wrapper.
- **Litter report location filter**: Add a search-by-location text input to the litter reports page filter bar. Filters by city or region (client-side, matching against existing location data from litter images).

## Test plan
- [ ] Navigate to Take Action > Create Event while having unsigned waivers — waiver dialog should appear immediately on page load
- [ ] After signing waivers and returning to Create Event — form should be usable without waiver prompt
- [ ] Hover over Explore/Take Action/etc. in the nav bar — dropdown should appear aligned to the left of the trigger, not centered on the bar
- [ ] Go to Litter Reports page — location filter input should appear between the date filter and the view toggle
- [ ] Type a city name — reports should filter to only those matching the city
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)