### PR TITLE
Community map routes, event filters, and route hover info

### DIFF
--- a/TrashMob/client-app/src/components/Map/RoutePolylines.tsx
+++ b/TrashMob/client-app/src/components/Map/RoutePolylines.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from 'react';
+import { useMap } from '@vis.gl/react-google-maps';
+import { DisplayAnonymizedRoute } from '@/components/Models/RouteData';
+import { formatDistance, formatDuration, formatWeight } from '@/lib/route-format';
+
+const ROUTE_COLORS = [
+    '#3B82F6',
+    '#EF4444',
+    '#10B981',
+    '#F59E0B',
+    '#8B5CF6',
+    '#EC4899',
+    '#06B6D4',
+    '#F97316',
+    '#6366F1',
+    '#14B8A6',
+];
+
+function getRouteColor(index: number): string {
+    return ROUTE_COLORS[index % ROUTE_COLORS.length];
+}
+
+function buildInfoContent(route: DisplayAnonymizedRoute): string {
+    const lines: string[] = [];
+    lines.push(`<strong>${formatDistance(route.totalDistanceMeters)}</strong>`);
+    lines.push(formatDuration(route.durationMinutes));
+    if (route.bagsCollected && route.bagsCollected > 0) {
+        lines.push(`${route.bagsCollected} bag${route.bagsCollected !== 1 ? 's' : ''}`);
+    }
+    if (route.weightCollected && route.weightCollected > 0) {
+        lines.push(formatWeight(route.weightCollected, route.weightUnitId));
+    }
+    return `<div style="font-size:12px;line-height:1.4">${lines.join(' &middot; ')}</div>`;
+}
+
+interface RoutePolylinesProps {
+    mapId?: string;
+    routes: DisplayAnonymizedRoute[];
+    fitBounds?: boolean;
+}
+
+export const RoutePolylines = ({ mapId, routes, fitBounds = false }: RoutePolylinesProps) => {
+    const map = useMap(mapId);
+    const polylinesRef = useRef<google.maps.Polyline[]>([]);
+    const infoWindowRef = useRef<google.maps.InfoWindow | null>(null);
+
+    useEffect(() => {
+        if (!map || routes.length === 0) return;
+
+        // Clean previous
+        polylinesRef.current.forEach((p) => p.setMap(null));
+        polylinesRef.current = [];
+        if (infoWindowRef.current) {
+            infoWindowRef.current.close();
+        }
+
+        const bounds = fitBounds ? new google.maps.LatLngBounds() : null;
+
+        routes.forEach((route, index) => {
+            if (route.locations.length < 2) return;
+
+            const path = route.locations
+                .sort((a, b) => a.sortOrder - b.sortOrder)
+                .map((loc) => {
+                    const latLng = { lat: loc.latitude, lng: loc.longitude };
+                    if (bounds) bounds.extend(latLng);
+                    return latLng;
+                });
+
+            const polyline = new google.maps.Polyline({
+                path,
+                strokeColor: getRouteColor(index),
+                strokeOpacity: 0.8,
+                strokeWeight: 3,
+                map,
+            });
+
+            polyline.addListener('mouseover', (e: google.maps.MapMouseEvent) => {
+                if (!infoWindowRef.current) {
+                    infoWindowRef.current = new google.maps.InfoWindow();
+                }
+                infoWindowRef.current.setContent(buildInfoContent(route));
+                if (e.latLng) {
+                    infoWindowRef.current.setPosition(e.latLng);
+                }
+                infoWindowRef.current.open(map);
+            });
+
+            polyline.addListener('mouseout', () => {
+                if (infoWindowRef.current) {
+                    infoWindowRef.current.close();
+                }
+            });
+
+            polylinesRef.current.push(polyline);
+        });
+
+        if (bounds && !bounds.isEmpty()) {
+            map.fitBounds(bounds, { top: 50, right: 50, bottom: 50, left: 50 });
+        }
+
+        return () => {
+            polylinesRef.current.forEach((p) => p.setMap(null));
+            polylinesRef.current = [];
+            if (infoWindowRef.current) {
+                infoWindowRef.current.close();
+                infoWindowRef.current = null;
+            }
+        };
+    }, [map, routes, fitBounds]);
+
+    return null;
+};

