### PR TITLE
Add force-update version check for mobile app

### DIFF
--- a/TrashMob.Models/Poco/AppVersionInfo.cs
+++ b/TrashMob.Models/Poco/AppVersionInfo.cs
@@ -1,0 +1,19 @@
+namespace TrashMob.Models.Poco;
+
+/// <summary>
+/// Represents app version requirements returned by the server.
+/// </summary>
+public class AppVersionInfo
+{
+    /// <summary>
+    /// Gets or sets the minimum required app version.
+    /// Users below this version are blocked from using the app.
+    /// </summary>
+    public string MinimumVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the recommended app version.
+    /// Users below this version see a dismissible update prompt.
+    /// </summary>
+    public string RecommendedVersion { get; set; } = string.Empty;
+}

--- a/TrashMob/Controllers/AppVersionController.cs
+++ b/TrashMob/Controllers/AppVersionController.cs
@@ -1,0 +1,37 @@
+namespace TrashMob.Controllers
+{
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using TrashMob.Models.Poco;
+
+    /// <summary>
+    /// Controller for retrieving minimum and recommended app version requirements.
+    /// </summary>
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/appversion")]
+    public class AppVersionController(IConfiguration configuration) : BaseController
+    {
+        /// <summary>
+        /// Gets the minimum and recommended app version requirements.
+        /// </summary>
+        /// <remarks>
+        /// Returns version strings used by the mobile app to determine
+        /// whether a forced update or soft nudge is needed.
+        /// No authentication required.
+        /// </remarks>
+        [HttpGet]
+        [ProducesResponseType(typeof(AppVersionInfo), StatusCodes.Status200OK)]
+        public IActionResult GetAppVersion()
+        {
+            var appVersionInfo = new AppVersionInfo
+            {
+                MinimumVersion = configuration["AppVersion:MinimumVersion"] ?? "1.0.0",
+                RecommendedVersion = configuration["AppVersion:RecommendedVersion"] ?? "1.0.0",
+            };
+
+            return Ok(appVersionInfo);
+        }
+    }
+}

--- a/TrashMob/appsettings.Development.json
+++ b/TrashMob/appsettings.Development.json
@@ -32,5 +32,9 @@
   },
   "VaultUri": "https://kv-tm-dev-westus2.vault.azure.net",
   "StorageAccountUri": "https://stortmdevwestus2.blob.core.windows.net",
-  "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb"
+  "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb",
+  "AppVersion": {
+    "MinimumVersion": "1.0.0",
+    "RecommendedVersion": "1.0.2"
+  }
 }

--- a/TrashMob/appsettings.json
+++ b/TrashMob/appsettings.json
@@ -21,5 +21,9 @@
     "Domain": "",
     "TenantId": ""
   },
-  "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb"
+  "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb",
+  "AppVersion": {
+    "MinimumVersion": "1.0.0",
+    "RecommendedVersion": "1.0.2"
+  }
 }

--- a/TrashMobMobile/Controls/UpdateRequiredPopup.xaml
+++ b/TrashMobMobile/Controls/UpdateRequiredPopup.xaml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.UpdateRequiredPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="280">
+        <VerticalStackLayout Spacing="16">
+
+            <Label x:Name="titleLabel"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Label x:Name="messageLabel"
+                   FontSize="14"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <Button Text="Update Now"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnUpdateNowClicked" />
+
+            <Button x:Name="laterButton"
+                    Text="Later"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnLaterClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/UpdateRequiredPopup.xaml.cs
+++ b/TrashMobMobile/Controls/UpdateRequiredPopup.xaml.cs
@@ -1,0 +1,36 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Extensions;
+
+public partial class UpdateRequiredPopup : ContentView
+{
+    public const string UpdateNow = "UpdateNow";
+
+    public UpdateRequiredPopup(bool isHardBlock)
+    {
+        InitializeComponent();
+
+        if (isHardBlock)
+        {
+            titleLabel.Text = "Update Required";
+            messageLabel.Text = "A critical update is available. Please update the app to continue.";
+            laterButton.IsVisible = false;
+        }
+        else
+        {
+            titleLabel.Text = "Update Available";
+            messageLabel.Text = "A new version of TrashMob is available with improvements and new features.";
+            laterButton.IsVisible = true;
+        }
+    }
+
+    private async void OnUpdateNowClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync(UpdateNow);
+    }
+
+    private async void OnLaterClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+}

