### PR TITLE
Fix Fastlane API key: raw PEM not base64

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ platform :ios do
         key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
         issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
         key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
-        is_key_content_base64: true,
+        is_key_content_base64: false,
         in_house: false
       )
     end


### PR DESCRIPTION
## Summary
- Change `is_key_content_base64` from `true` to `false` in Fastfile
- The `APPSTORE_PRIVATE_KEY` secret stores raw .p8 PEM content (confirmed by `publish-ios.yml` which writes it directly to a file for `xcrun altool`)
- Setting it to `true` caused "string contains null byte" error when Fastlane tried to base64-decode the raw PEM

## Test plan
- [ ] Re-run "iOS - Upload Screenshots" workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)