### PR TITLE
Add keychain unlock before TestFlight upload

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -45,6 +45,9 @@ jobs:
                 ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
                 PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
 
+            - name: Unlock keychain
+              run: security unlock-keychain -p "" ~/Library/Keychains/login.keychain-db || true
+
             - name: Upload signed IPA
               uses: apple-actions/upload-testflight-build@v4
               with:


### PR DESCRIPTION
## Summary
- Adds `security unlock-keychain` step before iTMSTransporter runs
- Error -10814 (`errSecDuplicateItem`) is a macOS Keychain error — unlocking the keychain may resolve it
- Keeps debug step temporarily for verification

## Test plan
- [ ] Merge and verify TestFlight upload succeeds
- [ ] Remove debug step once upload works

🤖 Generated with [Claude Code](https://claude.com/claude-code)