### PR TITLE
Add map views to dashboard and replace radio toggles

### DIFF
--- a/TrashMob/client-app/src/pages/MyDashboard/LitterReportsMapView.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/LitterReportsMapView.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { AdvancedMarker, InfoWindow } from '@vis.gl/react-google-maps';
+import { GoogleMapWithKey } from '@/components/Map/GoogleMap';
+import LitterReportData from '@/components/Models/LitterReportData';
+import { Badge } from '@/components/ui/badge';
+import {
+    LitterReportStatusEnum,
+    LitterReportStatusLabels,
+    LitterReportStatusColors,
+} from '@/components/Models/LitterReportStatus';
+
+const LITTER_MAP_ID = 'myLitterReportsMap';
+
+const LitterMarkerPin = () => (
+    <svg width='28' height='36' viewBox='0 0 28 36' fill='none' xmlns='http://www.w3.org/2000/svg'>
+        <path d='M14 0C6.268 0 0 6.268 0 14c0 10.5 14 22 14 22s14-11.5 14-22C28 6.268 21.732 0 14 0z' fill='#EF4444' />
+        <circle cx='14' cy='14' r='6' fill='white' />
+    </svg>
+);
+
+interface LitterReportsMapViewProps {
+    reports: LitterReportData[];
+}
+
+export const LitterReportsMapView = ({ reports }: LitterReportsMapViewProps) => {
+    const [selected, setSelected] = useState<LitterReportData | null>(null);
+
+    const reportsWithLocation = reports.filter((r) => {
+        const img = r.litterImages?.[0];
+        return img?.latitude && img?.longitude;
+    });
+
+    if (reportsWithLocation.length === 0) {
+        return (
+            <p className='text-sm text-muted-foreground py-4 text-center'>No reports with location data available.</p>
+        );
+    }
+
+    const avgLat =
+        reportsWithLocation.reduce((sum, r) => sum + (r.litterImages[0].latitude ?? 0), 0) / reportsWithLocation.length;
+    const avgLng =
+        reportsWithLocation.reduce((sum, r) => sum + (r.litterImages[0].longitude ?? 0), 0) /
+        reportsWithLocation.length;
+
+    const getLocation = (report: LitterReportData) => {
+        const firstImage = report.litterImages?.[0];
+        if (!firstImage) return '';
+        const parts = [firstImage.city, firstImage.region].filter(Boolean);
+        return parts.join(', ');
+    };
+
+    return (
+        <div className='rounded-md overflow-hidden border'>
+            <GoogleMapWithKey
+                id={LITTER_MAP_ID}
+                style={{ width: '100%', height: '400px' }}
+                defaultCenter={{ lat: avgLat, lng: avgLng }}
+                defaultZoom={10}
+            >
+                {reportsWithLocation.map((report) => (
+                    <AdvancedMarker
+                        key={report.id}
+                        position={{
+                            lat: report.litterImages[0].latitude!,
+                            lng: report.litterImages[0].longitude!,
+                        }}
+                        onClick={() => setSelected(report)}
+                    >
+                        <LitterMarkerPin />
+                    </AdvancedMarker>
+                ))}
+
+                {selected ? (
+                    <InfoWindow
+                        position={{
+                            lat: selected.litterImages[0].latitude!,
+                            lng: selected.litterImages[0].longitude!,
+                        }}
+                        onCloseClick={() => setSelected(null)}
+                    >
+                        <div className='text-sm space-y-1 max-w-[200px]'>
+                            <Link
+                                to={`/litterreports/${selected.id}`}
+                                className='font-semibold text-primary hover:underline block'
+                            >
+                                {selected.name || 'Untitled Report'}
+                            </Link>
+                            {getLocation(selected) ? (
+                                <p className='text-muted-foreground'>{getLocation(selected)}</p>
+                            ) : null}
+                            <Badge
+                                variant='outline'
+                                className={`${LitterReportStatusColors[selected.litterReportStatusId as LitterReportStatusEnum] || 'bg-gray-500'} text-white border-0`}
+                            >
+                                {LitterReportStatusLabels[selected.litterReportStatusId as LitterReportStatusEnum] ||
+                                    'Unknown'}
+                            </Badge>
+                        </div>
+                    </InfoWindow>
+                ) : null}
+            </GoogleMapWithKey>
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/pages/MyDashboard/MyTeamsMapView.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyTeamsMapView.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { AdvancedMarker, InfoWindow } from '@vis.gl/react-google-maps';
+import { Crown } from 'lucide-react';
+import { GoogleMapWithKey } from '@/components/Map/GoogleMap';
+import { Badge } from '@/components/ui/badge';
+import TeamData from '@/components/Models/TeamData';
+
+const TEAMS_MAP_ID = 'myTeamsMap';
+
+const TeamMarkerPin = () => (
+    <svg width='28' height='36' viewBox='0 0 28 36' fill='none' xmlns='http://www.w3.org/2000/svg'>
+        <path d='M14 0C6.268 0 0 6.268 0 14c0 10.5 14 22 14 22s14-11.5 14-22C28 6.268 21.732 0 14 0z' fill='#2563EB' />
+        <circle cx='14' cy='14' r='6' fill='white' />
+    </svg>
+);
+
+interface MyTeamsMapViewProps {
+    teams: TeamData[];
+    teamsILead: TeamData[];
+}
+
+export const MyTeamsMapView = ({ teams, teamsILead }: MyTeamsMapViewProps) => {
+    const [selected, setSelected] = useState<TeamData | null>(null);
+    const leadTeamIds = new Set(teamsILead.map((t) => t.id));
+
+    const teamsWithLocation = teams.filter((t) => t.latitude && t.longitude);
+
+    if (teamsWithLocation.length === 0) {
+        return <p className='text-sm text-muted-foreground py-4 text-center'>No teams with location data available.</p>;
+    }
+
+    const avgLat = teamsWithLocation.reduce((sum, t) => sum + (t.latitude ?? 0), 0) / teamsWithLocation.length;
+    const avgLng = teamsWithLocation.reduce((sum, t) => sum + (t.longitude ?? 0), 0) / teamsWithLocation.length;
+
+    const getLocation = (team: TeamData) => {
+        const parts = [team.city, team.region].filter(Boolean);
+        return parts.join(', ');
+    };
+
+    return (
+        <div className='rounded-md overflow-hidden border'>
+            <GoogleMapWithKey
+                id={TEAMS_MAP_ID}
+                style={{ width: '100%', height: '400px' }}
+                defaultCenter={{ lat: avgLat, lng: avgLng }}
+                defaultZoom={10}
+            >
+                {teamsWithLocation.map((team) => (
+                    <AdvancedMarker
+                        key={team.id}
+                        position={{ lat: team.latitude!, lng: team.longitude! }}
+                        onClick={() => setSelected(team)}
+                    >
+                        <TeamMarkerPin />
+                    </AdvancedMarker>
+                ))}
+
+                {selected ? (
+                    <InfoWindow
+                        position={{ lat: selected.latitude!, lng: selected.longitude! }}
+                        onCloseClick={() => setSelected(null)}
+                    >
+                        <div className='text-sm space-y-1 max-w-[200px]'>
+                            <Link
+                                to={`/teams/${selected.id}`}
+                                className='font-semibold text-primary hover:underline block'
+                            >
+                                {selected.name}
+                            </Link>
+                            {getLocation(selected) ? (
+                                <p className='text-muted-foreground'>{getLocation(selected)}</p>
+                            ) : null}
+                            {leadTeamIds.has(selected.id) ? (
+                                <Badge variant='outline' className='bg-primary text-white border-0'>
+                                    <Crown className='h-3 w-3 mr-1' /> Lead
+                                </Badge>
+                            ) : (
+                                <Badge variant='outline'>Member</Badge>
+                            )}
+                        </div>
+                    </InfoWindow>
+                ) : null}
+            </GoogleMapWithKey>
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/pages/MyDashboard/NearbyLitterReportsWidget.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/NearbyLitterReportsWidget.tsx
@@ -1,12 +1,14 @@
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { ExternalLink, Loader2, MapPin, Plus } from 'lucide-react';
+import { AdvancedMarker, InfoWindow } from '@vis.gl/react-google-maps';
 
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { GoogleMapWithKey } from '@/components/Map/GoogleMap';
 import LitterReportData from '@/components/Models/LitterReportData';
 import {
     LitterReportStatusEnum,
@@ -16,12 +18,24 @@ import {
 import { GetNewLitterReports } from '@/services/litter-report';
 import { calculateDistanceMiles } from '@/lib/distance';
 
+const NEARBY_LITTER_MAP_ID = 'nearbyLitterReportsMap';
+
+const NearbyLitterMarkerPin = () => (
+    <svg width='28' height='36' viewBox='0 0 28 36' fill='none' xmlns='http://www.w3.org/2000/svg'>
+        <path d='M14 0C6.268 0 0 6.268 0 14c0 10.5 14 22 14 22s14-11.5 14-22C28 6.268 21.732 0 14 0z' fill='#F97316' />
+        <circle cx='14' cy='14' r='6' fill='white' />
+    </svg>
+);
+
 interface NearbyLitterReportsWidgetProps {
+    viewMode: 'table' | 'map';
     userLocation: { lat: number; lng: number };
     radiusMiles: number;
 }
 
-export const NearbyLitterReportsWidget = ({ userLocation, radiusMiles }: NearbyLitterReportsWidgetProps) => {
+export const NearbyLitterReportsWidget = ({ viewMode, userLocation, radiusMiles }: NearbyLitterReportsWidgetProps) => {
+    const [selected, setSelected] = useState<{ report: LitterReportData; distance: number } | null>(null);
+
     const { data: litterReports, isLoading } = useQuery<AxiosResponse<LitterReportData[]>, unknown, LitterReportData[]>(
         {
             queryKey: GetNewLitterReports().key,
@@ -51,8 +65,7 @@ export const NearbyLitterReportsWidget = ({ userLocation, radiusMiles }: NearbyL
             .filter((item): item is { report: LitterReportData; distance: number } => {
                 return item !== null && item.distance <= radiusMiles;
             })
-            .sort((a, b) => a.distance - b.distance)
-            .slice(0, 5); // Show only top 5 closest
+            .sort((a, b) => a.distance - b.distance);
     }, [litterReports, userLocation, radiusMiles]);
 
     const getLocation = (report: LitterReportData) => {
@@ -83,6 +96,65 @@ export const NearbyLitterReportsWidget = ({ userLocation, radiusMiles }: NearbyL
         );
     }
 
+    if (viewMode === 'map') {
+        return (
+            <div className='rounded-md overflow-hidden border'>
+                <GoogleMapWithKey
+                    id={NEARBY_LITTER_MAP_ID}
+                    style={{ width: '100%', height: '400px' }}
+                    defaultCenter={userLocation}
+                    defaultZoom={11}
+                >
+                    {nearbyReports.map(({ report }) => {
+                        const img = report.litterImages[0];
+                        return (
+                            <AdvancedMarker
+                                key={report.id}
+                                position={{ lat: img.latitude!, lng: img.longitude! }}
+                                onClick={() =>
+                                    setSelected(nearbyReports.find((r) => r.report.id === report.id) ?? null)
+                                }
+                            >
+                                <NearbyLitterMarkerPin />
+                            </AdvancedMarker>
+                        );
+                    })}
+
+                    {selected ? (
+                        <InfoWindow
+                            position={{
+                                lat: selected.report.litterImages[0].latitude!,
+                                lng: selected.report.litterImages[0].longitude!,
+                            }}
+                            onCloseClick={() => setSelected(null)}
+                        >
+                            <div className='text-sm space-y-1 max-w-[200px]'>
+                                <Link
+                                    to={`/litterreports/${selected.report.id}`}
+                                    className='font-semibold text-primary hover:underline block'
+                                >
+                                    {selected.report.name || 'Untitled Report'}
+                                </Link>
+                                <p className='text-muted-foreground'>{selected.distance.toFixed(1)} mi away</p>
+                                <Badge
+                                    variant='outline'
+                                    className={`${LitterReportStatusColors[selected.report.litterReportStatusId as LitterReportStatusEnum] || 'bg-gray-500'} text-white border-0`}
+                                >
+                                    {LitterReportStatusLabels[
+                                        selected.report.litterReportStatusId as LitterReportStatusEnum
+                                    ] || 'Unknown'}
+                                </Badge>
+                            </div>
+                        </InfoWindow>
+                    ) : null}
+                </GoogleMapWithKey>
+            </div>
+        );
+    }
+
+    // Table view - show top 5
+    const displayReports = nearbyReports.slice(0, 5);
+
     return (
         <div className='overflow-auto'>
             <Table>
@@ -95,7 +167,7 @@ export const NearbyLitterReportsWidget = ({ userLocation, radiusMiles }: NearbyL
                     </TableRow>
                 </TableHeader>
                 <TableBody>
-                    {nearbyReports.map(({ report, distance }) => {
+                    {displayReports.map(({ report, distance }) => {
                         const statusId = report.litterReportStatusId as LitterReportStatusEnum;
 
                         return (

--- a/TrashMob/client-app/src/pages/MyDashboard/PickupRequestsMapView.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/PickupRequestsMapView.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { AdvancedMarker, InfoWindow } from '@vis.gl/react-google-maps';
+import { GoogleMapWithKey } from '@/components/Map/GoogleMap';
+import PickupLocationData from '@/components/Models/PickupLocationData';
+
+const PICKUP_MAP_ID = 'pickupRequestsMap';
+
+const PickupMarkerPin = () => (
+    <svg width='28' height='36' viewBox='0 0 28 36' fill='none' xmlns='http://www.w3.org/2000/svg'>
+        <path d='M14 0C6.268 0 0 6.268 0 14c0 10.5 14 22 14 22s14-11.5 14-22C28 6.268 21.732 0 14 0z' fill='#F59E0B' />
+        <circle cx='14' cy='14' r='6' fill='white' />
+    </svg>
+);
+
+interface PickupRequestsMapViewProps {
+    pickups: PickupLocationData[];
+}
+
+export const PickupRequestsMapView = ({ pickups }: PickupRequestsMapViewProps) => {
+    const [selected, setSelected] = useState<PickupLocationData | null>(null);
+
+    const pickupsWithLocation = pickups.filter((p) => p.latitude !== 0 && p.longitude !== 0);
+
+    if (pickupsWithLocation.length === 0) {
+        return (
+            <p className='text-sm text-muted-foreground py-4 text-center'>
+                No pickup requests with location data available.
+            </p>
+        );
+    }
+
+    const avgLat = pickupsWithLocation.reduce((sum, p) => sum + p.latitude, 0) / pickupsWithLocation.length;
+    const avgLng = pickupsWithLocation.reduce((sum, p) => sum + p.longitude, 0) / pickupsWithLocation.length;
+
+    return (
+        <div className='rounded-md overflow-hidden border'>
+            <GoogleMapWithKey
+                id={PICKUP_MAP_ID}
+                style={{ width: '100%', height: '400px' }}
+                defaultCenter={{ lat: avgLat, lng: avgLng }}
+                defaultZoom={10}
+            >
+                {pickupsWithLocation.map((pickup) => (
+                    <AdvancedMarker
+                        key={pickup.id}
+                        position={{ lat: pickup.latitude, lng: pickup.longitude }}
+                        onClick={() => setSelected(pickup)}
+                    >
+                        <PickupMarkerPin />
+                    </AdvancedMarker>
+                ))}
+
+                {selected ? (
+                    <InfoWindow
+                        position={{ lat: selected.latitude, lng: selected.longitude }}
+                        onCloseClick={() => setSelected(null)}
+                    >
+                        <div className='text-sm space-y-1 max-w-[200px]'>
+                            <p className='font-semibold'>{selected.name || selected.streetAddress}</p>
+                            <p className='text-muted-foreground'>{selected.city}</p>
+                            {selected.notes ? <p className='text-muted-foreground'>{selected.notes}</p> : null}
+                            <Link
+                                to={`/eventsummary/${selected.eventId}`}
+                                className='text-primary hover:underline text-xs'
+                            >
+                                View Event Summary
+                            </Link>
+                        </div>
+                    </InfoWindow>
+                ) : null}
+            </GoogleMapWithKey>
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary
- Replaces radio button list/map toggles with icon-based segmented buttons (List/Map icons) on Upcoming Events and Completed Events sections
- Adds map view toggle to My Litter Reports (red markers at image locations)
- Adds map view toggle to Nearby Litter Reports (orange markers, shows distance in info window)
- Adds map view toggle to My Teams (blue markers, shows role badge)
- Adds map view toggle to Pickup Requests Pending (amber markers, links to event summary)

## Test plan
- [ ] Verify Upcoming Events and Completed Events use icon toggles instead of radio buttons
- [ ] Toggle My Litter Reports to map view - verify markers at report locations
- [ ] Toggle Nearby Litter Reports to map view - verify all nearby reports shown on map
- [ ] Toggle My Teams to map view - verify team locations with role badges
- [ ] Toggle Pickup Requests to map view - verify pickup locations with info windows
- [ ] Verify all sections default to table/list view
- [ ] Verify empty states show correctly when no location data available

🤖 Generated with [Claude Code](https://claude.com/claude-code)