### PR TITLE
Fix area generation: accept point features + fix status polling

### DIFF
--- a/TrashMob.Shared/Managers/Areas/AreaGenerationOrchestrator.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaGenerationOrchestrator.cs
@@ -105,15 +105,7 @@ namespace TrashMob.Shared.Managers.Areas
 
                     batch.ProcessedCount++;
 
-                    // Skip features with no useful geometry
-                    if (string.IsNullOrEmpty(feature.GeoJson))
-                    {
-                        batch.SkippedCount++;
-                        await batchManager.UpdateAsync(batch, cancellationToken);
-                        continue;
-                    }
-
-                    // Skip features with no name (except city blocks which may have only display names)
+                    // Skip features with no name
                     var name = !string.IsNullOrWhiteSpace(feature.Name) ? feature.Name.Trim() : null;
                     if (name == null)
                     {

--- a/TrashMob.Shared/Managers/Areas/NominatimService.cs
+++ b/TrashMob.Shared/Managers/Areas/NominatimService.cs
@@ -226,7 +226,8 @@ namespace TrashMob.Shared.Managers.Areas
                             }
                         }
                         else if (string.Equals(geoType, "Polygon", StringComparison.OrdinalIgnoreCase)
-                            || string.Equals(geoType, "LineString", StringComparison.OrdinalIgnoreCase))
+                            || string.Equals(geoType, "LineString", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(geoType, "Point", StringComparison.OrdinalIgnoreCase))
                         {
                             geoJson = JsonSerializer.Serialize(item.Geojson, JsonOptions);
                         }


### PR DESCRIPTION
## Summary
- **Backend: Features without polygons no longer skipped** — Many OSM features (especially schools) are stored as nodes (Point geometry), not polygons. The orchestrator was skipping all features without polygon GeoJSON, resulting in "19 discovered, 0 staged". Now features with just name + coordinates are staged successfully. Also added Point geometry support in NominatimService.
- **Frontend: Fix stale "Discovering" status after completion** — When a batch completed between polling intervals, the status endpoint returned 404 but React Query kept stale data showing "Discovering" with 0/0 processed. Introduced `currentBatchStatus` that prefers `finishedBatch` when the status endpoint errors, fixing the race condition.

## Test plan
- [ ] Run area generation for Schools — verify features are discovered AND staged (not all skipped)
- [ ] Verify progress card updates correctly during generation
- [ ] Verify progress card transitions to "Complete" when batch finishes
- [ ] Verify staged areas appear in the review page after generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)