--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -46,6 +46,8 @@
             services.AddSingleton<IPickupLocationManager, PickupLocationManager>();
             services.AddSingleton<IPickupLocationRestService, PickupLocationRestService>();
             services.AddSingleton<IServiceTypeRestService, ServiceTypeRestService>();
+            services.AddSingleton<IAppVersionRestService, AppVersionRestService>();
+            services.AddSingleton<IAppVersionCheckService, AppVersionCheckService>();
             services.AddSingleton<IStatsRestService, StatsRestService>();
             services.AddSingleton<ITeamManager, TeamManager>();
             services.AddSingleton<ITeamRestService, TeamRestService>();

--- a/TrashMobMobile/Pages/WelcomePage.xaml.cs
+++ b/TrashMobMobile/Pages/WelcomePage.xaml.cs
@@ -1,13 +1,19 @@
 namespace TrashMobMobile.Pages;
 
+using CommunityToolkit.Maui.Extensions;
+using TrashMobMobile.Controls;
+using TrashMobMobile.Services;
+
 public partial class WelcomePage : ContentPage
 {
     private readonly WelcomeViewModel viewModel;
+    private readonly IAppVersionCheckService appVersionCheckService;
 
-    public WelcomePage(WelcomeViewModel viewModel)
+    public WelcomePage(WelcomeViewModel viewModel, IAppVersionCheckService appVersionCheckService)
     {
         InitializeComponent();
         this.viewModel = viewModel;
+        this.appVersionCheckService = appVersionCheckService;
         this.viewModel.Navigation = Navigation;
         BindingContext = this.viewModel;
     }
@@ -15,6 +21,60 @@ public partial class WelcomePage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
+        await CheckAppVersionAsync();
         await viewModel.Init();
+    }
+
+    private async Task CheckAppVersionAsync()
+    {
+        try
+        {
+            var result = await appVersionCheckService.CheckVersionAsync();
+
+            if (result == VersionCheckResult.HardBlock)
+            {
+                while (true)
+                {
+                    var popup = new UpdateRequiredPopup(isHardBlock: true);
+                    var popupResult = await this.ShowPopupAsync<string>(popup);
+
+                    await OpenStoreAsync();
+                }
+            }
+            else if (result == VersionCheckResult.SoftNudge)
+            {
+                var popup = new UpdateRequiredPopup(isHardBlock: false);
+                var popupResult = await this.ShowPopupAsync<string>(popup);
+
+                if (popupResult?.Result == UpdateRequiredPopup.UpdateNow)
+                {
+                    await OpenStoreAsync();
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // If anything goes wrong with the version check, allow app to continue
+        }
+    }
+
+    private static async Task OpenStoreAsync()
+    {
+        string storeUrl;
+
+        if (DeviceInfo.Platform == DevicePlatform.Android)
+        {
+            storeUrl = "https://play.google.com/store/apps/details?id=eco.trashmob.trashmobmobileapp";
+        }
+        else if (DeviceInfo.Platform == DevicePlatform.iOS)
+        {
+            storeUrl = "https://apps.apple.com/us/app/trashmob/id1599996743";
+        }
+        else
+        {
+            storeUrl = "https://www.trashmob.eco";
+        }
+
+        await Launcher.OpenAsync(new Uri(storeUrl));
     }
 }

--- a/TrashMobMobile/Services/AppVersionCheckService.cs
+++ b/TrashMobMobile/Services/AppVersionCheckService.cs
@@ -1,0 +1,49 @@
+namespace TrashMobMobile.Services;
+
+public class AppVersionCheckService(IAppVersionRestService appVersionRestService) : IAppVersionCheckService
+{
+    private bool hasChecked;
+
+    public async Task<VersionCheckResult> CheckVersionAsync(CancellationToken cancellationToken = default)
+    {
+        if (hasChecked)
+        {
+            return VersionCheckResult.Skipped;
+        }
+
+        hasChecked = true;
+
+        var versionInfo = await appVersionRestService.GetAppVersionAsync(cancellationToken);
+
+        if (versionInfo is null)
+        {
+            return VersionCheckResult.Skipped;
+        }
+
+        var currentVersion = ParseVersion(AppInfo.Current.VersionString);
+        var minimumVersion = ParseVersion(versionInfo.MinimumVersion);
+        var recommendedVersion = ParseVersion(versionInfo.RecommendedVersion);
+
+        if (currentVersion < minimumVersion)
+        {
+            return VersionCheckResult.HardBlock;
+        }
+
+        if (currentVersion < recommendedVersion)
+        {
+            return VersionCheckResult.SoftNudge;
+        }
+
+        return VersionCheckResult.UpToDate;
+    }
+
+    private static Version ParseVersion(string versionString)
+    {
+        if (Version.TryParse(versionString, out var version))
+        {
+            return version;
+        }
+
+        return new Version(0, 0, 0);
+    }
+}

--- a/TrashMobMobile/Services/AppVersionRestService.cs
+++ b/TrashMobMobile/Services/AppVersionRestService.cs
@@ -1,0 +1,26 @@
+namespace TrashMobMobile.Services;
+
+using Newtonsoft.Json;
+using TrashMob.Models.Poco;
+
+public class AppVersionRestService(IHttpClientFactory httpClientFactory)
+    : RestServiceBase(httpClientFactory), IAppVersionRestService
+{
+    protected override string Controller => "appversion";
+
+    public async Task<AppVersionInfo?> GetAppVersionAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await AnonymousHttpClient.GetAsync(Controller, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<AppVersionInfo>(responseString);
+        }
+        catch (Exception)
+        {
+            // Graceful failure: if version check fails, allow app to continue
+            return null;
+        }
+    }
+}

