### PR TITLE
Fix iOS simulator auth, crash, splash screen, and dashboard scrolling

### DIFF
--- a/TrashMobMobile/Authentication/AuthConstants.cs
+++ b/TrashMobMobile/Authentication/AuthConstants.cs
@@ -5,12 +5,12 @@ public static class AuthConstants
 #if USETEST
     public const string ClientId = "33bfdd2c-80a4-4e6e-b211-337b0467226d";
     private const string TenantName = "trashmobecodev";
-    private const string TenantDomain = "TrashMobEcoDev.onmicrosoft.com";
+    internal const string TenantDomain = "TrashMobEcoDev.onmicrosoft.com";
     public const string ApiBaseUri = "https://dev.trashmob.eco/api/";
 #else
     public const string ClientId = "33bfdd2c-80a4-4e6e-b211-337b0467226d"; // TODO: Register prod mobile app in Entra
     private const string TenantName = "trashmobecodev"; // TODO: Update to prod tenant
-    private const string TenantDomain = "TrashMobEcoDev.onmicrosoft.com"; // TODO: Update to prod tenant
+    internal const string TenantDomain = "TrashMobEcoDev.onmicrosoft.com"; // TODO: Update to prod tenant
     public const string ApiBaseUri = "https://www.trashmob.eco/api/";
 #endif
 

--- a/TrashMobMobile/Authentication/AuthService.cs
+++ b/TrashMobMobile/Authentication/AuthService.cs
@@ -1,6 +1,8 @@
 namespace TrashMobMobile.Authentication;
 
 using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Identity.Client;
 using Newtonsoft.Json.Linq;
@@ -129,6 +131,15 @@ public class AuthService : IAuthService
             return accessToken;
         }
 
+#if IOS
+        // On simulator, MSAL silent acquisition won't work (no keychain).
+        // Return empty to trigger re-authentication when the token expires.
+        if (DeviceInfo.DeviceType == DeviceType.Virtual)
+        {
+            return string.Empty;
+        }
+#endif
+
         var accounts = await pca.GetAccountsAsync();
 
         try
