### PR TITLE
Add news blog data layer (Project 50 Phase 1)

### DIFF
--- a/Planning/Projects/Project_50_News_Blog.md
+++ b/Planning/Projects/Project_50_News_Blog.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | Not Started |
+| **Status** | In Progress |
 | **Priority** | Medium |
 | **Risk** | Low |
 | **Size** | Medium |
@@ -43,11 +43,11 @@ Strapi CMS is already deployed and managing home page content (hero, what-is-tra
 ## Scope
 
 ### Phase 1 — Strapi Content Type & API Proxy
-- ❌ Create `news-post` collection type in Strapi with fields: title, slug, excerpt, body (rich text), coverImage (media), author, category, tags, publishedAt, isFeatured
-- ❌ Create `news-category` collection type: name, slug, description
-- ❌ Seed initial categories: "Platform Update", "Community Spotlight", "Event Recap", "Tips & Guides"
-- ❌ Add CMS proxy endpoints to `CmsController`: list posts (paginated), get post by slug, list categories
-- ❌ Add TypeScript types and service factories in `services/cms.ts`
+- ✅ Create `news-post` collection type in Strapi with fields: title, slug, excerpt, body (rich text), coverImage (media), author, category, tags, publishedAt, isFeatured
+- ✅ Create `news-category` collection type: name, slug, description
+- ❌ Seed initial categories: "Platform Update", "Community Spotlight", "Event Recap", "Tips & Guides" *(manual — create via Strapi admin after deploy)*
+- ✅ Add CMS proxy endpoints to `CmsController`: list posts (paginated), get post by slug, list categories
+- ✅ Add TypeScript types and service factories in `services/cms.ts`
 
 ### Phase 2 — News Listing Page
 - ❌ Create `/news` page with responsive card grid layout
@@ -318,5 +318,5 @@ None in this project. Mobile news feed would be a separate future project.
 
 **Last Updated:** February 22, 2026
 **Owner:** Product & Engineering Team
-**Status:** Not Started
-**Next Review:** When ready to begin Phase 1
+**Status:** In Progress — Phase 1 complete (content types + API proxy)
+**Next Review:** When ready to begin Phase 2 (News Listing Page)

--- a/Strapi/src/api/news-category/content-types/news-category/index.ts
+++ b/Strapi/src/api/news-category/content-types/news-category/index.ts
@@ -1,0 +1,5 @@
+import schema from './schema.json';
+
+export default {
+  schema,
+};

--- a/Strapi/src/api/news-category/content-types/news-category/schema.json
+++ b/Strapi/src/api/news-category/content-types/news-category/schema.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "news_categories",
+  "info": {
+    "singularName": "news-category",
+    "pluralName": "news-categories",
+    "displayName": "News Category",
+    "description": "Categories for organizing news and blog posts"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true,
+      "maxLength": 100
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name",
+      "required": true
+    },
+    "description": {
+      "type": "text",
+      "maxLength": 255
+    }
+  }
+}

--- a/Strapi/src/api/news-category/controllers/news-category.ts
+++ b/Strapi/src/api/news-category/controllers/news-category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::news-category.news-category');

--- a/Strapi/src/api/news-category/routes/news-category.ts
+++ b/Strapi/src/api/news-category/routes/news-category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::news-category.news-category');

--- a/Strapi/src/api/news-category/services/news-category.ts
+++ b/Strapi/src/api/news-category/services/news-category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::news-category.news-category');

--- a/Strapi/src/api/news-post/content-types/news-post/index.ts
+++ b/Strapi/src/api/news-post/content-types/news-post/index.ts
@@ -1,0 +1,5 @@
+import schema from './schema.json';
+
+export default {
+  schema,
+};

--- a/Strapi/src/api/news-post/content-types/news-post/schema.json
+++ b/Strapi/src/api/news-post/content-types/news-post/schema.json
@@ -1,0 +1,62 @@
+{
+  "kind": "collectionType",
+  "collectionName": "news_posts",
+  "info": {
+    "singularName": "news-post",
+    "pluralName": "news-posts",
+    "displayName": "News Post",
+    "description": "Blog posts and news articles"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "excerpt": {
+      "type": "text",
+      "required": true,
+      "maxLength": 500
+    },
+    "body": {
+      "type": "blocks",
+      "required": true
+    },
+    "coverImage": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images"]
+    },
+    "author": {
+      "type": "string",
+      "required": true,
+      "default": "TrashMob Team",
+      "maxLength": 100
+    },
+    "category": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::news-category.news-category"
+    },
+    "tags": {
+      "type": "json"
+    },
+    "isFeatured": {
+      "type": "boolean",
+      "default": false
+    },
+    "estimatedReadTime": {
+      "type": "integer"
+    }
+  }
+}

--- a/Strapi/src/api/news-post/controllers/news-post.ts
+++ b/Strapi/src/api/news-post/controllers/news-post.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::news-post.news-post');

--- a/Strapi/src/api/news-post/routes/news-post.ts
+++ b/Strapi/src/api/news-post/routes/news-post.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::news-post.news-post');

--- a/Strapi/src/api/news-post/services/news-post.ts
+++ b/Strapi/src/api/news-post/services/news-post.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::news-post.news-post');


### PR DESCRIPTION
## Summary
- **Strapi content types**: `news-post` (collection with title, slug, excerpt, Blocks body, cover image, author, category relation, tags, featured flag, read time) and `news-category` (name, slug, description). Draft/publish enabled on posts.
- **CMS proxy endpoints**: 3 new endpoints on `CmsController` — paginated post listing with category filter, single post by slug, and category list. All public/anonymous, following the existing proxy pattern.
- **Frontend services**: TypeScript types (`NewsPostData`, `NewsCategoryData`), `StrapiCollectionResponse` wrapper, and 3 service factories (`GetNewsPosts`, `GetNewsPostBySlug`, `GetNewsCategories`) with graceful empty-state fallbacks.

This is the data layer foundation. Phases 2-5 will add the listing page, detail page, navigation, and SEO on top of these services.

## Test plan
- [ ] `dotnet build` — backend compiles (verified, 0 errors)
- [ ] `npm run build` + `npm run lint` — frontend compiles and lints clean (verified)
- [ ] `dotnet test TrashMob.Shared.Tests` — all 444 tests pass (verified)
- [ ] After deploy: `cd Strapi && npm run develop` — verify News Post and News Category appear in Strapi admin
- [ ] After deploy: seed categories via Strapi admin, create a test post, verify `/api/cms/news-posts` returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)