### PR TITLE
Fix remaining data export EF Core query failures

### DIFF
--- a/TrashMob.Shared/Managers/UserDataExportManager.cs
+++ b/TrashMob.Shared/Managers/UserDataExportManager.cs
@@ -110,6 +110,7 @@ namespace TrashMob.Shared.Managers
             var events = await context.Events
                 .AsNoTracking()
                 .Where(e => e.CreatedByUserId == userId)
+                .OrderByDescending(e => e.EventDate)
                 .Select(e => new ExportedEventLed(
                     e.Id,
                     e.Name,
@@ -119,7 +120,6 @@ namespace TrashMob.Shared.Managers
                     e.Region,
                     e.DurationHours,
                     e.DurationMinutes))
-                .OrderByDescending(e => e.EventDate)
                 .ToListAsync(ct);
 
             writer.WritePropertyName("eventsLed");
@@ -265,6 +265,7 @@ namespace TrashMob.Shared.Managers
             var waivers = await context.UserWaivers
                 .AsNoTracking()
                 .Where(uw => uw.UserId == userId)
+                .OrderByDescending(uw => uw.AcceptedDate)
                 .Select(uw => new ExportedWaiver(
                     uw.AcceptedDate,
                     uw.ExpiryDate,
@@ -273,7 +274,6 @@ namespace TrashMob.Shared.Managers
                     uw.IsMinor,
                     uw.GuardianName,
                     uw.GuardianRelationship))
-                .OrderByDescending(w => w.AcceptedDate)
                 .ToListAsync(ct);
 
             writer.WritePropertyName("waivers");
@@ -286,12 +286,12 @@ namespace TrashMob.Shared.Managers
             var feedback = await context.UserFeedback
                 .AsNoTracking()
                 .Where(uf => uf.UserId == userId)
+                .OrderByDescending(uf => uf.CreatedDate)
                 .Select(uf => new ExportedFeedback(
                     uf.Category,
                     uf.Description,
                     uf.Status,
                     uf.CreatedDate))
-                .OrderByDescending(f => f.CreatedDate)
                 .ToListAsync(ct);
 
             writer.WritePropertyName("feedback");


### PR DESCRIPTION
## Summary
- Follow-up to #2898 — fixes the same EF Core translation issue in 3 more queries that use `Select` (not `Join`)
- `WriteEventsLedAsync`, `WriteWaiversAsync`, `WriteFeedbackAsync` all had `.Select(=> new Record(...)).OrderByDescending(r => r.Property)` which EF Core can't translate
- Fix: move `OrderByDescending` before `Select` so EF Core references the entity column directly

## Test plan
- [ ] Deploy to dev, click "Download My Data" — should get a non-empty JSON file with all sections
- [ ] Verify exported JSON contains `eventsLed`, `waivers`, and `feedback` sections with data sorted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)