### PR TITLE
Redesign Edit Event page with card-based layout

### DIFF
--- a/TrashMobMobile/Pages/EditEventPage.xaml
+++ b/TrashMobMobile/Pages/EditEventPage.xaml
@@ -51,22 +51,13 @@
                         UseActivityIndicator="True" />
             </tabs:ViewSwitcher>
 
-            <Grid ColumnDefinitions="*, *, *, *"
-                      RowDefinitions="Auto"
-                      VerticalOptions="End"
-                      Margin="0,0,0,20">
-
-                <Button Margin="10"
-                            Grid.Row="0"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="2"
-                            Command="{Binding SaveEventCommand}"
-                            Style="{StaticResource PrimaryLargeButton}"
-                            Text="Save Event"
-                            ContentLayout="Left, 12"
-                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconContentSave}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}">
-                </Button>
-            </Grid>
+            <Button Margin="16,8,16,20"
+                    Command="{Binding SaveEventCommand}"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Text="Save Event"
+                    HorizontalOptions="Fill"
+                    ContentLayout="Left, 12"
+                    ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconContentSave}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
         </VerticalStackLayout>
         <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Views/EditEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/EditEvent/TabDetails.xaml
@@ -4,62 +4,219 @@
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
              x:Class="TrashMobMobile.Views.EditEvent.TabDetails">
-    <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *, *" MaximumWidthRequest="400">
+    <ScrollView>
+        <VerticalStackLayout Spacing="0" Margin="0" Padding="0,8">
 
-        <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="4">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Name" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMEntry Text="{Binding EventViewModel.Name}" />
-        </VerticalStackLayout>
+            <!-- Event Name -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                <VerticalStackLayout Spacing="4" Margin="0">
+                    <Label Style="{StaticResource FieldLabel}">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="Event Name" />
+                                <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                            </FormattedString>
+                        </Label.FormattedText>
+                    </Label>
+                    <controls:TMEntry Text="{Binding EventViewModel.Name}" />
+                </VerticalStackLayout>
+            </Border>
 
-        <VerticalStackLayout Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Date" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMDatePicker Date="{Binding EventViewModel.EventDateOnly, Mode=TwoWay}" />
-        </VerticalStackLayout>
+            <!-- Date & Time -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                <VerticalStackLayout Spacing="8" Margin="0">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconCalendarCheck}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Date &amp; Time"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
 
-        <VerticalStackLayout Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Time" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMTimePicker Time="{Binding EventViewModel.EventTime, Mode=TwoWay}" />
-        </VerticalStackLayout>
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="12" RowDefinitions="Auto" Margin="0">
+                        <VerticalStackLayout Grid.Column="0" Spacing="4" Margin="0">
+                            <Label Style="{StaticResource FieldLabel}">
+                                <Label.FormattedText>
+                                    <FormattedString>
+                                        <Span Text="Date" />
+                                        <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                                    </FormattedString>
+                                </Label.FormattedText>
+                            </Label>
+                            <controls:TMDatePicker Date="{Binding EventViewModel.EventDateOnly, Mode=TwoWay}" />
+                        </VerticalStackLayout>
 
-        <VerticalStackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Duration Hours" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.DurationHours}" />
-        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1" Spacing="4" Margin="0">
+                            <Label Style="{StaticResource FieldLabel}">
+                                <Label.FormattedText>
+                                    <FormattedString>
+                                        <Span Text="Time" />
+                                        <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                                    </FormattedString>
+                                </Label.FormattedText>
+                            </Label>
+                            <controls:TMTimePicker Time="{Binding EventViewModel.EventTime, Mode=TwoWay}" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
 
-        <VerticalStackLayout Grid.Row="2" Grid.Column="2" Grid.ColumnSpan="2">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Duration Minutes" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.DurationMinutes}" />
-        </VerticalStackLayout>
+            <!-- Duration -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                <VerticalStackLayout Spacing="8" Margin="0">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconTimerOutline}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Duration"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
 
