### PR TITLE
Add OID-based auth and Graph API email resolution for CIAM

### DIFF
--- a/TrashMob.Shared.Tests/Security/UserIsValidUserAuthHandlerTest.cs
+++ b/TrashMob.Shared.Tests/Security/UserIsValidUserAuthHandlerTest.cs
@@ -9,6 +9,7 @@ namespace TrashMob.Shared.Tests.Security
     using Moq;
     using TrashMob.Models;
     using TrashMob.Security;
+    using TrashMob.Services;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Tests.Builders;
     using Xunit;
@@ -16,6 +17,7 @@ namespace TrashMob.Shared.Tests.Security
     public class UserIsValidUserAuthHandlerTest
     {
         private readonly Mock<IUserManager> _mockUserManager;
+        private readonly Mock<ICiamGraphService> _mockCiamGraphService;
         private readonly Mock<ILogger<UserIsValidUserAuthHandler>> _mockLogger;
         private readonly UserIsValidUserAuthHandler _sut;
         private readonly Mock<Microsoft.AspNetCore.Http.IHttpContextAccessor> _mockHttpContextAccessor;
@@ -23,11 +25,13 @@ namespace TrashMob.Shared.Tests.Security
         public UserIsValidUserAuthHandlerTest()
         {
             _mockUserManager = new Mock<IUserManager>();
+            _mockCiamGraphService = new Mock<ICiamGraphService>();
             _mockLogger = new Mock<ILogger<UserIsValidUserAuthHandler>>();
             _mockHttpContextAccessor = AuthHandlerTestHelper.CreateHttpContextAccessor();
             _sut = new UserIsValidUserAuthHandler(
                 _mockHttpContextAccessor.Object,
                 _mockUserManager.Object,
+                _mockCiamGraphService.Object,
                 _mockLogger.Object);
         }
 

--- a/TrashMob/Controllers/UsersController.cs
+++ b/TrashMob/Controllers/UsersController.cs
@@ -99,6 +99,26 @@ namespace TrashMob.Controllers
         }
 
         /// <summary>
