### PR TITLE
Use Overpass API for interchange/highway/city block generation

### DIFF
--- a/TrashMob.Shared/Managers/Areas/AreaGenerationOrchestrator.cs
+++ b/TrashMob.Shared/Managers/Areas/AreaGenerationOrchestrator.cs
@@ -64,14 +64,23 @@ namespace TrashMob.Shared.Managers.Areas
                               partner.BoundsEast.Value, partner.BoundsWest.Value);
                 }
 
-                // Map user-facing category to Nominatim search queries
-                var searchQueries = MapCategoryToSearchQueries(batch.Category);
+                // Discover features: use Overpass for tag-based queries, Nominatim for text search
                 var allDiscovered = new List<NominatimResult>();
+                var overpassQuery = MapCategoryToOverpassQuery(batch.Category);
 
-                foreach (var query in searchQueries)
+                if (!string.IsNullOrEmpty(overpassQuery))
                 {
-                    var results = await nominatimService.SearchByCategoryAsync(query, bounds.Value, cancellationToken);
+                    var results = await nominatimService.SearchByOverpassAsync(overpassQuery, bounds.Value, cancellationToken);
                     allDiscovered.AddRange(results);
+                }
+                else
+                {
+                    var searchQueries = MapCategoryToSearchQueries(batch.Category);
+                    foreach (var query in searchQueries)
+                    {
+                        var results = await nominatimService.SearchByCategoryAsync(query, bounds.Value, cancellationToken);
+                        allDiscovered.AddRange(results);
+                    }
                 }
 
                 // For highway sections, split LineString results into mile-length segments
@@ -245,18 +254,28 @@ namespace TrashMob.Shared.Managers.Areas
         }
 
         /// <summary>
-        /// Maps a user-facing category to one or more Nominatim search queries.
-        /// Some categories require multiple queries to get comprehensive results.
+        /// Maps a user-facing category to an Overpass QL query for tag-based OSM search.
+        /// Returns empty string for categories that work better with Nominatim text search.
+        /// {{bbox}} is replaced with the actual bounding box at query time.
         /// </summary>
-        private static List<string> MapCategoryToSearchQueries(string category)
+        private static string MapCategoryToOverpassQuery(string category)
         {
             return category.ToLowerInvariant() switch
             {
-                "interchange" => ["interchange", "exit", "junction"],
-                "cityblock" => ["neighbourhood", "city block"],
-                "highwaysection" => ["motorway", "trunk road", "interstate", "highway"],
-                _ => [category],
+                "interchange" => "[out:json][timeout:60];(node[\"highway\"=\"motorway_junction\"]({{bbox}}););out body;",
+                "cityblock" => "[out:json][timeout:60];(way[\"place\"=\"neighbourhood\"]({{bbox}});relation[\"place\"=\"neighbourhood\"]({{bbox}});way[\"place\"=\"city_block\"]({{bbox}}););out body geom;",
+                "highwaysection" => "[out:json][timeout:60];(way[\"highway\"=\"motorway\"]({{bbox}});way[\"highway\"=\"trunk\"]({{bbox}}););out body geom;",
+                _ => "", // Use Nominatim text search for school, park, trail, etc.
             };
+        }
+
+        /// <summary>
+        /// Maps a user-facing category to one or more Nominatim search queries (text-based).
+        /// Used as fallback when no Overpass query is defined.
+        /// </summary>
+        private static List<string> MapCategoryToSearchQueries(string category)
+        {
+            return [category];
         }
 
         private static string MapCategoryToAreaType(string category)

--- a/TrashMob.Shared/Managers/Areas/INominatimService.cs
+++ b/TrashMob.Shared/Managers/Areas/INominatimService.cs
@@ -34,6 +34,20 @@ namespace TrashMob.Shared.Managers.Areas
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Queries the Overpass API for all OSM features matching specific tags within a bounding box.
+        /// Use this instead of SearchByCategoryAsync when you need tag-based queries
+        /// (e.g., all highway=motorway_junction nodes) rather than text-based name searches.
+        /// </summary>
+        /// <param name="overpassQuery">The Overpass QL query body (the part inside the parentheses).</param>
+        /// <param name="bounds">The bounding box (North, South, East, West).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of results with geometry and metadata.</returns>
+        Task<IEnumerable<NominatimResult>> SearchByOverpassAsync(
+            string overpassQuery,
+            (double North, double South, double East, double West) bounds,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Looks up geographic bounding box for a location query using Nominatim search API.
         /// </summary>
         /// <param name="query">Location query string (e.g., "Issaquah, Washington, United States").</param>

--- a/TrashMob.Shared/Managers/Areas/StagedAdoptableAreaManager.cs
+++ b/TrashMob.Shared/Managers/Areas/StagedAdoptableAreaManager.cs
@@ -80,6 +80,8 @@ namespace TrashMob.Shared.Managers.Areas
                 AreaType = staged.AreaType,
                 GeoJson = staged.GeoJson,
                 PartnerId = staged.PartnerId,
+                StartLatitude = staged.CenterLatitude,
+                StartLongitude = staged.CenterLongitude,
             });
 
             var batch = await batchManager.GetAsync(batchId, cancellationToken);


### PR DESCRIPTION
## Summary
- **Overpass API for tag-based queries**: Interchanges, city blocks, and highway sections now use Overpass QL queries instead of Nominatim text search. Text search fails for these because features aren't named "interchange" or "motorway" — they're named "Exit 17" or "Interstate 90". Overpass queries by OSM tags (`highway=motorway_junction`, `place=neighbourhood`, `highway=motorway|trunk`) which finds the actual features.
- **Schools/parks unchanged**: Still use Nominatim text search (works well since those words appear in feature names)
- **Fix staged-to-area coordinate transfer**: `CenterLatitude`/`CenterLongitude` from staged areas now transfer to `StartLatitude`/`StartLongitude` when creating adoptable areas

## Test plan
- [ ] Generate interchanges — should find highway exits (e.g., "Exit 17") via Overpass
- [ ] Generate highway sections — should find motorways/trunk roads and split into ~1 mile segments
- [ ] Generate city blocks — should find neighbourhoods via Overpass
- [ ] Generate schools/parks — still works via Nominatim text search
- [ ] Approve and create staged areas — verify they appear in the adoptable areas list with coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)