### PR TITLE
Navigate to home when waiver is dismissed on create event

### DIFF
--- a/TrashMob/client-app/src/pages/events/create.tsx
+++ b/TrashMob/client-app/src/pages/events/create.tsx
@@ -270,8 +270,8 @@ export const CreateEventPage = () => {
             if (allSigned) {
                 refetchWaivers();
             } else {
-                // User dismissed waivers without signing — navigate away since waivers are required
-                navigate(-1);
+                // User dismissed waivers without signing — navigate to home since waivers are required
+                navigate('/');
             }
         },
         [refetchWaivers, navigate],


### PR DESCRIPTION
## Summary
- When a user cancels the waiver signing dialog on the Create Event page, they are now navigated to the home page (`/`) instead of staying on the form
- Previously `navigate(-1)` was used which could land back on the same page depending on browser history

## Test plan
- [ ] Navigate to Create Event with unsigned waivers — waiver dialog appears
- [ ] Cancel the waiver dialog — should navigate to home page, not stay on create event form
- [ ] Sign waivers — should be able to proceed with event creation normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)