### PR TITLE
Move validation errors inline, make pickup description optional

### DIFF
--- a/TrashMobMobile/Pages/ContactUsPage.xaml
+++ b/TrashMobMobile/Pages/ContactUsPage.xaml
@@ -31,6 +31,9 @@
                                                                         x:Name="nameValidator" />
                                 </controls:TMEntry.Behaviors>
                             </controls:TMEntry>
+                            <Label FontSize="Micro" TextColor="Red" Margin="4,0,0,0"
+                                   Text="Name is required and must be at least 5 characters."
+                                   IsVisible="{Binding Source={x:Reference nameValidator}, Path=IsNotValid}" />
                         </VerticalStackLayout>
 
                         <VerticalStackLayout>
@@ -48,6 +51,9 @@
                                     </toolkit:MultiValidationBehavior>
                                 </controls:TMEntry.Behaviors>
                             </controls:TMEntry>
+                            <Label FontSize="Micro" TextColor="Red" Margin="4,0,0,0"
+                                   Text="{Binding Source={x:Reference EmailValidator}, Path=Errors[0]}"
+                                   IsVisible="{Binding Source={x:Reference EmailValidator}, Path=IsNotValid}" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
@@ -66,6 +72,9 @@
                                                                         Flags="ValidateOnValueChanged" MinimumLength="10" />
                                 </controls:TMEditor.Behaviors>
                             </controls:TMEditor>
+                            <Label FontSize="Micro" TextColor="Red" Margin="4,0,0,0"
+                                   Text="Message is required and must be at least 10 characters."
+                                   IsVisible="{Binding Source={x:Reference messageValidator}, Path=IsNotValid}" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
@@ -93,47 +102,6 @@
                     </Button.Triggers>
                 </Button>
 
-                <Label
-                    Margin="10,0"
-                    FontSize="Micro"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Center"
-                    HorizontalTextAlignment="Center"
-                    TextColor="Red">
-                    <Label.Triggers>
-                        <MultiTrigger TargetType="Label">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition
-                                    Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                    Value="True" />
-                                <BindingCondition
-                                    Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
-                                    Value="True" />
-                                <BindingCondition
-                                    Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
-                                    Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="IsVisible" Value="False" />
-                        </MultiTrigger>
-                        <DataTrigger TargetType="Label"
-                                     Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                     Value="False">
-                            <Setter Property="Text" Value="Name is required and must be at least 5 characters." />
-                        </DataTrigger>
-                        <DataTrigger TargetType="Label"
-                                     Binding="{Binding Source={x:Reference EmailValidator}, Path=IsValid}"
-                                     Value="False">
-                            <Setter Property="Text"
-                                    Value="{Binding Source={x:Reference EmailValidator}, Path=Errors[0]}" />
-                        </DataTrigger>
-                        <DataTrigger TargetType="Label"
-                                     Binding="{Binding Source={x:Reference messageValidator}, Path=IsValid}"
-                                     Value="False">
-                            <Setter Property="Text"
-                                    Value="Message is required and must be at least 10 characters." />
-                        </DataTrigger>
-                    </Label.Triggers>
-                </Label>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
@@ -36,15 +36,13 @@
                                                                         x:Name="nameValidator" />
                                 </controls:TMEntry.Behaviors>
                             </controls:TMEntry>
+                            <Label FontSize="Micro" TextColor="Red" Margin="4,0,0,0"
+                                   Text="Name is required and must be at least 5 characters."
+                                   IsVisible="{Binding Source={x:Reference nameValidator}, Path=IsNotValid}" />
                         </VerticalStackLayout>
                         <VerticalStackLayout>
-                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                            <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
-                                <controls:TMEditor.Behaviors>
-                                    <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"
-                                                                        x:Name="notesValidator" />
-                                </controls:TMEditor.Behaviors>
-                            </controls:TMEditor>
+                            <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                            <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
@@ -100,45 +98,13 @@
                         Style="{StaticResource PrimaryLargeButton}"
                         Margin="10,8,10,10">
                     <Button.Triggers>
-                        <MultiTrigger TargetType="Button">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                                  Value="True" />
-                                <BindingCondition Binding="{Binding Source={x:Reference notesValidator}, Path=IsValid}"
-                                                  Value="True" />
-                            </MultiTrigger.Conditions>
+                        <DataTrigger TargetType="Button"
+                                     Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
+                                     Value="True">
                             <Setter Property="IsEnabled" Value="True" />
-                        </MultiTrigger>
+                        </DataTrigger>
                     </Button.Triggers>
                 </Button>
