### PR TITLE
Fix isUserLoaded: exclude empty GUID default

### DIFF
--- a/TrashMob/client-app/src/hooks/useLogin.ts
+++ b/TrashMob/client-app/src/hooks/useLogin.ts
@@ -1,14 +1,17 @@
 import UserData from '@/components/Models/UserData';
+import { Guid } from 'guid-typescript';
 import { useEffect, useState } from 'react';
 import * as msal from '@azure/msal-browser';
 import { getApiConfig, getMsalClientInstance } from '@/store/AuthStore';
 import { GetUserByEmail, GetUserById, GetUserByObjectId } from '@/services/users';
 import { useFeatureMetrics } from './useFeatureMetrics';
 
+const EMPTY_GUID = Guid.createEmpty().toString();
+
 export const useLogin = () => {
     const [callbackId, setCallbackId] = useState('');
     const [currentUser, setCurrentUser] = useState<UserData>(new UserData());
-    const isUserLoaded = !!currentUser.id;
+    const isUserLoaded = !!currentUser.id && currentUser.id !== EMPTY_GUID;
     const { trackAuth } = useFeatureMetrics();
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- `UserData.id` defaults to `Guid.createEmpty()` (`"00000000-0000-0000-0000-000000000000"`), which is truthy
- The `isUserLoaded = !!currentUser.id` check was always `true`, hiding Sign In buttons
- Now checks `!!currentUser.id && currentUser.id !== EMPTY_GUID`

Follow-up to PR #2838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)