### PR TITLE
Simplify regional settings and fix boundary preview

### DIFF
--- a/TrashMob/client-app/src/components/Map/CommunityBoundsOverlay.tsx
+++ b/TrashMob/client-app/src/components/Map/CommunityBoundsOverlay.tsx
@@ -15,7 +15,13 @@ interface CommunityBoundsOverlayProps {
  */
 function parseGeoJsonPaths(geoJson: string): google.maps.LatLngLiteral[][] | null {
     try {
-        const geo = JSON.parse(geoJson) as { type: string; coordinates: number[][][] | number[][] };
+        const geo = JSON.parse(geoJson) as { type: string; coordinates: number[][][][] | number[][][] | number[][] };
+
+        if (geo.type === 'MultiPolygon') {
+            // MultiPolygon coordinates: number[][][][] (array of polygons, each with rings)
+            const coords = geo.coordinates as number[][][][];
+            return coords.flatMap((polygon) => polygon.map((ring) => ring.map(([lon, lat]) => ({ lat, lng: lon }))));
+        }
 
         if (geo.type === 'Polygon') {
             // Polygon coordinates: number[][][] (array of rings, each ring is array of [lon, lat])
@@ -53,11 +59,11 @@ export const CommunityBoundsOverlay = ({ mapId, geoJson, fitBounds }: CommunityB
             polygonRef.current = new google.maps.Polygon({
                 map,
                 paths,
-                strokeColor: '#6B7280',
-                strokeOpacity: 0.7,
-                strokeWeight: 2,
-                fillColor: '#6B7280',
-                fillOpacity: 0.06,
+                strokeColor: '#E11D48',
+                strokeOpacity: 0.9,
+                strokeWeight: 2.5,
+                fillColor: '#E11D48',
+                fillOpacity: 0.12,
                 clickable: false,
                 zIndex: 0,
             });
@@ -67,7 +73,7 @@ export const CommunityBoundsOverlay = ({ mapId, geoJson, fitBounds }: CommunityB
 
         if (fitBounds) {
             const bounds = new google.maps.LatLngBounds();
-            paths[0].forEach((pt) => bounds.extend(pt));
+            paths.forEach((ring) => ring.forEach((pt) => bounds.extend(pt)));
             map.fitBounds(bounds, 40);
         }
 

--- a/TrashMob/client-app/src/components/communities/bounds-preview-map.tsx
+++ b/TrashMob/client-app/src/components/communities/bounds-preview-map.tsx
@@ -94,7 +94,7 @@ export const BoundsPreviewMap = (props: BoundsPreviewMapProps) => {
                             : { defaultZoom: 11 })}
                     >
                         {hasGeoJson ? (
-                            <CommunityBoundsOverlay mapId={MAP_ID} geoJson={boundaryGeoJson!} />
+                            <CommunityBoundsOverlay mapId={MAP_ID} geoJson={boundaryGeoJson!} fitBounds />
                         ) : hasBounds ? (
                             <BoundsRectangle
                                 boundsNorth={boundsNorth!}


### PR DESCRIPTION
## Summary
- Remove manual bounding box and center point fields from regional settings UI — bounds are now auto-derived when the user clicks "Detect Boundary"
- Fix boundary polygon not rendering for cities by adding `MultiPolygon` GeoJSON support
- Auto-fit map to boundary extents so the full region is always visible
- Change boundary color from subtle gray to visible rose (#E11D48)

## Test plan
- [ ] Open community regional settings, select City region type, click "Detect Boundary" — polygon appears on map
- [ ] Verify map auto-zooms to fit the detected boundary
- [ ] Verify boundary is clearly visible (rose/pink outline and fill)
- [ ] Save and reload — boundary persists from saved GeoJSON
- [ ] Test with County and State region types

🤖 Generated with [Claude Code](https://claude.com/claude-code)