### PR TITLE
Redesign Create Event wizard and add styled popups

### DIFF
--- a/TrashMobMobile/Pages/CreateEvent/Step1.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step1.xaml
@@ -58,44 +58,56 @@
             <Border Style="{StaticResource RoundBorder}" Margin="4,0">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Date &amp; Time" Style="{StaticResource SectionHeader}" Margin="0" />
-                    <Grid ColumnDefinitions="*, *, *" ColumnSpacing="8">
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="10">
                         <VerticalStackLayout Grid.Column="0" Spacing="4">
                             <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Date" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
                             <controls:TMDatePicker HeightRequest="45"
-                                       Date="{Binding EventViewModel.EventDateOnly}" />
+                                       Date="{Binding EventViewModel.EventDateOnly, Mode=TwoWay}" />
                         </VerticalStackLayout>
                         <VerticalStackLayout Grid.Column="1" Spacing="4">
-                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Start" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                            <controls:TMTimePicker Time="{Binding StartTime, Mode=TwoWay}" />
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Time" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMTimePicker Time="{Binding EventViewModel.EventTime, Mode=TwoWay}" />
                         </VerticalStackLayout>
-                        <VerticalStackLayout Grid.Column="2" Spacing="4">
-                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="End" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                            <controls:TMTimePicker Time="{Binding EndTime, Mode=TwoWay}" />
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Duration Card -->
+            <Border Style="{StaticResource RoundBorder}" Margin="4,0">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Duration" Style="{StaticResource SectionHeader}" Margin="0" />
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="10">
+                        <VerticalStackLayout Grid.Column="0" Spacing="4">
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Hours" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEntry Keyboard="Numeric" HeightRequest="40"
+                                              Text="{Binding EventViewModel.DurationHours}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1" Spacing="4">
+                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Minutes" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
+                            <controls:TMEntry Keyboard="Numeric" HeightRequest="40"
+                                              Text="{Binding EventViewModel.DurationMinutes}" />
                         </VerticalStackLayout>
                     </Grid>
                     <Label Style="{StaticResource ErrorLabel}"
                            IsVisible="{Binding EventDurationError, Converter={StaticResource StringToBoolConverter}}"
                            Text="{Binding EventDurationError}" />
-                    <Grid ColumnDefinitions="*, *" ColumnSpacing="10">
-                        <VerticalStackLayout Grid.Column="0" Spacing="4">
-                            <Label Text="Duration" Style="{StaticResource FieldLabel}" />
-                            <Label Text="{Binding FormattedEventDuration}" FontSize="Small"
-                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                        </VerticalStackLayout>
-                        <VerticalStackLayout Grid.Column="1" Spacing="4">
-                            <Label Text="Max Attendees" Style="{StaticResource FieldLabel}" />
-                            <controls:TMEntry Keyboard="Numeric"
-                                  HeightRequest="40"
-                                  Text="{Binding EventViewModel.MaxNumberOfParticipants}">
-                                <controls:TMEntry.Behaviors>
-                                    <toolkit:NumericValidationBehavior Flags="ValidateOnValueChanged"
-                                                           x:Name="maxNumberOfParticipantsValidator"
-                                                           MinimumValue="0"
-                                                           MaximumDecimalPlaces="0" />
-                                </controls:TMEntry.Behaviors>
-                            </controls:TMEntry>
-                        </VerticalStackLayout>
-                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Max Attendees Card -->
+            <Border Style="{StaticResource RoundBorder}" Margin="4,0">
+                <VerticalStackLayout Spacing="4">
+                    <Label Text="Max Attendees" Style="{StaticResource FieldLabel}" />
+                    <controls:TMEntry Keyboard="Numeric"
+                          HeightRequest="40"
+                          Text="{Binding EventViewModel.MaxNumberOfParticipants}">
+                        <controls:TMEntry.Behaviors>
+                            <toolkit:NumericValidationBehavior Flags="ValidateOnValueChanged"
+                                                   x:Name="maxNumberOfParticipantsValidator"
+                                                   MinimumValue="0"
+                                                   MaximumDecimalPlaces="0" />
+                        </controls:TMEntry.Behaviors>
+                    </controls:TMEntry>
                 </VerticalStackLayout>
             </Border>
 

--- a/TrashMobMobile/Pages/CreateEvent/Step2.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step2.xaml
@@ -8,59 +8,107 @@
                            x:DataType="viewModels:CreateEventViewModel"
                            xmlns:controls="clr-namespace:TrashMobMobile.Controls"
                            x:Class="TrashMobMobile.Pages.CreateEvent.Step2">
