### PR TITLE
Trim remaining doc duplication across README and CLAUDE.md files

### DIFF
--- a/Deploy/README.md
+++ b/Deploy/README.md
@@ -1,32 +1,26 @@
-# Deploying the infrastructure
+# Deploy
 
-## Prerequisites
-1. Install PowerShell
-1. Install the latest version of Azure CLI
-1. Download the TrashMob repo from GitHub
+Infrastructure-as-code (Bicep templates), deployment scripts, and operational documentation for TrashMob.
 
-## To deploy the Infrastructure needed to run TrashMob locally on your box, you will need to run the following steps:
-1. Open a Powershell window and go to the $GitRoot\Deploy folder
-1. Execute the following commands to log in and set your session to the correct subscription:
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [OPERATIONS_RUNBOOK.md](./OPERATIONS_RUNBOOK.md) | Infrastructure ops: rollback, backups, DNS, Key Vault, SSL, Strapi |
+| [CONTAINER_DEPLOYMENT_GUIDE.md](./CONTAINER_DEPLOYMENT_GUIDE.md) | Docker builds, Azure Container Apps deployment |
+| [CUSTOM_DOMAIN_MIGRATION.md](./CUSTOM_DOMAIN_MIGRATION.md) | Custom domain and SSL certificate setup |
+| [OIDC_SETUP_GUIDE.md](./OIDC_SETUP_GUIDE.md) | GitHub Actions OIDC federation for deployments |
+| [COST_ALERT_RUNBOOK.md](./COST_ALERT_RUNBOOK.md) | Azure cost alerts and budget monitoring |
+
+## Quick Start
+
+```powershell
+# Log in and set subscription
+az login
+az account set --subscription <subscriptionName>
+
+# Deploy infrastructure for a new environment
+.\deployInfra.ps1 -environment <env> -region <regionName> -subscriptionId <subscriptionId>
 ```
-    az login
-    az account set --subscription <subscriptionName>
-```
-  az login will ask you to log in with your Azure Credentials
-  If you have more than one subscription tied to your Azure account, you will need to specify it in the second line
-  
-1. Execute the following command to deploy the Infrastructure needed
-```
 
-.\deployInfra.ps1 -environment <env> -region <regionName> -subscriptionId <subscriptionId> -sqlAdminPassword <password> -alwaysOn $False
-
-i.e.
-
-.\deployInfra.ps1 -environment jb -region westus2 -subscriptionId <your subscription Id> -sqlAdminPassword "TestP$$wrd1" -alwaysOn $False
-
-```
-where:
-  env is the same as set above (i.e. jb)
-  regionName is the Azure Region you wish to deploy to (i.e. uswest2)
-  subscriptionId is the current subscription id
-  password is the password value you want to set for your sql server that is being created. The password must meet Azure minimum password standards
+See [OPERATIONS_RUNBOOK.md](./OPERATIONS_RUNBOOK.md) for detailed procedures.

--- a/README.md
+++ b/README.md
@@ -40,19 +40,7 @@ For detailed development setup instructions, see [CLAUDE.md](./CLAUDE.md).
 
 ### Build & Run
 
-```bash
-# Backend API
-cd TrashMob
-dotnet run --environment Development
-
-# Frontend (separate terminal)
-cd TrashMob/client-app
-npm install
-npm start
-```
-
-Local API: https://localhost:44332
-Swagger: https://localhost:44332/swagger/index.html
+See [CLAUDE.md](./CLAUDE.md) for full build commands, local URLs, and development setup.
 
 ---
 
@@ -139,60 +127,18 @@ Before starting work on a new feature, please check:
 
 ## Development Environment Setup
 
-### Using Shared Dev Environment
+See [CLAUDE.md](./CLAUDE.md) for full development setup, troubleshooting, and local URLs.
 
-If you're not making database changes, you can use the shared dev environment:
-
-1. Email [info@trashmob.eco](mailto:info@trashmob.eco) to request contributor access
-2. TrashMob will add you to the Sandbox subscription and Dev KeyVault
-3. Add your IP to the [Dev Azure SQL firewall](https://portal.azure.com/#@jobeedevids.onmicrosoft.com/resource/subscriptions/39a254b7-c01a-45ab-bebd-4038ea4adea9/resourceGroups/rg-trashmob-dev-westus2/providers/Microsoft.Sql/servers/sql-tm-dev-westus2/overview)
-4. Run setup script:
+**Quick start:** Email [info@trashmob.eco](mailto:info@trashmob.eco) to request contributor access, then:
 
 ```powershell
 az login
