### PR TITLE
Add Fastlane automation for store deployment and screenshots

### DIFF
--- a/.github/workflows/manual_android-rollout.yml
+++ b/.github/workflows/manual_android-rollout.yml
@@ -1,0 +1,71 @@
+# Adjust Google Play production rollout percentage.
+# Use this to increase rollout (10% → 50% → 100%) without redeploying.
+#
+# Prerequisites:
+#   - GCP_SERVICE_ACCOUNT secret with Google Play Developer API access
+#   - An existing staged rollout on the production track
+
+name: Android - Adjust Rollout
+
+on:
+  workflow_dispatch:
+    inputs:
+      rollout_percentage:
+        description: 'Rollout percentage (10, 25, 50, 100)'
+        required: true
+        type: choice
+        options:
+          - '10'
+          - '25'
+          - '50'
+          - '100'
+      package_name:
+        description: 'Package name'
+        required: false
+        default: 'eco.trashmob.trashmobmobileapp'
+
+permissions:
+  contents: read
+
+jobs:
+  rollout:
+    name: Update production rollout
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout (for Fastlane config)
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Adjust rollout
+        env:
+          SUPPLY_JSON_KEY_DATA: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          ANDROID_BUNDLE_ID: ${{ github.event.inputs.package_name }}
+        run: |
+          ROLLOUT=$(echo "scale=2; ${{ github.event.inputs.rollout_percentage }} / 100" | bc)
+          echo "Adjusting ${{ github.event.inputs.package_name }} production rollout to ${{ github.event.inputs.rollout_percentage }}%"
+
+          bundle exec fastlane android android_rollout rollout:$ROLLOUT
+
+      - name: Summary
+        run: |
+          echo ""
+          echo "========================================="
+          echo " Google Play Rollout Updated"
+          echo "========================================="
+          echo " Package:  ${{ github.event.inputs.package_name }}"
+          echo " Rollout:  ${{ github.event.inputs.rollout_percentage }}%"
+          echo "========================================="
+          if [ "${{ github.event.inputs.rollout_percentage }}" = "100" ]; then
+            echo ""
+            echo "✅ Full rollout complete — all users will receive this version."
+          else
+            echo ""
+            echo "Run this workflow again with a higher percentage to increase rollout."
+          fi

