### PR TITLE
Fix event save crash when navigating back then forward (fixes #2816)

### DIFF
--- a/TrashMobMobile/ViewModels/CreateEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/CreateEventViewModel.cs
@@ -559,7 +559,10 @@ public partial class CreateEventViewModel : BaseViewModel
 
             var mobEvent = EventViewModel.ToEvent();
 
-            var updatedEvent = await mobEventManager.AddEventAsync(mobEvent);
+            // If the event was already saved (has an ID), update instead of creating a duplicate
+            var updatedEvent = mobEvent.Id != Guid.Empty
+                ? await mobEventManager.UpdateEventAsync(mobEvent)
+                : await mobEventManager.AddEventAsync(mobEvent);
 
             EventViewModel = updatedEvent.ToEventViewModel(userManager.CurrentUser.Id);
             Events.Clear();


### PR DESCRIPTION
## Summary
- After saving an event, if the user taps "Previous" then "Next" again, `SaveEvent()` was called a second time with the same server-generated event ID
- This caused a duplicate key INSERT on the backend → HTTP 500 ("Internal Server Error")
- **Fix:** Check if `EventViewModel.Id != Guid.Empty` and call `UpdateEventAsync` instead of `AddEventAsync`

## Root cause
`SetCurrentStep(Forward)` at step index 2 (Review/Summary) always calls `SaveEvent()`. After the first save, the event ID is no longer `Guid.Empty`, so the backend's `KeyedManager.AddAsync()` tries to INSERT with the existing ID rather than generating a new one.

## Test plan
- [ ] Create a new event, go through to save step, save successfully
- [ ] Tap "Previous" to go back, then "Next" to go forward again — should succeed (update, not duplicate)
- [ ] Verify the event is not duplicated in the events list
- [ ] Verify on both iOS and Android

Fixes #2816

🤖 Generated with [Claude Code](https://claude.com/claude-code)