### PR TITLE
Add client-side image compression before upload (fixes #2826)

### DIFF
--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -67,15 +67,21 @@
             //ngrok.exe http https://localhost:44373 -host-header="localhost:44373"
             services.AddScoped<AuthHandler>();
             services.AddHttpClient($"ServerAPI", client =>
-                    client.BaseAddress = new Uri(Settings.ApiBaseUrl))
+                {
+                    client.BaseAddress = new Uri(Settings.ApiBaseUrl);
+                    client.Timeout = TimeSpan.FromSeconds(60);
+                })
                 .AddHttpMessageHandler<AuthHandler>()
                 .AddHttpMessageHandler<SentryHttpMessageHandler>()
-                .SetHandlerLifetime(TimeSpan.FromMinutes(5)) //Set lifetime to five minutes
+                .SetHandlerLifetime(TimeSpan.FromMinutes(5))
                 .AddPolicyHandler(GetRetryPolicy());
 
             services.AddHttpClient($"ServerAPI.Anonymous", client =>
-                    client.BaseAddress = new Uri(Settings.ApiBaseUrl))
-                .SetHandlerLifetime(TimeSpan.FromMinutes(5)) //Set lifetime to five minutes
+                {
+                    client.BaseAddress = new Uri(Settings.ApiBaseUrl);
+                    client.Timeout = TimeSpan.FromSeconds(60);
+                })
+                .SetHandlerLifetime(TimeSpan.FromMinutes(5))
                 .AddHttpMessageHandler<SentryHttpMessageHandler>()
                 .AddPolicyHandler(GetRetryPolicy());
 

--- a/TrashMobMobile/Pages/CreateLitterReportPage.xaml.cs
+++ b/TrashMobMobile/Pages/CreateLitterReportPage.xaml.cs
@@ -2,6 +2,7 @@ namespace TrashMobMobile.Pages;
 
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Core;
+using TrashMobMobile.Services;
 
 public partial class CreateLitterReportPage : ContentPage
 {
@@ -23,13 +24,16 @@ public partial class CreateLitterReportPage : ContentPage
 
             if (photo != null)
             {
-                // save the file into local storage
                 viewModel.LocalFilePath = Path.Combine(FileSystem.CacheDirectory, photo.FileName);
 
-                using var sourceStream = await photo.OpenReadAsync();
-                using var localFileStream = File.OpenWrite(viewModel.LocalFilePath);
+                using (var sourceStream = await photo.OpenReadAsync())
+                using (var localFileStream = File.OpenWrite(viewModel.LocalFilePath))
+                {
+                    await sourceStream.CopyToAsync(localFileStream);
+                }
 
-                await sourceStream.CopyToAsync(localFileStream);
+                await ImageCompressor.CompressAsync(viewModel.LocalFilePath);
+
                 await viewModel.AddImageToCollection();
                 viewModel.ValidateReport();
             }

--- a/TrashMobMobile/Pages/CreatePickupLocationPage.xaml.cs
+++ b/TrashMobMobile/Pages/CreatePickupLocationPage.xaml.cs
@@ -3,6 +3,7 @@ namespace TrashMobMobile.Pages;
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Core;
 using Microsoft.Maui.Maps;
+using TrashMobMobile.Services;
 
 [QueryProperty(nameof(EventId), nameof(EventId))]
 public partial class CreatePickupLocationPage : ContentPage
@@ -41,13 +42,15 @@ public partial class CreatePickupLocationPage : ContentPage
 
             if (photo != null)
             {
-                // save the file into local storage
                 viewModel.LocalFilePath = Path.Combine(FileSystem.CacheDirectory, photo.FileName);
 
-                using var sourceStream = await photo.OpenReadAsync();
-                using var localFileStream = File.OpenWrite(viewModel.LocalFilePath);
+                using (var sourceStream = await photo.OpenReadAsync())
+                using (var localFileStream = File.OpenWrite(viewModel.LocalFilePath))
+                {
+                    await sourceStream.CopyToAsync(localFileStream);
+                }
 
-                await sourceStream.CopyToAsync(localFileStream);
+                await ImageCompressor.CompressAsync(viewModel.LocalFilePath);
 
                 pickupPhoto.Source = viewModel.LocalFilePath;
                 pickupPhoto.IsVisible = true;

--- a/TrashMobMobile/Pages/EditLitterReportPage.xaml.cs
+++ b/TrashMobMobile/Pages/EditLitterReportPage.xaml.cs
@@ -3,6 +3,7 @@ namespace TrashMobMobile.Pages;
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Core;
 using Microsoft.Maui.Maps;
+using TrashMobMobile.Services;
 
 [QueryProperty(nameof(LitterReportId), nameof(LitterReportId))]
 public partial class EditLitterReportPage : ContentPage
@@ -41,13 +42,16 @@ public partial class EditLitterReportPage : ContentPage
 
             if (photo != null)
             {
-                // save the file into local storage
                 viewModel.LocalFilePath = Path.Combine(FileSystem.CacheDirectory, photo.FileName);
 
-                using var sourceStream = await photo.OpenReadAsync();
-                using var localFileStream = File.OpenWrite(viewModel.LocalFilePath);
+                using (var sourceStream = await photo.OpenReadAsync())
+                using (var localFileStream = File.OpenWrite(viewModel.LocalFilePath))
+                {
+                    await sourceStream.CopyToAsync(localFileStream);
+                }
 
-                await sourceStream.CopyToAsync(localFileStream);
+                await ImageCompressor.CompressAsync(viewModel.LocalFilePath);
+
                 await viewModel.AddImageToCollection();
                 viewModel.ValidateReport();
             }

--- a/TrashMobMobile/Services/ImageCompressor.cs
+++ b/TrashMobMobile/Services/ImageCompressor.cs
@@ -1,0 +1,84 @@
+namespace TrashMobMobile.Services;
+
+using System.Diagnostics;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Platform;
+
+/// <summary>
+/// Provides client-side image compression to reduce upload sizes on slow connections.
+/// Resizes images to a maximum dimension while preserving aspect ratio and compresses as JPEG.
+/// </summary>
+public static class ImageCompressor
+{
+    private const int MaxDimension = 1600;
+    private const float JpegQuality = 0.85f;
+
+    /// <summary>
+    /// Compresses an image file in place. Resizes to max 1600px on the longest dimension,
+    /// preserving aspect ratio, and re-encodes as JPEG at 85% quality.
+    /// If compression fails, the original file is left untouched.
+    /// </summary>
+    public static async Task<string> CompressAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+        {
+            return filePath;
+        }
+
+        var tempPath = filePath + ".compressed";
+
+        try
+        {
+            var originalSize = new FileInfo(filePath).Length;
+
+            Microsoft.Maui.Graphics.IImage image;
+
+            using (var inputStream = File.OpenRead(filePath))
+            {
+                image = PlatformImage.FromStream(inputStream);
+            }
+
+            if (image is null)
+            {
+                return filePath;
+            }
+
+            if (image.Width > MaxDimension || image.Height > MaxDimension)
+            {
+                image = image.Downsize(MaxDimension, MaxDimension);
+            }
+
+            await using (var outputStream = File.Create(tempPath))
+            {
+                await image.AsStream(ImageFormat.Jpeg, JpegQuality)
+                    .CopyToAsync(outputStream, cancellationToken);
+            }
+
+            var compressedSize = new FileInfo(tempPath).Length;
+
+            File.Delete(filePath);
+            File.Move(tempPath, filePath);
+
+            Debug.WriteLine($"ImageCompressor: {originalSize / 1024}KB -> {compressedSize / 1024}KB " +
+                $"({(int)image.Width}x{(int)image.Height})");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"ImageCompressor: compression failed, using original: {ex.Message}");
+            SentrySdk.CaptureException(ex, scope =>
+            {
+                scope.SetTag("operation", "image_compression");
+            });
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); }
+                catch { /* best effort cleanup */ }
+            }
+        }
+
+        return filePath;
+    }
+}

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -595,6 +595,17 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
                 return;
             }
 