-    <VerticalStackLayout Margin="0,10">
-        <Label
-                Margin="5"
-                FontSize="Micro"
-                HorizontalOptions="Center"
-                HorizontalTextAlignment="Center"
-                Text="Click on the map to set the event location."
-                VerticalOptions="Center" />
-        <controls:CustomMap x:Name="eventLocationMap"
-                      ItemsSource="{Binding Events}"
-                      MapClicked="OnMapClicked">
-            <maps:Map.ItemTemplate>
-                <DataTemplate x:DataType="viewModels:EventViewModel">
-                    <controls:CustomPin Address="{Binding Address.StreetAddress}"
-                                  Label="{Binding Name}"
-                                  ImageSource="{Binding Address.IconFile}"
-                                  Location="{Binding Address.Location}" />
-                </DataTemplate>
-            </maps:Map.ItemTemplate>
-        </controls:CustomMap>
-        <Grid ColumnDefinitions="*, *"
-                  RowDefinitions="Auto, Auto, Auto">
-            <VerticalStackLayout Grid.Row="0" Grid.ColumnSpan="2">
-                <Label Text="Address" Style="{StaticResource FieldLabel}" />
-                
-                    <Label FontSize="Micro"
-                               Text="{Binding EventViewModel.Address.StreetAddress}" />
+    <ScrollView>
+        <VerticalStackLayout Spacing="0" Padding="0,4">
 
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="1" Grid.Column="0">
-                <Label Text="City" Style="{StaticResource FieldLabel}" />
-                
-                    <Label FontSize="Micro"
-                               Text="{Binding EventViewModel.Address.City}" />
+            <!-- Instruction -->
+            <Border Style="{StaticResource RoundBorder}" Margin="4,4"
+                    BackgroundColor="{AppThemeBinding Light=#EEF7F5, Dark=#1A2F2C}">
+                <HorizontalStackLayout Spacing="10">
+                    <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                        <Image.Source>
+                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                             Glyph="{StaticResource IconInformationOutline}"
+                                             Size="20"
+                                             Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Image.Source>
+                    </Image>
+                    <Label Text="Tap on the map to set the event location."
+                           FontSize="Small"
+                           VerticalOptions="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                </HorizontalStackLayout>
+            </Border>
 
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="1" Grid.Column="1">
-                <Label Text="State/Region" Style="{StaticResource FieldLabel}" />
-                
-                    <Label FontSize="Micro"
-                               Text="{Binding EventViewModel.Address.Region}" />
+            <!-- Map -->
+            <Border StrokeShape="RoundRectangle 10"
+                    StrokeThickness="0"
+                    Padding="0"
+                    Margin="4,4">
+                <controls:CustomMap x:Name="eventLocationMap"
+                                    ItemsSource="{Binding Events}"
+                                    HeightRequest="320"
+                                    MapClicked="OnMapClicked">
+                    <maps:Map.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
+                            <controls:CustomPin Address="{Binding Address.StreetAddress}"
+                                                Label="{Binding Name}"
+                                                ImageSource="{Binding Address.IconFile}"
+                                                Location="{Binding Address.Location}" />
+                        </DataTemplate>
+                    </maps:Map.ItemTemplate>
+                </controls:CustomMap>
+            </Border>
 
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="2" Grid.Column="0">
-                <Label Text="Country" Style="{StaticResource FieldLabel}" />
-                    <Label FontSize="Micro"
-                               Text="{Binding EventViewModel.Address.Country}" />
-            </VerticalStackLayout>
-            <VerticalStackLayout Grid.Row="2" Grid.Column="1">
-                <Label Text="Postal Code" Style="{StaticResource FieldLabel}" />
-                    <Label FontSize="Micro"
-                               Text="{Binding EventViewModel.Address.PostalCode}" />
-            </VerticalStackLayout>
-        </Grid>
-    </VerticalStackLayout>
+            <!-- Address Details Card -->
+            <Border Style="{StaticResource RoundBorder}" Margin="4,4">
+                <VerticalStackLayout Spacing="10">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconMapMarkerOutline}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Location Details"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+
+                    <!-- Street Address -->
+                    <VerticalStackLayout Spacing="2">
+                        <Label Text="Street Address" Style="{StaticResource FieldLabel}"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="{Binding EventViewModel.Address.StreetAddress}" FontSize="Small" />
+                    </VerticalStackLayout>
+
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="12" RowDefinitions="Auto, Auto" RowSpacing="10">
+                        <!-- City -->
+                        <VerticalStackLayout Grid.Row="0" Grid.Column="0" Spacing="2">
+                            <Label Text="City" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.City}" FontSize="Small" />
+                        </VerticalStackLayout>
+
+                        <!-- State/Region -->
+                        <VerticalStackLayout Grid.Row="0" Grid.Column="1" Spacing="2">
+                            <Label Text="State/Region" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.Region}" FontSize="Small" />
+                        </VerticalStackLayout>
+
+                        <!-- Country -->
+                        <VerticalStackLayout Grid.Row="1" Grid.Column="0" Spacing="2">
+                            <Label Text="Country" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.Country}" FontSize="Small" />
+                        </VerticalStackLayout>
+
+                        <!-- Postal Code -->
+                        <VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="2">
+                            <Label Text="Postal Code" Style="{StaticResource FieldLabel}"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            <Label Text="{Binding EventViewModel.Address.PostalCode}" FontSize="Small" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <BoxView HeightRequest="12" BackgroundColor="Transparent" />
+
+        </VerticalStackLayout>
+    </ScrollView>
 </createEvent:BaseStepClass>

--- a/TrashMobMobile/Pages/CreateEvent/Step3.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step3.xaml
@@ -10,49 +10,128 @@
                            x:Class="TrashMobMobile.Pages.CreateEvent.Step3">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Label
-                    Text="{Binding EventViewModel.Name}" Style="{StaticResource Headline}"
-                    VerticalOptions="Center"
-                    Margin="5" />
+            <VerticalStackLayout Spacing="0" Padding="0,4">
 