-        <VerticalStackLayout Grid.Row="3" Grid.ColumnSpan="4">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMEditor Text="{Binding EventViewModel.Description}" />
-        </VerticalStackLayout>
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="12" RowDefinitions="Auto" Margin="0">
+                        <VerticalStackLayout Grid.Column="0" Spacing="4" Margin="0">
+                            <Label Style="{StaticResource FieldLabel}">
+                                <Label.FormattedText>
+                                    <FormattedString>
+                                        <Span Text="Hours" />
+                                        <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                                    </FormattedString>
+                                </Label.FormattedText>
+                            </Label>
+                            <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.DurationHours}" />
+                        </VerticalStackLayout>
 
-        <VerticalStackLayout Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Event Type" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMPicker Title="Event Type" ItemsSource="{Binding ETypes}"
-                                    SelectedItem="{Binding SelectedEventType, Mode=TwoWay}" />
-        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1" Spacing="4" Margin="0">
+                            <Label Style="{StaticResource FieldLabel}">
+                                <Label.FormattedText>
+                                    <FormattedString>
+                                        <Span Text="Minutes" />
+                                        <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                                    </FormattedString>
+                                </Label.FormattedText>
+                            </Label>
+                            <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.DurationMinutes}" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
 
-        <VerticalStackLayout Grid.Row="4" Grid.Column="2">
-            <Label Text="Max Attendees" Style="{StaticResource FieldLabel}" />
-            <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.MaxNumberOfParticipants}" />
-        </VerticalStackLayout>
+            <!-- Description -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                <VerticalStackLayout Spacing="4" Margin="0">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconFileDocument}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Style="{StaticResource FieldLabel}">
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="Description" />
+                                    <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+                    </HorizontalStackLayout>
+                    <controls:TMEditor Text="{Binding EventViewModel.Description}" />
+                </VerticalStackLayout>
+            </Border>
 
-        <VerticalStackLayout Grid.Row="4" Grid.Column="3">
-            <Label Text="Visibility" Style="{StaticResource FieldLabel}" />
-            <controls:TMPicker Title="Visibility"
-                               ItemsSource="{Binding VisibilityOptions}"
-                               SelectedItem="{Binding SelectedVisibility, Mode=TwoWay}" />
-        </VerticalStackLayout>
+            <!-- Event Settings -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                <VerticalStackLayout Spacing="8" Margin="0">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconTag}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Event Settings"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
 
-        <VerticalStackLayout Grid.Row="5" Grid.ColumnSpan="4"
-                             IsVisible="{Binding IsTeamPickerVisible}">
-            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Team" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-            <controls:TMPicker Title="Select Team"
-                               ItemsSource="{Binding TeamNames}"
-                               SelectedItem="{Binding SelectedTeam, Mode=TwoWay}" />
+                    <VerticalStackLayout Spacing="4" Margin="0">
+                        <Label Style="{StaticResource FieldLabel}">
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="Event Type" />
+                                    <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+                        <controls:TMPicker Title="Event Type" ItemsSource="{Binding ETypes}"
+                                           SelectedItem="{Binding SelectedEventType, Mode=TwoWay}" />
+                    </VerticalStackLayout>
+
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="12" RowDefinitions="Auto" Margin="0">
+                        <VerticalStackLayout Grid.Column="0" Spacing="4" Margin="0">
+                            <Label Text="Max Attendees" Style="{StaticResource FieldLabel}" />
+                            <controls:TMEntry Keyboard="Numeric" Text="{Binding EventViewModel.MaxNumberOfParticipants}" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout Grid.Column="1" Spacing="4" Margin="0">
+                            <Label Text="Visibility" Style="{StaticResource FieldLabel}" />
+                            <controls:TMPicker Title="Visibility"
+                                               ItemsSource="{Binding VisibilityOptions}"
+                                               SelectedItem="{Binding SelectedVisibility, Mode=TwoWay}" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Team (conditional) -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4"
+                    IsVisible="{Binding IsTeamPickerVisible}">
+                <VerticalStackLayout Spacing="4" Margin="0">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconAccountMultiple}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Style="{StaticResource FieldLabel}">
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="Team" />
+                                    <Span Text=" *" TextColor="{StaticResource Destructive}" />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+                    </HorizontalStackLayout>
+                    <controls:TMPicker Title="Select Team"
+                                       ItemsSource="{Binding TeamNames}"
+                                       SelectedItem="{Binding SelectedTeam, Mode=TwoWay}" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Bottom spacing for save button -->
+            <BoxView HeightRequest="16" BackgroundColor="Transparent" />
+
         </VerticalStackLayout>