+            // Copy to cache and compress before upload
+            var cachedPath = Path.Combine(FileSystem.CacheDirectory, result.FileName);
+
+            using (var sourceStream = await result.OpenReadAsync())
+            using (var cacheStream = File.Create(cachedPath))
+            {
+                await sourceStream.CopyToAsync(cacheStream);
+            }
+
+            await ImageCompressor.CompressAsync(cachedPath);
+
             var typePopup = new Controls.PhotoTypePopup();
             var typeResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(typePopup);
             var photoType = typeResult?.Result;
@@ -612,7 +623,7 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             };
 
             await eventPhotoManager.UploadPhotoAsync(
-                EventViewModel.Id, result.FullPath, eventPhotoType, string.Empty);
+                EventViewModel.Id, cachedPath, eventPhotoType, string.Empty);
 
             await LoadPhotos();
 


### PR DESCRIPTION
## Summary
- Photos were uploaded at full resolution (5-12MB), causing `net_http_content_stream_copy_error` on iOS and very slow saves on Android (#2826)
- Add `ImageCompressor` utility class that resizes images to max **1600px** and JPEG-compresses at **85% quality** using `Microsoft.Maui.Graphics.Platform.PlatformImage` (no new NuGet dependency)
- Compress photos in all **4 capture paths**: litter reports (create/edit), pickup locations, and event photos
- Add **60-second per-request HTTP timeout** to both HTTP clients to prevent indefinite hangs
- Expected size reduction: **~70-80%** (5-12MB → 200-500KB)
- Graceful fallback: if compression fails for any reason, uploads original file and logs to Sentry

## Test plan
- [ ] Create litter report with photos on iOS — verify upload succeeds without error
- [ ] Create litter report with photos on Android — verify upload completes quickly
- [ ] Edit litter report, add new photo — verify compression applies
- [ ] Create pickup location with photo — verify it works
- [ ] Upload event photo (Before/After) — verify it works
- [ ] Verify image quality is acceptable in the app after upload
- [ ] Test on slow network if possible (Network Link Conditioner)

Fixes #2826

🤖 Generated with [Claude Code](https://claude.com/claude-code)