-                <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="3"
-                      ColumnDefinitions="*, 2*">
-                    <Label Grid.Row="0" Grid.Column="0" Text="{Binding SelectedEventType}" FontSize="Small"
-                           Margin="10, 0, 10, 0" Grid.ColumnSpan="2" />
-                    <Label Grid.Row="1" Grid.Column="0" Text="{Binding EventViewModel.DisplayDate}"
-                           FontAttributes="Bold" Margin="10, 0, 10, 0" Grid.ColumnSpan="2" />
-                    <Label Grid.Row="2" Grid.Column="0" Text="{Binding EventViewModel.DisplayTime}" FontSize="Micro"
-                           Margin="10, 0, 10, 0" />
-                    <Label Grid.Row="2" Grid.Column="1" Text="{Binding FormattedEventDuration}" FontSize="Micro"
-                           Margin="10, 0, 10, 0" />
-                    <Label Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
-                           Text="{Binding EventViewModel.Address.DisplayAddress }" FontAttributes="Bold"
-                           Margin="10, 0, 10, 0" />
-                    <controls:CustomMap Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" x:Name="eventLocationMap"
-                              ItemsSource="{Binding Events}">
-                        <maps:Map.ItemTemplate>
-                            <DataTemplate x:DataType="viewModels:EventViewModel">
-                                <controls:CustomPin Location="{Binding Address.Location}"
-                                          Address="{Binding Address.StreetAddress}"
-                                          ImageSource="{Binding Address.IconFile}"
-                                          Label="{Binding Name}" />
-                            </DataTemplate>
-                        </maps:Map.ItemTemplate>
-                    </controls:CustomMap>
-                    <Label Grid.Row="5" 
-                           Grid.Column="0" 
-                           Text="About this event" 
-                           FontAttributes="Bold"
-                           Margin="10, 0, 10, 0"
-                           Grid.ColumnSpan="2" />
-                    <Label Grid.Row="6" 
-                           Grid.Column="0" 
-                           Grid.ColumnSpan="2" 
-                           Margin="10, 0, 10,0"
-                           Text="{Binding EventViewModel.Description}"
-                           FontSize="Micro" />
-                 </Grid>
+                <!-- Event Name Header -->
+                <Label Text="{Binding EventViewModel.Name}"
+                       FontFamily="LexendSemibold"
+                       FontSize="Large"
+                       Margin="8,4,8,0"
+                       LineBreakMode="WordWrap" />
+
+                <!-- Event Details Card -->
+                <Border Style="{StaticResource RoundBorder}" Margin="4,8,4,4">
+                    <VerticalStackLayout Spacing="8">
+                        <HorizontalStackLayout Spacing="8">
+                            <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                                <Image.Source>
+                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                     Glyph="{StaticResource IconCalendarCheck}"
+                                                     Size="20"
+                                                     Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                </Image.Source>
+                            </Image>
+                            <Label Text="Event Details"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Small"
+                                   VerticalOptions="Center" />
+                        </HorizontalStackLayout>
+
+                        <!-- Event Type -->
+                        <Label Text="{Binding SelectedEventType}"
+                               FontSize="Small"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                        <!-- Date -->
+                        <Label Text="{Binding EventViewModel.DisplayDate}"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small" />
+
+                        <!-- Time & Duration -->
+                        <Grid ColumnDefinitions="*, *" ColumnSpacing="8">
+                            <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                <Label Text="Time" Style="{StaticResource FieldLabel}"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding EventViewModel.DisplayTime}" FontSize="Small" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Column="1" Spacing="2">
+                                <Label Text="Duration" Style="{StaticResource FieldLabel}"
+                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                <Label Text="{Binding EventViewModel.DisplayDuration}" FontSize="Small" />
+                            </VerticalStackLayout>
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Location Card -->
+                <Border Style="{StaticResource RoundBorder}" Margin="4,4">
+                    <VerticalStackLayout Spacing="8">
+                        <HorizontalStackLayout Spacing="8">
+                            <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                                <Image.Source>
+                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                     Glyph="{StaticResource IconMapMarkerOutline}"
+                                                     Size="20"
+                                                     Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                </Image.Source>
+                            </Image>
+                            <Label Text="Location"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Small"
+                                   VerticalOptions="Center" />
+                        </HorizontalStackLayout>
+
+                        <Label Text="{Binding EventViewModel.Address.DisplayAddress}"
+                               FontSize="Small"
+                               LineBreakMode="WordWrap" />
+
+                        <!-- Map -->
+                        <Border StrokeShape="RoundRectangle 10"
+                                StrokeThickness="0"
+                                Padding="0">
+                            <controls:CustomMap x:Name="eventLocationMap"
+                                                ItemsSource="{Binding Events}"
+                                                HeightRequest="200">
+                                <maps:Map.ItemTemplate>
+                                    <DataTemplate x:DataType="viewModels:EventViewModel">
+                                        <controls:CustomPin Location="{Binding Address.Location}"
+                                                            Address="{Binding Address.StreetAddress}"
+                                                            ImageSource="{Binding Address.IconFile}"
+                                                            Label="{Binding Name}" />
+                                    </DataTemplate>
+                                </maps:Map.ItemTemplate>
+                            </controls:CustomMap>
+                        </Border>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- Description Card -->
+                <Border Style="{StaticResource RoundBorder}" Margin="4,4">
+                    <VerticalStackLayout Spacing="8">
+                        <HorizontalStackLayout Spacing="8">
+                            <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                                <Image.Source>
+                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                     Glyph="{StaticResource IconFileDocument}"
+                                                     Size="20"
+                                                     Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                </Image.Source>
+                            </Image>
+                            <Label Text="About This Event"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Small"
+                                   VerticalOptions="Center" />
+                        </HorizontalStackLayout>
+
+                        <Label Text="{Binding EventViewModel.Description}"
+                               FontSize="Small"
+                               LineBreakMode="WordWrap"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <BoxView HeightRequest="12" BackgroundColor="Transparent" />
+
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/CreateEvent/Step4.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step4.xaml
@@ -7,48 +7,96 @@
                             x:Class="TrashMobMobile.Pages.CreateEvent.Step4">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
-                <Grid RowDefinitions="Auto, Auto, Auto">
-                    <Label Grid.Row="0" Text="We're sorry. There are currently no partners available in your area." IsVisible="{Binding AreNoPartnersAvailable}" />
+            <VerticalStackLayout Spacing="0" Padding="0,4">
 
-                    <Label Grid.Row="0"
-                           Text="Available Event Partners"
-                           FontSize="Medium"
-                           VerticalOptions="Center"
-                           HorizontalOptions="Start"
-                           HorizontalTextAlignment="Center"
-                           IsVisible="{Binding ArePartnersAvailable}"
-                           Margin="10" />
+                <!-- No Partners Empty State -->
+                <Border Style="{StaticResource RoundBorder}" Margin="4,4"
+                        IsVisible="{Binding AreNoPartnersAvailable}">
+                    <VerticalStackLayout Spacing="12" HorizontalOptions="Center" Padding="0,20">
+                        <Image MaximumWidthRequest="48" MaximumHeightRequest="48" HorizontalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconHandshake}"
+                                                 Size="48"
+                                                 Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="No Partners Available"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small"
+                               HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="There are currently no partners available in your area."
+                               FontSize="Micro"
+                               HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
 
