### PR TITLE
Update screenshot script to use fastlane directories

### DIFF
--- a/Planning/StoreAssets/Screenshots/screenshot.sh
+++ b/Planning/StoreAssets/Screenshots/screenshot.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 # Usage: ./screenshot.sh <device> <name>
 #   device: iphone | ipad | both
-#   name:   screenshot name (e.g. 01_home, 02_map, 03_events)
+#   name:   screenshot name (e.g. 01_welcome, 02_home)
+#
+# Screenshots are saved to fastlane/screenshots/en-US/ with device-prefixed
+# names matching the convention expected by frameit and deliver:
+#   iPhone_6.9_01_welcome.png, iPad_13_01_welcome.png
+#
+# Names should match the Framefile.json filter values (e.g. 01_welcome, 02_home).
 #
 # Examples:
-#   ./screenshot.sh iphone 01_home
-#   ./screenshot.sh ipad 02_map
-#   ./screenshot.sh both 03_events
+#   ./screenshot.sh iphone 01_welcome
+#   ./screenshot.sh ipad 02_home
+#   ./screenshot.sh both 03_explore
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-IPHONE_DIR="$SCRIPT_DIR/iPhone_6.9"
-IPAD_DIR="$SCRIPT_DIR/iPad_13"
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCREENSHOTS_DIR="$REPO_ROOT/fastlane/screenshots/en-US"
 
 IPHONE_UUID="6C786817-7318-4B18-97F7-043FD62B40EB"
 IPAD_UUID="27EF59B9-8930-4DD7-98BB-C323A65716C8"
@@ -18,18 +23,22 @@ IPAD_UUID="27EF59B9-8930-4DD7-98BB-C323A65716C8"
 if [ -z "$1" ] || [ -z "$2" ]; then
     echo "Usage: ./screenshot.sh <device> <name>"
     echo "  device: iphone | ipad | both"
-    echo "  name:   screenshot name (e.g. 01_home, 02_map)"
+    echo "  name:   screenshot name (e.g. 01_welcome, 02_home)"
+    echo ""
+    echo "Screenshots are saved to fastlane/screenshots/en-US/"
     exit 1
 fi
 
 DEVICE="$1"
 NAME="$2"
 
+mkdir -p "$SCREENSHOTS_DIR"
+
 take_screenshot() {
     local uuid="$1"
-    local dir="$2"
+    local device_prefix="$2"
     local device_name="$3"
-    local file="$dir/${NAME}.png"
+    local file="$SCREENSHOTS_DIR/${device_prefix}_${NAME}.png"
 
     if xcrun simctl io "$uuid" screenshot "$file" 2>/dev/null; then
         echo "Saved $device_name screenshot: $file"
@@ -40,14 +49,14 @@ take_screenshot() {
 
 case "$DEVICE" in
     iphone)
-        take_screenshot "$IPHONE_UUID" "$IPHONE_DIR" "iPhone 17 Pro Max"
+        take_screenshot "$IPHONE_UUID" "iPhone_6.9" "iPhone 17 Pro Max"
         ;;
     ipad)
-        take_screenshot "$IPAD_UUID" "$IPAD_DIR" "iPad Pro 13\""
+        take_screenshot "$IPAD_UUID" "iPad_13" "iPad Pro 13\""
         ;;
     both)
-        take_screenshot "$IPHONE_UUID" "$IPHONE_DIR" "iPhone 17 Pro Max"
-        take_screenshot "$IPAD_UUID" "$IPAD_DIR" "iPad Pro 13\""
+        take_screenshot "$IPHONE_UUID" "iPhone_6.9" "iPhone 17 Pro Max"
+        take_screenshot "$IPAD_UUID" "iPad_13" "iPad Pro 13\""
         ;;
     *)
         echo "Unknown device: $DEVICE (use iphone, ipad, or both)"


### PR DESCRIPTION
## Summary
- Updated `Planning/StoreAssets/Screenshots/screenshot.sh` to save screenshots directly to `fastlane/screenshots/en-US/` instead of the old `Planning/StoreAssets/Screenshots/{device}/` folders
- Files are named with device prefix matching the fastlane convention: `iPhone_6.9_01_welcome.png`, `iPad_13_01_welcome.png`
- Names match the `Framefile.json` filter values so `frameit` can apply device frames correctly
- The `prepare_screenshots` lane in the Fastfile still works for backwards compatibility with the old source folder

## Test plan
- [ ] Run `./screenshot.sh both 01_welcome` and verify files appear in `fastlane/screenshots/en-US/`
- [ ] Verify filenames match `iPhone_6.9_01_welcome.png` / `iPad_13_01_welcome.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)