### PR TITLE
Use fastlane pilot for TestFlight upload (iTMSTransporter broken)

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -32,43 +32,55 @@ jobs:
             - name: Get ipa filename
               run: echo "IPA_FILENAME=$(ls -R *.ipa)" > $GITHUB_ENV
 
-            - name: Install API key and upload to TestFlight
+            - name: Setup API key
               run: |
-                # Write the private key to the expected location
+                echo "Runner OS: $(sw_vers -productVersion)"
+                echo "Xcode: $(xcodebuild -version | head -1)"
                 mkdir -p ~/private_keys
                 echo "$API_PRIVATE_KEY" > ~/private_keys/AuthKey_${API_KEY_ID}.p8
-
-                # Debug info
-                echo "Runner: $(sw_vers -productVersion)"
-                echo "Xcode: $(xcodebuild -version | head -1)"
-                xcrun iTMSTransporter -version 2>&1 || echo "iTMSTransporter version check failed"
-
-                # Try upload with Signiant transport (default)
-                xcrun iTMSTransporter \
-                  -m upload \
-                  -assetFile "$IPA_FILENAME" \
-                  -apiKey "$API_KEY_ID" \
-                  -apiIssuer "$API_ISSUER_ID" \
-                  -v eXtreme \
-                  -appPlatform ios 2>&1 || {
-                    echo "--- Signiant transport failed, trying DAV transport ---"
-                    xcrun iTMSTransporter \
-                      -m upload \
-                      -assetFile "$IPA_FILENAME" \
-                      -apiKey "$API_KEY_ID" \
-                      -apiIssuer "$API_ISSUER_ID" \
-                      -v eXtreme \
-                      -transport DAV \
-                      -appPlatform ios 2>&1 || {
-                        echo "--- DAV transport also failed ---"
-                        exit 1
-                      }
-                  }
-
-                # Cleanup
-                rm -rf ~/private_keys
+                mkdir -p /tmp/fastlane
+                printf '{"key_id":"%s","issuer_id":"%s","key":"%s","in_house":false}' "$API_KEY_ID" "$API_ISSUER_ID" "$API_PRIVATE_KEY" > /tmp/fastlane/api_key.json
               env:
                 API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
                 API_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
                 API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+
+            - name: Check available upload tools
+              run: |
+                echo "--- altool ---"
+                xcrun altool --help 2>&1 | head -3 || echo "NOT AVAILABLE"
+                echo "--- iTMSTransporter ---"
+                xcrun iTMSTransporter -help 2>&1 | head -3 || echo "NOT AVAILABLE"
+                echo "--- fastlane ---"
+                which fastlane 2>/dev/null && fastlane --version 2>/dev/null || echo "NOT AVAILABLE"
+
+            - name: Upload to TestFlight
+              run: |
+                if which fastlane >/dev/null 2>&1; then
+                  echo "Uploading via fastlane pilot..."
+                  fastlane pilot upload \
+                    --ipa "$IPA_FILENAME" \
+                    --api_key_path /tmp/fastlane/api_key.json \
+                    --skip_waiting_for_build_processing true
+                elif xcrun altool --help >/dev/null 2>&1; then
+                  echo "Uploading via altool..."
+                  xcrun altool --upload-app \
+                    -f "$IPA_FILENAME" \
+                    -t ios \
+                    --apiKey "$API_KEY_ID" \
+                    --apiIssuer "$API_ISSUER_ID"
+                else
+                  echo "No upload tool available!"
+                  echo "Tried: fastlane, altool, iTMSTransporter (broken with -10814)"
+                  exit 1
+                fi
+              env:
                 IPA_FILENAME: ${{ env.IPA_FILENAME }}
+                API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+                API_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+
+            - name: Cleanup
+              if: always()
+              run: |
+                rm -rf ~/private_keys
+                rm -rf /tmp/fastlane


### PR DESCRIPTION
## Summary
- `iTMSTransporter` is broken on both macos-14 and macos-15 runners (even `-version` fails with -10814)
- Switch to `fastlane pilot upload` for TestFlight uploads, with `altool` as fallback
- Includes diagnostic step to log which upload tools are available on the runner
- Upgrade runner to macos-15

## What we tried
1. New API key with Admin role - key format verified correct via hex dump
2. Keychain unlock before upload
3. DAV transport fallback
4. macos-14 and macos-15 runners
5. Direct iTMSTransporter invocation (bypassing the action)

All failed because `iTMSTransporter` itself can't initialize on these runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)