@@ -180,6 +191,16 @@ public class AuthService : IAuthService
 
     private async Task<SignInResult> SignInInteractive()
     {
+#if IOS
+        // On iOS simulator, MSAL cannot save tokens to keychain without entitlements
+        // (which require a provisioning profile not available for simulator builds).
+        // Use a manual OAuth 2.0 + PKCE flow instead.
+        if (DeviceInfo.DeviceType == DeviceType.Virtual)
+        {
+            return await SignInInteractiveManual();
+        }
+#endif
+
         if (pca == null)
         {
             InitializeClient();
@@ -210,6 +231,133 @@ public class AuthService : IAuthService
         {
             Succeeded = false,
         };
+    }
+
+    /// <summary>
+    /// Manual OAuth 2.0 Authorization Code + PKCE flow for iOS simulator,
+    /// bypassing MSAL's keychain-dependent token cache.
+    /// </summary>
+    private async Task<SignInResult> SignInInteractiveManual()
+    {
+        try
+        {
+            // Generate PKCE values
+            var codeVerifier = GenerateCodeVerifier();
+            var codeChallenge = GenerateCodeChallenge(codeVerifier);
+            var state = Guid.NewGuid().ToString("N");
+
+            var scopes = string.Join(" ", AuthConstants.Scopes);
+            var authorizeUrl = $"{AuthConstants.Authority}{AuthConstants.TenantDomain}/oauth2/v2.0/authorize" +
+                $"?client_id={Uri.EscapeDataString(AuthConstants.ClientId)}" +
+                $"&response_type=code" +
+                $"&redirect_uri={Uri.EscapeDataString(AuthConstants.RedirectUri)}" +
+                $"&scope={Uri.EscapeDataString(scopes)}" +
+                $"&state={state}" +
+                $"&code_challenge={codeChallenge}" +
+                $"&code_challenge_method=S256";
+
+            var callbackUri = new Uri(AuthConstants.RedirectUri);
+            var authResult = await WebAuthenticator.AuthenticateAsync(
+                new Uri(authorizeUrl),
+                callbackUri);
+
+            var code = authResult.Properties.TryGetValue("code", out var authCode) ? authCode : null;
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                Debug.WriteLine("Manual OAuth: No authorization code in callback");
+                return new SignInResult { Succeeded = false };
+            }
+
+            // Exchange authorization code for tokens
+            using var httpClient = new HttpClient();
+            var tokenEndpoint = $"{AuthConstants.Authority}{AuthConstants.TenantDomain}/oauth2/v2.0/token";
+            var tokenRequest = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["client_id"] = AuthConstants.ClientId,
+                ["grant_type"] = "authorization_code",
+                ["code"] = code,
+                ["redirect_uri"] = AuthConstants.RedirectUri,
+                ["code_verifier"] = codeVerifier,
+                ["scope"] = scopes,
+            });
+
+            var tokenResponse = await httpClient.PostAsync(tokenEndpoint, tokenRequest);
+            var tokenJson = await tokenResponse.Content.ReadAsStringAsync();
+
+            if (!tokenResponse.IsSuccessStatusCode)
+            {
+                Debug.WriteLine($"Manual OAuth: Token exchange failed: {tokenJson}");
+                return new SignInResult { Succeeded = false };
+            }
+
+            var tokenData = JObject.Parse(tokenJson);
+            var newAccessToken = tokenData["access_token"]?.ToString();
+            var idToken = tokenData["id_token"]?.ToString();
+            var expiresIn = tokenData["expires_in"]?.ToObject<int>() ?? 3600;
+
+            if (string.IsNullOrWhiteSpace(newAccessToken))
+            {
+                Debug.WriteLine("Manual OAuth: No access token in response");
+                return new SignInResult { Succeeded = false };
+            }
+
+            // Store tokens in memory
+            accessToken = newAccessToken;
+            expiresOn = DateTimeOffset.UtcNow.AddSeconds(expiresIn);
+
+            // Parse ID token for user info
+            var userClaims = !string.IsNullOrWhiteSpace(idToken) ? ParseIdToken(idToken) : null;
+            var email = userClaims?["email"]?.ToString()
+                ?? userClaims?["emailAddress"]?.ToString()
+                ?? string.Empty;
+
+            var context = new UserContext
+            {
+                AccessToken = newAccessToken,
+                EmailAddress = email,
+                IsLoggedOn = true,
+            };
+
+            UserState.UserContext = context;
+
+            if (!string.IsNullOrWhiteSpace(email))
+            {
+                userEmail = email;
+                var user = await userManager.GetUserByEmailAsync(email);
+                App.CurrentUser = user;
+            }
+
+            return new SignInResult { Succeeded = true };
+        }
+        catch (TaskCanceledException)
+        {
+            Debug.WriteLine("Manual OAuth: User cancelled authentication");
+            return new SignInResult { Succeeded = false };
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine($"Manual OAuth error: {e}");
+            return new SignInResult { Succeeded = false };
+        }
+    }
+
+    private static string GenerateCodeVerifier()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static string GenerateCodeChallenge(string codeVerifier)
+    {
+        var hash = SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier));
+        return Convert.ToBase64String(hash)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
     }
 
     private async Task SetAuthenticated(AuthenticationResult result)

--- a/TrashMobMobile/Platforms/iOS/Info.plist
+++ b/TrashMobMobile/Platforms/iOS/Info.plist
@@ -66,5 +66,7 @@
     </array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
   </dict>
 </plist>

--- a/TrashMobMobile/TrashMobMobile.csproj
+++ b/TrashMobMobile/TrashMobMobile.csproj
@@ -56,7 +56,7 @@
 		<MauiIcon Include="Resources\AppIcon\appiconfg.svg" />
 
 		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#FBFBFA" />