-    </Grid>
+    </ScrollView>
 </ContentView>

--- a/TrashMobMobile/Views/EditEvent/TabLitterReports.xaml
+++ b/TrashMobMobile/Views/EditEvent/TabLitterReports.xaml
@@ -6,96 +6,197 @@
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:Class="TrashMobMobile.Views.EditEvent.TabLitterReports">
-    <Grid RowDefinitions="*, *, *">
+    <ScrollView>
+        <VerticalStackLayout Spacing="0" Margin="0" Padding="0,8">
 
-        <Label Grid.Row="0"
-                           Text="Nearby Litter Reports"
-                           FontSize="Medium"
-                           VerticalOptions="Center"
-                           HorizontalOptions="Start"
+            <!-- No Litter Reports Empty State -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4"
+                    IsVisible="{Binding AreNoLitterReportsAvailable}">
+                <VerticalStackLayout Spacing="12" Margin="0" HorizontalOptions="Center" Padding="0,20">
+                    <Image MaximumWidthRequest="48" MaximumHeightRequest="48" HorizontalOptions="Center">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconTrashCanOutline}"
+                                             Size="48"
+                                             Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Text="No Litter Reports Nearby"
+                           FontFamily="LexendSemibold"
+                           FontSize="Small"
                            HorizontalTextAlignment="Center"
-                           IsVisible="{Binding AreLitterReportsAvailable}"
-                           Margin="10" />
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <Label Text="There are currently no litter reports in the area of your event."
+                           FontSize="Micro"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+            </Border>
 
-        <Label Text="There are currently no litter reports in the area of your event." IsVisible="{Binding AreNoLitterReportsAvailable}" Margin="10" Grid.Row="1" />
+            <!-- Content when litter reports exist -->
+            <VerticalStackLayout Spacing="0" Margin="0"
+                                 IsVisible="{Binding AreLitterReportsAvailable}">
 
-        <Label Grid.Row="1" 
-                       Text="Add a nearby litter report to your event for your team to clean!" 
-                       FontSize="Micro" 
-                       IsVisible="{Binding AreLitterReportsAvailable}"
-                       Margin="10, 0"/>
+                <!-- Header with instruction -->
+                <VerticalStackLayout Spacing="4" Margin="16,8,16,4">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconTrashCanOutline}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Nearby Litter Reports"
+                               FontFamily="LexendSemibold"
+                               FontSize="Medium"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                    <Label Text="Add a nearby litter report to your event for your team to clean!"
+                           FontSize="Micro"
+                           Margin="28,0,0,0"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
 
-        <Grid RowDefinitions="*, *, *, *" IsVisible="{Binding AreLitterReportsAvailable}" Grid.Row="2">
-            <Grid Margin="5" Grid.Row="0"
-                      ColumnDefinitions="6*, *, *"
-                      RowDefinitions="Auto">
-                <ImageButton Grid.Column="1"
-                             HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
-                             Command="{Binding MapSelectedCommand}" />
-                <ImageButton Grid.Column="2" 
-                             HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
-                             Command="{Binding ListSelectedCommand}" />
-            </Grid>
+                <!-- Map/List Toggle -->
+                <Border Style="{StaticResource RoundBorder}" Margin="8,4" Padding="4">
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="4" Margin="0">
+                        <Button Grid.Column="0"
+                                Text="Map View"
+                                Command="{Binding MapSelectedCommand}"
+                                Style="{StaticResource PrimarySmallButton}"
+                                ContentLayout="Left, 8"
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Size=16, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
+                        <Button Grid.Column="1"
+                                Text="List View"
+                                Command="{Binding ListSelectedCommand}"
+                                Style="{StaticResource SecondarySmallButton}"
+                                ContentLayout="Left, 8"
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Size=16, Color={AppThemeBinding Light={StaticResource SecondaryText}, Dark={StaticResource SecondaryDarkText}}}" />
+                    </Grid>
+                </Border>
 
