### PR TITLE
Add area export to GeoJSON and KML (Project 44 Phase 5)

### DIFF
--- a/TrashMob/Controllers/AdoptableAreasController.cs
+++ b/TrashMob/Controllers/AdoptableAreasController.cs
@@ -2,9 +2,13 @@ namespace TrashMob.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
+    using System.Text;
+    using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Xml.Linq;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -367,6 +371,54 @@ namespace TrashMob.Controllers
         }
 
         /// <summary>
+        /// Exports all adoptable areas for a community as GeoJSON or KML.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="format">The export format: geojson or kml.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("export")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ExportAreas(
+            Guid partnerId,
+            [FromQuery] string format,
+            CancellationToken cancellationToken)
+        {
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var areas = await areaManager.GetByCommunityAsync(partnerId, cancellationToken);
+            var areaList = areas.ToList();
+
+            var safeName = partner.Name.Replace(" ", "_", StringComparison.Ordinal);
+            var dateSuffix = DateTime.UtcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+            if (string.Equals(format, "kml", StringComparison.OrdinalIgnoreCase))
+            {
+                var kml = BuildKml(partner.Name, areaList);
+                var bytes = Encoding.UTF8.GetBytes(kml);
+                return File(bytes, "application/vnd.google-earth.kml+xml", $"{safeName}_Areas_{dateSuffix}.kml");
+            }
+
+            // Default to GeoJSON
+            var geoJson = BuildGeoJson(areaList);
+            var geoJsonBytes = Encoding.UTF8.GetBytes(geoJson);
+            return File(geoJsonBytes, "application/geo+json", $"{safeName}_Areas_{dateSuffix}.geojson");
+        }
+
+        /// <summary>
         /// Deletes (deactivates) an adoptable area. Only community admins can delete areas.
         /// </summary>
         /// <param name="partnerId">The community (partner) ID.</param>
@@ -409,5 +461,156 @@ namespace TrashMob.Controllers
             await areaManager.UpdateAsync(existingArea, UserId, cancellationToken);
             return NoContent();
         }
