### PR TITLE
Fix iOS deploy to use correct environment for secrets

### DIFF
--- a/.github/workflows/main_trashmobmobileapp.yml
+++ b/.github/workflows/main_trashmobmobileapp.yml
@@ -140,10 +140,11 @@ jobs:
 
   calliOSDeploy:
     name: Call iOS deploy workflow
-    needs: calliOSBuild
+    needs: [calliOSBuild, exposeEnvironmentVariables]
     uses: ./.github/workflows/publish-ios.yml
     with:
       artifact_name: ${{ needs.calliOSBuild.outputs.artifact_name }}
+      environment: ${{ needs.exposeEnvironmentVariables.outputs.environment }}
     secrets:
       APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
       APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -6,6 +6,9 @@ on:
             artifact_name:
                 required: true
                 type: string
+            environment:
+                required: true
+                type: string
         secrets:
             APPSTORE_ISSUER_ID:
                 required: true
@@ -19,7 +22,7 @@ jobs:
     deploy-ios:
         name: Deploy iOS to TestFlight
         runs-on: macos-14
-        environment: production
+        environment: ${{ inputs.environment }}
         steps:
             - name: Download artifact
               uses: actions/download-artifact@v4

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -141,10 +141,11 @@ jobs:
 
   calliOSDeploy:
     name: Call iOS deploy workflow
-    needs: calliOSBuild
+    needs: [calliOSBuild, exposeEnvironmentVariables]
     uses: ./.github/workflows/publish-ios.yml
     with:
       artifact_name: ${{ needs.calliOSBuild.outputs.artifact_name }}
+      environment: ${{ needs.exposeEnvironmentVariables.outputs.environment }}
     secrets:
       APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
       APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}


### PR DESCRIPTION
## Summary
- The `publish-ios.yml` workflow had `environment: production` hardcoded, causing the dev deploy to use production environment secrets instead of test
- Added `environment` input to `publish-ios.yml` so callers control which GitHub environment is used
- Dev workflow (`main_trashmobmobileapp.yml`) now passes `test`
- Release workflow (`release_trashmobmobileapp.yml`) now passes `production`

## Test plan
- [ ] Merge and trigger dev mobile build → verify iOS deploy uses `test` environment
- [ ] Verify TestFlight upload succeeds with the correct API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)