### PR TITLE
Add least-privilege database access task to Project 6

### DIFF
--- a/Planning/Projects/Project_06_Backend_Standards.md
+++ b/Planning/Projects/Project_06_Backend_Standards.md
@@ -72,6 +72,7 @@ Comprehensive code quality sweep across the entire backend:
 - ? Add `[Authorize]` attributes where missing
 - ? Validate input on all endpoints
 - ? Add rate limiting where appropriate
+- ? **Least-privilege database access** — Split database credentials so the application runtime user has only the permissions it needs (read/write on application tables) rather than admin/owner access. Create a separate migration user for schema changes. This reduces blast radius if the app is compromised.
 
 ### Phase 4 - Documentation
 - ✓ Add XML comments to all public APIs


### PR DESCRIPTION
## Summary
- Adds a task to Project 6 Phase 3 (Security Audit) to split database credentials so the app runtime user has only read/write permissions, not admin/owner access
- A separate migration user would be used for schema changes during deployments

## Test plan
- [ ] Planning doc only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)