+
+        #region Export Helpers
+
+        private static readonly JsonSerializerOptions GeoJsonSerializerOptions = new() { WriteIndented = true };
+
+        private static string BuildGeoJson(List<AdoptableArea> areas)
+        {
+            var features = new List<object>();
+
+            foreach (var area in areas)
+            {
+                object geometry = null;
+                if (!string.IsNullOrWhiteSpace(area.GeoJson))
+                {
+                    try
+                    {
+                        geometry = JsonSerializer.Deserialize<JsonElement>(area.GeoJson);
+                    }
+                    catch (JsonException)
+                    {
+                        // Skip malformed geometry
+                    }
+                }
+
+                features.Add(new
+                {
+                    type = "Feature",
+                    geometry,
+                    properties = new
+                    {
+                        name = area.Name,
+                        description = area.Description ?? "",
+                        areaType = area.AreaType,
+                        status = area.Status,
+                        cleanupFrequencyDays = area.CleanupFrequencyDays,
+                        minEventsPerYear = area.MinEventsPerYear,
+                        safetyRequirements = area.SafetyRequirements ?? "",
+                        allowCoAdoption = area.AllowCoAdoption,
+                    },
+                });
+            }
+
+            var featureCollection = new
+            {
+                type = "FeatureCollection",
+                features,
+            };
+
+            return JsonSerializer.Serialize(featureCollection, GeoJsonSerializerOptions);
+        }
+
+        private static string BuildKml(string communityName, List<AdoptableArea> areas)
+        {
+            XNamespace kmlNs = "http://www.opengis.net/kml/2.2";
+
+            var placemarks = new List<XElement>();
+
+            foreach (var area in areas)
+            {
+                var placemark = new XElement(kmlNs + "Placemark",
+                    new XElement(kmlNs + "name", area.Name),
+                    new XElement(kmlNs + "description", area.Description ?? ""),
+                    new XElement(kmlNs + "ExtendedData",
+                        KmlDataElement(kmlNs, "areaType", area.AreaType),
+                        KmlDataElement(kmlNs, "status", area.Status),
+                        KmlDataElement(kmlNs, "cleanupFrequencyDays", area.CleanupFrequencyDays.ToString(CultureInfo.InvariantCulture)),
+                        KmlDataElement(kmlNs, "minEventsPerYear", area.MinEventsPerYear.ToString(CultureInfo.InvariantCulture)),
+                        KmlDataElement(kmlNs, "safetyRequirements", area.SafetyRequirements ?? ""),
+                        KmlDataElement(kmlNs, "allowCoAdoption", area.AllowCoAdoption.ToString())));
+
+                var geometryElement = GeoJsonToKmlGeometry(kmlNs, area.GeoJson);
+                if (geometryElement != null)
+                {
+                    placemark.Add(geometryElement);
+                }
+
+                placemarks.Add(placemark);
+            }
+
+            var doc = new XDocument(
+                new XDeclaration("1.0", "UTF-8", null),
+                new XElement(kmlNs + "kml",
+                    new XElement(kmlNs + "Document",
+                        new XElement(kmlNs + "name", $"{communityName} Areas"),
+                        placemarks)));
+
+            return doc.Declaration + Environment.NewLine + doc;
+        }
+
+        private static XElement KmlDataElement(XNamespace kmlNs, string name, string value)
+        {
+            return new XElement(kmlNs + "Data",
+                new XAttribute("name", name),
+                new XElement(kmlNs + "value", value));
+        }
+
+        private static XElement GeoJsonToKmlGeometry(XNamespace kmlNs, string geoJson)
+        {
+            if (string.IsNullOrWhiteSpace(geoJson))
+            {
+                return null;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(geoJson);
+                var root = doc.RootElement;
+                var type = root.GetProperty("type").GetString();
+
+                if (type == "Polygon")
+                {
+                    var coords = root.GetProperty("coordinates");
+                    var outerRing = coords[0];
+                    return new XElement(kmlNs + "Polygon",
+                        new XElement(kmlNs + "outerBoundaryIs",
+                            new XElement(kmlNs + "LinearRing",
+                                new XElement(kmlNs + "coordinates", CoordinateArrayToKml(outerRing)))));
+                }
+
+                if (type == "LineString")
+                {
+                    var coords = root.GetProperty("coordinates");
+                    return new XElement(kmlNs + "LineString",
+                        new XElement(kmlNs + "coordinates", CoordinateArrayToKml(coords)));
+                }
+
+                return null;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
+        private static string CoordinateArrayToKml(JsonElement coordinates)
+        {
+            var sb = new StringBuilder();
+            foreach (var coord in coordinates.EnumerateArray())
+            {
+                var lon = coord[0].GetDouble().ToString(CultureInfo.InvariantCulture);
+                var lat = coord[1].GetDouble().ToString(CultureInfo.InvariantCulture);
+                var alt = coord.GetArrayLength() > 2
+                    ? coord[2].GetDouble().ToString(CultureInfo.InvariantCulture)
+                    : "0";
+                sb.Append($"{lon},{lat},{alt} ");
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        #endregion
     }
 }

--- a/TrashMob/client-app/src/services/adoptable-areas.ts
+++ b/TrashMob/client-app/src/services/adoptable-areas.ts
@@ -94,6 +94,21 @@ export const DeleteAdoptableArea = () => ({
 });
 
 // ============================================================================
+// Export
+// ============================================================================
+
+export type ExportAreas_Params = { partnerId: string; format: 'geojson' | 'kml' };
+export const ExportAreas = (params: ExportAreas_Params) => ({
+    key: ['/communities/', params.partnerId, '/areas/export', params.format],
+    service: async () =>
+        ApiService('protected').fetchData<Blob>({
+            url: `/communities/${params.partnerId}/areas/export?format=${params.format}`,
+            method: 'get',
+            responseType: 'blob',
+        }),
+});
+
+// ============================================================================
 // AI Area Suggestion
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/communities/{partnerId}/areas/export?format=geojson|kml` endpoint that exports all adoptable areas as a GeoJSON FeatureCollection or KML Document
- Adds Export dropdown button on the areas list page with "Export as GeoJSON" and "Export as KML" options (hidden when no areas exist)
- Completes Project 44 Phase 5 (Export)

## Test plan
- [ ] Navigate to a community's adoptable areas page with existing areas
- [ ] Click Export > "Export as GeoJSON" — verify a `.geojson` file downloads with valid FeatureCollection containing area geometries and properties
- [ ] Click Export > "Export as KML" — verify a `.kml` file downloads that opens in Google Earth or similar GIS tools
- [ ] Verify Export button is not shown when community has no areas
- [ ] Verify exported GeoJSON can be re-imported via the Import feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)