-                    <Label Grid.Row="1" 
-                       Text="Click on a Partner listed below to request services for your event." 
-                       IsVisible="{Binding ArePartnersAvailable}" 
-                       FontSize="Micro" 
-                       Margin="10, 0"/>
+                <!-- Header with instruction -->
+                <VerticalStackLayout Spacing="4" Margin="12,8,12,4"
+                                     IsVisible="{Binding ArePartnersAvailable}">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconHandshake}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Available Event Partners"
+                               FontFamily="LexendSemibold"
+                               FontSize="Medium"
+                               VerticalOptions="Center" />
+                    </HorizontalStackLayout>
+                    <Label Text="Tap a partner to request services for your event."
+                           FontSize="Micro"
+                           Margin="28,0,0,0"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
 
-                    <CollectionView Grid.Row="2" x:Name="AvailableEventPartners"
-                                    ItemsSource="{Binding AvailablePartners}"
-                                    SelectedItem="{Binding SelectedEventPartnerLocation}"
-                                    SelectionMode="Single" 
-                                    IsVisible="{Binding ArePartnersAvailable}">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate 
-                                x:DataType="viewModels:EventPartnerLocationViewModel">
-                                <Border Style="{StaticResource RoundBorder}" Margin="5">
-                                    <Grid RowDefinitions="1*, 2*, 1*" ColumnDefinitions="*, *"
-                                          x:Name="PartnerLocationItem">
-                                        <Label Text="Partner Name" Style="{StaticResource FieldLabel}" Grid.Row="0" />
-                                        <Label Text="{Binding PartnerLocationName}" Grid.Column="1" Grid.Row="0" />
-                                        <Label Text="Info" Style="{StaticResource FieldLabel}" Grid.Row="1" />
-                                        <Label Text="{Binding PartnerLocationNotes}" Grid.Row="1" Grid.Column="1" />
-                                        <Label Text="Services Requested" Style="{StaticResource FieldLabel}" Grid.Row="2" />
-                                        <Label Text="{Binding PartnerServicesEngaged}" Grid.Row="2" Grid.Column="1" />
-                                    </Grid>
-                                </Border>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </Grid>
+                <!-- Partner List -->
+                <CollectionView x:Name="AvailableEventPartners"
+                                ItemsSource="{Binding AvailablePartners}"
+                                SelectedItem="{Binding SelectedEventPartnerLocation}"
+                                SelectionMode="Single"
+                                IsVisible="{Binding ArePartnersAvailable}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:EventPartnerLocationViewModel">
+                            <Border Style="{StaticResource RoundBorder}" Margin="4,4">
+                                <VerticalStackLayout Spacing="8">
+                                    <!-- Partner Name as header -->
+                                    <Label Text="{Binding PartnerLocationName}"
+                                           FontFamily="LexendSemibold"
+                                           FontSize="Small"
+                                           LineBreakMode="WordWrap" />
+
+                                    <!-- Info -->
+                                    <VerticalStackLayout Spacing="2">
+                                        <Label Text="Info" Style="{StaticResource FieldLabel}"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding PartnerLocationNotes}"
+                                               FontSize="Micro"
+                                               LineBreakMode="WordWrap" />
+                                    </VerticalStackLayout>
+
+                                    <!-- Services Requested -->
+                                    <VerticalStackLayout Spacing="2">
+                                        <Label Text="Services Requested" Style="{StaticResource FieldLabel}"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Text="{Binding PartnerServicesEngaged}"
+                                               FontSize="Micro"
+                                               LineBreakMode="WordWrap" />
+                                    </VerticalStackLayout>
+                                </VerticalStackLayout>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <BoxView HeightRequest="12" BackgroundColor="Transparent" />
+
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/CreateEvent/Step5.xaml
+++ b/TrashMobMobile/Pages/CreateEvent/Step5.xaml
@@ -10,102 +10,194 @@
                            x:Class="TrashMobMobile.Pages.CreateEvent.Step5">
     <ScrollView>
         <Grid>
-            <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+            <VerticalStackLayout Spacing="0" Padding="0,4">
 
-                <Label Text="There are currently no litter reports in the area of your event." IsVisible="{Binding AreNoLitterReportsAvailable}" />
+                <!-- No Litter Reports Empty State -->
+                <Border Style="{StaticResource RoundBorder}" Margin="4,4"
+                        IsVisible="{Binding AreNoLitterReportsAvailable}">
+                    <VerticalStackLayout Spacing="12" HorizontalOptions="Center" Padding="0,20">
+                        <Image MaximumWidthRequest="48" MaximumHeightRequest="48" HorizontalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconTrashCanOutline}"
+                                                 Size="48"
+                                                 Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="No Litter Reports Nearby"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small"
+                               HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        <Label Text="There are currently no litter reports in the area of your event."
+                               FontSize="Micro"
+                               HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
+                </Border>
 
-                <Grid IsVisible="{Binding AreLitterReportsAvailable}" RowDefinitions="*, *, *">
+                <!-- Content when litter reports exist -->
+                <VerticalStackLayout Spacing="0"
+                                     IsVisible="{Binding AreLitterReportsAvailable}">
 
