### PR TITLE
Fix mobile route tracking and emulator experience

### DIFF
--- a/TrashMobMobile/Services/AppVersionCheckService.cs
+++ b/TrashMobMobile/Services/AppVersionCheckService.cs
@@ -13,6 +13,13 @@ public class AppVersionCheckService(IAppVersionRestService appVersionRestService
 
         hasChecked = true;
 
+        // Skip version check on emulators — store links don't work and
+        // the dev build version will always mismatch.
+        if (DeviceInfo.DeviceType == DeviceType.Virtual)
+        {
+            return VersionCheckResult.Skipped;
+        }
+
         var versionInfo = await appVersionRestService.GetAppVersionAsync(cancellationToken);
 
         if (versionInfo is null)

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -187,7 +187,7 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             EnableEditEvent = mobEvent.IsEventLead(userManager.CurrentUser.Id) && !mobEvent.IsCompleted();
             EnableViewEventSummary = mobEvent.IsCompleted();
 
-            EnableStartTrackEventRoute = mobEvent.IsEventLead(userManager.CurrentUser.Id) && !mobEvent.IsCompleted();
+            EnableStartTrackEventRoute = !mobEvent.IsCompleted();
             EnableStopTrackEventRoute = false;
 
             WhatToExpect =

--- a/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabRoutes.xaml
@@ -17,6 +17,16 @@
                     <Ellipse WidthRequest="10" HeightRequest="10" Fill="Red" VerticalOptions="Center" />
                     <Label Text="Recording" FontSize="Micro" TextColor="Red" VerticalOptions="Center" />
                 </HorizontalStackLayout>
+                <Button Text="Start Route"
+                        Command="{Binding RealTimeLocationTrackerCommand}"
+                        IsVisible="{Binding EnableStartTrackEventRoute}"
+                        Style="{StaticResource PrimarySmallButton}" />
+                <Button Text="Stop Route"
+                        Command="{Binding RealTimeLocationTrackerCancelCommand}"
+                        IsVisible="{Binding EnableStopTrackEventRoute}"
+                        BackgroundColor="{StaticResource Destructive}"
+                        TextColor="White"
+                        Style="{StaticResource PrimarySmallButton}" />
                 <Button Text="Simulate Route"
                         Command="{Binding SimulateRouteCommand}"
                         IsVisible="{Binding EnableSimulateRoute}"


### PR DESCRIPTION
## Summary
- **Skip version check on emulators** — store links don't work on virtual devices and dev build versions always mismatch, causing unnecessary blocks
- **Add Start/Stop Route buttons** to the event Routes tab — the ViewModel had `RealTimeLocationTrackerCommand` wired up but the UI buttons were never added
- **Allow all users to track routes** — previously restricted to event leads only; now any user can record their cleanup route on non-completed events

## Test plan
- [ ] Open event details on Android emulator — verify no version check popup
- [ ] On Routes tab, verify "Start Route" button is visible for non-completed events
- [ ] Tap "Start Route" — verify recording indicator appears and "Stop Route" button shows
- [ ] Tap "Stop Route" — verify route is saved and appears in the route list
- [ ] Verify "Simulate Route" button still appears only on emulators

🤖 Generated with [Claude Code](https://claude.com/claude-code)