### PR TITLE
Fix litter report thumbnails, home feed loading, and button icon visibility

### DIFF
--- a/Planning/Projects/Project_04_Mobile_Robustness.md
+++ b/Planning/Projects/Project_04_Mobile_Robustness.md
@@ -76,6 +76,7 @@ Mobile app quality directly impacts user retention and app store visibility. A c
 - [ ] Streamline event registration flow
 - [ ] Polish litter reporting flow (camera, location, submission)
 - [ ] Enhance dashboard/home screen with clear calls to action
+- [ ] Add lightweight API endpoint for litter report list views with first-image thumbnail URL (avoids N+1 image URL fetches per report; relates to #2340)
 - [x] Consistent loading states and feedback throughout app (PR #2588 — `IsBusy` state + user-friendly error messages)
 - [x] Add required field indicators to all forms (PR #2591)
 

--- a/TrashMobMobile/Extensions/LitterReportExtensions.cs
+++ b/TrashMobMobile/Extensions/LitterReportExtensions.cs
@@ -165,10 +165,12 @@
 
         public static LitterImageViewModel? ToLitterImageViewModel(this LitterImage litterImage, int litterReportStatusId, INotificationService notificationService)
         {
-            if (litterImage?.Latitude == null || litterImage.Longitude == null)
+            if (litterImage == null)
             {
                 return null;
             }
+
+            var hasLocation = litterImage.Latitude.HasValue && litterImage.Longitude.HasValue;
 
             return new LitterImageViewModel(notificationService)
             {
@@ -189,7 +191,9 @@
                     PostalCode = litterImage.PostalCode,
                     Region = litterImage.Region,
                     StreetAddress = litterImage.StreetAddress,
-                    Location = new Microsoft.Maui.Devices.Sensors.Location(litterImage.Latitude.Value, litterImage.Longitude.Value),
+                    Location = hasLocation
+                        ? new Microsoft.Maui.Devices.Sensors.Location(litterImage.Latitude!.Value, litterImage.Longitude!.Value)
+                        : null,
                     IconFile = GetMapIcon(litterReportStatusId),
                 },
             };
@@ -197,10 +201,12 @@
 
         public static LitterImageViewModel? ToLitterImageViewModel(this FullLitterImage litterImage, int litterReportStatusId, INotificationService notificationService)
         {
-            if (litterImage?.Latitude == null || litterImage.Longitude == null)
+            if (litterImage == null)
             {
                 return null;
             }
+
+            var hasLocation = litterImage.Latitude.HasValue && litterImage.Longitude.HasValue;
 
             return new LitterImageViewModel(notificationService)
             {
@@ -221,7 +227,9 @@
                     PostalCode = litterImage.PostalCode,
                     Region = litterImage.Region,
                     StreetAddress = litterImage.StreetAddress,
-                    Location = new Microsoft.Maui.Devices.Sensors.Location(litterImage.Latitude.Value, litterImage.Longitude.Value),
+                    Location = hasLocation
+                        ? new Microsoft.Maui.Devices.Sensors.Location(litterImage.Latitude!.Value, litterImage.Longitude!.Value)
+                        : null,
                     IconFile = GetMapIcon(litterReportStatusId),
                 },
             };

--- a/TrashMobMobile/Pages/CreatePickupLocationPage.xaml.cs
+++ b/TrashMobMobile/Pages/CreatePickupLocationPage.xaml.cs
@@ -27,7 +27,7 @@ public partial class CreatePickupLocationPage : ContentPage
         // Default the map zoom to the location of the event
         if (viewModel?.EventViewModel?.Address != null)
         {
-            var mapSpan = new MapSpan(viewModel.EventViewModel.Address.Location, 0.05, 0.05);
+            var mapSpan = new MapSpan(viewModel.EventViewModel.Address.Location!, 0.05, 0.05);
             pickupLocationMap.InitialMapSpanAndroid = mapSpan;
             pickupLocationMap.MoveToRegion(mapSpan);
         }

--- a/TrashMobMobile/Pages/EditLitterReportPage.xaml.cs
+++ b/TrashMobMobile/Pages/EditLitterReportPage.xaml.cs
@@ -26,7 +26,7 @@ public partial class EditLitterReportPage : ContentPage
 
         if (viewModel?.LitterImageViewModels?.FirstOrDefault()?.Address?.Location != null)
         {
-            var mapSpan = new MapSpan(viewModel!.LitterImageViewModels!.First().Address.Location, 0.05,
+            var mapSpan = new MapSpan(viewModel!.LitterImageViewModels!.First().Address.Location!, 0.05,
                 0.05);
             litterReportLocationMap.InitialMapSpanAndroid = mapSpan;
             litterReportLocationMap.MoveToRegion(mapSpan);

--- a/TrashMobMobile/Pages/MyDashboardPage.xaml
+++ b/TrashMobMobile/Pages/MyDashboardPage.xaml
@@ -89,7 +89,7 @@
                             Style="{StaticResource SecondarySmallButton}"
                             Text="Report Litter"
                             ContentLayout="Left, 8"
-                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconClipboardText}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconClipboardText}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                 </Grid>
 
                 <tabs:TabHostView Padding="10" 

--- a/TrashMobMobile/Services/ILitterReportManager.cs
+++ b/TrashMobMobile/Services/ILitterReportManager.cs
@@ -23,5 +23,8 @@
 
         Task<IEnumerable<TrashMob.Models.Poco.Location>> GetLocationsByTimeRangeAsync(DateTimeOffset startDate,
             DateTimeOffset endDate, CancellationToken cancellationToken = default);
+
+        Task<string> GetLitterImageUrlAsync(Guid litterImageId, ImageSizeEnum imageSize,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobMobile/Services/LitterReportManager.cs
+++ b/TrashMobMobile/Services/LitterReportManager.cs
@@ -88,5 +88,11 @@
         {
             return litterReportRestService.GetLocationsByTimeRangeAsync(startDate, endDate, cancellationToken);
         }
+
+        public Task<string> GetLitterImageUrlAsync(Guid litterImageId, ImageSizeEnum imageSize,
+            CancellationToken cancellationToken = default)
+        {
+            return litterReportRestService.GetLitterImageUrlAsync(litterImageId, imageSize, cancellationToken);
+        }
     }
 }

--- a/TrashMobMobile/ViewModels/AddressViewModel.cs
+++ b/TrashMobMobile/ViewModels/AddressViewModel.cs
@@ -31,7 +31,7 @@ public partial class AddressViewModel : ObservableObject
     private double? latitude;
 
     [ObservableProperty]
-    private Location location = null!;
+    private Location? location;
 
     [ObservableProperty]
     private double? longitude;

--- a/TrashMobMobile/ViewModels/ExploreViewModel.cs
+++ b/TrashMobMobile/ViewModels/ExploreViewModel.cs
@@ -477,7 +477,7 @@ public partial class ExploreViewModel(
             {
                 var vm = report.ToLitterReportViewModel(NotificationService);
                 LitterReports.Add(vm);
-                foreach (var image in vm.LitterImageViewModels)
+                foreach (var image in vm.LitterImageViewModels.Where(i => i.Address.Location != null))
                 {
                     Addresses.Add(image.Address);
                 }

--- a/TrashMobMobile/ViewModels/MainViewModel.cs
+++ b/TrashMobMobile/ViewModels/MainViewModel.cs
@@ -168,7 +168,7 @@ public partial class MainViewModel(IAuthService authService,
             var vm = litterReport.ToLitterReportViewModel(notificationService);
             LitterReports.Add(vm);
 
-            foreach (var litterImageViewModel in vm.LitterImageViewModels)
+            foreach (var litterImageViewModel in vm.LitterImageViewModels.Where(i => i.Address.Location != null))
             {
                 Addresses.Add(litterImageViewModel.Address);
             }

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -305,6 +305,7 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
             StartDate = startDate,
             EndDate = endDate,
             CreatedByUserId = userManager.CurrentUser.Id,
+            IncludeLitterImages = true,
         };
 
         var litterReports = await litterReportManager.GetLitterReportsAsync(litterReportFilter, TrashMob.Models.ImageSizeEnum.Thumb, true);

--- a/TrashMobMobile/ViewModels/ProfileViewModel.cs
+++ b/TrashMobMobile/ViewModels/ProfileViewModel.cs
@@ -254,6 +254,7 @@ public partial class ProfileViewModel(
             StartDate = DateTimeOffset.UtcNow.AddYears(-1),
             EndDate = DateTimeOffset.UtcNow,
             CreatedByUserId = userManager.CurrentUser.Id,
+            IncludeLitterImages = true,
         };
 
         var reports = await litterReportManager.GetLitterReportsAsync(filter, ImageSizeEnum.Thumb, true);


### PR DESCRIPTION
## Summary
- **Home feed thumbnails**: Fix litter report thumbnails not appearing on the home feed by fetching the report list without images first, then resolving thumbnails only for the 3 displayed reports (avoids empty results from `IncludeLitterImages` filter and N+1 image URL overhead)
- **Double-load fix**: Add `IsBusy` guard to `HomeFeedViewModel.Init()` to prevent `RefreshView` from double-triggering the initial load
- **Images without coordinates**: Allow `LitterImage` entries without lat/lng to still produce view models with thumbnails (previously dropped entirely)
- **Button icon visibility**: Fix "Report Litter" button icon on MyDashboard page — was invisible (icon color matched button background)
- **Nullable Location**: Make `AddressViewModel.Location` nullable and filter null locations when populating map pins
- **Profile/Dashboard thumbnails**: Enable `IncludeLitterImages` on Profile and MyDashboard litter report filters

## Test plan
- [ ] Home feed shows litter report thumbnails (up to 3 recent reports)
- [ ] Reports without images render normally (no broken placeholder)
- [ ] Reports don't appear twice on home feed
- [ ] Explore, Profile, Search, MyDashboard all show litter report thumbnails
- [ ] MyDashboard "Report Litter" button icon is visible (white on teal)
- [ ] Map pins still work correctly on Explore and Main pages (no null location crashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)