### PR TITLE
Fix screenshot workflow: install full MAUI workload

### DIFF
--- a/.github/workflows/manual_capture-screenshots.yml
+++ b/.github/workflows/manual_capture-screenshots.yml
@@ -47,13 +47,19 @@ jobs:
           java-version: '17'
 
       - name: Install .NET MAUI workload
-        run: dotnet workload install maui-android
+        run: |
+          dotnet workload install maui --ignore-failed-sources
+          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json
+
+      - name: Restore dependencies
+        run: dotnet restore TrashMobMobileApp.sln
 
       - name: Build Android APK
         run: |
           dotnet publish TrashMobMobile/TrashMobMobile.csproj \
             -c Release \
             -f net10.0-android \
+            --no-restore \
             /p:AndroidPackageFormat=apk \
             -o ./build-output
 


### PR DESCRIPTION
## Summary

- Install full `maui` workload instead of just `maui-android` — the project targets `net10.0-ios` too, so restore needs iOS SDK stubs even on Linux
- Add separate `dotnet restore` step and `--no-restore` on publish, matching the existing `build-android.yml` pattern

Fixes the `NETSDK1178` error: `Microsoft.iOS.Sdk.net10.0_26.2` workload pack not found.

## Test plan

- [ ] Re-run "Capture App Screenshots" workflow — build step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)