+        /// Retrieves a user by their identity provider object ID.
+        /// </summary>
+        /// <param name="objectId">The object ID from the identity provider.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <remarks>User details if found.</remarks>
+        [HttpGet("getbyobjectid/{objectId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        public async Task<IActionResult> GetUserByObjectId(Guid objectId, CancellationToken cancellationToken)
+        {
+            var user = await userManager.GetUserByObjectIdAsync(objectId, cancellationToken);
+
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(user);
+        }
+
+        /// <summary>
         /// Retrieves a user by their internal ID.
         /// </summary>
         /// <param name="id">The internal ID of the user.</param>

--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -226,6 +226,9 @@ public class Program
         builder.Services.AddScoped<IAuthorizationHandler, UserIsEventLeadOrIsAdminAuthHandler>();
         builder.Services.AddScoped<IAuthorizationHandler, UserIsProfessionalCompanyUserOrIsAdminAuthHandler>();
 
+        builder.Services.AddHttpClient("CiamGraph");
+        builder.Services.AddSingleton<ICiamGraphService, CiamGraphService>();
+
         builder.Services.AddManagers();
         builder.Services.AddRepositories();
 

--- a/TrashMob/Services/CiamGraphService.cs
+++ b/TrashMob/Services/CiamGraphService.cs
@@ -1,0 +1,143 @@
+namespace TrashMob.Services
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Identity;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Queries user information from the CIAM directory via Microsoft Graph API.
+    /// Uses client credentials flow (app-only) to read user profiles.
+    /// Requires AzureAdEntra:ClientSecret and Microsoft Graph User.Read.All permission.
+    /// </summary>
+    public class CiamGraphService(
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory,
+        ILogger<CiamGraphService> logger) : ICiamGraphService
+    {
+        private ClientSecretCredential credential;
+        private bool initialized;
+        private bool disabled;
+
+        public async Task<string> GetUserEmailAsync(Guid objectId, CancellationToken cancellationToken = default)
+        {
+            EnsureInitialized();
+
+            if (disabled)
+            {
+                return null;
+            }
+
+            try
+            {
+                var token = await credential.GetTokenAsync(
+                    new Azure.Core.TokenRequestContext(["https://graph.microsoft.com/.default"]),
+                    cancellationToken);
+
+                var client = httpClientFactory.CreateClient("CiamGraph");
+                var request = new HttpRequestMessage(HttpMethod.Get,
+                    $"https://graph.microsoft.com/v1.0/users/{objectId}?$select=mail,otherMails,identities");
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+
+                var response = await client.SendAsync(request, cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.LogWarning("Graph API call for user {ObjectId} returned {StatusCode}",
+                        objectId, response.StatusCode);
+                    return null;
+                }
+
+                var json = await response.Content.ReadAsStringAsync(cancellationToken);
+                return ExtractEmail(json);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to fetch user email from CIAM Graph API for ObjectId {ObjectId}", objectId);
+                return null;
+            }
+        }
+
+        private void EnsureInitialized()
+        {
+            if (initialized)
+            {
+                return;
+            }
+
+            initialized = true;
+
+            var tenantId = configuration["AzureAdEntra:TenantId"];
+            var clientId = configuration["AzureAdEntra:ClientId"];
+            var clientSecret = configuration["AzureAdEntra:ClientSecret"];
+
+            if (string.IsNullOrWhiteSpace(tenantId) ||
+                string.IsNullOrWhiteSpace(clientId) ||
+                string.IsNullOrWhiteSpace(clientSecret))
+            {
+                logger.LogWarning("CiamGraphService disabled: AzureAdEntra:ClientSecret not configured");
+                disabled = true;
+                return;
+            }
+
+            credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+        }
+
+        private static string ExtractEmail(string json)
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            // Try 'mail' property first
+            if (root.TryGetProperty("mail", out var mailProp) &&
+                mailProp.ValueKind == JsonValueKind.String)
+            {
+                var mail = mailProp.GetString();
+                if (!string.IsNullOrWhiteSpace(mail))
+                {
+                    return mail;
+                }
+            }
+
+            // Try 'otherMails' array
+            if (root.TryGetProperty("otherMails", out var otherMailsProp) &&
+                otherMailsProp.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in otherMailsProp.EnumerateArray())
+                {
+                    var email = item.GetString();
+                    if (!string.IsNullOrWhiteSpace(email))
+                    {
+                        return email;
+                    }
+                }
+            }
+
+            // Try 'identities' array — CIAM stores sign-up email here for email+password users
+            if (root.TryGetProperty("identities", out var identitiesProp) &&
+                identitiesProp.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var identity in identitiesProp.EnumerateArray())
+                {
+                    if (identity.TryGetProperty("signInType", out var signInType) &&
+                        signInType.GetString() == "emailAddress" &&
+                        identity.TryGetProperty("issuerAssignedId", out var issuerId))
+                    {
+                        var email = issuerId.GetString();
+                        if (!string.IsNullOrWhiteSpace(email))
+                        {
+                            return email;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/TrashMob/Services/ICiamGraphService.cs
+++ b/TrashMob/Services/ICiamGraphService.cs
@@ -1,0 +1,21 @@
+namespace TrashMob.Services
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Service for querying user information from the CIAM (Entra External ID) directory via Microsoft Graph API.
+    /// Used when token claims don't contain the email (common in CIAM tenants).
+    /// </summary>
+    public interface ICiamGraphService
+    {
+        /// <summary>
+        /// Gets a user's email address from the CIAM directory by their object ID.
+        /// </summary>
+        /// <param name="objectId">The user's object ID in the CIAM directory.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The user's email address, or null if not found.</returns>
+        Task<string> GetUserEmailAsync(Guid objectId, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob/appsettings.json
+++ b/TrashMob/appsettings.json
@@ -16,6 +16,7 @@
   "AzureAdEntra": {
     "Instance": "",
     "ClientId": "",
+    "ClientSecret": "",
     "FrontendClientId": "",
     "Domain": "",
     "TenantId": ""

--- a/TrashMob/client-app/src/services/users.ts
+++ b/TrashMob/client-app/src/services/users.ts
@@ -33,6 +33,17 @@ export const GetUserByEmail = (params: GetUserByEmail_Params) => ({
         }),
 });
 
+export type GetUserByObjectId_Params = { objectId: string };
+export type GetUserByObjectId_Response = UserData | null;
+export const GetUserByObjectId = (params: GetUserByObjectId_Params) => ({
+    key: ['/Users/getbyobjectid', params],
+    service: async () =>
+        ApiService('protected').fetchData<GetUserByObjectId_Response>({
+            url: `/Users/getbyobjectid/${params.objectId}`,
+            method: 'get',
+        }),
+});
+
 export type UpdateUser_Body = UserData;
 export type UpdateUser_Response = unknown;
 export const UpdateUser = () => ({


### PR DESCRIPTION
## Summary
- Auth handler now resolves users by ObjectId when email claim is missing from CIAM tokens
- New `CiamGraphService` fetches user email from CIAM directory via Microsoft Graph API (client credentials)
- Auto-links CIAM ObjectId to existing B2C users found by email (seamless migration)
- Frontend `useLogin.ts` falls back to OID-based lookup when email is unavailable
- New `GET /api/users/getbyobjectid/{objectId}` endpoint

## Configuration Required Before Testing
1. **Graph API permission**: Add `User.Read.All` (Application) on the backend API app registration in the dev CIAM tenant
2. **Client secret**: Create a client secret on the backend API app registration and store it in Key Vault as `AzureAdEntra--ClientSecret`
3. **Grant admin consent** for the Graph API permission

## How It Works
1. User signs in via CIAM → token has `oid` but no `email`
2. Auth handler tries email lookup → misses (no email in token)
3. Auth handler tries ObjectId lookup → hits if user already linked
4. If not found, calls Graph API to get email from CIAM directory
5. Finds existing user by email → auto-links ObjectId for future logins
6. New users: auto-creates with email from Graph API

## Test plan
- [ ] Configure Graph API permission + client secret in dev Key Vault
- [ ] Sign in on dev.trashmob.eco with Entra account
- [ ] Verify user profile loads (OID linked via Graph API email resolution)
- [ ] Verify subsequent sign-ins use fast OID path (no Graph API call)
- [ ] Verify new user sign-up creates account via Graph email resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)