### PR TITLE
Fix boundary GeoJSON not persisted on save

### DIFF
--- a/TrashMob.Shared/Managers/Communities/CommunityManager.cs
+++ b/TrashMob.Shared/Managers/Communities/CommunityManager.cs
@@ -362,10 +362,13 @@ namespace TrashMob.Shared.Managers.Communities
             existing.Website = community.Website;
             existing.RegionType = community.RegionType;
             existing.CountyName = community.CountyName;
+            existing.Latitude = community.Latitude;
+            existing.Longitude = community.Longitude;
             existing.BoundsNorth = community.BoundsNorth;
             existing.BoundsSouth = community.BoundsSouth;
             existing.BoundsEast = community.BoundsEast;
             existing.BoundsWest = community.BoundsWest;
+            existing.BoundaryGeoJson = community.BoundaryGeoJson;
             existing.DefaultCleanupFrequencyDays = community.DefaultCleanupFrequencyDays;
             existing.DefaultMinEventsPerYear = community.DefaultMinEventsPerYear;
             existing.DefaultSafetyRequirements = community.DefaultSafetyRequirements;

--- a/TrashMob/client-app/src/components/communities/bounds-preview-map.tsx
+++ b/TrashMob/client-app/src/components/communities/bounds-preview-map.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef } from 'react';
-import { useMap } from '@vis.gl/react-google-maps';
 import { GoogleMapWithKey as GoogleMap } from '../Map/GoogleMap';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CommunityBoundsOverlay } from '@/components/Map/CommunityBoundsOverlay';
@@ -17,53 +15,6 @@ interface BoundsPreviewMapProps {
 
 const MAP_ID = 'boundsPreviewMap';
 
-/** Fallback: draws a simple rectangle when no GeoJSON polygon is available. */
-const BoundsRectangle = ({
-    boundsNorth,
-    boundsSouth,
-    boundsEast,
-    boundsWest,
-}: {
-    boundsNorth: number;
-    boundsSouth: number;
-    boundsEast: number;
-    boundsWest: number;
-}) => {
-    const map = useMap(MAP_ID);
-    const rectangleRef = useRef<google.maps.Rectangle | null>(null);
-
-    useEffect(() => {
-        if (!map) return;
-
-        if (!rectangleRef.current) {
-            rectangleRef.current = new google.maps.Rectangle({
-                map,
-                strokeColor: '#3B82F6',
-                strokeOpacity: 0.8,
-                strokeWeight: 2,
-                fillColor: '#3B82F6',
-                fillOpacity: 0.15,
-            });
-        }
-
-        rectangleRef.current.setBounds({
-            north: boundsNorth,
-            south: boundsSouth,
-            east: boundsEast,
-            west: boundsWest,
-        });
-
-        return () => {
-            if (rectangleRef.current) {
-                rectangleRef.current.setMap(null);
-                rectangleRef.current = null;
-            }
-        };
-    }, [map, boundsNorth, boundsSouth, boundsEast, boundsWest]);
-
-    return null;
-};
-
 export const BoundsPreviewMap = (props: BoundsPreviewMapProps) => {
     const { centerLat, centerLng, boundsNorth, boundsSouth, boundsEast, boundsWest, boundaryGeoJson } = props;
 
@@ -76,7 +27,7 @@ export const BoundsPreviewMap = (props: BoundsPreviewMapProps) => {
                 <CardTitle className='text-lg'>Boundary Preview</CardTitle>
             </CardHeader>
             <CardContent>
-                <div className='h-[300px] rounded-lg overflow-hidden'>
+                <div className='h-[500px] rounded-lg overflow-hidden'>
                     <GoogleMap
                         id={MAP_ID}
                         gestureHandling='cooperative'
@@ -95,13 +46,6 @@ export const BoundsPreviewMap = (props: BoundsPreviewMapProps) => {
                     >
                         {hasGeoJson ? (
                             <CommunityBoundsOverlay mapId={MAP_ID} geoJson={boundaryGeoJson!} fitBounds />
-                        ) : hasBounds ? (
-                            <BoundsRectangle
-                                boundsNorth={boundsNorth!}
-                                boundsSouth={boundsSouth!}
-                                boundsEast={boundsEast!}
-                                boundsWest={boundsWest!}
-                            />
                         ) : null}
                     </GoogleMap>
                 </div>


### PR DESCRIPTION
## Summary
- **Fix BoundaryGeoJson not saved**: `CommunityManager.UpdateCommunityContentAsync()` was not copying `BoundaryGeoJson` or `Latitude`/`Longitude` to the entity, so the detected polygon was silently dropped on save and reverted to a bounding box rectangle on reload
- **Remove rectangle fallback**: Since we always have GeoJSON when bounds exist, removed the `BoundsRectangle` component
- **Enlarge map**: Increased boundary preview map from 300px to 500px for better visibility

## Test plan
- [ ] Go to Regional Settings, click Detect Boundary, verify polygon appears
- [ ] Click Save, verify polygon persists after page reloads (no blue rectangle)
- [ ] Verify map is larger and fills the card nicely

🤖 Generated with [Claude Code](https://claude.com/claude-code)