### PR TITLE
Fix spelling, broken link, and malformed HTML in email templates

### DIFF
--- a/TrashMob.Shared/Engine/EmailCopy/ContactRequestReceived.html
+++ b/TrashMob.Shared/Engine/EmailCopy/ContactRequestReceived.html
@@ -1,9 +1,7 @@
 ﻿<p>
     A TrashMob.eco contact request has been received from {UserName} ({UserEmail}).
 </p>
-<p>
-    <h3>Message:</h3>
-</p>
+<h3>Message:</h3>
 <p>
     {Message}
 </p>

--- a/TrashMob.Shared/Engine/EmailCopy/InviteBusinessPartner.html
+++ b/TrashMob.Shared/Engine/EmailCopy/InviteBusinessPartner.html
@@ -12,7 +12,7 @@
             Where do they get starter kits? (buckets, litter pickers, gloves, safety vests)
         </li>
         <li>
-            Where do they get safety gear and supplies]? (signs, bags)
+            Where do they get safety gear and supplies? (signs, bags)
         </li>
         <li>
             How do they get the picked litter from the cleanup location to the disposal site? Many volunteers don't have vehicles capable of hauling more than one or two bags of litter
@@ -24,7 +24,7 @@
             Being a partner could be as simple as allowing TrashMob.eco to drop off a few bags of picked garbage in your dumpster a couple of times a month.
         </li>
         <li>
-            How do they raise awareness of their efforts to clean up the community in order to attract more volunteers? Business Partners can help with social media and advertising to help build the number of volunteers active in the communuity.
+            How do they raise awareness of their efforts to clean up the community in order to attract more volunteers? Business Partners can help with social media and advertising to help build the number of volunteers active in the community.
         </li>
     </ul>
 </p>

--- a/TrashMob.Shared/Engine/EmailCopy/InviteExistingUserToBePartnerAdmin.html
+++ b/TrashMob.Shared/Engine/EmailCopy/InviteExistingUserToBePartnerAdmin.html
@@ -1,6 +1,6 @@
 ﻿<p>
     You have been invited to become an administrator on a TrashMob.eco Partner! This will allow you to help set up the TrashMob.eco Partner so that people in your community can more easily
-    take avantages of the services your organization is offering.
+    take advantage of the services your organization is offering.
 </p>
 <p>
     To accept this invitation, log in to your TrashMob.eco account, and proceed to your <a href="https://www.trashmob.eco/mydashboard">Dashboard</a>. There you will see a list of pending invitations to accept or decline.

--- a/TrashMob.Shared/Engine/EmailCopy/InviteGovernmentPartner.html
+++ b/TrashMob.Shared/Engine/EmailCopy/InviteGovernmentPartner.html
@@ -12,7 +12,7 @@
             Where do they get starter kits? (buckets, litter pickers, gloves, safety vests)
         </li>
         <li>
-            Where do they get safety gear and supplies]? (signs, bags)
+            Where do they get safety gear and supplies? (signs, bags)
         </li>
         <li>
             How do they get the picked litter from the cleanup location to the disposal site? Many volunteers don't have vehicles capable of hauling more than one or two bags of litter
@@ -24,7 +24,7 @@
             Being a partner could be as simple as allowing TrashMob.eco to drop off a few bags of picked garbage in your dumpster a couple of times a month.
         </li>
         <li>
-            How do they raise awareness of their efforts to clean up the community in order to attract more volunteers? Community Partners can help with social media and advertising to help build the number of volunteers active in the communuity.
+            How do they raise awareness of their efforts to clean up the community in order to attract more volunteers? Community Partners can help with social media and advertising to help build the number of volunteers active in the community.
         </li>
     </ul>
 </p>
@@ -55,7 +55,7 @@
     <ol>
         <li>Create an Account on <a href="https://www.trashmob.eco">TrashMob.eco</a></li>
         <li>Fill out and submit the <a href="https://www.trashmob.eco/becomeapartner">Become a Partner form</a></li>