-            <controls:CustomMap x:Name="litterImagesMap"
-                              Grid.Row="1"
-                              ItemsSource="{Binding LitterImages}"
-                              IsVisible="{Binding IsLitterReportMapSelected}">
-                <maps:Map.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                        <controls:CustomPin Location="{Binding Address.Location}"
-                                          Address="{Binding Address.StreetAddress}"
-                                          Label="{Binding Address.StreetAddress}"
-                                          AutomationId="{Binding LitterReportId}"
-                                          ImageSource="{Binding Address.IconFile}"
-                                          InfoWindowClicked="Pin_InfoWindowClicked" />
-                    </DataTemplate>
-                </maps:Map.ItemTemplate>
-            </controls:CustomMap>
+                <!-- Map -->
+                <Border StrokeShape="RoundRectangle 10"
+                        StrokeThickness="0"
+                        Padding="0"
+                        Margin="8,4"
+                        IsVisible="{Binding IsLitterReportMapSelected}">
+                    <controls:CustomMap x:Name="litterImagesMap"
+                                      ItemsSource="{Binding LitterImages}"
+                                      HeightRequest="300">
+                        <maps:Map.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                <controls:CustomPin Location="{Binding Address.Location}"
+                                                  Address="{Binding Address.StreetAddress}"
+                                                  Label="{Binding Address.StreetAddress}"
+                                                  AutomationId="{Binding LitterReportId}"
+                                                  ImageSource="{Binding Address.IconFile}"
+                                                  InfoWindowClicked="Pin_InfoWindowClicked" />
+                            </DataTemplate>
+                        </maps:Map.ItemTemplate>
+                    </controls:CustomMap>
+                </Border>
 
