### PR TITLE
Replace native popups with styled custom popups and center route map

### DIFF
--- a/TrashMobMobile/Controls/ConfirmPopup.xaml
+++ b/TrashMobMobile/Controls/ConfirmPopup.xaml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.ConfirmPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="280">
+        <VerticalStackLayout Spacing="16">
+
+            <Label x:Name="titleLabel"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Label x:Name="messageLabel"
+                   FontSize="14"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <Button x:Name="confirmButton"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnConfirmClicked" />
+
+            <Button Text="Cancel"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnCancelClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/ConfirmPopup.xaml.cs
+++ b/TrashMobMobile/Controls/ConfirmPopup.xaml.cs
@@ -1,0 +1,26 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Extensions;
+
+public partial class ConfirmPopup : ContentView
+{
+    public const string Confirmed = "Confirmed";
+
+    public ConfirmPopup(string title, string message, string confirmText = "Confirm")
+    {
+        InitializeComponent();
+        titleLabel.Text = title;
+        messageLabel.Text = message;
+        confirmButton.Text = confirmText;
+    }
+
+    private async void OnConfirmClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync(Confirmed);
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+}

--- a/TrashMobMobile/Controls/ListSelectorPopup.xaml
+++ b/TrashMobMobile/Controls/ListSelectorPopup.xaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.ListSelectorPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="300"
+            MaximumHeightRequest="450">
+        <VerticalStackLayout Spacing="16">
+
+            <Label x:Name="titleLabel"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <CollectionView x:Name="itemsList"
+                            SelectionMode="Single"
+                            SelectionChanged="OnSelectionChanged"
+                            MaximumHeightRequest="300">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Border Padding="12,10"
+                                Margin="0,2"
+                                StrokeShape="RoundRectangle 8"
+                                BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}"
+                                Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+                                StrokeThickness="1">
+                            <Label Text="{Binding .}"
+                                   FontSize="14"
+                                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Button Text="Cancel"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnCancelClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/ListSelectorPopup.xaml.cs
+++ b/TrashMobMobile/Controls/ListSelectorPopup.xaml.cs
@@ -1,0 +1,26 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Extensions;
+
+public partial class ListSelectorPopup : ContentView
+{
+    public ListSelectorPopup(string title, IEnumerable<string> items)
+    {
+        InitializeComponent();
+        titleLabel.Text = title;
+        itemsList.ItemsSource = items.ToList();
+    }
+
+    private async void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (e.CurrentSelection.Count > 0 && e.CurrentSelection[0] is string selected)
+        {
+            await Shell.Current.ClosePopupAsync(selected);
+        }
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+}