--- a/TrashMobMobile/Services/IAppVersionCheckService.cs
+++ b/TrashMobMobile/Services/IAppVersionCheckService.cs
@@ -1,0 +1,14 @@
+namespace TrashMobMobile.Services;
+
+public enum VersionCheckResult
+{
+    UpToDate,
+    SoftNudge,
+    HardBlock,
+    Skipped,
+}
+
+public interface IAppVersionCheckService
+{
+    Task<VersionCheckResult> CheckVersionAsync(CancellationToken cancellationToken = default);
+}

--- a/TrashMobMobile/Services/IAppVersionRestService.cs
+++ b/TrashMobMobile/Services/IAppVersionRestService.cs
@@ -1,0 +1,8 @@
+namespace TrashMobMobile.Services;
+
+using TrashMob.Models.Poco;
+
+public interface IAppVersionRestService
+{
+    Task<AppVersionInfo?> GetAppVersionAsync(CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary
- Adds **API endpoint** `GET /api/appversion` (public, no auth) returning minimum and recommended version from `appsettings.json` / Key Vault
- Mobile app **checks version on launch** (WelcomePage `OnAppearing`, before user interaction)
- **Hard block** if current version < minimum: non-dismissible popup with only "Update Now" button, loops until app is updated
- **Soft nudge** if current version < recommended: dismissible popup with "Update Now" + "Later"
- **Graceful failure**: if API unreachable (no network, server down), app continues normally
- Check runs **once per app launch** (singleton service with `hasChecked` flag)
- Version comparison uses `System.Version` for proper semantic version ordering
- "Update Now" opens the correct store (Google Play / Apple App Store) via platform detection

Part of **Project 4 — Mobile Robustness** (resolves Open Question #7).

To update versions in production without redeploying, set Key Vault secrets:
- `AppVersion--MinimumVersion` (e.g. `1.1.0`)
- `AppVersion--RecommendedVersion` (e.g. `1.2.0`)

## Test plan
- [ ] Backend: `GET /api/appversion` returns correct JSON with `minimumVersion` and `recommendedVersion`
- [ ] Set `MinimumVersion` to `99.0.0` in dev config — hard block popup appears, only "Update Now" button visible
- [ ] Set `RecommendedVersion` to `99.0.0`, `MinimumVersion` to `1.0.0` — soft nudge popup appears, "Later" dismisses
- [ ] Kill backend before app launch — app starts normally (graceful failure)
- [ ] Navigate away and back to WelcomePage — no second popup (once-per-launch guard)
- [ ] "Update Now" opens Google Play on Android / App Store on iOS
- [ ] `dotnet build` succeeds for both backend and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)