+		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#FBFBFA" BaseSize="256,67" />
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
@@ -369,6 +369,14 @@
              Value="$(GOOGLE_MAPS_API_KEY)" />
     <Message Condition="'$(GOOGLE_MAPS_API_KEY)' != ''" Text="Google Maps API key injected successfully" Importance="high" />
     <Warning Condition="'$(GOOGLE_MAPS_API_KEY)' == ''" Text="Google Maps API key not found. Maps will not work. Set GOOGLE_MAPS_API_KEY env var or run 'az login' with Key Vault access." />
+  </Target>
+
+  <!-- Allow keychain entitlements on iOS simulator without a provisioning profile -->
+  <Target Name="SkipProvisioningForSimulator" BeforeTargets="_DetectSigningIdentity"
+          Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <PropertyGroup Condition="$(RuntimeIdentifier.Contains('simulator'))">
+      <CodesignRequireProvisioningProfile>false</CodesignRequireProvisioningProfile>
+    </PropertyGroup>
   </Target>
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">

--- a/TrashMobMobile/Views/MyDashboard/TabCompletedEvents.xaml
+++ b/TrashMobMobile/Views/MyDashboard/TabCompletedEvents.xaml
@@ -18,7 +18,6 @@
                                 SelectedItem="{Binding CompletedSelectedEvent}"
                                 SelectionMode="Single"
                                 Margin="10, 0, 10, 0"
-                                MaximumHeightRequest="250"
                                 IsVisible="{Binding AreCompletedEventsFound}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:EventViewModel">

--- a/TrashMobMobile/Views/MyDashboard/TabLitterReports.xaml
+++ b/TrashMobMobile/Views/MyDashboard/TabLitterReports.xaml
@@ -18,7 +18,6 @@
                                 SelectedItem="{Binding SelectedLitterReport}"
                                 SelectionMode="Single"
                                 Margin="10, 0, 10, 0"
-                                MaximumHeightRequest="250"
                                 IsVisible="{Binding AreLitterReportsFound}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:LitterReportViewModel">

--- a/TrashMobMobile/Views/MyDashboard/TabUpcomingEvents.xaml
+++ b/TrashMobMobile/Views/MyDashboard/TabUpcomingEvents.xaml
@@ -18,7 +18,6 @@
                                 SelectedItem="{Binding UpcomingSelectedEvent}"
                                 SelectionMode="Single"
                                 Margin="10, 0, 10, 0"
-                                MaximumHeightRequest="250"
                                 IsVisible="{Binding AreUpcomingEventsFound}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:EventViewModel">


### PR DESCRIPTION
## Summary
- **iOS 26 crash fix:** Added `UIDesignRequiresCompatibility=true` to Info.plist to opt out of Liquid Glass, fixing SIGSEGV in `libswiftObservation`
- **Splash screen:** Added `BaseSize="256,67"` to `MauiSplashScreen` to fix logo cutoff
- **Simulator build:** Added MSBuild target to skip provisioning profile requirement for simulator builds
- **Auth on simulator:** Implemented manual OAuth 2.0 + PKCE flow bypassing MSAL's keychain-dependent token cache (entitlements unavailable without provisioning profile)
- **TenantDomain visibility:** Changed from `private` to `internal` so `AuthService` can construct OAuth URLs
- **Dashboard scrolling:** Removed `MaximumHeightRequest="250"` from all three dashboard tab `CollectionView`s, allowing full scrolling of events and litter reports

## Test plan
- [ ] Build and deploy to iOS simulator (net10.0-ios)
- [ ] Verify app launches without SIGSEGV crash on iOS 26
- [ ] Verify splash screen logo is not cut off
- [ ] Verify sign-in completes via manual OAuth flow on simulator
- [ ] Verify dashboard tabs show all events/litter reports with full scrolling
- [ ] Verify existing Android and physical iOS device builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)