### PR TITLE
Set event creator as event lead when creating event

### DIFF
--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -219,6 +219,7 @@ namespace TrashMob.Shared.Managers.Events
                 UserId = userId,
                 EventId = instance.Id,
                 SignUpDate = DateTime.UtcNow,
+                IsEventLead = true,
             };
 
             await eventAttendeeManager.AddAsync(newEventAttendee, userId, cancellationToken);


### PR DESCRIPTION
## Summary
- Set `IsEventLead = true` on the `EventAttendee` record created for the event creator during event creation
- Previously the flag defaulted to `false`, so the creator didn't appear in the event leads list returned by `GetEventLeadsAsync()`
- Authorization worked around this by checking `Event.CreatedByUserId` separately, but features like the co-leads list would not include the creator

## Test plan
- [ ] Create a new event and verify the creator appears in the event leads list
- [ ] Verify co-lead promotion/demotion still works correctly
- [ ] Verify existing event lead authorization checks still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)