-        <li>A TrashMob.eco will process your application and send you a response with instructions on how to move forward!</li>
+        <li>TrashMob.eco staff will process your application and send you a response with instructions on how to move forward!</li>
     </ol>
 </p>
 <p>

--- a/TrashMob.Shared/Engine/EmailCopy/InviteNewUserToBePartnerAdmin.html
+++ b/TrashMob.Shared/Engine/EmailCopy/InviteNewUserToBePartnerAdmin.html
@@ -1,6 +1,6 @@
 ﻿<p>
     You have been invited to become an administrator on a TrashMob.eco Partner! This will allow you to help set up the TrashMob.eco Partner so that people in your community can more easily
-    take avantages of the services your organization is offering.
+    take advantage of the services your organization is offering.
 </p>
 <p>
     TrashMob.eco allows communities to easily organize litter cleanups, and Partners help to take care of the logistics of the cleanup, from advertising the events on their social media accounts, to hauling and disposal of the picked up litter.

--- a/TrashMob.Shared/Engine/EmailCopy/PartnerRequestAccepted.html
+++ b/TrashMob.Shared/Engine/EmailCopy/PartnerRequestAccepted.html
@@ -7,7 +7,7 @@
 <p>
     <ol>
         <li>
-            The first step is to log in to the TrashMob.eco account that created this request, and go to your <a href="https://www.trashmob.com/mydashboard">Dashboard</a>. Look for the
+            The first step is to log in to the TrashMob.eco account that created this request, and go to your <a href="https://www.trashmob.eco/mydashboard">Dashboard</a>. Look for the
             section titled "My Partnerships"
         </li>
         <li>Select the ... in the Action Column next to you partnership, and click 'Activate Partnership'. Note that Partnerships are created in an inactive state until you are ready to activate them.</li>
@@ -19,9 +19,9 @@
         <li>
             Add / Update your Partner Locations as needed
             <ul>
-                <li>Set up the details of the location by filling out the form and setting the phsycial location by clicking on the map. Save changes.</li>
+                <li>Set up the details of the location by filling out the form and setting the physical location by clicking on the map. Save changes.</li>
                 <li>Add / Update your Partner Location Contacts as needed. You need to have at least one contact per partner location in order for events to use your services. Save changes.</li>
-                <li>Add / Update your Partner Location Services as needed. You need to have at least one serice offering per partner location in order for events to use your services. Save changes.</li>
+                <li>Add / Update your Partner Location Services as needed. You need to have at least one service offering per partner location in order for events to use your services. Save changes.</li>
             </ul>
         </li>
         <li>
@@ -44,6 +44,6 @@
     Need help?
 </h3>
 <p>
-    Please <a mailto:"info@trashmob.eco"email>email</a> us! We want your Partnership to be a great experience for you and your community. Let us know if you run into any issues or have suggestions for improvements
+    Please <a href="mailto:info@trashmob.eco">email us</a>! We want your Partnership to be a great experience for you and your community. Let us know if you run into any issues or have suggestions for improvements
     to our site or our programs!
 </p>


### PR DESCRIPTION
## Summary

Audit of all 46 outbound email templates found 11 issues across 6 files:

- **PartnerRequestAccepted.html** — broken dashboard link (`trashmob.com` → `trashmob.eco`), malformed `<a mailto:>` tag, "phsycial" → "physical", "serice" → "service"
- **InviteBusinessPartner.html** — stray `]` bracket in "supplies]?", "communuity" → "community"
- **InviteGovernmentPartner.html** — same bracket and typo as above, plus "A TrashMob.eco will" → "TrashMob.eco staff will"
- **InviteExistingUserToBePartnerAdmin.html** — "avantages" → "advantage"
- **InviteNewUserToBePartnerAdmin.html** — "avantages" → "advantage"
- **ContactRequestReceived.html** — `<h3>` improperly nested inside `<p>` tag

## Test plan

- [ ] Verify PartnerRequestAccepted dashboard link points to trashmob.eco
- [ ] Verify PartnerRequestAccepted "email us" mailto link is clickable
- [ ] Spot-check corrected spelling in each template

🤖 Generated with [Claude Code](https://claude.com/claude-code)