-            <CollectionView x:Name="LitterReportsCollection" Grid.Row="1"
-                                    ItemsSource="{Binding EventLitterReports}"
-                                    IsVisible="{Binding IsLitterReportListSelected}"
-                                    SelectionMode="None">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:EventLitterReportViewModel">
-                        <StackLayout Margin="5">
-                            <Border Style="{StaticResource RoundBorder}" Margin="5">
-                                <Grid ColumnDefinitions="*, *"
-                                              RowDefinitions="*, *, *, *, *, *, *"
-                                              x:Name="LitterReportItem">
-                                    <Label Text="Name" Style="{StaticResource FieldLabel}" Grid.Row="0" />
-                                    <Label Text="{Binding Name}" Grid.Row="0" Grid.Column="1" />
-                                    <Label Text="Date Created" Style="{StaticResource FieldLabel}" Grid.Row="1" />
-                                    <Label Text="{Binding CreatedDate}" Grid.Row="1" Grid.Column="1" />
-                                    <Label Text="Status" Style="{StaticResource FieldLabel}" Grid.Row="2" />
-                                    <Label Text="{Binding Status}" Grid.Row="2" Grid.Column="1"/>
-                                    <Label Text="Description" Style="{StaticResource FieldLabel}" Grid.Row="3" />
-                                    <Label Text="{Binding Description}" Grid.Row="3" Grid.Column="1" />
-                                    <Button Text="Add" Command="{Binding AddToEventCommand}" IsVisible="{Binding CanAddToEvent}" Grid.Row="4" Grid.Column="0" />
-                                    <Button Text="Remove" Command="{Binding RemoveFromEventCommand}" IsVisible="{Binding CanRemoveFromEvent}" Grid.Row="4" Grid.Column="1" />
-                                    <Label Text="Locations" Grid.Row="5" Style="{StaticResource FieldLabel}" />
-                                    <CollectionView ItemsSource="{Binding LitterImageViewModels}" Grid.Row="6"
-                                                            Grid.Column="0" Grid.ColumnSpan="2">
-                                        <CollectionView.ItemTemplate>
-                                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                                <Border Style="{StaticResource RoundBorder}" Margin="0, 3">
-                                                    <Grid ColumnDefinitions="*, *">
-                                                        <Label Text="{Binding Address.DisplayAddress}" Grid.Column="0" LineBreakMode="WordWrap" FontSize="Micro" />
-                                                        <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="60" Grid.Column="1" />
-                                                    </Grid>
-                                                </Border>
-                                            </DataTemplate>
-                                        </CollectionView.ItemTemplate>
-                                    </CollectionView>
-                                </Grid>
+                <!-- List -->
+                <CollectionView x:Name="LitterReportsCollection"
+                                ItemsSource="{Binding EventLitterReports}"
+                                IsVisible="{Binding IsLitterReportListSelected}"
+                                SelectionMode="None">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventLitterReportViewModel">
+                            <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                                <VerticalStackLayout Spacing="8" Margin="0">
+                                    <!-- Name -->
+                                    <Label Text="{Binding Name}"
+                                           FontFamily="LexendSemibold"
+                                           FontSize="Small" />
+
+                                    <!-- Date & Status row -->
+                                    <Grid ColumnDefinitions="*, *" ColumnSpacing="12" Margin="0">
+                                        <VerticalStackLayout Grid.Column="0" Spacing="2" Margin="0">
+                                            <Label Text="Date Created" Style="{StaticResource FieldLabel}"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding CreatedDate}" FontSize="Micro" />
+                                        </VerticalStackLayout>
+                                        <VerticalStackLayout Grid.Column="1" Spacing="2" Margin="0">
+                                            <Label Text="Status" Style="{StaticResource FieldLabel}"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding Status}" FontSize="Micro" />
+                                        </VerticalStackLayout>
+                                    </Grid>
+
+                                    <!-- Description -->
+                                    <VerticalStackLayout Spacing="2" Margin="0">
+                                        <Label Text="Description" Style="{StaticResource FieldLabel}"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding Description}" FontSize="Micro" LineBreakMode="WordWrap" />
+                                    </VerticalStackLayout>
+
+                                    <!-- Action Buttons -->
+                                    <Grid ColumnDefinitions="*, *" ColumnSpacing="8" Margin="0">
+                                        <Button Text="Add to Event"
+                                                Command="{Binding AddToEventCommand}"
+                                                IsVisible="{Binding CanAddToEvent}"
+                                                Style="{StaticResource PrimarySmallButton}"
+                                                Grid.Column="0"
+                                                ContentLayout="Left, 8"
+                                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconPlusCircle}, Size=16, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
+                                        <Button Text="Remove"
+                                                Command="{Binding RemoveFromEventCommand}"
+                                                IsVisible="{Binding CanRemoveFromEvent}"
+                                                Style="{StaticResource SecondarySmallButton}"
+                                                Grid.Column="1"
+                                                ContentLayout="Left, 8"
+                                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconDelete}, Size=16, Color={AppThemeBinding Light={StaticResource SecondaryText}, Dark={StaticResource SecondaryDarkText}}}" />
+                                    </Grid>
+
+                                    <!-- Locations -->
+                                    <VerticalStackLayout Spacing="4" Margin="0">
+                                        <Label Text="Locations" Style="{StaticResource FieldLabel}"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <CollectionView ItemsSource="{Binding LitterImageViewModels}">
+                                            <CollectionView.ItemTemplate>
+                                                <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                                    <Border Padding="8"
+                                                            Margin="0,2"
+                                                            StrokeShape="RoundRectangle 8"
+                                                            BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}"
+                                                            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+                                                            StrokeThickness="1">
+                                                        <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                                                            <Label Text="{Binding Address.DisplayAddress}"
+                                                                   Grid.Column="0"
+                                                                   LineBreakMode="WordWrap"
+                                                                   FontSize="Micro"
+                                                                   VerticalOptions="Center" />
+                                                            <Border Grid.Column="1"
+                                                                    StrokeShape="RoundRectangle 6"
+                                                                    StrokeThickness="0"
+                                                                    Padding="0"
+                                                                    WidthRequest="56"
+                                                                    HeightRequest="56">
+                                                                <Image Source="{Binding AzureBlobUrl}"
+                                                                       Aspect="AspectFill" />
+                                                            </Border>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </CollectionView.ItemTemplate>
+                                        </CollectionView>
+                                    </VerticalStackLayout>
+                                </VerticalStackLayout>
                             </Border>