--- a/.github/workflows/manual_capture-screenshots.yml
+++ b/.github/workflows/manual_capture-screenshots.yml
@@ -1,0 +1,132 @@
+# Captures app screenshots on an Android emulator for store listings.
+# Uses Appium with the existing UI test framework.
+#
+# Screenshots are uploaded as artifacts and can be downloaded for
+# manual upload to App Store Connect / Google Play Console.
+#
+# Note: iOS screenshots require a macOS runner with Xcode simulator.
+# This workflow currently supports Android only.
+
+name: Capture App Screenshots
+
+on:
+  workflow_dispatch:
+    inputs:
+      emulator_api_level:
+        description: 'Android API level for emulator'
+        required: false
+        default: '34'
+      include_authenticated:
+        description: 'Include authenticated screenshots (requires test account)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  screenshots:
+    name: Capture Android screenshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '17'
+
+      - name: Install .NET MAUI workload
+        run: dotnet workload install maui-android
+
+      - name: Build Android APK
+        run: |
+          dotnet publish TrashMobMobile/TrashMobMobile.csproj \
+            -c Release \
+            -f net10.0-android \
+            /p:AndroidPackageFormat=apk \
+            -o ./build-output
+
+      - name: Find APK
+        id: find_apk
+        run: |
+          APK=$(find ./build-output -name "*.apk" | head -1)
+          echo "apk_path=$APK" >> $GITHUB_OUTPUT
+          echo "Found APK: $APK"
+
+      - name: Install Appium
+        run: |
+          npm install -g appium
+          appium driver install uiautomator2
+
+      - name: Start Appium server
+        run: |
+          appium --log-level info &
+          sleep 5
+          echo "Appium server started"
+
+      - name: Run screenshot tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ github.event.inputs.emulator_api_level }}
+          arch: x86_64
+          profile: pixel_6
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          script: |
+            # Wait for emulator to be fully booted
+            adb wait-for-device
+            sleep 10
+
+            # Set environment variables
+            export TRASHMOB_APK_PATH="${{ steps.find_apk.outputs.apk_path }}"
+            export APPIUM_SERVER="http://127.0.0.1:4723"
+
+            # Run screenshot tests
+            FILTER="Category=Screenshots"
+            if [ "${{ github.event.inputs.include_authenticated }}" != "true" ]; then
+              FILTER="Category=Screenshots&Category!=Authenticated"
+            fi
+
+            dotnet test TrashMobMobile.UITests/TrashMobMobile.UITests.csproj \
+              --filter "$FILTER" \
+              --logger "console;verbosity=normal" \
+              --results-directory ./TestResults \
+              || true  # Don't fail workflow if some screenshots fail
+
+            echo "Screenshot capture complete"
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-screenshots
+          path: |
+            **/TestResults/Screenshots/*.png
+          retention-days: 30
+
+      - name: Summary
+        if: always()
+        run: |
+          echo ""
+          echo "========================================="
+          echo " Screenshot Capture Results"
+          echo "========================================="
+          SCREENSHOT_COUNT=$(find . -path "*/TestResults/Screenshots/*.png" | wc -l)
+          echo " Screenshots captured: $SCREENSHOT_COUNT"
+          echo ""
+          echo "Download the 'app-screenshots' artifact to get the files."
+          echo ""
+          echo "Upload to stores:"
+          echo "  Apple: App Store Connect → Screenshots"
+          echo "  Google: Play Console → Store listing → Phone screenshots"
+          echo "========================================="

--- a/.github/workflows/manual_ios-submit.yml
+++ b/.github/workflows/manual_ios-submit.yml
@@ -1,0 +1,65 @@
+# Submit the latest TestFlight build for App Store review.
+# Uses Fastlane Deliver to submit with metadata from fastlane/metadata/.
+#
+# Prerequisites:
+#   - A build already uploaded to TestFlight
+#   - App Store Connect API key secrets configured
+#   - Metadata files in fastlane/metadata/en-US/
+
+name: iOS - Submit for App Store Review
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: 'Build number to submit (leave empty for latest)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit to App Store
+    runs-on: macos-15
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Submit for review
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+        run: |
+          BUILD_ARG=""
+          if [ -n "${{ github.event.inputs.build_number }}" ]; then
+            BUILD_ARG="build_number:${{ github.event.inputs.build_number }}"
+          fi
+
+          echo "Submitting TrashMob for App Store review..."
+          bundle exec fastlane ios ios_submit $BUILD_ARG
+
+      - name: Summary
+        run: |
+          echo ""
+          echo "========================================="
+          echo " App Store Submission"
+          echo "========================================="
+          echo " Build: ${{ github.event.inputs.build_number || 'latest' }}"
+          echo " Status: Submitted for review"
+          echo "========================================="
+          echo ""
+          echo "Monitor review status at:"
+          echo "  https://appstoreconnect.apple.com"
+          echo ""
+          echo "Apple review typically takes 24-48 hours."

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,6 +1,6 @@
 name: Publish Android app
 
-on:    
+on:
     workflow_call:
         inputs:
             bundle_id:
@@ -9,6 +9,15 @@ on:
             artifact_name:
                 required: true
                 type: string
+            promote_to_production:
+                required: false
+                type: boolean
+                default: false
+            rollout_percentage:
+                description: 'Rollout percentage (0.0-1.0) when promoting to production'
+                required: false
+                type: string
+                default: '0.1'
         secrets:
             GCP_SERVICE_ACCOUNT:
                 required: true
@@ -33,3 +42,30 @@ jobs:
                     track: internal
                     status: completed
                     changesNotSentForReview: false
+
+            - name: Promote to production (staged rollout)
+              if: inputs.promote_to_production
+              run: |
+                echo "Promoting ${{ inputs.bundle_id }} from internal → production at ${{ inputs.rollout_percentage }} rollout"
+
+                # Install Fastlane
+                gem install fastlane --no-document
+
+                # Write GCP service account key
+                echo '${{ secrets.GCP_SERVICE_ACCOUNT }}' > /tmp/gcp-key.json
+
+                fastlane supply \
+                  --package_name "${{ inputs.bundle_id }}" \
+                  --track internal \
+                  --track_promote_to production \
+                  --rollout "${{ inputs.rollout_percentage }}" \
+                  --json_key /tmp/gcp-key.json \
+                  --skip_upload_apk true \
+                  --skip_upload_aab true \
+                  --skip_upload_metadata true \
+                  --skip_upload_changelogs true \
+                  --skip_upload_images true \
+                  --skip_upload_screenshots true
+
+                rm -f /tmp/gcp-key.json
+                echo "✅ Promoted to production at $(echo "${{ inputs.rollout_percentage }} * 100" | bc)% rollout"

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -24,6 +24,9 @@ jobs:
         runs-on: macos-15
         environment: ${{ inputs.environment }}
         steps:
+            - name: Checkout (for Fastlane config)
+              uses: actions/checkout@v6
+
             - name: Download artifact
               uses: actions/download-artifact@v4
               with:
@@ -32,26 +35,16 @@ jobs:
             - name: Get ipa filename
               run: echo "IPA_FILENAME=$(ls -R *.ipa)" > $GITHUB_ENV
 
-            - name: Setup API key
-              run: |
-                mkdir -p ~/private_keys
-                echo "$API_PRIVATE_KEY" > ~/private_keys/AuthKey_${API_KEY_ID}.p8
-              env:
-                API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-                API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+            - name: Set up Ruby
+              uses: ruby/setup-ruby@v1
+              with:
+                ruby-version: '3.3'
+                bundler-cache: true
 
-            - name: Upload to TestFlight
-              run: |
-                xcrun altool --upload-app \
-                  -f "$IPA_FILENAME" \
-                  -t ios \
-                  --apiKey "$API_KEY_ID" \
-                  --apiIssuer "$API_ISSUER_ID"
+            - name: Upload to TestFlight via Fastlane Pilot
               env:
-                IPA_FILENAME: ${{ env.IPA_FILENAME }}
-                API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-                API_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
-
-            - name: Cleanup
-              if: always()
-              run: rm -rf ~/private_keys
+                APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+                APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+                APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+              run: |
+                bundle exec fastlane ios ios_upload ipa:"$IPA_FILENAME"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "fastlane", "~> 2.225"
+
+plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
+eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/TrashMobMobile.UITests/Tests/ScreenshotTests.cs
+++ b/TrashMobMobile.UITests/Tests/ScreenshotTests.cs
@@ -1,0 +1,120 @@
+namespace TrashMobMobile.UITests.Tests;
+
+using TrashMobMobile.UITests.Setup;
+using Xunit;
+
+/// <summary>
+/// Captures screenshots of key app screens for store listings.
+/// Run via: dotnet test --filter "Category=Screenshots"
+/// Screenshots are saved to TestResults/Screenshots/.
+/// </summary>
+[Collection(TestCollection.Name)]
+[Trait("Category", "Screenshots")]
+public class ScreenshotTests : BaseTest
+{
+    public ScreenshotTests(AppiumFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void Screenshot_01_WelcomePage()
+    {
+        // Welcome page is the first screen for unauthenticated users
+        WaitForElement("WelcomeLogo", TimeSpan.FromSeconds(30));
+
+        // Wait for animations to settle
+        Thread.Sleep(1000);
+
+        CaptureScreenshot("01_Welcome");
+    }
+
+    [Fact]
+    public void Screenshot_02_GetStarted()
+    {
+        // Show the Get Started button prominently
+        WaitForElement("GetStartedButton", TimeSpan.FromSeconds(15));
+        Thread.Sleep(500);
+
+        CaptureScreenshot("02_GetStarted");
+    }
+
+    // The following tests require authentication (Category=Authenticated).
+    // They will be skipped if the app is not logged in.
+    // To capture these, set up a test account and log in before running.
+
+    [Fact]
+    [Trait("Category", "Authenticated")]
+    public void Screenshot_03_EventsMap()
+    {
+        // Main events map showing nearby events
+        try
+        {
+            WaitForElement("EventsMap", TimeSpan.FromSeconds(15));
+            Thread.Sleep(2000); // Wait for map tiles to load
+
+            CaptureScreenshot("03_EventsMap");
+        }
+        catch
+        {
+            // If not authenticated, capture whatever is on screen
+            CaptureScreenshot("03_EventsMap_NoAuth");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Authenticated")]
+    public void Screenshot_04_Dashboard()
+    {
+        try
+        {
+            // Navigate to Dashboard tab
+            TapElement("DashboardTab");
+            Thread.Sleep(1500);
+
+            CaptureScreenshot("04_Dashboard");
+        }
+        catch
+        {
+            CaptureScreenshot("04_Dashboard_NoAuth");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Authenticated")]
+    public void Screenshot_05_Teams()
+    {
+        try
+        {
+            // Navigate to Teams tab
+            TapElement("TeamsTab");
+            Thread.Sleep(1500);
+
+            CaptureScreenshot("05_Teams");
+        }
+        catch
+        {
+            CaptureScreenshot("05_Teams_NoAuth");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Authenticated")]
+    public void Screenshot_06_CreateEvent()
+    {
+        try
+        {
+            // Navigate to Create Event
+            TapElement("CreateEventButton");
+            Thread.Sleep(1500);
+
+            CaptureScreenshot("06_CreateEvent");
+
+            // Go back
+            Driver.Navigate().Back();
+        }
+        catch
+        {
+            CaptureScreenshot("06_CreateEvent_NoAuth");
+        }
+    }
+}

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,16 @@
+# App identifiers for TrashMob mobile apps.
+# Environment-specific values are set via environment variables in CI.
+
+# iOS
+app_identifier ENV["IOS_BUNDLE_ID"] || "eco.trashmob"
+apple_id ENV["APPLE_ID"] || "joe@trashmob.eco"
+team_name ENV["APPLE_TEAM_NAME"] || "TrashMob"
+
+# App Store Connect API key (preferred over Apple ID for CI)
+# Set via environment variables:
+#   APP_STORE_CONNECT_API_KEY_KEY_ID
+#   APP_STORE_CONNECT_API_KEY_ISSUER_ID
+#   APP_STORE_CONNECT_API_KEY_KEY (base64-encoded .p8 contents)
+
+# Android
+json_key_data ENV["SUPPLY_JSON_KEY_DATA"] || ""

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,111 @@
+# TrashMob Fastlane Configuration
+#
+# Lanes:
+#   iOS:
+#     ios_upload       — Upload IPA to TestFlight (replaces xcrun altool)
+#     ios_submit       — Submit latest TestFlight build for App Store review
+#   Android:
+#     android_promote  — Promote from internal track to production with staged rollout
+#     android_rollout  — Update rollout percentage for production track
+
+default_platform(:ios)
+
+# ── iOS Lanes ──────────────────────────────────────────────────
+
+platform :ios do
+  before_all do
+    # Configure App Store Connect API key from environment
+    if ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"]
+      app_store_connect_api_key(
+        key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+        issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+        key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
+        is_key_content_base64: true,
+        in_house: false
+      )
+    end
+  end
+
+  desc "Upload IPA to TestFlight"
+  lane :ios_upload do |options|
+    ipa_path = options[:ipa] || Dir["*.ipa"].first
+
+    UI.user_error!("No IPA file found") unless ipa_path && File.exist?(ipa_path)
+    UI.message("Uploading #{ipa_path} to TestFlight...")
+
+    pilot(
+      ipa: ipa_path,
+      skip_waiting_for_build_processing: true,
+      skip_submission: true,
+      distribute_external: false
+    )
+  end
+
+  desc "Submit latest TestFlight build for App Store review"
+  lane :ios_submit do |options|
+    build_number = options[:build_number]
+
+    deliver(
+      skip_binary_upload: true,
+      submit_for_review: true,
+      automatic_release: false,
+      force: true, # Skip HTML preview in CI
+      precheck_include_in_app_purchases: false,
+      submission_information: {
+        add_id_info_uses_idfa: false
+      },
+      build_number: build_number
+    )
+  end
+end
+
+# ── Android Lanes ──────────────────────────────────────────────
+
+platform :android do
+  desc "Promote from internal track to production with staged rollout"
+  lane :android_promote do |options|
+    package_name = options[:package_name] || ENV["ANDROID_BUNDLE_ID"] || "eco.trashmob.trashmobmobileapp"
+    rollout = (options[:rollout] || 0.1).to_f
+
+    UI.message("Promoting #{package_name} from internal → production at #{(rollout * 100).to_i}% rollout")
+
+    supply(
+      package_name: package_name,
+      track: "internal",
+      track_promote_to: "production",
+      rollout: rollout.to_s,
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
+
+  desc "Update rollout percentage for production track"
+  lane :android_rollout do |options|
+    package_name = options[:package_name] || ENV["ANDROID_BUNDLE_ID"] || "eco.trashmob.trashmobmobileapp"
+    rollout = options[:rollout].to_f
+
+    UI.user_error!("rollout must be between 0 and 1") unless rollout > 0 && rollout <= 1
+
+    if rollout >= 1.0
+      UI.message("Completing rollout for #{package_name} (100%)")
+    else
+      UI.message("Updating #{package_name} production rollout to #{(rollout * 100).to_i}%")
+    end
+
+    supply(
+      package_name: package_name,
+      track: "production",
+      rollout: rollout.to_s,
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
+end

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -1,0 +1,29 @@
+Make a real difference in your neighborhood.
+
+TrashMob connects you with community cleanup events happening near you. Whether you want to organize a cleanup or join one, TrashMob makes it easy to take action against litter and build a cleaner world.
+
+Find and join events
+Browse cleanup events on an interactive map. See what's happening near you today, this week, or this month. One tap to RSVP and get directions.
+
+Report litter
+Spot a mess? Snap a photo to create a litter report. Your report appears on the community map so others can see problem areas and organize cleanups where they're needed most.
+
+Track your route
+Turn on route tracking during a cleanup to see exactly where you covered. Your path shows on the event map so the team can see the area cleaned.
+
+See your impact
+Your personal dashboard shows your stats: events attended, hours volunteered, bags collected, and litter reports submitted. Watch your impact grow with every cleanup.
+
+Build a team
+Create or join a team to track collective impact. Compete on leaderboards, coordinate events, and celebrate milestones together.
+
+Pickup coordination
+After a cleanup, drop pins where bags of trash are waiting. Hauling partners can see pickup locations and collect them — no bags left behind.
+
+Why TrashMob?
+- 100% free, no ads, open source
+- Events in cities across the United States and Canada
+- Works offline for route tracking
+- Available on iOS and Android
+
+Join thousands of volunteers making their communities cleaner. Download TrashMob and start your first cleanup today.

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,0 +1,1 @@
+cleanup,litter,volunteer,community,environment,trash,recycle,pickup,green,eco,team,event,map,route

--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,0 +1,1 @@
+TrashMob

--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,0 +1,1 @@
+https://www.trashmob.eco/privacypolicy

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,6 @@
+- Redesigned Create Event and Edit Event pages with improved date/time and duration controls
+- Route tracking during cleanup events — see your walking path on the map
+- Team support — create or join a team, track collective impact
+- Improved litter report flow with photo support
+- Better form validation with inline error messages
+- Performance and stability improvements

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Clean Up Your Community

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://www.trashmob.eco/contactus


### PR DESCRIPTION
## Summary

- **Fastlane infrastructure:** Added `Gemfile`, `fastlane/Appfile`, `fastlane/Fastfile`, and App Store metadata files (`fastlane/metadata/en-US/`)
- **iOS upload migration:** Replaced deprecated `xcrun altool` with `fastlane pilot upload` in `publish-ios.yml`
- **Google Play staged rollout:** Added optional `promote_to_production` input to `publish-android.yml` using Fastlane Supply, plus `manual_android-rollout.yml` for adjusting rollout percentage (10%/25%/50%/100%)
- **App Store submission:** Added `manual_ios-submit.yml` for submitting TestFlight builds for App Store review via Fastlane Deliver
- **Screenshot capture:** Added `manual_capture-screenshots.yml` workflow and `ScreenshotTests.cs` (6 Appium test cases) for automated Android screenshot capture
- **Checklist:** Marked automation opportunities #4-#6 as Done, added reference sections R17-R19

## Test plan

- [ ] Verify `Gemfile` and `fastlane/Fastfile` syntax: `bundle install && bundle exec fastlane lanes`
- [ ] Verify Android publish workflow YAML is valid (no syntax errors in `publish-android.yml`)
- [ ] Verify iOS publish workflow YAML is valid (no syntax errors in `publish-ios.yml`)
- [ ] Test manual Android rollout workflow with dry run
- [ ] Test manual iOS submit workflow with dry run
- [ ] Test screenshot capture workflow on next manual trigger
- [ ] Verify `ScreenshotTests.cs` compiles with existing UI test project

🤖 Generated with [Claude Code](https://claude.com/claude-code)