### PR TITLE
Mobile app improvements: registration, validation, dirty tracking, filters, paging

### DIFF
--- a/TrashMobMobile/Pages/EditEventPage.xaml
+++ b/TrashMobMobile/Pages/EditEventPage.xaml
@@ -53,6 +53,7 @@
 
             <Button Margin="16,8,16,20"
                     Command="{Binding SaveEventCommand}"
+                    IsEnabled="{Binding HasChanges}"
                     Style="{StaticResource PrimaryLargeButton}"
                     Text="Save Event"
                     HorizontalOptions="Fill"

--- a/TrashMobMobile/Pages/SearchEventsPage.xaml
+++ b/TrashMobMobile/Pages/SearchEventsPage.xaml
@@ -106,7 +106,7 @@
                     </maps:Map.ItemTemplate>
                 </controls:CustomMap>
 
-                <Grid Grid.Row="3" IsVisible="{Binding IsListSelected}">
+                <VerticalStackLayout Grid.Row="3" IsVisible="{Binding IsListSelected}">
                     <Label Text="There are no events matching the selected criteria." IsVisible="{Binding AreNoEventsFound}" Margin="10" />
                     <CollectionView x:Name="EventsCollection"
                                     ItemsSource="{Binding Events}"
@@ -140,7 +140,12 @@
                             </DataTemplate>
                         </CollectionView.ItemTemplate>
                     </CollectionView>
-                </Grid>
+                    <Button Text="Load More"
+                            Command="{Binding LoadMoreEventsCommand}"
+                            IsVisible="{Binding HasMoreResults}"
+                            Style="{StaticResource SecondaryLargeButton}"
+                            Margin="10,4" />
+                </VerticalStackLayout>
             </Grid>
         </VerticalStackLayout>
         <BoxView BackgroundColor="{StaticResource TransparentBlack}" HorizontalOptions="Fill"

--- a/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
+++ b/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
@@ -99,6 +99,7 @@
 
                 <Button Text="Update Location"
                         Command="{Binding UpdateLocationCommand}"
+                        IsEnabled="{Binding HasChanges}"
                         Style="{StaticResource PrimaryLargeButton}"
                         Margin="10,8,10,10" />
             </VerticalStackLayout>

--- a/TrashMobMobile/Views/MyDashboard/TabCompletedEvents.xaml
+++ b/TrashMobMobile/Views/MyDashboard/TabCompletedEvents.xaml
@@ -5,11 +5,18 @@
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:Class="TrashMobMobile.Views.MyDashboard.TabCompletedEvents">
     <VerticalStackLayout>
-        <controls:TMPicker Title="Completed Date Range"
-                                   HeightRequest="40"
-                                   Margin="10, 0, 10, 0"
-                                   ItemsSource="{Binding CompletedDateRanges}"
-                                   SelectedItem="{Binding SelectedCompletedDateRange, Mode=TwoWay}" />
+        <Grid ColumnDefinitions="*, *" ColumnSpacing="8" Margin="10, 0, 10, 0">
+            <controls:TMPicker Grid.Column="0"
+                               Title="Date Range"
+                               HeightRequest="40"
+                               ItemsSource="{Binding CompletedDateRanges}"
+                               SelectedItem="{Binding SelectedCompletedDateRange, Mode=TwoWay}" />
+            <controls:TMPicker Grid.Column="1"
+                               Title="Filter"
+                               HeightRequest="40"
+                               ItemsSource="{Binding EventFilterOptions}"
+                               SelectedItem="{Binding SelectedEventFilter, Mode=TwoWay}" />
+        </Grid>
 
         <Label Text="There are no completed events matching the selected criteria." IsVisible="{Binding AreNoCompletedEventsFound}" Margin="10" />
 

--- a/TrashMobMobile/Views/MyDashboard/TabUpcomingEvents.xaml
+++ b/TrashMobMobile/Views/MyDashboard/TabUpcomingEvents.xaml
@@ -5,11 +5,18 @@
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              x:Class="TrashMobMobile.Views.MyDashboard.TabUpcomingEvents">
     <VerticalStackLayout>
-        <controls:TMPicker Title="Upcoming Date Range"
-                                   HeightRequest="40"
-                                   Margin="10, 0, 10, 0"
-                                   ItemsSource="{Binding UpcomingDateRanges}"
-                                   SelectedItem="{Binding SelectedUpcomingDateRange, Mode=TwoWay}" />
+        <Grid ColumnDefinitions="*, *" ColumnSpacing="8" Margin="10, 0, 10, 0">
+            <controls:TMPicker Grid.Column="0"
+                               Title="Date Range"
+                               HeightRequest="40"
+                               ItemsSource="{Binding UpcomingDateRanges}"
+                               SelectedItem="{Binding SelectedUpcomingDateRange, Mode=TwoWay}" />
+            <controls:TMPicker Grid.Column="1"
+                               Title="Filter"
+                               HeightRequest="40"
+                               ItemsSource="{Binding EventFilterOptions}"
+                               SelectedItem="{Binding SelectedEventFilter, Mode=TwoWay}" />
+        </Grid>
 
         <Label Text="There are no upcoming events matching the selected criteria." IsVisible="{Binding AreNoUpcomingEventsFound}" Margin="10" />
 


### PR DESCRIPTION
## Summary
- **#1463** — Prevent registration to full events: checks attendee count against `MaxNumberOfParticipants` and disables the Register button when full
- **#1465** — Replace fleeting toast with styled `ConfirmPopup` for register/unregister confirmations
- **#1468** — Add field-level validation to edit event form (name, description, duration 1-10h, location) matching the create flow
- **#1475** — Add dirty tracking to `EditEventPage` and `SetUserLocationPreferencePage` — Save/Update button starts disabled and only enables when changes are detected
- **#215** — Add "All / My Events / Attending" filter picker to dashboard upcoming and completed event tabs
- **#1453** — Add incremental paging to search events (page size 25) with a "Load More" button
- Closed **#1462** (create event validation already solid) and **#302** (website-labeled, dirty tracking addresses core concern)

## Test plan
- [ ] View a full event → verify Register button is disabled and "event is currently full" text shows
- [ ] Register for an event → verify styled popup appears (not just a toast)
- [ ] Unregister from an event → verify styled popup appears
- [ ] Edit event → clear the name field → Save → verify "Event name is required" error
- [ ] Edit event → set duration < 1 hour → Save → verify error
- [ ] Edit event → verify Save button is disabled until a field is changed
- [ ] Edit event → change a field → verify Save button enables
- [ ] Set User Location → verify "Update Location" button is disabled until location/travel distance changes
- [ ] Dashboard → switch between "All", "My Events", "Attending" filter → verify list updates
- [ ] Search events → verify initial page loads 25 results
- [ ] Search events → tap "Load More" → verify next page appends

🤖 Generated with [Claude Code](https://claude.com/claude-code)