### PR TITLE
Show routes as polylines on map; consolidate partner menu

### DIFF
--- a/TrashMob.Models/Poco/DisplayUserRouteHistory.cs
+++ b/TrashMob.Models/Poco/DisplayUserRouteHistory.cs
@@ -69,5 +69,10 @@
         /// Gets or sets the end time of the route.
         /// </summary>
         public DateTimeOffset EndTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the GPS path coordinates for map display.
+        /// </summary>
+        public List<SortableLocation> Locations { get; set; } = [];
     }
 }

--- a/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
@@ -117,6 +117,7 @@ namespace TrashMob.Shared.Managers.Events
                 EventLongitude = r.Event?.Longitude ?? 0,
                 StartTime = r.StartTime,
                 EndTime = r.EndTime,
+                Locations = ExtractLocations(r.UserPath),
             });
         }
 
@@ -166,6 +167,28 @@ namespace TrashMob.Shared.Managers.Events
 
             var updated = await Repository.UpdateAsync(route);
             return ServiceResult<EventAttendeeRoute>.Success(updated);
+        }
+
+        private static List<SortableLocation> ExtractLocations(Geometry userPath)
+        {
+            if (userPath is not LineString lineString || lineString.NumPoints < 2)
+            {
+                return [];
+            }
+
+            var locations = new List<SortableLocation>();
+            var order = 0;
+            foreach (var coordinate in lineString.Coordinates)
+            {
+                locations.Add(new SortableLocation
+                {
+                    Latitude = coordinate.Y,
+                    Longitude = coordinate.X,
+                    SortOrder = order++,
+                });
+            }
+
+            return locations;
         }
 
         private const double GridCellSizeMeters = 25.0;

--- a/TrashMob/client-app/src/components/Models/RouteData.ts
+++ b/TrashMob/client-app/src/components/Models/RouteData.ts
@@ -41,4 +41,5 @@ export interface DisplayUserRouteHistory {
     eventLongitude: number;
     startTime: string;
     endTime: string;
+    locations: SortableLocation[];
 }

--- a/TrashMob/client-app/src/pages/MyDashboard/MyPartnersTable.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyPartnersTable.tsx
@@ -3,7 +3,6 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
-    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -12,7 +11,7 @@ import DisplayPartnershipData from '@/components/Models/DisplayPartnershipData';
 import { getDisplayPartnershipStatus } from '@/store/displayPartnershipStatusHelper';
 import { useGetPartnerStatuses } from '@/hooks/useGetPartnerStatuses';
 import { useGetPartnerRequestStatuses } from '@/hooks/useGetPartnerRequestStatuses';
-import { Ellipsis, Globe, Pencil, SquareArrowRight } from 'lucide-react';
+import { Ellipsis, Pencil, SquareArrowRight } from 'lucide-react';
 import { PartnerStatusActive } from '@/components/Models/Constants';
 
 type MyPartnersTableProps = {
@@ -36,59 +35,45 @@ export const MyPartnersTable = ({ items }: MyPartnersTableProps) => {
             <TableBody>
                 {(items || [])
                     .sort((a, b) => (a.name < b.name ? 1 : -1))
-                    .map((displayPartner) => {
-                        const hasCommunityPage = displayPartner.homePageEnabled && displayPartner.slug;
-                        return (
-                            <TableRow key={displayPartner.id.toString()}>
-                                <TableCell>{displayPartner.name}</TableCell>
-                                <TableCell>
-                                    {getDisplayPartnershipStatus(
-                                        partnerStatusList || [],
-                                        partnerRequestStatusList || [],
-                                        displayPartner.partnerStatusId,
-                                        displayPartner.partnerRequestStatusId,
-                                    )}
-                                </TableCell>
-                                <TableCell className='py-0'>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <Button variant='ghost' size='icon'>
-                                                <Ellipsis />
-                                            </Button>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent className='w-56'>
-                                            {displayPartner.partnerStatusId === PartnerStatusActive ? (
-                                                <DropdownMenuItem asChild>
-                                                    <Link to={`/partnerdashboard/${displayPartner.id}`}>
-                                                        <Pencil />
-                                                        <span>Manage partnership</span>
-                                                    </Link>
-                                                </DropdownMenuItem>
-                                            ) : (
-                                                <DropdownMenuItem asChild>
-                                                    <Link to={`/partnerdashboard/${displayPartner.id}/edit`}>
-                                                        <SquareArrowRight />
-                                                        <span>Activate Partnership</span>
-                                                    </Link>
-                                                </DropdownMenuItem>
-                                            )}
-                                            {hasCommunityPage ? (
-                                                <>
-                                                    <DropdownMenuSeparator />
-                                                    <DropdownMenuItem asChild>
-                                                        <Link to={`/partnerdashboard/${displayPartner.id}/community`}>
-                                                            <Globe />
-                                                            <span>Manage Community Page</span>
-                                                        </Link>
-                                                    </DropdownMenuItem>
-                                                </>
-                                            ) : null}
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
-                                </TableCell>
-                            </TableRow>
-                        );
-                    })}
+                    .map((displayPartner) => (
+                        <TableRow key={displayPartner.id.toString()}>
+                            <TableCell>{displayPartner.name}</TableCell>
+                            <TableCell>
+                                {getDisplayPartnershipStatus(
+                                    partnerStatusList || [],
+                                    partnerRequestStatusList || [],
+                                    displayPartner.partnerStatusId,
+                                    displayPartner.partnerRequestStatusId,
+                                )}
+                            </TableCell>
+                            <TableCell className='py-0'>
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button variant='ghost' size='icon'>
+                                            <Ellipsis />
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent className='w-56'>
+                                        {displayPartner.partnerStatusId === PartnerStatusActive ? (
+                                            <DropdownMenuItem asChild>
+                                                <Link to={`/partnerdashboard/${displayPartner.id}`}>
+                                                    <Pencil />
+                                                    <span>Manage</span>
+                                                </Link>
+                                            </DropdownMenuItem>
+                                        ) : (
+                                            <DropdownMenuItem asChild>
+                                                <Link to={`/partnerdashboard/${displayPartner.id}/edit`}>
+                                                    <SquareArrowRight />
+                                                    <span>Activate Partnership</span>
+                                                </Link>
+                                            </DropdownMenuItem>
+                                        )}
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </TableCell>
+                        </TableRow>
+                    ))}
             </TableBody>
         </Table>
     );


### PR DESCRIPTION
## Summary
- Routes in My Dashboard map view are now drawn as **colored polylines** showing the actual GPS path walked, instead of just point markers at event locations
- Each route gets a distinct color (purple, rose, amber, green, blue, pink, violet, teal) and the map auto-fits to show all routes
- Clicking a route line shows an info popup with event name, date, distance, and duration
- Removed redundant "Manage Community Page" menu item from My Partners dropdown — the community page is accessible from within the partner dashboard

## Test plan
- [ ] Open My Dashboard, scroll to My Routes, toggle to map view — routes appear as colored lines
- [ ] Click on a route line — info window shows event details
- [ ] Verify map auto-zooms to fit all routes
- [ ] In My Partners table, verify only one "Manage" option appears (no separate "Manage Community Page")
- [ ] Verify "Manage" link goes to partner dashboard correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)