### PR TITLE
Fix Android deploy: flatten artifact directory structure

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -182,10 +182,21 @@ jobs:
             cd TrashMobMobile
             jarsigner -keystore android/trashmobmobileapp.decrypted.jks -storepass "${{ secrets.android_keystore_password }}" -signedjar bin/${{ inputs.configuration }}/net10.0-android/publish/${{ inputs.bundle_id }}-Signed.aab bin/${{ inputs.configuration }}/net10.0-android/publish/${{ inputs.bundle_id }}.aab ${{ inputs.android_key_name }}
 
+        - name: Stage artifacts into flat directory
+          shell: pwsh
+          run: |
+            New-Item -ItemType Directory -Path artifact-staging -Force | Out-Null
+            Copy-Item TrashMobMobile\bin\${{ inputs.configuration }}\net10.0-android\publish\*.aab artifact-staging\
+            if (Test-Path TrashMobMobile\native-debug-symbols.zip) {
+              Copy-Item TrashMobMobile\native-debug-symbols.zip artifact-staging\
+            }
+            if (Test-Path TrashMobMobile\mapping.txt) {
+              Copy-Item TrashMobMobile\mapping.txt artifact-staging\
+            }
+            Write-Host "Staged artifacts:"
+            Get-ChildItem artifact-staging
+
         - uses: actions/upload-artifact@v4.6.2
           with:
             name: artifacts-android-${{ env.semVer }}
-            path: |
-              TrashMobMobile\bin\${{ inputs.configuration }}\net10.0-android\publish\*.aab
-              TrashMobMobile\native-debug-symbols.zip
-              TrashMobMobile\mapping.txt
+            path: artifact-staging\


### PR DESCRIPTION
## Summary
- Fixes the Android deploy-to-Google-Play failure (`Unable to find any release file matching ./*Signed.aab`) affecting both dev and prod workflows since #2864
- Root cause: adding `native-debug-symbols.zip` and `mapping.txt` paths to the artifact upload changed the `upload-artifact@v4` common ancestor from the publish directory to `TrashMobMobile\`, nesting the AAB files in subdirectories
- Fix: stage all files into a flat `artifact-staging\` directory before upload so the AAB, debug symbols, and mapping file are always at the artifact root

## Test plan
- [ ] Merge to main → dev mobile build should succeed (Android deploy step finds `*Signed.aab`)
- [ ] Merge to release → prod mobile build should succeed
- [ ] Verify artifact contents are flat (AAB + optional debug symbols at root)

Closes #2882 (partially — fixes the build; Google sign-in is a separate Entra config issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)