### PR TITLE
Prevent concurrent route tracking across events

### DIFF
--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@
             services.AddSingleton<IUserRestService, UserRestService>();
             services.AddSingleton<IWaiverManager, WaiverManager>();
             services.AddSingleton<IWaiverRestService, WaiverRestService>();
+            services.AddSingleton<IRouteTrackingSessionManager, RouteTrackingSessionManager>();
 
             return services;
         }

--- a/TrashMobMobile/Services/IRouteTrackingSessionManager.cs
+++ b/TrashMobMobile/Services/IRouteTrackingSessionManager.cs
@@ -1,0 +1,21 @@
+namespace TrashMobMobile.Services;
+
+public interface IRouteTrackingSessionManager
+{
+    bool IsTracking { get; }
+
+    Guid? ActiveEventId { get; }
+
+    string? ActiveEventName { get; }
+
+    /// <summary>
+    /// Try to start a tracking session for the given event.
+    /// Returns false if a session is already active for a different event.
+    /// </summary>
+    bool TryStartSession(Guid eventId, string eventName);
+
+    /// <summary>
+    /// End the current tracking session.
+    /// </summary>
+    void EndSession();
+}

--- a/TrashMobMobile/Services/RouteTrackingSessionManager.cs
+++ b/TrashMobMobile/Services/RouteTrackingSessionManager.cs
@@ -1,0 +1,38 @@
+namespace TrashMobMobile.Services;
+
+public class RouteTrackingSessionManager : IRouteTrackingSessionManager
+{
+    private readonly object syncLock = new();
+
+    public bool IsTracking { get; private set; }
+
+    public Guid? ActiveEventId { get; private set; }
+
+    public string? ActiveEventName { get; private set; }
+
+    public bool TryStartSession(Guid eventId, string eventName)
+    {
+        lock (syncLock)
+        {
+            if (IsTracking && ActiveEventId != eventId)
+            {
+                return false;
+            }
+
+            IsTracking = true;
+            ActiveEventId = eventId;
+            ActiveEventName = eventName;
+            return true;
+        }
+    }
+
+    public void EndSession()
+    {
+        lock (syncLock)
+        {
+            IsTracking = false;
+            ActiveEventId = null;
+            ActiveEventName = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2868 — Users could navigate away from an event while route tracking was active and start a new tracking session on a different event, resulting in concurrent GPS sessions.

- Add singleton `IRouteTrackingSessionManager` service that tracks whether a GPS recording session is active and for which event
- Block starting a new session if one is already active for a different event, with a popup informing the user
- Restore recording UI state (Stop button, red indicator) when navigating back to the actively-tracked event
- End session on both emulator and real device cancellation paths

## Test plan

- [ ] Open Event A → tap Start Route → navigate back → open Event B → tap Start Route
  - Expected: popup says "You're already tracking a route for [Event A name]"
- [ ] Navigate back to Event A → recording indicator and Stop button are visible
- [ ] Tap Stop → route saves normally
- [ ] Start and stop a route on Event A, then start a new route on Event B → works without blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)