-                    <Label Grid.Row="0"
-                           Text="Nearby Litter Reports"
-                           FontSize="Medium"
-                           VerticalOptions="Center"
-                           HorizontalOptions="Start"
-                           HorizontalTextAlignment="Center"
-                           IsVisible="{Binding AreLitterReportsAvailable}"
-                           Margin="10" />
+                    <!-- Header with instruction -->
+                    <VerticalStackLayout Spacing="4" Margin="12,8,12,4">
+                        <HorizontalStackLayout Spacing="8">
+                            <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                                <Image.Source>
+                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                     Glyph="{StaticResource IconTrashCanOutline}"
+                                                     Size="20"
+                                                     Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                </Image.Source>
+                            </Image>
+                            <Label Text="Nearby Litter Reports"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Medium"
+                                   VerticalOptions="Center" />
+                        </HorizontalStackLayout>
+                        <Label Text="Add a nearby litter report to your event for your team to clean!"
+                               FontSize="Micro"
+                               Margin="28,0,0,0"
+                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    </VerticalStackLayout>
 
-                    <Label Text="There are currently no litter reports in the area of your event." IsVisible="{Binding AreNoLitterReportsAvailable}" Margin="10" Grid.Row="1" />
-
-                    <Label Grid.Row="1" 
-                       Text="Add a nearby litter report to your event for your team to clean!" 
-                       FontSize="Micro" 
-                       IsVisible="{Binding AreLitterReportsAvailable}"
-                       Margin="10, 0"/>
-
-                    <Grid RowDefinitions="*, *, *, *" IsVisible="{Binding AreLitterReportsAvailable}" Grid.Row="2">
-                        <Grid Margin="5" Grid.Row="0"
-                      ColumnDefinitions="6*, *, *"
-                      RowDefinitions="Auto">
-                            <ImageButton Grid.Column="1"
-                             HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
-                             Command="{Binding MapSelectedCommand}" />
-                            <ImageButton Grid.Column="2" 
-                             HeightRequest="24"
-                             Source="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" 
-                             Command="{Binding ListSelectedCommand}" />
+                    <!-- Map/List Toggle -->
+                    <Border Style="{StaticResource RoundBorder}" Margin="4,4" Padding="4">
+                        <Grid ColumnDefinitions="*, *" ColumnSpacing="4">
+                            <Button Grid.Column="0"
+                                    Text="Map View"
+                                    Command="{Binding MapSelectedCommand}"
+                                    Style="{StaticResource PrimarySmallButton}"
+                                    ContentLayout="Left, 8"
+                                    ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconMap}, Size=16, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
+                            <Button Grid.Column="1"
+                                    Text="List View"
+                                    Command="{Binding ListSelectedCommand}"
+                                    Style="{StaticResource SecondarySmallButton}"
+                                    ContentLayout="Left, 8"
+                                    ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconViewList}, Size=16, Color={AppThemeBinding Light={StaticResource SecondaryText}, Dark={StaticResource SecondaryDarkText}}}" />
                         </Grid>
+                    </Border>
 
+                    <!-- Map -->
+                    <Border StrokeShape="RoundRectangle 10"
+                            StrokeThickness="0"
+                            Padding="0"
+                            Margin="4,4"
+                            IsVisible="{Binding IsLitterReportMapSelected}">
                         <controls:CustomMap x:Name="litterImagesMap"
-                              Grid.Row="1"
-                              ItemsSource="{Binding LitterImages}"
-                              IsVisible="{Binding IsLitterReportMapSelected}">
+                                            ItemsSource="{Binding LitterImages}"
+                                            HeightRequest="300">
                             <maps:Map.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                                     <controls:CustomPin Location="{Binding Address.Location}"
-                                          Address="{Binding Address.StreetAddress}"
-                                          Label="{Binding Address.StreetAddress}"
-                                          AutomationId="{Binding LitterReportId}"
-                                          ImageSource="{Binding Address.IconFile}"
-                                          InfoWindowClicked="Pin_InfoWindowClicked" />
+                                                        Address="{Binding Address.StreetAddress}"
+                                                        Label="{Binding Address.StreetAddress}"
+                                                        AutomationId="{Binding LitterReportId}"
+                                                        ImageSource="{Binding Address.IconFile}"
+                                                        InfoWindowClicked="Pin_InfoWindowClicked" />
                                 </DataTemplate>
                             </maps:Map.ItemTemplate>
                         </controls:CustomMap>
+                    </Border>
 