-.\setupdev.ps1 -environment dev -region westus2 -subscription 39a254b7-c01a-45ab-bebd-4038ea4adea9
+.\setupdev.ps1 -environment dev -region westus2 -subscription <guid>
 ```
-
-### Creating Your Own Environment
-
-For major database changes, create your own environment:
-
-1. Follow [Deploy/README.md](./Deploy/README.md)
-2. Run setup with your parameters:
-
-```powershell
-.\setupdev.ps1 -environment <yourenv> -region <yourregion> -subscription <yourguid>
-```
-
-### Troubleshooting
-
-**Data doesn't load:** Your IP may have changed. Check the VS Code debug output for your actual IP and update the Azure SQL firewall rule.
-
-**Email not sending:** Set a dummy key to disable email:
-```bash
-dotnet user-secrets set "sendGridApiKey" "x"
-```
-
----
 
 ## Mobile App Development
 
-See [TrashMobMobile/readme.md](./TrashMobMobile/readme.md) for detailed mobile setup.
-
-### Quick Setup (Windows)
-
-1. Install Visual Studio with .NET MAUI workload
-2. Install [Android Studio](https://developer.android.com/studio) and create an emulator
-3. Open `TrashMobMobileApp.sln`
-4. Get Google Maps API key from Dev KeyVault or create your own
-5. Update `Platforms/Android/AndroidManifest.xml` with your key
-
-⚠️ **Never commit API keys to the repository!**
-
-### Test Builds
-
-- **Android:** Request internal tester access at [info@trashmob.eco](mailto:info@trashmob.eco)
-- **iOS:** Request TestFlight access at [info@trashmob.eco](mailto:info@trashmob.eco)
+See [TrashMobMobile/readme.md](./TrashMobMobile/readme.md) for mobile setup, test builds, and store links.
 
 ---
 

--- a/TrashMob/CLAUDE.md
+++ b/TrashMob/CLAUDE.md
@@ -39,50 +39,9 @@ TrashMob/
 - `SecureController : BaseController` — Adds `UserId`, `AuthorizationService`, `IsAuthorizedAsync()`
 - `KeyedController<T> : SecureController` — Generic CRUD for entities with GUID keys (provides `Manager` property)
 
-### Standard REST Controller Template
-
-```csharp
-// Use primary constructors — this is the current standard pattern
-public class ThingsController(
-    IThingManager thingManager,
-    IOtherManager otherManager)
-    : KeyedController<Thing>(thingManager)
-{
-    /// <summary>
-    /// Gets a thing by ID.
-    /// </summary>
-    [HttpGet("{id}")]
-    [ProducesResponseType(typeof(Thing), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
-    {
-        return Ok(await Manager.GetAsync(id, cancellationToken));
-    }
-
-    /// <summary>
-    /// Creates a new thing.
-    /// </summary>
-    [HttpPost]
-    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
-    [RequiredScope(Constants.TrashMobWriteScope)]
-    [ProducesResponseType(typeof(Thing), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Add(Thing instance, CancellationToken cancellationToken)
-    {
-        // Authorization check (if entity-level access control needed)
-        var parent = await otherManager.GetAsync(instance.ParentId, cancellationToken);
-        if (!await IsAuthorizedAsync(parent, AuthorizationPolicyConstants.UserIsEventLead))
-        {
-            return Forbid();
-        }
-
-        var result = await Manager.AddAsync(instance, UserId, cancellationToken);
-        TrackEvent("AddThing");
-        return Ok(result);
-    }
-}
-```
-
 ### Controller Checklist (New Endpoints)
+
+See [root CLAUDE.md](../CLAUDE.md#controller-template-current-pattern) for the standard controller template.
 
 - [ ] Use **primary constructor** (not field injection)
 - [ ] Add **`CancellationToken cancellationToken`** as last parameter on all async methods


### PR DESCRIPTION
## Summary
Follow-up to #2860. Removes remaining duplication across documentation files:

- **Deploy/README.md:** Replaced outdated `deployInfra.ps1` instructions with a navigation hub linking to all 5 Deploy guides (OPERATIONS_RUNBOOK, CONTAINER_DEPLOYMENT_GUIDE, CUSTOM_DOMAIN_MIGRATION, OIDC_SETUP_GUIDE, COST_ALERT_RUNBOOK)
- **README.md:** Removed build commands and dev setup instructions duplicated from CLAUDE.md; replaced with pointers (-54 lines, 23% reduction)
- **TrashMob/CLAUDE.md:** Removed controller template duplicated from root CLAUDE.md; references root instead (-41 lines, 12% reduction)

Net: -101 lines, no information lost.

## Test plan
- [ ] Verify Deploy/README.md links resolve to correct files
- [ ] Verify README.md still reads well as the repo landing page
- [ ] Verify TrashMob/CLAUDE.md controller checklist still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)