-                        </StackLayout>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-        </Grid>
-    </Grid>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+            </VerticalStackLayout>
+
+            <!-- Bottom spacing -->
+            <BoxView HeightRequest="16" BackgroundColor="Transparent" />
+
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentView>

--- a/TrashMobMobile/Views/EditEvent/TabLocation.xaml
+++ b/TrashMobMobile/Views/EditEvent/TabLocation.xaml
@@ -5,48 +5,106 @@
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:Class="TrashMobMobile.Views.EditEvent.TabLocation">
-    <VerticalStackLayout>
-        <Label
-                    Text="Click on the map to set the event location."
-                    FontSize="Micro"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Center"
-                    HorizontalTextAlignment="Center"
-                    Margin="5" />
+    <ScrollView>
+        <VerticalStackLayout Spacing="0" Margin="0" Padding="0,8">
 
-        <controls:CustomMap x:Name="eventLocationMap" ItemsSource="{Binding Events}" IsShowingUser="True" HeightRequest="400"
-                          MapClicked="OnMapClicked">
-            <maps:Map.ItemTemplate>
-                <DataTemplate x:DataType="viewModels:EventViewModel">
-                    <controls:CustomPin Location="{Binding Address.Location}"
-                                      Address="{Binding Address.StreetAddress}"
-                                      ImageSource="{Binding Address.IconFile}"
-                                      Label="{Binding Name}" />
-                </DataTemplate>
-            </maps:Map.ItemTemplate>
-        </controls:CustomMap>
+            <!-- Instruction -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4"
+                    BackgroundColor="{AppThemeBinding Light=#EEF7F5, Dark=#1A2F2C}">
+                <HorizontalStackLayout Spacing="10" Margin="0">
+                    <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconInformationOutline}"
+                                             Size="20"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Text="Tap on the map to set the event location."
+                           FontSize="Small"
+                           VerticalOptions="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                </HorizontalStackLayout>
+            </Border>
 
-        <Grid RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *">
-            <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2">
-                <Label Text="Address" Style="{StaticResource FieldLabel}" />
-                <Label Text="{Binding EventViewModel.Address.StreetAddress }" FontSize="Micro" />
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="1" Grid.Column="0">
-                <Label Text="City" Style="{StaticResource FieldLabel}" />
-                <Label Text="{Binding EventViewModel.Address.City }" FontSize="Micro" />
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="1" Grid.Column="1">
-                <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
-                <Label Text="{Binding EventViewModel.Address.Region }" FontSize="Micro" />
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="2" Grid.Column="0">
-                <Label Text="Country" Style="{StaticResource FieldLabel}" />
-                <Label Text="{Binding EventViewModel.Address.Country }" FontSize="Micro" />
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="2" Grid.Column="1">
-                <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
-                <Label Text="{Binding EventViewModel.Address.PostalCode }" FontSize="Micro" />
-            </VerticalStackLayout>
-        </Grid>
-    </VerticalStackLayout>
+            <!-- Map -->
+            <Border StrokeShape="RoundRectangle 10"
+                    StrokeThickness="0"
+                    Padding="0"
+                    Margin="8,4">
+                <controls:CustomMap x:Name="eventLocationMap" ItemsSource="{Binding Events}" IsShowingUser="True" HeightRequest="350"
+                                  MapClicked="OnMapClicked">
+                    <maps:Map.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
+                            <controls:CustomPin Location="{Binding Address.Location}"
+                                              Address="{Binding Address.StreetAddress}"
+                                              ImageSource="{Binding Address.IconFile}"
+                                              Label="{Binding Name}" />
+                        </DataTemplate>
+                    </maps:Map.ItemTemplate>
+                </controls:CustomMap>
+            </Border>
+
+            <!-- Address Details Card -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                <VerticalStackLayout Spacing="10" Margin="0">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconMapMarkerOutline}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Location Details"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+
+                    <!-- Street Address -->
+                    <VerticalStackLayout Spacing="2" Margin="0">
+                        <Label Text="Street Address" Style="{StaticResource FieldLabel}"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding EventViewModel.Address.StreetAddress}" FontSize="Small" />
+                    </VerticalStackLayout>
+
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="12" RowDefinitions="Auto, Auto" RowSpacing="10" Margin="0">
+                        <!-- City -->
+                        <VerticalStackLayout Grid.Row="0" Grid.Column="0" Spacing="2" Margin="0">
+                            <Label Text="City" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.City}" FontSize="Small" />
+                        </VerticalStackLayout>
+
+                        <!-- State/Region -->
+                        <VerticalStackLayout Grid.Row="0" Grid.Column="1" Spacing="2" Margin="0">
+                            <Label Text="State/Region" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.Region}" FontSize="Small" />
+                        </VerticalStackLayout>
+
+                        <!-- Country -->
+                        <VerticalStackLayout Grid.Row="1" Grid.Column="0" Spacing="2" Margin="0">
+                            <Label Text="Country" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.Country}" FontSize="Small" />
+                        </VerticalStackLayout>
+
+                        <!-- Postal Code -->
+                        <VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="2" Margin="0">
+                            <Label Text="Postal Code" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.PostalCode}" FontSize="Small" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Bottom spacing -->
+            <BoxView HeightRequest="16" BackgroundColor="Transparent" />
+
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentView>

