### PR TITLE
Upload native debug symbols and R8 mapping with Android builds

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -123,6 +123,48 @@ jobs:
           run: |
             dotnet publish TrashMobMobile/TrashMobMobile.csproj -c:${{ inputs.configuration }} -f:net10.0-android --no-restore /p:AndroidPackageFormat="aab"
 
+        - name: Collect native debug symbols
+          shell: pwsh
+          run: |
+            $objDir = "TrashMobMobile\obj\${{ inputs.configuration }}\net10.0-android"
+            $symbolsRoot = "TrashMobMobile\native-debug-symbols"
+            $found = $false
+
+            # Look for native .so files in intermediate android lib directories
+            $androidLibDir = Join-Path $objDir "android\lib"
+            if (Test-Path $androidLibDir) {
+              Get-ChildItem -Path $androidLibDir -Directory | ForEach-Object {
+                $abi = $_.Name
+                $soFiles = Get-ChildItem -Path $_.FullName -Filter "*.so" -ErrorAction SilentlyContinue
+                if ($soFiles) {
+                  $destDir = Join-Path $symbolsRoot "lib\$abi"
+                  New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+                  $soFiles | Copy-Item -Destination $destDir
+                  $found = $true
+                  Write-Host "Found $($soFiles.Count) .so files for ABI: $abi"
+                }
+              }
+            }
+
+            if ($found) {
+              Compress-Archive -Path (Join-Path $symbolsRoot "lib") -DestinationPath "TrashMobMobile\native-debug-symbols.zip" -Force
+              Write-Host "::notice::Native debug symbols zip created successfully"
+            } else {
+              Write-Host "::warning::No native debug symbols found in intermediate output at $androidLibDir"
+            }
+
+        - name: Collect R8 mapping file
+          shell: pwsh
+          run: |
+            $objDir = "TrashMobMobile\obj\${{ inputs.configuration }}\net10.0-android"
+            $mapping = Get-ChildItem -Path $objDir -Recurse -Filter "mapping.txt" -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($mapping) {
+              Copy-Item $mapping.FullName "TrashMobMobile\mapping.txt"
+              Write-Host "::notice::R8 mapping file found at $($mapping.FullName)"
+            } else {
+              Write-Host "::notice::No R8 mapping file found (expected for .NET MAUI — Java code is not obfuscated)"
+            }
+
         # Store Android Signing Keystore and password in Secrets using base64 encoding
         # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/certutil
         # command line util to encode to base64 on windows
@@ -145,3 +187,5 @@ jobs:
             name: artifacts-android-${{ env.semVer }}
             path: |
               TrashMobMobile\bin\${{ inputs.configuration }}\net10.0-android\publish\*.aab
+              TrashMobMobile\native-debug-symbols.zip
+              TrashMobMobile\mapping.txt

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -33,6 +33,22 @@ jobs:
               with:
                     name: ${{ inputs.artifact_name }}
 
+            - name: Check for debug artifacts
+              id: debug_files
+              run: |
+                if [ -f "native-debug-symbols.zip" ]; then
+                  echo "debug_symbols=native-debug-symbols.zip" >> $GITHUB_OUTPUT
+                  echo "Found native debug symbols"
+                else
+                  echo "No native debug symbols found in artifact"
+                fi
+                if [ -f "mapping.txt" ]; then
+                  echo "mapping_file=mapping.txt" >> $GITHUB_OUTPUT
+                  echo "Found R8 mapping file"
+                else
+                  echo "No R8 mapping file found in artifact"
+                fi
+
             - name: Upload signed AAB
               uses: r0adkll/upload-google-play@v1
               with:
@@ -42,6 +58,8 @@ jobs:
                     track: internal
                     status: completed
                     changesNotSentForReview: false
+                    debugSymbols: ${{ steps.debug_files.outputs.debug_symbols }}
+                    mappingFile: ${{ steps.debug_files.outputs.mapping_file }}
 
             - name: Promote to production (staged rollout)
               if: inputs.promote_to_production


### PR DESCRIPTION
## Summary
- **build-android.yml**: After `dotnet publish`, collect native `.so` files from the intermediate `obj/` output directory and zip them into `native-debug-symbols.zip`. Also search for R8 `mapping.txt` if present. Both files are included in the build artifact.
- **publish-android.yml**: Check for debug artifacts in the downloaded bundle and pass `debugSymbols` and `mappingFile` to the `r0adkll/upload-google-play` action when available.

Both steps are gracefully optional — if no symbols or mapping file are found (e.g., R8 mapping is not expected for .NET MAUI), the build succeeds normally and the upload proceeds without them.

Closes #2836
Closes #2837

## Test plan
- [ ] Trigger an Android build and verify the "Collect native debug symbols" step finds `.so` files in the intermediate output
- [ ] Verify the symbols zip and/or mapping file appear in the uploaded artifact
- [ ] On next Google Play upload, confirm the debug symbols warning is resolved in Play Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)