### PR TITLE
Fix screenshot workflow: use maui-android with TargetFrameworks override

### DIFF
--- a/.github/workflows/manual_capture-screenshots.yml
+++ b/.github/workflows/manual_capture-screenshots.yml
@@ -47,19 +47,14 @@ jobs:
           java-version: '17'
 
       - name: Install .NET MAUI workload
-        run: |
-          dotnet workload install maui --ignore-failed-sources
-          dotnet workload install android maui wasm-tools --source https://api.nuget.org/v3/index.json
-
-      - name: Restore dependencies
-        run: dotnet restore TrashMobMobileApp.sln
+        run: dotnet workload install maui-android
 
       - name: Build Android APK
         run: |
           dotnet publish TrashMobMobile/TrashMobMobile.csproj \
             -c Release \
             -f net10.0-android \
-            --no-restore \
+            /p:TargetFrameworks=net10.0-android \
             /p:AndroidPackageFormat=apk \
             -o ./build-output
 


### PR DESCRIPTION
## Summary

- The full `maui` workload (from #2830) isn't available on Linux runners — `Workload ID maui isn't supported on this platform`
- Use `maui-android` workload instead, and pass `/p:TargetFrameworks=net10.0-android` to override the csproj multi-target list so restore never looks for iOS/macCatalyst SDK stubs

## Test plan

- [ ] Re-run "Capture App Screenshots" workflow — build step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)