### PR TITLE
Fix community photos 500: add AsNoTracking to prevent lazy load cascade

### DIFF
--- a/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerPhotoManager.cs
@@ -23,6 +23,7 @@ namespace TrashMob.Shared.Managers.Partners
         public async Task<IEnumerable<PartnerPhoto>> GetByPartnerIdAsync(Guid partnerId, CancellationToken cancellationToken = default)
         {
             return await Repository.Get()
+                .AsNoTracking()
                 .Where(p => p.PartnerId == partnerId)
                 .OrderByDescending(p => p.UploadedDate)
                 .ToListAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- Fix `GET /api/communities/{slug}/photos` returning HTTP 500

## Root cause
`PartnerPhotoManager.GetByPartnerIdAsync` returned tracked entities. With `UseLazyLoadingProxies()` enabled, JSON serialization triggered lazy loading of navigation properties (`Partner`, `UploadedByUser`, etc.), causing a cascade of additional queries and ultimately a 500 error.

## Fix
Added `.AsNoTracking()` to the query. This disables the lazy loading proxy on the returned entities, so only the scalar properties are serialized.

## Test plan
- [ ] Visit a community page with photos (e.g. `/communities/issaquah-wa`) — photos section should load without 500
- [ ] Upload a new photo to a community — should still work (uses `AddAsync`, not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)