### PR TITLE
E6: Custom auth domains (auth.trashmob.eco)

### DIFF
--- a/Deploy/CONTAINER_DEPLOYMENT_GUIDE.md
+++ b/Deploy/CONTAINER_DEPLOYMENT_GUIDE.md
@@ -222,7 +222,7 @@ Both containers use these environment variables:
 - `InstanceName=as-tm-<env>-<region>` (Jobs only)
 
 Azure AD Entra External ID configuration (public values, set based on environment parameter in Bicep):
-- `AzureAdEntra__Instance` - Entra login endpoint (e.g., https://trashmobecodev.ciamlogin.com/)
+- `AzureAdEntra__Instance` - Entra login endpoint (e.g., https://auth-dev.trashmob.eco/)
 - `AzureAdEntra__ClientId` - Backend API client ID for JWT validation
 - `AzureAdEntra__FrontendClientId` - Frontend SPA client ID for MSAL
 - `AzureAdEntra__Domain` - Entra tenant domain (e.g., TrashMobEcoDev.onmicrosoft.com)

--- a/Deploy/containerApp.bicep
+++ b/Deploy/containerApp.bicep
@@ -23,7 +23,7 @@ var appInsightsName = 'ai-tm-${environment}-${region}'
 
 // Azure AD Entra External ID configuration - these are public values, not secrets
 // Note: Microsoft accounts work natively in Entra External ID (no external IDP setup needed)
-var entraInstance = environment == 'dev' ? 'https://trashmobecodev.ciamlogin.com/' : 'https://trashmobecopr.ciamlogin.com/'
+var entraInstance = environment == 'dev' ? 'https://auth-dev.trashmob.eco/' : 'https://auth.trashmob.eco/'
 var entraDomain = environment == 'dev' ? 'TrashMobEcoDev.onmicrosoft.com' : 'trashmobecopr.onmicrosoft.com'
 var entraBackendClientId = environment == 'dev' ? '84df543d-6535-45f5-afab-4d38528b721a' : 'dc09e17b-bce4-4af9-82ab-f7b12af586b4'
 var entraTenantId = environment == 'dev' ? '8577fa31-4b86-4e4b-8b02-93fba708cb19' : 'b5fc8717-29eb-496e-8e09-cf90d344ce9f'

--- a/Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md
+++ b/Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md
@@ -1706,8 +1706,8 @@ Replace `trashmobecopr.ciamlogin.com` with a branded domain (e.g., `auth.trashmo
 - [ ] **197.** Configure custom URL domain in Entra portal: External Identities > Custom URL domains > Add `auth.trashmob.eco`
 - [ ] **198.** Update redirect URIs in all 3 app registrations (Web SPA, API, Mobile) to use `auth.trashmob.eco`
 - [ ] **199.** Update social IDP redirect URIs (Google, Facebook, Apple) to use `auth.trashmob.eco`
-- [ ] **200.** Update `Deploy/containerApp.bicep` `entraInstance` to `https://auth.trashmob.eco/`
-- [ ] **201.** Update mobile `AuthConstants.cs` with new auth domain
+- [x] **200.** Update `Deploy/containerApp.bicep` `entraInstance` to `https://auth.trashmob.eco/`
+- [x] **201.** Update mobile `AuthConstants.cs` with new auth domain
 - [ ] **202.** Test sign-in on web and mobile with the new domain
 
 ---

--- a/TrashMob/Controllers/ConfigController.cs
+++ b/TrashMob/Controllers/ConfigController.cs
@@ -46,7 +46,7 @@ namespace TrashMob.Controllers
 
             if (!string.IsNullOrWhiteSpace(entraInstance) && !string.IsNullOrWhiteSpace(entraTenantId))
             {
-                // Entra External ID authority: https://{tenant}.ciamlogin.com/{tenantId}
+                // Entra External ID authority: https://{customDomain}/{tenantId}
                 authority = $"{entraInstance}/{entraTenantId}";
 
                 if (entraInstance.StartsWith("https://"))

--- a/TrashMob/appsettings.Development.json
+++ b/TrashMob/appsettings.Development.json
@@ -16,7 +16,7 @@
   },
   "AllowedHosts": "*",
   "AzureAdEntra": {
-    "Instance": "https://trashmobecodev.ciamlogin.com/",
+    "Instance": "https://auth-dev.trashmob.eco/",
     "ClientId": "84df543d-6535-45f5-afab-4d38528b721a",
     "FrontendClientId": "1e6ae74d-0160-4a01-9d75-04048e03b17e",
     "Domain": "TrashMobEcoDev.onmicrosoft.com",

--- a/TrashMob/client-app/e2e/fixtures/auth.fixture.ts
+++ b/TrashMob/client-app/e2e/fixtures/auth.fixture.ts
@@ -91,7 +91,7 @@ export async function loginWithEntra(page: Page, email: string, password: string
     await page.getByRole('button', { name: /sign in/i }).click();
 
     // Wait for Entra External ID redirect and fill credentials
-    await page.waitForURL(/.*ciamlogin\.com.*/);
+    await page.waitForURL(/.*(?:ciamlogin\.com|auth(?:-dev)?\.trashmob\.eco).*/);
 
     // Fill email
     await page.fill('input[type="email"], input[name="signInName"], #email', email);

--- a/TrashMob/client-app/src/store/AuthStore.tsx
+++ b/TrashMob/client-app/src/store/AuthStore.tsx
@@ -5,8 +5,8 @@ import { getAppConfig, getCachedConfig, type EntraConfig } from '../services/con
 // Uses dev settings as fallback since they're safer for testing
 const fallbackEntraConfig: EntraConfig = {
     clientId: '1e6ae74d-0160-4a01-9d75-04048e03b17e',
-    authorityDomain: 'trashmobecodev.ciamlogin.com',
-    authority: 'https://trashmobecodev.ciamlogin.com/',
+    authorityDomain: 'auth-dev.trashmob.eco',
+    authority: 'https://auth-dev.trashmob.eco/',
     scopes: [
         'https://TrashMobEcoDev.onmicrosoft.com/api/TrashMob.Read',
         'https://TrashMobEcoDev.onmicrosoft.com/api/TrashMob.Writes',

--- a/TrashMobMobile/Authentication/AuthConstants.cs
+++ b/TrashMobMobile/Authentication/AuthConstants.cs
@@ -4,14 +4,14 @@ public static class AuthConstants
 {
 #if USETEST
     public const string ClientId = "33bfdd2c-80a4-4e6e-b211-337b0467226d";
-    private const string TenantName = "trashmobecodev";
     internal const string TenantDomain = "TrashMobEcoDev.onmicrosoft.com";
     public const string ApiBaseUri = "https://dev.trashmob.eco/api/";
+    public const string Authority = "https://auth-dev.trashmob.eco/";
 #else
     public const string ClientId = "9fce4b6e-9df5-4e41-a425-75535ba99fbe";
-    private const string TenantName = "trashmobecopr";
     internal const string TenantDomain = "trashmobecopr.onmicrosoft.com";
     public const string ApiBaseUri = "https://www.trashmob.eco/api/";
+    public const string Authority = "https://auth.trashmob.eco/";
 #endif
 
     public static readonly string[] Scopes =
@@ -22,8 +22,6 @@ public static class AuthConstants
         "openid",
         "offline_access",
     ];
-
-    public const string Authority = $"https://{TenantName}.ciamlogin.com/";
 
     public const string IosKeychainSecurityGroup = "com.microsoft.adalcache";
     public const string RedirectUri = "eco.trashmob.trashmobmobile://auth";


### PR DESCRIPTION
## Summary
Replaces Microsoft's `ciamlogin.com` URLs with branded custom auth domains so users see `auth.trashmob.eco` during sign-in instead of `trashmobecopr.ciamlogin.com`.

- **Production:** `auth.trashmob.eco` (was `trashmobecopr.ciamlogin.com`)
- **Development:** `auth-dev.trashmob.eco` (was `trashmobecodev.ciamlogin.com`)

### Changes
- `Deploy/containerApp.bicep` — Updated `entraInstance` variable for both environments
- `TrashMob/appsettings.Development.json` — Updated local dev `Instance`
- `TrashMobMobile/Authentication/AuthConstants.cs` — Removed `TenantName` constant, added explicit `Authority` per `#if` branch
- `TrashMob/client-app/src/store/AuthStore.tsx` — Updated fallback `authorityDomain` and `authority`
- `TrashMob/client-app/e2e/fixtures/auth.fixture.ts` — Updated redirect URL regex (supports both old and new domains)
- `TrashMob/Controllers/ConfigController.cs` — Updated comment
- `Deploy/CONTAINER_DEPLOYMENT_GUIDE.md` — Updated example URL
- `Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md` — Marked items 200-201 complete

### Prerequisites (before merging/deploying)
These manual steps must be completed first:
1. Add DNS CNAME records: `auth` → `trashmobecopr.ciamlogin.com`, `auth-dev` → `trashmobecodev.ciamlogin.com`
2. Configure custom URL domains in both Entra External ID portals
3. Update redirect URIs in all app registrations (Web SPA, API, Mobile)
4. Update social IDP redirect URIs (Google, Facebook, Apple)

## Test plan
- [x] Backend builds successfully (`dotnet build TrashMob/TrashMob.csproj`)
- [x] Mobile builds successfully (`dotnet build TrashMobMobile/TrashMobMobile.csproj -f net10.0-android`)
- [ ] After DNS/Entra setup: verify `/api/config` returns correct authority
- [ ] After DNS/Entra setup: test sign-in on web (dev.trashmob.eco)
- [ ] After DNS/Entra setup: test sign-in on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)