--- a/TrashMobMobile/Controls/PrivacyPopup.xaml
+++ b/TrashMobMobile/Controls/PrivacyPopup.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.PrivacyPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="280">
+        <VerticalStackLayout Spacing="16">
+
+            <Label Text="Route Privacy"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Button Text="Private"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnPrivateClicked" />
+
+            <Button Text="Event Only"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnEventOnlyClicked" />
+
+            <Button Text="Public"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnPublicClicked" />
+
+            <Button Text="Cancel"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnCancelClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/PrivacyPopup.xaml.cs
+++ b/TrashMobMobile/Controls/PrivacyPopup.xaml.cs
@@ -1,0 +1,40 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Extensions;
+
+public partial class PrivacyPopup : ContentView
+{
+    public const string Private = "Private";
+    public const string EventOnly = "EventOnly";
+    public const string Public = "Public";
+
+    public string? SelectedPrivacy { get; private set; }
+
+    public PrivacyPopup()
+    {
+        InitializeComponent();
+    }
+
+    private async void OnPrivateClicked(object? sender, EventArgs e)
+    {
+        SelectedPrivacy = Private;
+        await Shell.Current.ClosePopupAsync(SelectedPrivacy);
+    }
+
+    private async void OnEventOnlyClicked(object? sender, EventArgs e)
+    {
+        SelectedPrivacy = EventOnly;
+        await Shell.Current.ClosePopupAsync(SelectedPrivacy);
+    }
+
+    private async void OnPublicClicked(object? sender, EventArgs e)
+    {
+        SelectedPrivacy = Public;
+        await Shell.Current.ClosePopupAsync(SelectedPrivacy);
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+}

--- a/TrashMobMobile/Pages/QuickActionPlaceholderPage.xaml.cs
+++ b/TrashMobMobile/Pages/QuickActionPlaceholderPage.xaml.cs
@@ -1,5 +1,8 @@
 namespace TrashMobMobile.Pages;
 
+using CommunityToolkit.Maui.Extensions;
+using TrashMobMobile.Controls;
+
 public partial class QuickActionPlaceholderPage : ContentPage
 {
     public QuickActionPlaceholderPage()
@@ -11,14 +14,16 @@ public partial class QuickActionPlaceholderPage : ContentPage
     {
         base.OnNavigatedTo(args);
 
-        // Fallback: if the Navigating interception didn't work, show action sheet here
-        var action = await DisplayActionSheetAsync("Quick Actions", "Cancel", null, "Create Event", "Report Litter");
+        // Fallback: if the Navigating interception didn't work, show styled popup here
+        var popup = new QuickActionPopup();
+        var result = await this.ShowPopupAsync<string>(popup);
+        var action = result?.Result;
 
-        if (action == "Create Event")
+        if (action == QuickActionPopup.CreateEvent)
         {
             await Shell.Current.GoToAsync($"../{nameof(CreateEventPage)}");
         }
-        else if (action == "Report Litter")
+        else if (action == QuickActionPopup.ReportLitter)
         {
             await Shell.Current.GoToAsync($"../{nameof(CreateLitterReportPage)}");
         }

--- a/TrashMobMobile/ViewModels/NewsletterPreferencesViewModel.cs
+++ b/TrashMobMobile/ViewModels/NewsletterPreferencesViewModel.cs
@@ -1,6 +1,7 @@
 namespace TrashMobMobile.ViewModels;
 
 using System.Collections.ObjectModel;
+using CommunityToolkit.Maui.Extensions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TrashMobMobile.Services;
@@ -63,13 +64,10 @@ public partial class NewsletterPreferencesViewModel(
     [RelayCommand]
     private async Task UnsubscribeAll()
     {
-        var confirm = await Shell.Current.DisplayAlertAsync(
-            "Unsubscribe from All",
-            "Are you sure you want to unsubscribe from all newsletters?",
-            "Unsubscribe All",
-            "Cancel");
-
-        if (!confirm)
+        var popup = new Controls.ConfirmPopup("Unsubscribe from All",
+            "Are you sure you want to unsubscribe from all newsletters?", "Unsubscribe All");
+        var result = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        if (result?.Result != Controls.ConfirmPopup.Confirmed)
         {
             return;
         }

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -623,10 +623,9 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             return;
         }
 
-        var confirm = await Shell.Current.DisplayAlertAsync(
-            "Delete Photo", "Are you sure you want to delete this photo?", "Delete", "Cancel");
-
-        if (!confirm)
+        var popup = new Controls.ConfirmPopup("Delete Photo", "Are you sure you want to delete this photo?", "Delete");
+        var result = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        if (result?.Result != Controls.ConfirmPopup.Confirmed)
         {
             return;
         }
@@ -664,10 +663,9 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             return;
         }
 
-        var confirm = await Shell.Current.DisplayAlertAsync(
-            "Delete Route", "Are you sure you want to delete this route?", "Delete", "Cancel");
-
-        if (!confirm)
+        var popup = new Controls.ConfirmPopup("Delete Route", "Are you sure you want to delete this route?", "Delete");
+        var result = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        if (result?.Result != Controls.ConfirmPopup.Confirmed)
         {
             return;
         }
@@ -698,14 +696,24 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             return;
         }
 
+        var popup = new Controls.PrivacyPopup();
+        var popupResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        var selectedPrivacy = popupResult?.Result;
+        if (string.IsNullOrEmpty(selectedPrivacy))
+        {
+            return;
+        }
+
         await ExecuteAsync(async () =>
         {
             var request = new UpdateRouteMetadataRequest
             {
-                PrivacyLevel = routeVm.PrivacyLevel,
+                PrivacyLevel = selectedPrivacy,
             };
 
             var updated = await eventAttendeeRouteRestService.UpdateRouteMetadataAsync(routeVm.Id, request);
+
+            routeVm.PrivacyLevel = updated.PrivacyLevel;
 
             var rawRoute = EventAttendeeRoutes.FirstOrDefault(r => r.Id == routeVm.Id);
             if (rawRoute != null)

--- a/TrashMobMobile/ViewModels/ViewTeamViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewTeamViewModel.cs
@@ -1,6 +1,7 @@
 namespace TrashMobMobile.ViewModels;
 
 using System.Collections.ObjectModel;
+using CommunityToolkit.Maui.Extensions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TrashMobMobile.Extensions;
@@ -109,17 +110,18 @@ public partial class ViewTeamViewModel(
 
             if (availableEvents.Count == 0)
             {
-                await Shell.Current.DisplayAlertAsync("No Events",
-                    "You have no upcoming events available to link to this team.",
-                    "OK");
+                var alertPopup = new Controls.ConfirmPopup("No Events",
+                    "You have no upcoming events available to link to this team.", "OK");
+                await Shell.Current.CurrentPage.ShowPopupAsync<string>(alertPopup);
                 return;
             }
 
             var eventNames = availableEvents.Select(e => e.Name).ToArray();
-            var selected = await Shell.Current.DisplayActionSheetAsync(
-                "Select an event to link", "Cancel", null, eventNames);
+            var listPopup = new Controls.ListSelectorPopup("Select an event to link", eventNames);
+            var popupResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(listPopup);
+            var selected = popupResult?.Result;
 
-            if (string.IsNullOrEmpty(selected) || selected == "Cancel")
+            if (string.IsNullOrEmpty(selected))
             {
                 return;
             }
@@ -139,13 +141,10 @@ public partial class ViewTeamViewModel(
             return;
         }
 
-        var confirm = await Shell.Current.DisplayAlertAsync(
-            "Unlink Event",
-            $"Remove \"{eventVm.Name}\" from this team?",
-            "Unlink",
-            "Cancel");
-
-        if (!confirm)
+        var popup = new Controls.ConfirmPopup("Unlink Event",
+            $"Remove \"{eventVm.Name}\" from this team?", "Unlink");
+        var result = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        if (result?.Result != Controls.ConfirmPopup.Confirmed)
         {
             return;
         }

--- a/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml
@@ -99,7 +99,7 @@
                             <!-- Privacy badge -->
                             <Border Grid.Row="0" Grid.Column="1"
                                     Padding="6,2" StrokeShape="RoundRectangle 8"
-                                    BackgroundColor="{AppThemeBinding Light={StaticResource LightGray}, Dark={StaticResource DarkGray}}">
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray600}}">
                                 <Label Text="{Binding PrivacyDisplay}" FontSize="Micro" />
                             </Border>
 
@@ -115,13 +115,7 @@
                             <!-- Actions row (own routes only) -->
                             <HorizontalStackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
                                                    Spacing="8" IsVisible="{Binding IsOwnRoute}" Margin="0,4,0,0">
-                                <Picker Title="Privacy"
-                                        ItemsSource="{Binding Source={x:Reference TabRoutesView}, Path=BindingContext.PrivacyOptions}"
-                                        SelectedItem="{Binding PrivacyLevel}"
-                                        IsVisible="{Binding CanChangePrivacy}"
-                                        WidthRequest="120"
-                                        FontSize="Micro" />
-                                <Button Text="Save"
+                                <Button Text="{Binding PrivacyDisplay, StringFormat='Privacy: {0}'}"
                                         Command="{Binding Source={x:Reference TabRoutesView}, Path=BindingContext.ChangeRoutePrivacyCommand}"
                                         CommandParameter="{Binding .}"
                                         IsVisible="{Binding CanChangePrivacy}"

--- a/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml.cs
+++ b/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml.cs
@@ -3,6 +3,7 @@ namespace TrashMobMobile.Views.ViewEvent;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Maps;
 using TrashMob.Models.Poco;
 using TrashMobMobile.ViewModels;
 
@@ -65,6 +66,8 @@ public partial class TabRoutes : ContentView
     {
         routeMap.MapElements.Clear();
 
+        var allPoints = new List<Microsoft.Maui.Devices.Sensors.Location>();
+
         foreach (var route in routes)
         {
             var polyline = new Polyline
@@ -75,10 +78,32 @@ public partial class TabRoutes : ContentView
 
             foreach (var location in route.Locations)
             {
-                polyline.Geopath.Add(new Microsoft.Maui.Devices.Sensors.Location(location.Latitude, location.Longitude));
+                var point = new Microsoft.Maui.Devices.Sensors.Location(location.Latitude, location.Longitude);
+                polyline.Geopath.Add(point);
+                allPoints.Add(point);
             }
 
             routeMap.MapElements.Add(polyline);
+        }
+
+        if (allPoints.Count > 0)
+        {
+            var minLat = allPoints.Min(p => p.Latitude);
+            var maxLat = allPoints.Max(p => p.Latitude);
+            var minLon = allPoints.Min(p => p.Longitude);
+            var maxLon = allPoints.Max(p => p.Longitude);
+
+            var centerLat = (minLat + maxLat) / 2;
+            var centerLon = (minLon + maxLon) / 2;
+
+            // Add padding so the route doesn't touch the map edges
+            var latDelta = Math.Max((maxLat - minLat) * 1.3, 0.002);
+            var lonDelta = Math.Max((maxLon - minLon) * 1.3, 0.002);
+
+            var center = new Microsoft.Maui.Devices.Sensors.Location(centerLat, centerLon);
+            var mapSpan = new MapSpan(center, latDelta, lonDelta);
+            routeMap.InitialMapSpanAndroid = mapSpan;
+            routeMap.MoveToRegion(mapSpan);
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Fix TabRoutes crash**: `StaticResource LightGray`/`DarkGray` don't exist — replaced with `Gray100`/`Gray600`
- **Center route map**: compute bounding box of all route points and call `MoveToRegion` so the map zooms to show the actual route instead of a default location
- **New popup controls**: `PrivacyPopup`, `ConfirmPopup`, `ListSelectorPopup` — all styled to match the existing `QuickActionPopup`/`PhotoSourcePopup` design (rounded border, themed colors, Lexend font)
- **Replace all native dialogs**: every `DisplayAlertAsync`, `DisplayActionSheetAsync`, and native `Picker` popup in the mobile app now uses the styled custom popups

## Test plan
- [ ] Open an event with routes — verify the map centers on the route (not a default world location)
- [ ] On the routes tab, tap "Privacy: EventOnly" — verify styled popup appears with Private/Event Only/Public options
- [ ] Select a privacy option — verify it saves and the badge updates
- [ ] Tap Delete on a route — verify styled confirmation popup appears
- [ ] On the Photos tab, tap Delete on a photo — verify styled confirmation popup
- [ ] On Team view, tap Link Event — verify styled list selector popup with event names
- [ ] On Team view, tap Unlink on an event — verify styled confirmation popup
- [ ] On Newsletter preferences, tap Unsubscribe All — verify styled confirmation popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)