### PR TITLE
Fix Strapi deploy: parse SQL admin creds from connection string

### DIFF
--- a/.github/workflows/container_strapi-tm-dev-westus2.yml
+++ b/.github/workflows/container_strapi-tm-dev-westus2.yml
@@ -92,10 +92,11 @@ jobs:
         run: |
           export PATH="$PATH:/opt/mssql-tools18/bin"
 
-          # Get admin credentials
+          # Get admin credentials from the main app connection string (format: Server=...;User ID=dbadmin;Password=<pw>;...)
           SQL_SERVER="sql-tm-dev-${{ env.REGION }}"
-          SQL_ADMIN=$(az keyvault secret show --name sql-admin-username --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
-          SQL_ADMIN_PASSWORD=$(az keyvault secret show --name sql-admin-password --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
+          CONN_STR=$(az keyvault secret show --name TMDBServerConnectionString --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
+          SQL_ADMIN=$(echo "$CONN_STR" | grep -oP '(?<=User ID=)[^;]+')
+          SQL_ADMIN_PASSWORD=$(echo "$CONN_STR" | grep -oP '(?<=Password=)[^;]+')
           STRAPI_PASSWORD=$(az keyvault secret show --name strapi-db-password --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
 
           # Create user if not exists (idempotent)


### PR DESCRIPTION
## Summary
- The Strapi deployment workflow was failing at "Create Strapi SQL User" because it referenced nonexistent Key Vault secrets (`sql-admin-username`, `sql-admin-password`)
- The SQL admin credentials are already stored inside the `TMDBServerConnectionString` secret (created by `deployInfra.ps1` with `User ID=dbadmin;Password=...`)
- Updated the workflow to parse the username and password from that connection string instead

## Root cause
The `deployInfra.ps1` script stores the SQL admin credentials inside `TMDBServerConnectionString` but never creates separate `sql-admin-username`/`sql-admin-password` secrets. The Strapi workflow was written expecting those separate secrets to exist.

## Test plan
- [ ] Merge and verify the Strapi deployment workflow passes (triggered on push to main when Strapi paths change)
- [ ] Alternatively, trigger manually via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)