### PR TITLE
Fix validateToken to accept CIAM tokens without email claim

### DIFF
--- a/TrashMob/client-app/src/store/AuthStore.tsx
+++ b/TrashMob/client-app/src/store/AuthStore.tsx
@@ -186,7 +186,8 @@ export async function initializeMsalClient(): Promise<msal.PublicClientApplicati
 }
 
 export function validateToken(idTokenClaims: object): boolean {
-    if (!idTokenClaims.hasOwnProperty('email')) {
+    // CIAM id_tokens may not include an email claim — accept tokens with either email or oid
+    if (!idTokenClaims.hasOwnProperty('email') && !idTokenClaims.hasOwnProperty('oid')) {
         return false;
     }
 


### PR DESCRIPTION
## Summary
- CIAM id_tokens don't include an `email` claim (only `oid`, `given_name`, `family_name`)
- `validateToken()` in `AuthStore.tsx` rejected these tokens, causing every protected API call to throw `CanceledError: User not found!` before reaching the backend
- Fix: accept tokens with either `email` or `oid` claim

## Root Cause
The axios request interceptor in `services/index.ts` calls `validateToken(tokenResponse.idTokenClaims)` before attaching the access token. With CIAM, the id_token lacks an `email` property, so validation failed and all API requests were canceled.

## Test plan
- [ ] Sign in on production with CIAM — protected API calls succeed
- [ ] User profile loads correctly after sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)