### PR TITLE
Add area generation for interchanges, city blocks, highway sections

### DIFF
--- a/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaSuggestionService.cs
@@ -35,7 +35,7 @@ namespace TrashMob.Shared.Managers.Areas
               - "address": string — a specific address or intersection to geocode
               - "type": string — either "point" (single location) or "street_segment" (a stretch of road)
             - "suggestedName": string — a concise, descriptive name for this area (e.g. "200 Block of Main St")
-            - "suggestedAreaType": string — one of: "Highway", "Park", "School", "Trail", "Waterway", "Street", "Spot"
+            - "suggestedAreaType": string — one of: "Highway", "Park", "School", "Trail", "Waterway", "Street", "Spot", "Interchange", "CityBlock", "HighwaySection"
             - "geometryType": string — either "polygon" (for parks, lots, blocks) or "linestring" (for streets, trails, waterways)
             - "confidence": number — your confidence in the interpretation, from 0.0 to 1.0
             - "isNamedFeature": boolean — true if the description refers to a specific named place
@@ -45,6 +45,9 @@ namespace TrashMob.Shared.Managers.Areas
             - For street segments: provide start and end intersection addresses as two queries with type "street_segment"
             - For parks or landmarks: provide the park/landmark name as a single query with type "point"
             - For blocks: provide the two nearest cross-street intersections as queries
+            - For interchanges: use "Interchange" type for highway on/off ramps and junction areas
+            - For city blocks: use "CityBlock" type for blocks bounded by streets
+            - For highway sections: use "HighwaySection" type for mile-length stretches of highways or interstates
             - Include the city/community name in each address for accurate geocoding
             - If the description is ambiguous, use your best interpretation and lower the confidence
 

--- a/TrashMob/client-app/src/components/Models/AdoptableAreaData.tsx
+++ b/TrashMob/client-app/src/components/Models/AdoptableAreaData.tsx
@@ -1,6 +1,16 @@
 import { Guid } from 'guid-typescript';
 
-export type AdoptableAreaType = 'Highway' | 'Park' | 'School' | 'Trail' | 'Waterway' | 'Street' | 'Spot';
+export type AdoptableAreaType =
+    | 'Highway'
+    | 'Park'
+    | 'School'
+    | 'Trail'
+    | 'Waterway'
+    | 'Street'
+    | 'Spot'
+    | 'Interchange'
+    | 'CityBlock'
+    | 'HighwaySection';
 export type AdoptableAreaStatus = 'Available' | 'Adopted' | 'Unavailable';
 
 class AdoptableAreaData {

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/create.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/create.tsx
@@ -23,7 +23,18 @@ import { GetCommunityForAdmin } from '@/services/communities';
 import { AreaMapEditor, SuggestionMetadata } from '@/components/Map/AreaMapEditor';
 import { AreaBoundingBox } from '@/lib/geojson';
 
-const areaTypes: AdoptableAreaType[] = ['Highway', 'Park', 'School', 'Trail', 'Waterway', 'Street', 'Spot'];
+const areaTypes: AdoptableAreaType[] = [
+    'Highway',
+    'Park',
+    'School',
+    'Trail',
+    'Waterway',
+    'Street',
+    'Spot',
+    'Interchange',
+    'CityBlock',
+    'HighwaySection',
+];
 
 interface FormInputs {
     name: string;
@@ -39,7 +50,18 @@ interface FormInputs {
 const formSchema = z.object({
     name: z.string().min(1, 'Name is required').max(200, 'Name must be less than 200 characters'),
     description: z.string().max(2048, 'Description must be less than 2048 characters'),
-    areaType: z.enum(['Highway', 'Park', 'School', 'Trail', 'Waterway', 'Street', 'Spot']),
+    areaType: z.enum([
+        'Highway',
+        'Park',
+        'School',
+        'Trail',
+        'Waterway',
+        'Street',
+        'Spot',
+        'Interchange',
+        'CityBlock',
+        'HighwaySection',
+    ]),
     cleanupFrequencyDays: z.coerce.number().min(1, 'Must be at least 1 day').max(365, 'Must be less than 365 days'),
     minEventsPerYear: z.coerce.number().min(1, 'Must be at least 1 event').max(52, 'Must be less than 52 events'),
     safetyRequirements: z.string().max(4000, 'Safety requirements must be less than 4000 characters'),

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/generate.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/areas/generate.tsx
@@ -27,6 +27,9 @@ const CATEGORIES = [
     { value: 'School', label: 'Schools' },
     { value: 'Park', label: 'Parks' },
     { value: 'Trail', label: 'Trails' },
+    { value: 'Interchange', label: 'Interchanges' },
+    { value: 'CityBlock', label: 'City Blocks' },
+    { value: 'HighwaySection', label: 'Highway / Interstate Sections' },
 ];
 
 const statusIcons: Record<BatchStatus, React.ReactNode> = {


### PR DESCRIPTION
## Summary
- Add three new area types: **Interchange**, **CityBlock**, **HighwaySection**
- Add batch generation support for all three via the AI Area Generation page
- **Interchanges**: Searches Nominatim for highway interchanges and motorway junctions
- **City Blocks**: Searches for neighbourhoods and city blocks
- **Highway Sections**: Searches for motorways/interstates and automatically **splits them into ~1 mile segments** with mile marker naming (e.g., "I-90 - Mile 0-1", "I-90 - Mile 1-2")
- Categories now support multiple Nominatim queries per category for comprehensive results
- Updated AI suggestion prompt to recognize and suggest the new area types

## Test plan
- [ ] Open area generation page, verify new categories appear in dropdown
- [ ] Generate "Interchanges" for a community with highways — verify interchange features are discovered
- [ ] Generate "City Blocks" — verify neighbourhood features are discovered  
- [ ] Generate "Highway / Interstate Sections" — verify highways are split into mile-length segments
- [ ] Create a single area manually — verify new area types appear in the type dropdown
- [ ] Use AI suggest with a description like "I-90 interchange at exit 17" — verify it suggests Interchange type

🤖 Generated with [Claude Code](https://claude.com/claude-code)