### PR TITLE
Fix garbled AM/PM text in TimePicker on iPad

### DIFF
--- a/TrashMobMobile/Resources/Styles/Styles.xaml
+++ b/TrashMobMobile/Resources/Styles/Styles.xaml
@@ -628,7 +628,6 @@
         <Setter Property="TextColor"
                 Value="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryDarkText}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="LexendRegular" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="MinimumHeightRequest" Value="44" />
         <Setter Property="MinimumWidthRequest" Value="44" />


### PR DESCRIPTION
## Summary
- Remove `FontFamily="LexendRegular"` from the `TimePicker` global style
- The Lexend font lacks locale-specific AM/PM glyphs that iOS uses, causing garbled characters (e.g. "ΗΘδ" instead of "AM") on iPad
- Falls back to the system font which renders AM/PM correctly

## Test plan
- [ ] Verify TimePicker shows correct AM/PM text on iPad simulator
- [ ] Verify TimePicker still looks correct on iPhone simulator
- [ ] Verify TimePicker on Android is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)