--- a/TrashMob/client-app/src/components/events/EventRouteStatsCard.tsx
+++ b/TrashMob/client-app/src/components/events/EventRouteStatsCard.tsx
@@ -1,31 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { GetEventRouteStats } from '@/services/event-routes';
-
-function formatDistance(meters: number): string {
-    if (meters >= 1609) {
-        return `${(meters / 1609.34).toFixed(1)} mi`;
-    }
-    return `${meters.toLocaleString()} m`;
-}
-
-function formatDuration(minutes: number): string {
-    if (minutes >= 60) {
-        const hours = Math.floor(minutes / 60);
-        const mins = minutes % 60;
-        return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
-    }
-    return `${minutes}m`;
-}
-
-function formatArea(sqMeters: number): string {
-    const sqMetersPerAcre = 4046.86;
-    if (sqMeters >= sqMetersPerAcre) {
-        return `${(sqMeters / sqMetersPerAcre).toFixed(1)} acres`;
-    }
-    const sqFeet = sqMeters * 10.7639;
-    return `${Math.round(sqFeet).toLocaleString()} sq ft`;
-}
+import { formatDistance, formatDuration, formatArea } from '@/lib/route-format';
 
 interface EventRouteStatsCardProps {
     eventId: string;

--- a/TrashMob/client-app/src/components/events/EventRoutesMap.tsx
+++ b/TrashMob/client-app/src/components/events/EventRoutesMap.tsx
@@ -4,72 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import { GoogleMapWithKey } from '@/components/Map/GoogleMap/GoogleMap';
 import { GetEventRoutes } from '@/services/event-routes';
 import { DisplayAnonymizedRoute } from '@/components/Models/RouteData';
+import { RoutePolylines } from '@/components/Map/RoutePolylines';
 
-const ROUTE_COLORS = [
-    '#3B82F6',
-    '#EF4444',
-    '#10B981',
-    '#F59E0B',
-    '#8B5CF6',
-    '#EC4899',
-    '#06B6D4',
-    '#F97316',
-    '#6366F1',
-    '#14B8A6',
-];
-
-function getRouteColor(index: number): string {
-    return ROUTE_COLORS[index % ROUTE_COLORS.length];
-}
-
-interface RoutePolylinesProps {
-    routes: DisplayAnonymizedRoute[];
-}
-
-const RoutePolylines = ({ routes }: RoutePolylinesProps) => {
-    const map = useMap();
-
-    useEffect(() => {
-        if (!map || routes.length === 0) return;
-
-        const polylines: google.maps.Polyline[] = [];
-        const bounds = new google.maps.LatLngBounds();
-
-        routes.forEach((route, index) => {
-            if (route.locations.length < 2) return;
-
-            const path = route.locations
-                .sort((a, b) => a.sortOrder - b.sortOrder)
-                .map((loc) => {
-                    const latLng = { lat: loc.latitude, lng: loc.longitude };
-                    bounds.extend(latLng);
-                    return latLng;
-                });
-
-            const polyline = new google.maps.Polyline({
-                path,
-                strokeColor: getRouteColor(index),
-                strokeOpacity: 0.8,
-                strokeWeight: 3,
-                map,
-            });
-
-            polylines.push(polyline);
-        });
-
-        if (!bounds.isEmpty()) {
-            map.fitBounds(bounds, { top: 50, right: 50, bottom: 50, left: 50 });
-        }
-
-        return () => {
-            polylines.forEach((p) => p.setMap(null));
-        };
-    }, [map, routes]);
-
-    return null;
-};
-
-const HeatmapOverlay = ({ routes }: RoutePolylinesProps) => {
+const HeatmapOverlay = ({ routes }: { routes: DisplayAnonymizedRoute[] }) => {
     const map = useMap();
     const visualization = useMapsLibrary('visualization');
 
@@ -168,7 +105,11 @@ export const EventRoutesMap = ({ eventId, defaultCenter }: EventRoutesMapProps) 
                 </button>
             </div>
             <GoogleMapWithKey defaultCenter={defaultCenter} style={{ width: '100%', height: '400px' }}>
-                {viewMode === 'routes' ? <RoutePolylines routes={routeList} /> : <HeatmapOverlay routes={routeList} />}
+                {viewMode === 'routes' ? (
+                    <RoutePolylines routes={routeList} fitBounds />
+                ) : (
+                    <HeatmapOverlay routes={routeList} />
+                )}
             </GoogleMapWithKey>
         </div>
     );

--- a/TrashMob/client-app/src/lib/route-format.ts
+++ b/TrashMob/client-app/src/lib/route-format.ts
@@ -1,0 +1,28 @@
+export function formatDistance(meters: number): string {
+    if (meters >= 1609) {
+        return `${(meters / 1609.34).toFixed(1)} mi`;
+    }
+    return `${meters.toLocaleString()} m`;
+}
+
+export function formatDuration(minutes: number): string {
+    if (minutes >= 60) {
+        const hours = Math.floor(minutes / 60);
+        const mins = minutes % 60;
+        return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+    }
+    return `${minutes}m`;
+}
+
+export function formatArea(sqMeters: number): string {
+    const sqMetersPerAcre = 4046.86;
+    if (sqMeters >= sqMetersPerAcre) {
+        return `${(sqMeters / sqMetersPerAcre).toFixed(1)} acres`;
+    }
+    const sqFeet = sqMeters * 10.7639;
+    return `${Math.round(sqFeet).toLocaleString()} sq ft`;
+}
+
+export function formatWeight(weight: number, weightUnitId: number | null): string {
+    return `${weight.toFixed(1)} ${weightUnitId === 2 ? 'kg' : 'lbs'}`;
+}

--- a/TrashMob/client-app/src/pages/MyDashboard/MyRoutesCard.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyRoutesCard.tsx
@@ -9,25 +9,10 @@ import { Button } from '@/components/ui/button';
 import { GoogleMapWithKey } from '@/components/Map/GoogleMap';
 import { GetMyRoutes } from '@/services/event-routes';
 import { DisplayUserRouteHistory } from '@/components/Models/RouteData';
+import { formatDistance, formatDuration } from '@/lib/route-format';
 import moment from 'moment';
 
 const MY_ROUTES_MAP_ID = 'myRoutesMap';
-
-function formatDistance(meters: number): string {
-    if (meters >= 1609) {
-        return `${(meters / 1609.34).toFixed(1)} mi`;
-    }
-    return `${meters.toLocaleString()} m`;
-}
-
-function formatDuration(minutes: number): string {
-    if (minutes >= 60) {
-        const hours = Math.floor(minutes / 60);
-        const mins = minutes % 60;
-        return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
-    }
-    return `${minutes}m`;
-}
 
 const privacyColors: Record<string, string> = {
     Public: 'bg-green-100 text-green-700',

--- a/TrashMob/client-app/src/pages/communities/$slug/index.tsx
+++ b/TrashMob/client-app/src/pages/communities/$slug/index.tsx
@@ -229,7 +229,6 @@ export const CommunityDetailPage = () => {
                                 events={events}
                                 teams={teams}
                                 litterReports={litterReports}
-                                areas={areas}
                                 centerLat={community.latitude!}
                                 centerLng={community.longitude!}
                                 boundsNorth={community.boundsNorth}


### PR DESCRIPTION
## Summary
- **Remove adoptable areas** from community detail map (already shown in dedicated section below, reducing visual clutter)
- **Add route polylines** from completed events to community map with a toggle checkbox (lazy-loads up to 25 recent completed events' routes)
- **Add Upcoming/Completed tabs + date range filters** to community events section, matching the main page event section pattern
- **Add hover info** to route polylines everywhere in the app — hovering shows distance, duration, bags collected, and weight collected
- **Extract shared format utilities** (`formatDistance`, `formatDuration`, `formatArea`, `formatWeight`) to `src/lib/route-format.ts` to eliminate duplication

## Test plan
- [ ] Community page map: verify adoptable areas are no longer shown on the map
- [ ] Community page map: toggle "Routes" checkbox — polylines render for completed events
- [ ] Hover over a route polyline on the community map — info window shows distance, duration, bags, weight
- [ ] Community events section: switch between Upcoming and Completed tabs, verify correct events shown
- [ ] Community events section: change date range dropdown, verify filtering works
- [ ] Community events section: verify "Show all / Show fewer" toggle when >5 events
- [ ] Event detail page: hover over route polylines — same info window appears
- [ ] My Dashboard routes card: verify formatting still correct after shared utility extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)