### PR TITLE
Add news navigation, home page section, SEO, and RSS feed (Project 50 Phases 4-5)

### DIFF
--- a/Planning/Projects/Project_50_News_Blog.md
+++ b/Planning/Projects/Project_50_News_Blog.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress |
+| **Status** | Complete |
 | **Priority** | Medium |
 | **Risk** | Low |
 | **Size** | Medium |
@@ -64,16 +64,16 @@ Strapi CMS is already deployed and managing home page content (hero, what-is-tra
 - ✅ Related posts section at the bottom (same category, max 3)
 
 ### Phase 4 — Navigation & Home Page Integration
-- ❌ Add "News" to the main site navigation (top-level nav item)
-- ❌ Add "Latest News" section to the home page (3 most recent posts as cards)
-- ❌ Add "News" link to the site footer
-- ❌ Update sitemap generation to include news posts
+- ✅ Add "News" to the main site navigation (Explore dropdown + mobile nav)
+- ✅ Add "Latest News" section to the home page (3 most recent posts as cards)
+- ✅ Add "News" link to the site footer
+- ✅ Update sitemap to include `/news` page
 
 ### Phase 5 — SEO & Polish
-- ❌ Open Graph and Twitter Card meta tags per post
-- ❌ Structured data (JSON-LD Article schema) per post
-- ❌ RSS feed endpoint (`/news/feed.xml` or `/api/cms/news-feed`)
-- ❌ Social sharing buttons on post detail page
+- ✅ Open Graph (`og:image`, `og:type`) and Twitter Card (`twitter:card`, `twitter:site`) meta tags per post
+- ✅ Structured data (JSON-LD Article schema) per post
+- ✅ RSS feed endpoint (`GET /api/cms/news-feed`) with RSS autodiscovery `<link>` tag
+- ✅ Social sharing buttons on post detail page (reuses existing `ShareDialog` component)
 
 ---
 
@@ -318,5 +318,5 @@ None in this project. Mobile news feed would be a separate future project.
 
 **Last Updated:** February 22, 2026
 **Owner:** Product & Engineering Team
-**Status:** In Progress — Phases 1-3 complete (content types + API proxy + news listing + post detail)
-**Next Review:** When ready to begin Phase 4 (Navigation & Home Page Integration)
+**Status:** Complete — All 5 phases delivered (content types + API proxy + news listing + post detail + navigation & home page + SEO & polish)
+**Next Review:** Post-launch content review

--- a/TrashMob/client-app/public/sitemap.xml
+++ b/TrashMob/client-app/public/sitemap.xml
@@ -65,6 +65,11 @@
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://www.trashmob.eco/news</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
 
   <!-- Partner Pages -->
   <url>

--- a/TrashMob/client-app/src/components/SEO/PageHead.tsx
+++ b/TrashMob/client-app/src/components/SEO/PageHead.tsx
@@ -4,6 +4,8 @@ import { useLocation } from 'react-router';
 interface PageHeadProps {
     title?: string;
     description?: string;
+    image?: string;
+    type?: string;
 }
 
 const BASE_URL = 'https://www.trashmob.eco';
@@ -14,7 +16,7 @@ const DEFAULT_DESCRIPTION =
  * SEO component for managing page-specific meta tags and canonical URLs.
  * Automatically generates canonical URL based on current path.
  */
-export const PageHead = ({ title, description }: PageHeadProps) => {
+export const PageHead = ({ title, description, image, type }: PageHeadProps) => {
     const location = useLocation();
 
     // Generate canonical URL from current path (without query params or hash)
@@ -36,8 +38,14 @@ export const PageHead = ({ title, description }: PageHeadProps) => {
 
             {/* Open Graph */}
             <meta property='og:url' content={canonicalUrl} />
+            <meta property='og:type' content={type || 'website'} />
             {title ? <meta property='og:title' content={fullTitle} /> : null}
             {description ? <meta property='og:description' content={description} /> : null}
+            {image ? <meta property='og:image' content={image} /> : null}
+
+            {/* Twitter Card */}
+            <meta name='twitter:card' content={image ? 'summary_large_image' : 'summary'} />
+            <meta name='twitter:site' content='@TrashMobEco' />
         </Helmet>
     );
 };
@@ -54,6 +62,7 @@ export const DefaultPageHead = () => {
         <Helmet>
             <link rel='canonical' href={canonicalUrl} />
             <meta property='og:url' content={canonicalUrl} />
+            <link rel='alternate' type='application/rss+xml' title='TrashMob News' href='/api/cms/news-feed' />
         </Helmet>
     );
 };

--- a/TrashMob/client-app/src/components/SiteFooter/SiteFooter.tsx
+++ b/TrashMob/client-app/src/components/SiteFooter/SiteFooter.tsx
@@ -14,6 +14,7 @@ export const SiteFooter = () => {
         { href: '/partnerships', title: 'Partners' },
         { href: '/for-communities', title: 'For Communities' },
         { href: '/faq', title: 'FAQ' },
+        { href: '/news', title: 'News' },
         { href: '/volunteeropportunities', title: 'Recruiting' },
         { href: '/contactus', title: 'Contact us' },
         { href: '/privacypolicy', title: 'Privacy policy' },

--- a/TrashMob/client-app/src/components/SiteHeader/MainNav.tsx
+++ b/TrashMob/client-app/src/components/SiteHeader/MainNav.tsx
@@ -17,6 +17,7 @@ import {
     BookOpen,
     HelpCircle,
     MessageCircleQuestion,
+    Newspaper,
     ShoppingBag,
     List,
     Users,
@@ -118,6 +119,9 @@ export const MainNav = ({ className, isUserLoaded, ...props }: MainNavProps) => 
                                         icon={<Trophy className='h-4 w-4' />}
                                     >
                                         See top volunteers and teams.
+                                    </ListItem>
+                                    <ListItem to='/news' title='News' icon={<Newspaper className='h-4 w-4' />}>
+                                        Stories and updates from the TrashMob community.
                                     </ListItem>
                                 </ul>
                             </NavigationMenuContent>
@@ -249,6 +253,7 @@ export const MainNav = ({ className, isUserLoaded, ...props }: MainNavProps) => 
                     <MobileNavItem to='/teams'>Teams</MobileNavItem>
                     <MobileNavItem to='/communities'>Communities</MobileNavItem>
                     <MobileNavItem to='/leaderboards'>Leaderboards</MobileNavItem>
+                    <MobileNavItem to='/news'>News</MobileNavItem>
                 </div>
                 <div className='border-l-2 border-muted pl-3 ml-2 space-y-1'>
                     <p className='text-xs text-muted-foreground uppercase tracking-wide pt-1'>Take Action</p>

--- a/TrashMob/client-app/src/components/sharing/ShareDialog.tsx
+++ b/TrashMob/client-app/src/components/sharing/ShareDialog.tsx
@@ -68,6 +68,8 @@ export const ShareDialog = ({ content, open, onOpenChange, message, emailSubject
                 return 'Share Team';
             case 'community':
                 return 'Share Community';
+            case 'article':
+                return 'Share Article';
             default:
                 return 'Share';
         }
@@ -82,6 +84,8 @@ export const ShareDialog = ({ content, open, onOpenChange, message, emailSubject
                 return `Check out this team on TrashMob.eco: ${content.title}`;
             case 'community':
                 return `Check out this community on TrashMob.eco: ${content.title}`;
+            case 'article':
+                return `${content.title} — TrashMob.eco News`;
             default:
                 return `Check out this on TrashMob.eco: ${content.title}`;
         }

--- a/TrashMob/client-app/src/components/sharing/types.ts
+++ b/TrashMob/client-app/src/components/sharing/types.ts
@@ -1,6 +1,6 @@
 // Shareable content types for social sharing
 
-export type ShareableContentType = 'event' | 'team' | 'community';
+export type ShareableContentType = 'event' | 'team' | 'community' | 'article';
 
 export interface ShareableContent {
     type: ShareableContentType;

--- a/TrashMob/client-app/src/lib/sharing-messages.ts
+++ b/TrashMob/client-app/src/lib/sharing-messages.ts
@@ -1,6 +1,7 @@
 import type TeamData from '@/components/Models/TeamData';
 import type CommunityData from '@/components/Models/CommunityData';
 import type EventData from '@/components/Models/EventData';
+import type { NewsPostData } from '@/services/cms';
 import type { ShareableContent } from '@/components/sharing';
 import compact from 'lodash/compact';
 
@@ -150,4 +151,25 @@ export function getCancellationMessage(event: EventData, cancellationReason: str
         `Sorry everyone, we had to cancel our {{TrashMob}} event ${event.name} in #${event.city} on ${eventDate}. ${cancellationReason}.\n` +
         'Sign up using the link to get notified the next time we are having an event. Help us clean up the planet!'
     );
+}
+
+/**
+ * Creates ShareableContent for a news post
+ */
+export function getNewsPostShareableContent(post: NewsPostData, slug: string): ShareableContent {
+    return {
+        type: 'article',
+        title: post.title,
+        description: post.excerpt,
+        url: `${window.location.origin}/news/${slug}`,
+        imageUrl: post.coverImage?.data?.attributes?.url,
+    };
+}
+
+/**
+ * Gets a shareable message for a news post
+ */
+export function getNewsPostShareMessage(post: NewsPostData): string {
+    const truncated = post.excerpt.length > 100 ? post.excerpt.substring(0, 100) + '...' : post.excerpt;
+    return `Check out "${post.title}" on {{TrashMob}}! ${truncated}`;
 }

--- a/TrashMob/client-app/src/pages/_home/index.tsx
+++ b/TrashMob/client-app/src/pages/_home/index.tsx
@@ -3,6 +3,7 @@ import { EventSection } from './event-section';
 import { FeaturedCommunitiesSection } from './featured-communities-section';
 import { GettingStartSection } from './getting-start-section';
 import { HeroSection } from './hero-section';
+import { LatestNewsSection } from './latest-news-section';
 import { WhatIsTrashmobSection } from './whatistrashmob-section';
 
 export const Home = () => {
@@ -12,6 +13,7 @@ export const Home = () => {
             <WhatIsTrashmobSection />
             <StatsSection />
             <FeaturedCommunitiesSection />
+            <LatestNewsSection />
             <EventSection />
             <GettingStartSection />
         </>

--- a/TrashMob/client-app/src/pages/_home/latest-news-section.tsx
+++ b/TrashMob/client-app/src/pages/_home/latest-news-section.tsx
@@ -1,0 +1,109 @@
+import { Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { Calendar, Newspaper, User } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useIsInViewport } from '@/hooks/useIsInViewport';
+import { cn } from '@/lib/utils';
+import { GetNewsPosts, NewsPostData } from '@/services/cms';
+import { Services } from '@/config/services.config';
+
+function formatDate(dateStr: string): string {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    });
+}
+
+function NewsCard({ post }: { post: { id: number; attributes: NewsPostData } }) {
+    const { attributes } = post;
+    const coverUrl = attributes.coverImage?.data?.attributes?.url;
+    const categoryName = attributes.category?.data?.attributes?.name;
+
+    return (
+        <Link to={`/news/${attributes.slug}`} className='group'>
+            <Card className='h-full overflow-hidden transition-shadow hover:shadow-lg'>
+                <div className='aspect-video overflow-hidden bg-muted'>
+                    {coverUrl ? (
+                        <img
+                            src={coverUrl}
+                            alt={attributes.coverImage?.data?.attributes?.alternativeText || attributes.title}
+                            className='h-full w-full object-cover transition-transform group-hover:scale-105'
+                        />
+                    ) : (
+                        <div className='flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/10 to-primary/5'>
+                            <Newspaper className='h-12 w-12 text-muted-foreground/50' />
+                        </div>
+                    )}
+                </div>
+                <CardContent className='p-4'>
+                    {categoryName ? (
+                        <Badge variant='outline' className='mb-2'>
+                            {categoryName}
+                        </Badge>
+                    ) : null}
+                    <h3 className='mb-2 text-lg font-semibold leading-tight line-clamp-2 group-hover:text-primary'>
+                        {attributes.title}
+                    </h3>
+                    <p className='mb-3 text-sm text-muted-foreground line-clamp-2'>{attributes.excerpt}</p>
+                    <div className='flex flex-wrap items-center gap-3 text-xs text-muted-foreground'>
+                        <span className='flex items-center gap-1'>
+                            <User className='h-3 w-3' />
+                            {attributes.author}
+                        </span>
+                        <span className='flex items-center gap-1'>
+                            <Calendar className='h-3 w-3' />
+                            {formatDate(attributes.publishedAt)}
+                        </span>
+                    </div>
+                </CardContent>
+            </Card>
+        </Link>
+    );
+}
+
+export const LatestNewsSection = () => {
+    const { ref: viewportRef, isInViewPort } = useIsInViewport<HTMLDivElement>();
+
+    const { data: postsResponse } = useQuery({
+        queryKey: GetNewsPosts({ pageSize: 3 }).key,
+        queryFn: GetNewsPosts({ pageSize: 3 }).service,
+        staleTime: Services.CACHE.FOR_ONE_MINUTE * 5,
+    });
+
+    const posts = postsResponse?.data;
+
+    // Don't render the section if there are no posts
+    if (!posts || posts.length === 0) return null;
+
+    return (
+        <section className='bg-card py-16' ref={viewportRef}>
+            <div className='container'>
+                <div
+                    className={cn('transition-all duration-700 ease-out', {
+                        'opacity-100 translate-y-0': isInViewPort,
+                        'opacity-0 translate-y-10': !isInViewPort,
+                    })}
+                >
+                    <h2 className='text-3xl font-bold text-center mb-2'>Latest News</h2>
+                    <p className='text-center text-muted-foreground mb-10 max-w-2xl mx-auto'>
+                        Stories, updates, and highlights from the TrashMob community.
+                    </p>
+                    <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6'>
+                        {posts.map((post) => (
+                            <NewsCard key={post.id} post={post} />
+                        ))}
+                    </div>
+                    <div className='flex justify-center mt-10'>
+                        <Button variant='outline' asChild>
+                            <Link to='/news'>View All News</Link>
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};


### PR DESCRIPTION
## Summary
- **Phase 4 — Navigation & Home Page Integration:** Adds "News" to site header (Explore dropdown + mobile nav), footer, home page ("Latest News" section with 3 most recent posts), and sitemap
- **Phase 5 — SEO & Polish:** Enhances PageHead with OG image/type and Twitter Card meta tags, adds JSON-LD Article structured data on post detail pages, adds RSS 2.0 feed endpoint (`GET /api/cms/news-feed`) with autodiscovery link, and adds Share button on post detail page using the existing ShareDialog component

This completes all 5 phases of Project 50 (News & Blog).

## Test plan
- [ ] Verify "News" appears in the Explore dropdown on desktop
- [ ] Verify "News" appears in mobile navigation
- [ ] Verify "News" link appears in the site footer
- [ ] Verify "Latest News" section appears on home page (or hides gracefully when no posts exist)
- [ ] Verify `/news/:slug` shows Share button that opens ShareDialog
- [ ] Verify page source for a news post contains `og:image`, `og:type`, `twitter:card`, and JSON-LD script
- [ ] Verify `/api/cms/news-feed` returns valid RSS 2.0 XML (when Strapi is running)
- [ ] Verify `/news` is listed in sitemap.xml
- [ ] Backend tests pass (455 tests)
- [ ] Frontend builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)