--- a/TrashMobMobile/Views/EditEvent/TabPartners.xaml
+++ b/TrashMobMobile/Views/EditEvent/TabPartners.xaml
@@ -3,46 +3,97 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:Class="TrashMobMobile.Views.EditEvent.TabPartners">
-    <Grid RowDefinitions="Auto, Auto, Auto">
-        <Label Grid.Row="0" Text="We're sorry. There are currently no partners available in your area." IsVisible="{Binding AreNoPartnersAvailable}" />
+    <ScrollView>
+        <VerticalStackLayout Spacing="0" Margin="0" Padding="0,8">
 
-        <Label Grid.Row="0"
-                           Text="Available Event Partners"
-                           FontSize="Medium"
-                           VerticalOptions="Center"
-                           HorizontalOptions="Start"
+            <!-- No Partners Empty State -->
+            <Border Style="{StaticResource RoundBorder}" Margin="8,4"
+                    IsVisible="{Binding AreNoPartnersAvailable}">
+                <VerticalStackLayout Spacing="12" Margin="0" HorizontalOptions="Center" Padding="0,20">
+                    <Image MaximumWidthRequest="48" MaximumHeightRequest="48" HorizontalOptions="Center">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconHandshake}"
+                                             Size="48"
+                                             Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Text="No Partners Available"
+                           FontFamily="LexendSemibold"
+                           FontSize="Small"
                            HorizontalTextAlignment="Center"
-                           IsVisible="{Binding ArePartnersAvailable}"
-                           Margin="10" />
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <Label Text="There are currently no partners available in your area."
+                           FontSize="Micro"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+            </Border>
 
-        <Label Grid.Row="1" 
-                       Text="Click on a Partner listed below to request services for your event." 
-                       IsVisible="{Binding ArePartnersAvailable}" 
-                       FontSize="Micro" 
-                       Margin="10, 0"/>
+            <!-- Header with instruction -->
+            <VerticalStackLayout Spacing="4" Margin="16,8,16,4"
+                                 IsVisible="{Binding ArePartnersAvailable}">
+                <HorizontalStackLayout Spacing="8">
+                    <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconHandshake}"
+                                             Size="20"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Text="Available Event Partners"
+                           FontFamily="LexendSemibold"
+                           FontSize="Medium"
+                           VerticalOptions="Center" />
+                </HorizontalStackLayout>
+                <Label Text="Tap a partner to request services for your event."
+                       FontSize="Micro"
+                       Margin="28,0,0,0"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+            </VerticalStackLayout>
 
