### PR TITLE
Fix photo upload 500: attendee check calls unimplemented method

### DIFF
--- a/TrashMob/Controllers/EventPhotosController.cs
+++ b/TrashMob/Controllers/EventPhotosController.cs
@@ -2,6 +2,7 @@ namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authorization;


### PR DESCRIPTION
## Summary
- **Root cause**: `EventPhotosController.UploadPhoto` called `eventAttendeeManager.GetAsync(eventId, UserId, cancellationToken)` which resolved to `BaseManager.GetAsync(Guid, Guid, CancellationToken)` — a virtual method that throws `NotImplementedException`
- **Fix**: Use the expression-based overload `GetAsync(ea => ea.EventId == eventId && ea.UserId == UserId, ...)` which is properly implemented in `BaseManager`
- The `EventAttendee` model has a composite key (EventId + UserId), so the two-Guid `GetAsync` is the correct overload, but it was never overridden in `EventAttendeeManager`

## Test plan
- [ ] Upload a photo to an event as an attendee — should succeed (was returning 500)
- [ ] Upload a photo as the event creator — should succeed
- [ ] Attempt upload as a non-attendee — should return 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)