-                        <CollectionView x:Name="LitterReportsCollection" Grid.Row="1"
+                    <!-- List -->
+                    <CollectionView x:Name="LitterReportsCollection"
                                     ItemsSource="{Binding EventLitterReports}"
                                     IsVisible="{Binding IsLitterReportListSelected}"
                                     SelectionMode="None">
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="viewModels:EventLitterReportViewModel">
-                                    <StackLayout Margin="5">
-                                        <Border Style="{StaticResource RoundBorder}" Margin="5">
-                                            <Grid ColumnDefinitions="*, *"
-                                              RowDefinitions="*, *, *, *, *, *, *"
-                                              x:Name="LitterReportItem">
-                                                <Label Text="Name" Style="{StaticResource FieldLabel}" Grid.Row="0" />
-                                                <Label Text="{Binding Name}" Grid.Row="0" Grid.Column="1" />
-                                                <Label Text="Date Created" Style="{StaticResource FieldLabel}" Grid.Row="1" />
-                                                <Label Text="{Binding CreatedDate}" Grid.Row="1" Grid.Column="1" />
-                                                <Label Text="Status" Style="{StaticResource FieldLabel}" Grid.Row="2" />
-                                                <Label Text="{Binding Status}" Grid.Row="2" Grid.Column="1"/>
-                                                <Label Text="Description" Style="{StaticResource FieldLabel}" Grid.Row="3" />
-                                                <Label Text="{Binding Description}" Grid.Row="3" Grid.Column="1" />
-                                                <Button Text="Add" Command="{Binding AddToEventCommand}" IsVisible="{Binding CanAddToEvent}" Grid.Row="4" Grid.Column="0" />
-                                                <Button Text="Remove" Command="{Binding RemoveFromEventCommand}" IsVisible="{Binding CanRemoveFromEvent}" Grid.Row="4" Grid.Column="1" />
-                                                <Label Text="Locations" Grid.Row="5" Style="{StaticResource FieldLabel}" />
-                                                <CollectionView ItemsSource="{Binding LitterImageViewModels}" Grid.Row="6"
-                                                            Grid.Column="0" Grid.ColumnSpan="2">
-                                                    <CollectionView.ItemTemplate>
-                                                        <DataTemplate x:DataType="viewModels:LitterImageViewModel">
-                                                            <Border Style="{StaticResource RoundBorder}" Margin="0, 3">
-                                                                <Grid ColumnDefinitions="*, *">
-                                                                    <Label Text="{Binding Address.DisplayAddress}" Grid.Column="0" LineBreakMode="WordWrap" FontSize="Micro" />
-                                                                    <Image Source="{Binding AzureBlobUrl}" MaximumWidthRequest="60" Grid.Column="1" />
-                                                                </Grid>
-                                                            </Border>
-                                                        </DataTemplate>
-                                                    </CollectionView.ItemTemplate>
-                                                </CollectionView>
-                                            </Grid>
-                                        </Border>
-                                    </StackLayout>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
-                    </Grid>
-                </Grid>
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="viewModels:EventLitterReportViewModel">
+                                <Border Style="{StaticResource RoundBorder}" Margin="4,4">
+                                    <VerticalStackLayout Spacing="8">
+                                        <!-- Name -->
+                                        <Label Text="{Binding Name}"
+                                               FontFamily="LexendSemibold"
+                                               FontSize="Small"
+                                               LineBreakMode="WordWrap" />
+
+                                        <!-- Date & Status row -->
+                                        <Grid ColumnDefinitions="*, *" ColumnSpacing="12">
+                                            <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                                <Label Text="Date Created" Style="{StaticResource FieldLabel}"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                <Label Text="{Binding CreatedDate}" FontSize="Micro" />
+                                            </VerticalStackLayout>
+                                            <VerticalStackLayout Grid.Column="1" Spacing="2">
+                                                <Label Text="Status" Style="{StaticResource FieldLabel}"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                <Label Text="{Binding Status}" FontSize="Micro" />
+                                            </VerticalStackLayout>
+                                        </Grid>
+
+                                        <!-- Description -->
+                                        <VerticalStackLayout Spacing="2">
+                                            <Label Text="Description" Style="{StaticResource FieldLabel}"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <Label Text="{Binding Description}" FontSize="Micro" LineBreakMode="WordWrap" />
+                                        </VerticalStackLayout>
+
+                                        <!-- Action Buttons -->
+                                        <Grid ColumnDefinitions="*, *" ColumnSpacing="8">
+                                            <Button Text="Add to Event"
+                                                    Command="{Binding AddToEventCommand}"
+                                                    IsVisible="{Binding CanAddToEvent}"
+                                                    Style="{StaticResource PrimarySmallButton}"
+                                                    Grid.Column="0"
+                                                    ContentLayout="Left, 8"
+                                                    ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconPlusCircle}, Size=16, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
+                                            <Button Text="Remove"
+                                                    Command="{Binding RemoveFromEventCommand}"
+                                                    IsVisible="{Binding CanRemoveFromEvent}"
+                                                    Style="{StaticResource SecondarySmallButton}"
+                                                    Grid.Column="1"
+                                                    ContentLayout="Left, 8"
+                                                    ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconDelete}, Size=16, Color={AppThemeBinding Light={StaticResource SecondaryText}, Dark={StaticResource SecondaryDarkText}}}" />
+                                        </Grid>
+
+                                        <!-- Locations -->
+                                        <VerticalStackLayout Spacing="4">
+                                            <Label Text="Locations" Style="{StaticResource FieldLabel}"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            <CollectionView ItemsSource="{Binding LitterImageViewModels}">
+                                                <CollectionView.ItemTemplate>
+                                                    <DataTemplate x:DataType="viewModels:LitterImageViewModel">
+                                                        <Border Padding="8"
+                                                                Margin="0,2"
+                                                                StrokeShape="RoundRectangle 8"
+                                                                BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}"
+                                                                Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+                                                                StrokeThickness="1">
+                                                            <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                                                                <Label Text="{Binding Address.DisplayAddress}"
+                                                                       Grid.Column="0"
+                                                                       LineBreakMode="WordWrap"
+                                                                       FontSize="Micro"
+                                                                       VerticalOptions="Center" />
+                                                                <Border Grid.Column="1"
+                                                                        StrokeShape="RoundRectangle 6"
+                                                                        StrokeThickness="0"
+                                                                        Padding="0"
+                                                                        WidthRequest="56"
+                                                                        HeightRequest="56">
+                                                                    <Image Source="{Binding AzureBlobUrl}"
+                                                                           Aspect="AspectFill" />
+                                                                </Border>
+                                                            </Grid>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </CollectionView.ItemTemplate>
+                                            </CollectionView>
+                                        </VerticalStackLayout>
+                                    </VerticalStackLayout>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+
+                <BoxView HeightRequest="12" BackgroundColor="Transparent" />
 
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"

--- a/TrashMobMobile/Pages/ViewEventPage.xaml.cs
+++ b/TrashMobMobile/Pages/ViewEventPage.xaml.cs
@@ -1,9 +1,12 @@
 namespace TrashMobMobile.Pages;
 
