### PR TITLE
Fix iPad map rendering with responsive heights

### DIFF
--- a/TrashMobMobile/Pages/ExplorePage.xaml
+++ b/TrashMobMobile/Pages/ExplorePage.xaml
@@ -100,7 +100,9 @@
         <controls:CustomMap Grid.Row="4"
                             x:Name="exploreMap"
                             ItemsSource="{Binding Addresses}"
-                            IsVisible="{Binding IsMapSelected}">
+                            IsVisible="{Binding IsMapSelected}"
+                            HeightRequest="-1"
+                            VerticalOptions="Fill">
             <maps:Map.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:AddressViewModel">
                     <controls:CustomPin Location="{Binding Location}"

--- a/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
+++ b/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
@@ -23,7 +23,9 @@
         <Grid Grid.Row="1">
             <controls:CustomMap x:Name="userLocationMap"
                       ItemsSource="{Binding Addresses}"
-                      MapClicked="OnMapClicked">
+                      MapClicked="OnMapClicked"
+                      HeightRequest="-1"
+                      VerticalOptions="Fill">
                 <maps:Map.ItemTemplate>
                     <DataTemplate x:DataType="viewModels:AddressViewModel">
                         <controls:CustomPin Location="{Binding Location}"

--- a/TrashMobMobile/Resources/Styles/Styles.xaml
+++ b/TrashMobMobile/Resources/Styles/Styles.xaml
@@ -423,7 +423,7 @@
     <Style TargetType="controls:CustomMap">
         <Setter Property="IsShowingUser" Value="True" />
         <Setter Property="Margin" Value="10" />
-        <Setter Property="HeightRequest" Value="300" />
+        <Setter Property="HeightRequest" Value="{OnIdiom Phone=300, Tablet=500, Default=300}" />
         <Setter Property="IsScrollEnabled" Value="True" />
     </Style>
 


### PR DESCRIPTION
## Summary
- Maps rendered as thin horizontal strips on iPad because the global `CustomMap` style used a fixed `HeightRequest="300"` which is too small relative to the iPad screen
- Changed global style to use `OnIdiom` (`Phone=300, Tablet=500`) for proportional map sizing across device types
- For `SetUserLocationPreferencePage` and `ExplorePage` where maps are in star-sized Grid rows, override `HeightRequest` to `-1` with `VerticalOptions="Fill"` so the map expands to fill available space instead of being constrained to the style's fixed height

## Test plan
- [ ] Verify maps on iPad simulator render at ~500px height in scrollable pages (MainPage, CreatePickupLocation, ViewLitterReport, ViewPickupLocation, ViewEventSummary)
- [ ] Verify SetUserLocationPreferencePage map fills the screen between the header and form on iPad
- [ ] Verify ExplorePage map fills available space on iPad
- [ ] Verify maps on iPhone still render at 300px height (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)