-
-                <Label
-                    FontSize="Micro"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Center"
-                    HorizontalTextAlignment="Center"
-                    TextColor="Red">
-                    <Label.Triggers>
-                        <MultiTrigger TargetType="Label">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                                  Value="True" />
-                                <BindingCondition Binding="{Binding Source={x:Reference notesValidator}, Path=IsValid}"
-                                                  Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="IsVisible" Value="False" />
-                        </MultiTrigger>
-                        <DataTrigger TargetType="Label"
-                                     Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}" Value="False">
-                            <Setter Property="Text" Value="Name is required and must be at least 5 characters." />
-                        </DataTrigger>
-                        <DataTrigger TargetType="Label"
-                                     Binding="{Binding Source={x:Reference notesValidator}, Path=IsValid}"
-                                     Value="False">
-                            <Setter Property="Text" Value="Notes is required and must be at least 10 characters." />
-                        </DataTrigger>
-                    </Label.Triggers>
-                </Label>
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"
                      VerticalOptions="Fill" IsVisible="{Binding IsBusy}" />

--- a/TrashMobMobile/Pages/EditPickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/EditPickupLocationPage.xaml
@@ -25,15 +25,13 @@
                                                                     x:Name="nameValidator" />
                                 </controls:TMEntry.Behaviors>
                             </controls:TMEntry>
+                            <Label FontSize="Micro" TextColor="Red" Margin="4,0,0,0"
+                                   Text="Name is required and must be at least 5 characters."
+                                   IsVisible="{Binding Source={x:Reference nameValidator}, Path=IsNotValid}" />
                         </VerticalStackLayout>
                         <VerticalStackLayout>
-                            <Label Style="{StaticResource FieldLabel}"><Label.FormattedText><FormattedString><Span Text="Description" /><Span Text=" *" TextColor="{StaticResource Destructive}" /></FormattedString></Label.FormattedText></Label>
-                            <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}">
-                                <controls:TMEditor.Behaviors>
-                                    <toolkit:TextValidationBehavior Flags="ValidateOnValueChanged" MinimumLength="10"
-                                                                    x:Name="notesValidator" />
-                                </controls:TMEditor.Behaviors>
-                            </controls:TMEditor>
+                            <Label Text="Description" Style="{StaticResource FieldLabel}" />
+                            <controls:TMEditor Text="{Binding PickupLocationViewModel.Notes}" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
@@ -42,45 +40,13 @@
                         Style="{StaticResource PrimaryLargeButton}"
                         Margin="10,8,10,10">
                     <Button.Triggers>
-                        <MultiTrigger TargetType="Button">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                                  Value="True" />
-                                <BindingCondition Binding="{Binding Source={x:Reference notesValidator}, Path=IsValid}"
-                                                  Value="True" />
-                            </MultiTrigger.Conditions>
+                        <DataTrigger TargetType="Button"
+                                     Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
+                                     Value="True">
                             <Setter Property="IsEnabled" Value="True" />
-                        </MultiTrigger>
+                        </DataTrigger>
                     </Button.Triggers>
                 </Button>
-
-                <Label
-                    FontSize="Micro"
-                    VerticalOptions="Center"
-                    HorizontalOptions="Center"
-                    HorizontalTextAlignment="Center"
-                    TextColor="Red">
-                    <Label.Triggers>
-                        <MultiTrigger TargetType="Label">
-                            <MultiTrigger.Conditions>
-                                <BindingCondition Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}"
-                                                  Value="True" />
-                                <BindingCondition Binding="{Binding Source={x:Reference notesValidator}, Path=IsValid}"
-                                                  Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="IsVisible" Value="False" />
-                        </MultiTrigger>
-                        <DataTrigger TargetType="Label"
-                                     Binding="{Binding Source={x:Reference nameValidator}, Path=IsValid}" Value="False">
-                            <Setter Property="Text" Value="Name is required and must be at least 5 characters." />
-                        </DataTrigger>
-                        <DataTrigger TargetType="Label"
-                                     Binding="{Binding Source={x:Reference notesValidator}, Path=IsValid}"
-                                     Value="False">
-                            <Setter Property="Text" Value="Notes is required and must be at least 10 characters." />
-                        </DataTrigger>
-                    </Label.Triggers>
-                </Label>
 
             </VerticalStackLayout>
             <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"


### PR DESCRIPTION
## Summary
- Make Description/Notes field optional on Create and Edit Pickup Location pages (removed required `*` indicator and `MinimumLength` validator)
- Move validation error messages from a single label at the bottom of the form to inline labels directly below each field on all three pages:
  - **CreatePickupLocationPage** — Name error inline
  - **EditPickupLocationPage** — Name error inline
  - **ContactUsPage** — Name, Email, and Message errors inline

## Test plan
- [ ] Create Pickup Location: verify Name error shows below the field, Description accepts empty input, Save button enables with just a valid Name
- [ ] Edit Pickup Location: same as above
- [ ] Contact Us: verify Name, Email, and Message errors each show below their respective fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)