+using TrashMobMobile.Views.ViewEvent;
+
 [QueryProperty(nameof(EventId), nameof(EventId))]
 public partial class ViewEventPage : ContentPage
 {
     private readonly ViewEventViewModel viewModel;
+    private bool isInitialized;
 
     public ViewEventPage(ViewEventViewModel viewModel)
     {
@@ -19,28 +22,28 @@ public partial class ViewEventPage : ContentPage
     protected override async void OnNavigatedTo(NavigatedToEventArgs args)
     {
         base.OnNavigatedTo(args);
-        await viewModel.Init(new Guid(EventId), UpdateRoutes);
-        Switcher.SelectedIndex = 0;
+
+        // Only initialize on first navigation, not when returning from popups
+        if (!isInitialized)
+        {
+            isInitialized = true;
+            await viewModel.Init(new Guid(EventId), RenderRoutesOnDetailsMap);
+            Switcher.SelectedIndex = 0;
+        }
     }
 
-    private void UpdateRoutes()
+    protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
     {
-        //eventLocationMap.MapElements.Clear();
+        base.OnNavigatedFrom(args);
+        // Reset so re-entering this page (for a different event) will re-initialize
+        isInitialized = false;
+    }
 
-        //foreach (var route in viewModel.EventAttendeeRoutes)
-        //{
-        //    var polyline = new Polyline
-        //    {
-        //        StrokeColor = Color.FromArgb("c7d762"),
-        //        StrokeWidth = 5,
-        //    };
-
-        //    foreach (var location in route.Locations)
-        //    {
-        //        polyline.Geopath.Add(new Location(location.Latitude, location.Longitude));
-        //    }
-
-        //    eventLocationMap.MapElements.Add(polyline);
-        //}
+    private void RenderRoutesOnDetailsMap()
+    {
+        if (tabDetails.Content is TabDetails details)
+        {
+            details.RenderRoutes(viewModel.EventAttendeeRoutes);
+        }
     }
 }

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -324,7 +324,7 @@
     <!-- <x:String x:Key="IconChevronDoubleLeft">&#xf013d;</x:String> -->
     <!-- <x:String x:Key="IconChevronDoubleRight">&#xf013e;</x:String> -->
     <!-- <x:String x:Key="IconChevronDoubleUp">&#xf013f;</x:String> -->
-    <!-- <x:String x:Key="IconChevronDown">&#xf0140;</x:String> -->
+    <x:String x:Key="IconChevronDown">&#xf0140;</x:String>
     <!-- <x:String x:Key="IconChevronLeft">&#xf0141;</x:String> -->
     <x:String x:Key="IconChevronRight">&#xf0142;</x:String>
     <!-- <x:String x:Key="IconChevronUp">&#xf0143;</x:String> -->

--- a/TrashMobMobile/ViewModels/EditEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/EditEventViewModel.cs
@@ -1,11 +1,13 @@
 ﻿namespace TrashMobMobile.ViewModels;
 
 using System.Collections.ObjectModel;
+using CommunityToolkit.Maui.Extensions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Sentry;
 using TrashMob.Models;
 using TrashMob.Models.Extensions;
+using TrashMobMobile.Controls;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
 
@@ -232,6 +234,42 @@ public partial class EditEventViewModel(IMobEventManager mobEventManager,
         }
 
         await LoadLitterReports();
+    }
+
+    [RelayCommand]
+    private async Task SelectEventType()
+    {
+        var popup = new ListSelectorPopup("Event Type", ETypes);
+        var popupResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        var selected = popupResult?.Result;
+        if (!string.IsNullOrEmpty(selected))
+        {
+            SelectedEventType = selected;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SelectVisibility()
+    {
+        var popup = new ListSelectorPopup("Visibility", VisibilityOptions);
+        var popupResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        var selected = popupResult?.Result;
+        if (!string.IsNullOrEmpty(selected))
+        {
+            SelectedVisibility = selected;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SelectTeam()
+    {
+        var popup = new ListSelectorPopup("Select Team", TeamNames);
+        var popupResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        var selected = popupResult?.Result;
+        if (!string.IsNullOrEmpty(selected))
+        {
+            SelectedTeam = selected;
+        }
     }
 
     [RelayCommand]

--- a/TrashMobMobile/ViewModels/EventViewModel.cs
+++ b/TrashMobMobile/ViewModels/EventViewModel.cs
@@ -27,6 +27,11 @@ public partial class EventViewModel : ObservableObject
     [ObservableProperty]
     private int durationMinutes;
 
+    public string DisplayDuration => $"{DurationHours}h {DurationMinutes}m";
+
+    partial void OnDurationHoursChanged(int value) => OnPropertyChanged(nameof(DisplayDuration));
+    partial void OnDurationMinutesChanged(int value) => OnPropertyChanged(nameof(DisplayDuration));
+
     [ObservableProperty]
     private int eventStatusId;
 

--- a/TrashMobMobile/Views/EditEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/EditEvent/TabDetails.xaml
@@ -166,8 +166,23 @@
                                 </FormattedString>
                             </Label.FormattedText>
                         </Label>
-                        <controls:TMPicker Title="Event Type" ItemsSource="{Binding ETypes}"
-                                           SelectedItem="{Binding SelectedEventType, Mode=TwoWay}" />
+                        <Border Padding="12,10" Style="{StaticResource InputStyle}">
+                            <Border.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding SelectEventTypeCommand}" />
+                            </Border.GestureRecognizers>
+                            <Grid ColumnDefinitions="*, Auto">
+                                <Label Text="{Binding SelectedEventType, TargetNullValue='Select Event Type'}"
+                                       FontSize="14" VerticalOptions="Center" />
+                                <Image Grid.Column="1" MaximumWidthRequest="16" MaximumHeightRequest="16" VerticalOptions="Center">
+                                    <Image.Source>
+                                        <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                         Glyph="{StaticResource IconChevronDown}"
+                                                         Size="16"
+                                                         Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </Image.Source>
+                                </Image>
+                            </Grid>
+                        </Border>
                     </VerticalStackLayout>
 
                     <Grid ColumnDefinitions="*, *" ColumnSpacing="12" RowDefinitions="Auto" Margin="0">
@@ -178,9 +193,23 @@
 
                         <VerticalStackLayout Grid.Column="1" Spacing="4" Margin="0">
                             <Label Text="Visibility" Style="{StaticResource FieldLabel}" />
-                            <controls:TMPicker Title="Visibility"
-                                               ItemsSource="{Binding VisibilityOptions}"
-                                               SelectedItem="{Binding SelectedVisibility, Mode=TwoWay}" />
+                            <Border Padding="12,10" Style="{StaticResource InputStyle}">
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding SelectVisibilityCommand}" />
+                                </Border.GestureRecognizers>
+                                <Grid ColumnDefinitions="*, Auto">
+                                    <Label Text="{Binding SelectedVisibility}"
+                                           FontSize="14" VerticalOptions="Center" />
+                                    <Image Grid.Column="1" MaximumWidthRequest="16" MaximumHeightRequest="16" VerticalOptions="Center">
+                                        <Image.Source>
+                                            <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                             Glyph="{StaticResource IconChevronDown}"
+                                                             Size="16"
+                                                             Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        </Image.Source>
+                                    </Image>
+                                </Grid>
+                            </Border>
                         </VerticalStackLayout>
                     </Grid>
                 </VerticalStackLayout>
@@ -208,9 +237,23 @@
                             </Label.FormattedText>
                         </Label>
                     </HorizontalStackLayout>
-                    <controls:TMPicker Title="Select Team"
-                                       ItemsSource="{Binding TeamNames}"
-                                       SelectedItem="{Binding SelectedTeam, Mode=TwoWay}" />
+                    <Border Padding="12,10" Style="{StaticResource InputStyle}">
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding SelectTeamCommand}" />
+                        </Border.GestureRecognizers>
+                        <Grid ColumnDefinitions="*, Auto">
+                            <Label Text="{Binding SelectedTeam, TargetNullValue='Select Team'}"
+                                   FontSize="14" VerticalOptions="Center" />
+                            <Image Grid.Column="1" MaximumWidthRequest="16" MaximumHeightRequest="16" VerticalOptions="Center">
+                                <Image.Source>
+                                    <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                     Glyph="{StaticResource IconChevronDown}"
+                                                     Size="16"
+                                                     Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </Image.Source>
+                            </Image>
+                        </Grid>
+                    </Border>
                 </VerticalStackLayout>
             </Border>
 

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml.cs
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml.cs
@@ -1,6 +1,9 @@
 namespace TrashMobMobile.Views.ViewEvent;
 
+using System.Collections.Specialized;
 using Microsoft.Maui.Maps;
+using TrashMob.Models.Poco;
+using MauiLocation = Microsoft.Maui.Devices.Sensors.Location;
 
 public partial class TabDetails : ContentView
 {
@@ -15,7 +18,7 @@ public partial class TabDetails : ContentView
 
         if (BindingContext is ViewEventViewModel viewModel)
         {
-            MapSpan mapSpan = new MapSpan(new Location(0, 0), 0.05, 0.05);
+            MapSpan mapSpan = new MapSpan(new MauiLocation(0, 0), 0.05, 0.05);
 
             if (viewModel?.EventViewModel?.Address?.Location != null)
             {
@@ -24,6 +27,44 @@ public partial class TabDetails : ContentView
 
             eventLocationMap.InitialMapSpanAndroid = mapSpan;
             eventLocationMap.MoveToRegion(mapSpan);
+
+            // Render any routes that were already loaded
+            if (viewModel?.EventAttendeeRoutes.Count > 0)
+            {
+                RenderRoutes(viewModel.EventAttendeeRoutes);
+            }
+
+            // Subscribe to route changes so map stays current
+            viewModel!.EventAttendeeRoutes.CollectionChanged += OnRoutesChanged;
+        }
+    }
+
+    private void OnRoutesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (BindingContext is ViewEventViewModel viewModel)
+        {
+            RenderRoutes(viewModel.EventAttendeeRoutes);
+        }
+    }
+
+    public void RenderRoutes(IEnumerable<DisplayEventAttendeeRoute> routes)
+    {
+        eventLocationMap.MapElements.Clear();
+
+        foreach (var route in routes)
+        {
+            var polyline = new Microsoft.Maui.Controls.Maps.Polyline
+            {
+                StrokeColor = Color.FromArgb("#c7d762"),
+                StrokeWidth = 5,
+            };
+
+            foreach (var location in route.Locations)
+            {
+                polyline.Geopath.Add(new MauiLocation(location.Latitude, location.Longitude));
+            }
+
+            eventLocationMap.MapElements.Add(polyline);
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Create Event date/time**: Replaced Start Time + End Time with single Time picker + editable Duration (Hours/Minutes) to match the Edit Event page
- **Create Event wizard redesign**: Redesigned Step 2-5 pages with card-based layouts, styled empty states, and consistent Material Design icons
- **Edit Event styled popups**: Replaced native TMPicker controls with styled `ListSelectorPopup` popups for Event Type, Visibility, and Team selectors
- **Route fixes**: Fixed privacy popup redirecting to Details tab; added event route polyline rendering on the main Details map
- **Bug fixes**: Fixed missing icon resources causing page crash, fixed close button navigation

## Test plan
- [ ] Create a new event — verify Date, Time, Duration (Hours/Minutes) fields work correctly
- [ ] Verify duration validation (min 1h, max 10h) shows error messages
- [ ] Walk through all Create Event wizard steps (Details → Location → Review → Partners → Litter Reports)
- [ ] Verify the X (close) button navigates back from Create Event
- [ ] Edit an existing event — verify styled popup selectors for Event Type, Visibility, and Team
- [ ] View an event with routes — verify polylines render on the Details tab map
- [ ] Change route visibility via popup — verify staying on Routes tab (no redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)