### PR TITLE
Add auto-detect geographic bounds for all community types

### DIFF
--- a/TrashMob.Models/Poco/SuggestedBounds.cs
+++ b/TrashMob.Models/Poco/SuggestedBounds.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco
+{
+    /// <summary>
+    /// Suggested geographic bounds auto-derived from a community's location.
+    /// </summary>
+    public class SuggestedBounds
+    {
+        /// <summary>Northern latitude bound.</summary>
+        public double North { get; set; }
+
+        /// <summary>Southern latitude bound.</summary>
+        public double South { get; set; }
+
+        /// <summary>Eastern longitude bound.</summary>
+        public double East { get; set; }
+
+        /// <summary>Western longitude bound.</summary>
+        public double West { get; set; }
+
+        /// <summary>Center latitude (midpoint of north and south).</summary>
+        public double CenterLatitude { get; set; }
+
+        /// <summary>Center longitude (midpoint of east and west).</summary>
+        public double CenterLongitude { get; set; }
+
+        /// <summary>The query string that was sent to Nominatim.</summary>
+        public string Query { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Shared/Managers/Areas/INominatimService.cs
+++ b/TrashMob.Shared/Managers/Areas/INominatimService.cs
@@ -32,6 +32,16 @@ namespace TrashMob.Shared.Managers.Areas
             string category,
             (double North, double South, double East, double West) bounds,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Looks up geographic bounding box for a location query using Nominatim search API.
+        /// </summary>
+        /// <param name="query">Location query string (e.g., "Issaquah, Washington, United States").</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Bounding box tuple (North, South, East, West) or null if not found.</returns>
+        Task<(double North, double South, double East, double West)?> LookupBoundsAsync(
+            string query,
+            CancellationToken cancellationToken = default);
     }
 
     public class NominatimResult

--- a/TrashMob.Shared/Managers/Communities/CommunityManager.cs
+++ b/TrashMob.Shared/Managers/Communities/CommunityManager.cs
@@ -115,14 +115,14 @@ namespace TrashMob.Shared.Managers.Communities
         }
 
         /// <summary>
-        /// Determines whether a community uses bounding-box filtering instead of exact city/region match.
-        /// County, state, and regional communities with defined bounds use bounding-box filtering.
+        /// Determines whether a community uses bounding-box filtering.
+        /// Any community with all four bounds defined uses bounding-box filtering,
+        /// including City communities. Falls back to city/region string matching only
+        /// when bounds are not configured.
         /// </summary>
         private static bool UsesBoundingBoxFilter(Partner community)
         {
-            return community.RegionType.HasValue
-                && community.RegionType.Value != (int)RegionTypeEnum.City
-                && community.BoundsNorth.HasValue && community.BoundsSouth.HasValue
+            return community.BoundsNorth.HasValue && community.BoundsSouth.HasValue
                 && community.BoundsEast.HasValue && community.BoundsWest.HasValue;
         }
 

--- a/TrashMob/client-app/src/services/communities.ts
+++ b/TrashMob/client-app/src/services/communities.ts
@@ -195,6 +195,31 @@ export const UpdateCommunityContent = () => ({
 });
 
 // ============================================================================
+// Community Bounds Auto-Detection
+// ============================================================================
+
+export interface SuggestedBoundsData {
+    north: number;
+    south: number;
+    east: number;
+    west: number;
+    centerLatitude: number;
+    centerLongitude: number;
+    query: string;
+}
+
+export type SuggestCommunityBounds_Params = { communityId: string };
+export type SuggestCommunityBounds_Response = SuggestedBoundsData;
+export const SuggestCommunityBounds = (params: SuggestCommunityBounds_Params) => ({
+    key: ['/communities/admin/', params.communityId, '/suggest-bounds'],
+    service: async () =>
+        ApiService('protected').fetchData<SuggestCommunityBounds_Response>({
+            url: `/communities/admin/${params.communityId}/suggest-bounds`,
+            method: 'get',
+        }),
+});
+
+// ============================================================================
 // Community Branding Image Uploads
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- Adds Nominatim-powered "Auto-detect" button to Regional Settings that derives geographic bounds from the community's city/region/country
- Shows bounds and center point fields for **all** region types (previously hidden for City communities)
- City communities can now use AI Area Generation (which requires bounds)
- Communities with bounds use bounding-box filtering regardless of region type

## Changes
- **NominatimService**: New `LookupBoundsAsync` method for geocoding location queries to bounding boxes
- **CommunitiesController**: New `GET /communities/admin/{id}/suggest-bounds` endpoint
- **CommunityManager**: `UsesBoundingBoxFilter` simplified to check bounds presence only (not region type)
- **Regional Settings UI**: Removed `isNonCity` guards, added Auto-detect button with mutation
- **SuggestedBounds POCO**: New response model for the suggest-bounds endpoint

## Test plan
- [ ] Navigate to Regional Settings for a City community (e.g., Issaquah)
- [ ] Verify bounds and center point fields are now visible
- [ ] Click "Auto-detect" — bounds should populate from Nominatim
- [ ] Verify map preview appears after auto-detect
- [ ] Save and confirm bounds persist
- [ ] Navigate to AI Area Generation — should no longer show "bounds not configured" error
- [ ] Verify non-City communities still work as before
- [ ] `dotnet test` — 444 tests pass
- [ ] `npm run build && npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)