-        <CollectionView Grid.Row="2" x:Name="AvailableEventPartners"
-                                    ItemsSource="{Binding AvailablePartners}"
-                                    SelectedItem="{Binding SelectedEventPartnerLocation}"
-                                    SelectionMode="Single" 
-                                    IsVisible="{Binding ArePartnersAvailable}">
-            <CollectionView.ItemTemplate>
-                <DataTemplate 
-                                x:DataType="viewModels:EventPartnerLocationViewModel">
-                    <Border Style="{StaticResource RoundBorder}" Margin="5">
-                        <Grid RowDefinitions="1*, 2*, 1*" ColumnDefinitions="*, *"
-                                          x:Name="PartnerLocationItem">
-                            <Label Text="Partner Name" Style="{StaticResource FieldLabel}" Grid.Row="0" />
-                            <Label Text="{Binding PartnerLocationName}" Grid.Column="1" Grid.Row="0" />
-                            <Label Text="Info" Style="{StaticResource FieldLabel}" Grid.Row="1" />
-                            <Label Text="{Binding PartnerLocationNotes}" Grid.Row="1" Grid.Column="1" />
-                            <Label Text="Services Requested" Style="{StaticResource FieldLabel}" Grid.Row="2" />
-                            <Label Text="{Binding PartnerServicesEngaged}" Grid.Row="2" Grid.Column="1" />
-                        </Grid>
-                    </Border>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
-    </Grid>
+            <!-- Partner List -->
+            <CollectionView x:Name="AvailableEventPartners"
+                            ItemsSource="{Binding AvailablePartners}"
+                            SelectedItem="{Binding SelectedEventPartnerLocation}"
+                            SelectionMode="Single"
+                            IsVisible="{Binding ArePartnersAvailable}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="viewModels:EventPartnerLocationViewModel">
+                        <Border Style="{StaticResource RoundBorder}" Margin="8,4">
+                            <VerticalStackLayout Spacing="8" Margin="0">
+                                <!-- Partner Name -->
+                                <Label Text="{Binding PartnerLocationName}"
+                                       FontFamily="LexendSemibold"
+                                       FontSize="Small" />
 
+                                <!-- Info -->
+                                <VerticalStackLayout Spacing="2" Margin="0">
+                                    <Label Text="Info" Style="{StaticResource FieldLabel}"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    <Label Text="{Binding PartnerLocationNotes}"
+                                           FontSize="Micro"
+                                           LineBreakMode="WordWrap" />
+                                </VerticalStackLayout>
+
+                                <!-- Services Requested -->
+                                <VerticalStackLayout Spacing="2" Margin="0">
+                                    <Label Text="Services Requested" Style="{StaticResource FieldLabel}"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    <Label Text="{Binding PartnerServicesEngaged}"
+                                           FontSize="Micro"
+                                           LineBreakMode="WordWrap" />
+                                </VerticalStackLayout>
+                            </VerticalStackLayout>
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <!-- Bottom spacing -->
+            <BoxView HeightRequest="16" BackgroundColor="Transparent" />
+
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentView>


### PR DESCRIPTION
## Summary
- Redesigned all 4 Edit Event tabs (Details, Location, Partners, Litter Reports) with card-based sections, icon headers, and consistent spacing
- Added ScrollView wrappers to all tabs for proper scrolling
- Upgraded empty states (Partners, Litter Reports) with centered icons and descriptive text
- Improved map display with rounded borders and styled instruction callout on Location tab
- Made Save Event button full-width for better touch target
- Styled Map/List toggle buttons and Add/Remove action buttons on Litter Reports tab

## Test plan
- [ ] Open Edit Event page and verify Details tab displays form fields in grouped cards with icons
- [ ] Switch to Location tab and verify map has rounded corners with styled instruction banner
- [ ] Switch to Partners tab and verify partner cards show vertical layout with proper labels
- [ ] Switch to Litter Reports tab and verify empty state shows icon with descriptive message
- [ ] Verify Save Event button is full-width at the bottom of the page
- [ ] Test scrolling on Details tab with all form fields visible
- [ ] Verify dark mode rendering on all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)