### PR TITLE
Add mobile attendee metrics integration (Project 38 Phase 5)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -51,7 +51,31 @@
       "Bash(do)",
       "Bash(echo:*)",
       "Bash(az ad app permission grant:*)",
-      "Bash(done)"
+      "Bash(done)",
+      "Bash(dotnet ef database update:*)",
+      "Bash(dotnet add:*)",
+      "Bash(dotnet remove:*)",
+      "Bash(name 'New'\" crash that blocked leaderboard and achievement updates\n- Wrap each daily job processor in try-catch so one failure doesn''t\n  prevent the others from running\n- Add OpenTelemetry logging with Azure Monitor exporter to both daily\n  and hourly jobs so exceptions appear in App Insights and get caught\n  by the exception-monitor workflow\n\nFixes #2881\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>\nEOF\n\\)\")",
+      "Bash(az resource show:*)",
+      "Bash(az extension add:*)",
+      "Bash(az monitor app-insights query:*)",
+      "Bash(python -m json.tool:*)",
+      "Bash(# Query via ARM REST API \\(same as az monitor app-insights query uses under the hood\\) az rest --method post \\\\ --url \"\"/subscriptions/39a254b7-c01a-45ab-bebd-4038ea4adea9/resourceGroups/rg-trashmob-dev-westus2/providers/microsoft.insights/components/ai-tm-dev-westus2/query?api-version=2018-04-20\"\" \\\\ --body \"\"{\\\\\"\"query\\\\\"\": \\\\\"\"exceptions | where timestamp > ago\\(48h\\) | summarize Count=count\\(\\), FirstSeen=min\\(timestamp\\), LastSeen=max\\(timestamp\\), SampleDetails=take_any\\(details\\) by type, outerMessage | order by Count desc | take 2\\\\\"\"}\"\")",
+      "Bash(# Download the logs for the most recent run gh run view 22296561349 --log)",
+      "Bash(# Get the DEV job log to see what the query actually returned gh api repos/TrashMob-eco/TrashMob/actions/jobs/64494317089/logs)",
+      "Bash(# Get the relevant part of the DEV job log - the query step gh api repos/TrashMob-eco/TrashMob/actions/jobs/64494317089/logs)",
+      "Bash(az monitor log-analytics query:*)",
+      "Bash(git -C d:/repos/TrashMob branch --show-current:*)",
+      "Bash(git -C:*)",
+      "Bash(git -C d:/repos/TrashMob pull)",
+      "Bash(gh issue view:*)",
+      "Bash(for issue in 2886 2887 2888 2889 2890 2891 2892 2893)",
+      "Bash(do echo \"=== ISSUE #$issue ===\")",
+      "Bash(find:*)",
+      "Bash(gh issue close:*)",
+      "Bash(for issue in 302 215 1453 1462 1463 1465 1468 1475)",
+      "Bash(npx tsc:*)",
+      "Bash(git branch:*)"
     ]
   }
 }

--- a/Planning/Projects/Project_38_Mobile_Feature_Parity.md
+++ b/Planning/Projects/Project_38_Mobile_Feature_Parity.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 1-4, 6-7 Complete; Phase 5 blocked on Project 22) |
+| **Status** | In Progress (Phases 1-4, 6-7 Complete; Phase 5 In Progress) |
 | **Priority** | High |
 | **Risk** | High |
 | **Size** | Very Large |
@@ -635,7 +635,7 @@ services.AddSingleton<IUserPreferencesRestService, UserPreferencesRestService>()
 | 2 | Teams Integration | P0 | ✅ Complete (PR #2585) |
 | 3 | Event Photos | P1 | ✅ Complete (PR #2612) |
 | 4 | Leaderboards & Achievements | P1 | ✅ Complete (PR #2612) |
-| 5 | Attendee Metrics | P1 | ⚠️ Blocked (awaiting Project 22 backend) |
+| 5 | Attendee Metrics | P1 | In Progress |
 | 6 | Newsletter & Preferences | P2 | ✅ Complete (PR #2615) |
 | 7 | Team Events (Limited Admin) | P2 | ✅ Complete (PR #2615) |
 
@@ -647,7 +647,7 @@ services.AddSingleton<IUserPreferencesRestService, UserPreferencesRestService>()
 - **Project 9 (Teams):** Backend APIs must exist ✅ Complete
 - **Project 18 (Event Photos):** Backend APIs must exist ✅ Phase 1 Complete
 - **Project 20 (Gamification):** Leaderboard APIs must exist ✅ Backend Complete
-- **Project 22 (Attendee Metrics):** Individual metrics APIs ⚠️ Partial
+- **Project 22 (Attendee Metrics):** Individual metrics APIs ✅ Phases 1-3 Complete
 
 ### Enables
 - Improved volunteer retention
@@ -716,7 +716,7 @@ services.AddSingleton<IUserPreferencesRestService, UserPreferencesRestService>()
 
 ---
 
-**Last Updated:** February 8, 2026
+**Last Updated:** February 23, 2026
 **Owner:** Mobile Team + Product Lead
-**Status:** In Progress (6 of 7 phases complete; Phase 5 blocked on Project 22)
-**Next Review:** When Project 22 backend APIs are ready for Phase 5
+**Status:** In Progress (Phases 1-4, 6-7 complete; Phase 5 in progress)
+**Next Review:** When Phase 5 implementation is complete

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -38,7 +38,7 @@
 | [Project 13 - Bulk Email Invites](./Projects/Project_13_Bulk_Email_Invites.md) | Scale email invitations | ✅ Complete |
 | [Project 23 - Parental Consent](./Projects/Project_23_Parental_Consent.md) | Privo.com integration for minors (combined with Project 1) | Planning (combined with Project 1) |
 | [Project 24 - API v2 Modernization](./Projects/Project_24_API_v2_Modernization.md) | Pagination, error handling, auto-generated clients | Not Started |
-| [Project 38 - Mobile Feature Parity](./Projects/Project_38_Mobile_Feature_Parity.md) | Teams, leaderboards, photos for mobile volunteers | In Progress (Phases 1-4, 6-7 Complete) |
+| [Project 38 - Mobile Feature Parity](./Projects/Project_38_Mobile_Feature_Parity.md) | Teams, leaderboards, photos for mobile volunteers | In Progress (Phases 1-4, 6-7 Complete; Phase 5 In Progress) |
 | [Project 44 - Area Map Editor](./Projects/Project_44_Area_Map_Editor.md) | Interactive map editor, AI area suggestions, bulk import/export, AI generation | ✅ Complete |
 
 #### Medium Priority (Enhancements)
@@ -156,7 +156,7 @@
 | Status | Count | Projects |
 |--------|-------|----------|
 | ✅ **Complete** | 28 | Projects 3, 7, 9, 10, 11, 13, 14, 16, 17, 18, 19, 20, 21, 26, 27, 28, 29, 32, 34, 35, 37, 39, 40, 42, 44, 47, 49, 50 |
-| **In Progress** | 13 | Projects 1 (Phases 0-5a Complete, Production Live; Phase 6 Partial, Phase 7 Remaining), 4 (Phases 1-2, 6 Complete; Phases 3-5 Substantial), 5 (Phases 1-3 Complete; Phase 4 Partial), 6 (Phases 1, 2.5, 3 Substantial), 8 (Phases 1-4, 6 Complete), 15 (Backend & Website Complete), 22 (Phase 1-3 Complete), 25 (Phase 1 Complete), 30, 38 (Phases 1-4, 6-7 Complete), 41 (Phases 1-4 Complete), 45 (Phases 1-4 Complete), 48 (Phase 1 Complete) |
+| **In Progress** | 13 | Projects 1 (Phases 0-5a Complete, Production Live; Phase 6 Partial, Phase 7 Remaining), 4 (Phases 1-2, 6 Complete; Phases 3-5 Substantial), 5 (Phases 1-3 Complete; Phase 4 Partial), 6 (Phases 1, 2.5, 3 Substantial), 8 (Phases 1-4, 6 Complete), 15 (Backend & Website Complete), 22 (Phase 1-3 Complete), 25 (Phase 1 Complete), 30, 38 (Phases 1-4, 6-7 Complete; Phase 5 In Progress), 41 (Phases 1-4 Complete), 45 (Phases 1-4 Complete), 48 (Phase 1 Complete) |
 | **Ready for Review** | 1 | Project 2 |
 | **Planning** | 1 | Project 23 (combined with Project 1) |
 | **Not Started** | 6 | Projects 12, 24, 31, 36, 43, 46 |

--- a/TrashMob.Models/Poco/AttendeeMetricsTotals.cs
+++ b/TrashMob.Models/Poco/AttendeeMetricsTotals.cs
@@ -1,4 +1,4 @@
-namespace TrashMob.Shared.Poco
+namespace TrashMob.Models.Poco
 {
     /// <summary>
     /// Represents aggregated metrics totals from approved attendee submissions.

--- a/TrashMob.Models/Poco/PublicAttendeeMetrics.cs
+++ b/TrashMob.Models/Poco/PublicAttendeeMetrics.cs
@@ -1,4 +1,4 @@
-namespace TrashMob.Shared.Poco
+namespace TrashMob.Models.Poco
 {
     using System;
 
@@ -16,7 +16,7 @@ namespace TrashMob.Shared.Poco
         /// <summary>
         /// Gets or sets the user's display name.
         /// </summary>
-        public string UserName { get; set; }
+        public string UserName { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the bags collected (adjusted value if available, otherwise original).
@@ -36,7 +36,7 @@ namespace TrashMob.Shared.Poco
         /// <summary>
         /// Gets or sets the approval status.
         /// </summary>
-        public string Status { get; set; }
+        public string Status { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/TrashMob.Models/Poco/UserImpactStats.cs
+++ b/TrashMob.Models/Poco/UserImpactStats.cs
@@ -1,4 +1,4 @@
-namespace TrashMob.Shared.Poco
+namespace TrashMob.Models.Poco
 {
     using System.Collections.Generic;
 
@@ -51,7 +51,7 @@ namespace TrashMob.Shared.Poco
         /// <summary>
         /// Gets or sets the event name.
         /// </summary>
-        public string EventName { get; set; }
+        public string EventName { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the event date.
@@ -76,6 +76,6 @@ namespace TrashMob.Shared.Poco
         /// <summary>
         /// Gets or sets the approval status.
         /// </summary>
-        public string Status { get; set; }
+        public string Status { get; set; } = string.Empty;
     }
 }

--- a/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
@@ -9,6 +9,7 @@ namespace TrashMob.Shared.Managers.Events
     using TrashMob.Models;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Models.Poco;
     using TrashMob.Shared.Poco;
 
     /// <summary>

--- a/TrashMob.Shared/Managers/Interfaces/IEventAttendeeMetricsManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IEventAttendeeMetricsManager.cs
@@ -5,6 +5,7 @@ namespace TrashMob.Shared.Managers.Interfaces
     using System.Threading;
     using System.Threading.Tasks;
     using TrashMob.Models;
+    using TrashMob.Models.Poco;
     using TrashMob.Shared.Poco;
 
     /// <summary>

--- a/TrashMob/Controllers/EventAttendeeMetricsController.cs
+++ b/TrashMob/Controllers/EventAttendeeMetricsController.cs
@@ -11,7 +11,7 @@ namespace TrashMob.Controllers
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
-    using TrashMob.Shared.Poco;
+    using TrashMob.Models.Poco;
 
     /// <summary>
     /// Controller for attendee-submitted event metrics.

--- a/TrashMob/Controllers/UsersController.cs
+++ b/TrashMob/Controllers/UsersController.cs
@@ -13,6 +13,7 @@ namespace TrashMob.Controllers
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Models.Poco;
     using TrashMob.Shared.Poco;
 
     /// <summary>

--- a/TrashMobMobile/Controls/LogImpactPopup.xaml
+++ b/TrashMobMobile/Controls/LogImpactPopup.xaml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.LogImpactPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="320">
+        <VerticalStackLayout Spacing="16">
+
+            <Label Text="Log Your Impact"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Label Text="How much did you collect during this event?"
+                   FontSize="Micro"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <!-- Bags -->
+            <VerticalStackLayout Spacing="4">
+                <Label Text="Bags Collected" FontSize="Small" FontFamily="LexendSemibold" />
+                <Entry x:Name="BagsEntry"
+                       Placeholder="0"
+                       Keyboard="Numeric" />
+            </VerticalStackLayout>
+
+            <!-- Weight -->
+            <VerticalStackLayout Spacing="4">
+                <Label Text="Weight Collected" FontSize="Small" FontFamily="LexendSemibold" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <Entry x:Name="WeightEntry"
+                           Placeholder="0"
+                           Keyboard="Numeric" />
+                    <Picker x:Name="WeightUnitPicker"
+                            Grid.Column="1"
+                            WidthRequest="80">
+                        <Picker.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>lbs</x:String>
+                                <x:String>kg</x:String>
+                            </x:Array>
+                        </Picker.ItemsSource>
+                    </Picker>
+                </Grid>
+            </VerticalStackLayout>
+
+            <!-- Duration -->
+            <VerticalStackLayout Spacing="4">
+                <Label Text="Time Spent (minutes)" FontSize="Small" FontFamily="LexendSemibold" />
+                <Entry x:Name="DurationEntry"
+                       Placeholder="0"
+                       Keyboard="Numeric" />
+            </VerticalStackLayout>
+
+            <!-- Notes -->
+            <VerticalStackLayout Spacing="4">
+                <Label Text="Notes (optional)" FontSize="Small" FontFamily="LexendSemibold" />
+                <Editor x:Name="NotesEditor"
+                        Placeholder="Any notes about your contribution..."
+                        HeightRequest="60"
+                        MaxLength="500" />
+            </VerticalStackLayout>
+
+            <Button Text="Submit"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnSubmitClicked" />
+
+            <Button Text="Cancel"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnCancelClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/LogImpactPopup.xaml.cs
+++ b/TrashMobMobile/Controls/LogImpactPopup.xaml.cs
@@ -1,0 +1,82 @@
+namespace TrashMobMobile.Controls;
+
+using System.Text.Json;
+using CommunityToolkit.Maui.Extensions;
+using TrashMob.Models;
+
+public partial class LogImpactPopup : ContentView
+{
+    // Weight unit IDs matching the WeightUnit lookup table
+    private const int PoundsUnitId = 1;
+    private const int KilogramsUnitId = 2;
+
+    public LogImpactPopup(EventAttendeeMetrics? existing = null)
+    {
+        InitializeComponent();
+
+        WeightUnitPicker.SelectedIndex = 0; // Default to lbs
+
+        if (existing is not null)
+        {
+            if (existing.BagsCollected.HasValue)
+            {
+                BagsEntry.Text = existing.BagsCollected.Value.ToString();
+            }
+
+            if (existing.PickedWeight.HasValue)
+            {
+                WeightEntry.Text = existing.PickedWeight.Value.ToString("0.##");
+            }
+
+            if (existing.PickedWeightUnitId == KilogramsUnitId)
+            {
+                WeightUnitPicker.SelectedIndex = 1;
+            }
+
+            if (existing.DurationMinutes.HasValue)
+            {
+                DurationEntry.Text = existing.DurationMinutes.Value.ToString();
+            }
+
+            if (!string.IsNullOrEmpty(existing.Notes))
+            {
+                NotesEditor.Text = existing.Notes;
+            }
+        }
+    }
+
+    private async void OnSubmitClicked(object? sender, EventArgs e)
+    {
+        int.TryParse(BagsEntry.Text, out var bags);
+        decimal.TryParse(WeightEntry.Text, out var weight);
+        int.TryParse(DurationEntry.Text, out var duration);
+
+        var weightUnitId = WeightUnitPicker.SelectedIndex == 1 ? KilogramsUnitId : PoundsUnitId;
+
+        var result = new LogImpactResult
+        {
+            BagsCollected = bags,
+            PickedWeight = weight,
+            PickedWeightUnitId = weightUnitId,
+            DurationMinutes = duration,
+            Notes = NotesEditor.Text?.Trim()
+        };
+
+        var json = JsonSerializer.Serialize(result);
+        await Shell.Current.ClosePopupAsync(json);
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+
+    public class LogImpactResult
+    {
+        public int BagsCollected { get; set; }
+        public decimal PickedWeight { get; set; }
+        public int PickedWeightUnitId { get; set; }
+        public int DurationMinutes { get; set; }
+        public string? Notes { get; set; }
+    }
+}

--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@
             services.AddSingleton<IContactRequestManager, ContactRequestManager>();
             services.AddSingleton<IContactRequestRestService, ContactRequestRestService>();
             services.AddSingleton<IEventAttendeeRestService, EventAttendeeRestService>();
+            services.AddSingleton<IEventAttendeeMetricsRestService, EventAttendeeMetricsRestService>();
             services.AddSingleton<IEventAttendeeRouteRestService, EventAttendeeRouteRestService>();
             services.AddSingleton<IEventLitterReportManager, EventLitterReportManager>();
             services.AddSingleton<IEventLitterReportRestService, EventLitterReportRestService>();

--- a/TrashMobMobile/Pages/ImpactPage.xaml
+++ b/TrashMobMobile/Pages/ImpactPage.xaml
@@ -3,6 +3,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             xmlns:poco="clr-namespace:TrashMob.Models.Poco;assembly=TrashMob.Models"
              x:DataType="viewModels:ImpactViewModel"
              x:Class="TrashMobMobile.Pages.ImpactPage"
              Title="Impact">
@@ -191,6 +192,62 @@
                                 </VerticalStackLayout>
                             </Border>
                         </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <!-- My Event Contributions -->
+                <Border Style="{StaticResource RoundBorder}" Margin="10,0"
+                        IsVisible="{Binding HasEventContributions}">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="My Event Contributions" Style="{StaticResource SectionHeader}" Margin="0" />
+                        <CollectionView ItemsSource="{Binding EventContributions}"
+                                        SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="poco:UserEventMetricsSummary">
+                                    <Border Padding="10"
+                                            StrokeShape="RoundRectangle 8"
+                                            StrokeThickness="0"
+                                            Margin="0,2"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource MutedLight}, Dark={StaticResource MutedDark}}">
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ImpactViewModel}}, Path=ViewEventContributionCommand}"
+                                                                  CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
+                                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="4">
+                                            <Label Grid.Row="0" Grid.Column="0"
+                                                   Text="{Binding EventName}"
+                                                   FontFamily="LexendSemibold"
+                                                   FontSize="Small"
+                                                   LineBreakMode="TailTruncation" />
+                                            <Border Grid.Row="0" Grid.Column="1"
+                                                    Padding="6,2"
+                                                    StrokeShape="RoundRectangle 8"
+                                                    StrokeThickness="0"
+                                                    BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                                    VerticalOptions="Center">
+                                                <Label Text="{Binding Status}"
+                                                       FontSize="Micro"
+                                                       TextColor="White" />
+                                            </Border>
+                                            <HorizontalStackLayout Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Spacing="12">
+                                                <Label Text="{Binding EventDate, StringFormat='{0:MMM d, yyyy}'}"
+                                                       FontSize="Micro"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                <Label Text="{Binding BagsCollected, StringFormat='{0} bags'}"
+                                                       FontSize="Micro"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                <Label Text="{Binding WeightPounds, StringFormat='{0:0.##} lbs'}"
+                                                       FontSize="Micro"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                                <Label Text="{Binding DurationMinutes, StringFormat='{0} min'}"
+                                                       FontSize="Micro"
+                                                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            </HorizontalStackLayout>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
                     </VerticalStackLayout>
                 </Border>
 

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -338,7 +338,7 @@
     <!-- <x:String x:Key="IconClipboardArrowLeft">&#xf014b;</x:String> -->
     <!-- <x:String x:Key="IconClipboardOutline">&#xf014c;</x:String> -->
     <x:String x:Key="IconClipboardText">&#xf014d;</x:String>
-    <!-- <x:String x:Key="IconClipboardCheck">&#xf014e;</x:String> -->
+    <x:String x:Key="IconClipboardCheck">&#xf014e;</x:String>
     <!-- <x:String x:Key="IconClippy">&#xf014f;</x:String> -->
      <x:String x:Key="IconClockOutline">&#xf0150;</x:String> 
     <!-- <x:String x:Key="IconClockEnd">&#xf0151;</x:String> -->
@@ -5443,7 +5443,7 @@
     <!-- <x:String x:Key="IconSortClockAscendingOutline">&#xf154a;</x:String> -->
     <!-- <x:String x:Key="IconSortClockDescending">&#xf154b;</x:String> -->
     <!-- <x:String x:Key="IconSortClockDescendingOutline">&#xf154c;</x:String> -->
-    <!-- <x:String x:Key="IconChartBox">&#xf154d;</x:String> -->
+    <x:String x:Key="IconChartBox">&#xf154d;</x:String>
     <!-- <x:String x:Key="IconChartBoxOutline">&#xf154e;</x:String> -->
     <!-- <x:String x:Key="IconChartBoxPlusOutline">&#xf154f;</x:String> -->
     <!-- <x:String x:Key="IconMouseMoveDown">&#xf1550;</x:String> -->

--- a/TrashMobMobile/Services/EventAttendeeMetricsRestService.cs
+++ b/TrashMobMobile/Services/EventAttendeeMetricsRestService.cs
@@ -1,0 +1,76 @@
+namespace TrashMobMobile.Services
+{
+    using System.Net;
+    using System.Net.Http.Json;
+    using Newtonsoft.Json;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+
+    public class EventAttendeeMetricsRestService(IHttpClientFactory httpClientFactory)
+        : RestServiceBase(httpClientFactory), IEventAttendeeMetricsRestService
+    {
+        protected override string Controller => "events/";
+
+        public async Task<EventAttendeeMetrics?> GetMyMetricsAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/attendee-metrics/my-metrics";
+
+            using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content);
+        }
+
+        public async Task<EventAttendeeMetrics> SubmitMyMetricsAsync(Guid eventId, EventAttendeeMetrics metrics, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/attendee-metrics/my-metrics";
+            var body = JsonContent.Create(metrics, typeof(EventAttendeeMetrics), null, SerializerOptions);
+
+            using var response = await AuthorizedHttpClient.PostAsync(requestUri, body, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content)!;
+        }
+
+        public async Task<EventMetricsPublicSummary> GetPublicMetricsAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/attendee-metrics/public";
+
+            using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<EventMetricsPublicSummary>(content) ?? new EventMetricsPublicSummary();
+        }
+
+        public async Task<int> ApproveAllPendingAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/attendee-metrics/approve-all";
+
+            using var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<int>(content);
+        }
+
+        public async Task<UserImpactStats> GetUserImpactAsync(Guid userId, CancellationToken cancellationToken = default)
+        {
+            // This endpoint is on the users controller: api/users/{userId}/impact
+            // Need to use a different base path
+            var httpClient = httpClientFactory.CreateClient("ServerAPI");
+            httpClient.BaseAddress = new Uri(TrashMobApiAddress + "users/");
+
+            var requestUri = userId + "/impact";
+
+            using var response = await httpClient.GetAsync(requestUri, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<UserImpactStats>(content) ?? new UserImpactStats();
+        }
+    }
+}

--- a/TrashMobMobile/Services/IEventAttendeeMetricsRestService.cs
+++ b/TrashMobMobile/Services/IEventAttendeeMetricsRestService.cs
@@ -1,0 +1,18 @@
+namespace TrashMobMobile.Services
+{
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+
+    public interface IEventAttendeeMetricsRestService
+    {
+        Task<EventAttendeeMetrics?> GetMyMetricsAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+        Task<EventAttendeeMetrics> SubmitMyMetricsAsync(Guid eventId, EventAttendeeMetrics metrics, CancellationToken cancellationToken = default);
+
+        Task<EventMetricsPublicSummary> GetPublicMetricsAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+        Task<int> ApproveAllPendingAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+        Task<UserImpactStats> GetUserImpactAsync(Guid userId, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -24,7 +24,8 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     IEventPartnerLocationServiceRestService eventPartnerLocationServiceRestService,
     ILitterReportManager litterReportManager,
     IEventPhotoManager eventPhotoManager,
-    IRouteTrackingSessionManager routeTrackingSessionManager) : BaseViewModel(notificationService)
+    IRouteTrackingSessionManager routeTrackingSessionManager,
+    IEventAttendeeMetricsRestService eventAttendeeMetricsRestService) : BaseViewModel(notificationService)
 {
     private readonly IEventAttendeeRestService eventAttendeeRestService = eventAttendeeRestService;
     private readonly IEventLitterReportManager eventLitterReportManager = eventLitterReportManager;
@@ -35,6 +36,7 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     private readonly IMobEventManager mobEventManager = mobEventManager;
     private readonly IWaiverManager waiverManager = waiverManager;
     private readonly IEventPhotoManager eventPhotoManager = eventPhotoManager;
+    private readonly IEventAttendeeMetricsRestService eventAttendeeMetricsRestService = eventAttendeeMetricsRestService;
  
     [ObservableProperty]
     private string attendeeCount = string.Empty;
@@ -147,6 +149,32 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     [ObservableProperty]
     private string totalBagsDisplay = "0";
 
+    [ObservableProperty]
+    private bool showLogImpactButton;
+
+    [ObservableProperty]
+    private bool showMyContribution;
+
+    [ObservableProperty]
+    private int myBagsCollected;
+
+    [ObservableProperty]
+    private string myWeightDisplay = string.Empty;
+
+    [ObservableProperty]
+    private int myDurationMinutes;
+
+    [ObservableProperty]
+    private string myMetricsStatus = string.Empty;
+
+    [ObservableProperty]
+    private int pendingMetricsCount;
+
+    [ObservableProperty]
+    private bool showLeadMetricsActions;
+
+    private EventAttendeeMetrics? existingMetrics;
+
     public List<string> PrivacyOptions { get; } = ["Private", "EventOnly", "Public"];
 
     public ObservableCollection<EventPhotoViewModel> EventPhotos { get; set; } = [];
@@ -211,8 +239,9 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
             WhatToExpect =
                 "What to Expect:\n\u2022 Cleanup supplies provided\n\u2022 Meet fellow community members\n\u2022 Contribute to a cleaner environment";
 
-            // Load only what the Details tab needs — registration status and attendee count
+            // Load only what the Details tab needs — registration status, attendee count, and metrics
             await Task.WhenAll(SetRegistrationOptions(), GetAttendeeCount());
+            await LoadMyMetrics();
         }, "An error occurred while loading the event. Please try again.");
     }
 
@@ -996,5 +1025,116 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
         var totalBags = EventAttendeeRoutes.Sum(r => r.BagsCollected ?? 0);
         TotalBagsDisplay = totalBags.ToString();
+    }
+
+    private async Task LoadMyMetrics()
+    {
+        if (!mobEvent.IsCompleted())
+        {
+            return;
+        }
+
+        var isAttending = await mobEventManager.IsUserAttendingAsync(mobEvent.Id, userManager.CurrentUser.Id);
+        var isLead = mobEvent.IsEventLead(userManager.CurrentUser.Id);
+
+        if (isAttending || isLead)
+        {
+            existingMetrics = await eventAttendeeMetricsRestService.GetMyMetricsAsync(mobEvent.Id);
+
+            if (existingMetrics != null)
+            {
+                MyBagsCollected = existingMetrics.BagsCollected ?? 0;
+                MyWeightDisplay = FormatWeight(existingMetrics.PickedWeight, existingMetrics.PickedWeightUnitId);
+                MyDurationMinutes = existingMetrics.DurationMinutes ?? 0;
+                MyMetricsStatus = existingMetrics.Status ?? "Pending";
+                ShowMyContribution = true;
+                ShowLogImpactButton = false;
+            }
+            else
+            {
+                ShowLogImpactButton = true;
+                ShowMyContribution = false;
+            }
+        }
+
+        if (isLead)
+        {
+            var publicMetrics = await eventAttendeeMetricsRestService.GetPublicMetricsAsync(mobEvent.Id);
+            PendingMetricsCount = publicMetrics.Contributors.Count(c => c.Status == "Pending");
+            ShowLeadMetricsActions = PendingMetricsCount > 0;
+        }
+    }
+
+    private static string FormatWeight(decimal? weight, int? unitId)
+    {
+        if (!weight.HasValue || weight.Value == 0)
+        {
+            return "0 lbs";
+        }
+
+        var unit = unitId == 2 ? "kg" : "lbs";
+        return $"{weight.Value:0.##} {unit}";
+    }
+
+    [RelayCommand]
+    private async Task LogImpact()
+    {
+        await ExecuteAsync(async () =>
+        {
+            var popup = new Controls.LogImpactPopup(existingMetrics);
+            var result = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+            var json = result?.Result;
+
+            if (string.IsNullOrEmpty(json))
+            {
+                return;
+            }
+
+            var impactResult = System.Text.Json.JsonSerializer.Deserialize<Controls.LogImpactPopup.LogImpactResult>(json);
+            if (impactResult == null)
+            {
+                return;
+            }
+
+            var metrics = new EventAttendeeMetrics
+            {
+                EventId = mobEvent.Id,
+                UserId = userManager.CurrentUser.Id,
+                BagsCollected = impactResult.BagsCollected,
+                PickedWeight = impactResult.PickedWeight,
+                PickedWeightUnitId = impactResult.PickedWeightUnitId,
+                DurationMinutes = impactResult.DurationMinutes,
+                Notes = impactResult.Notes,
+            };
+
+            await eventAttendeeMetricsRestService.SubmitMyMetricsAsync(mobEvent.Id, metrics);
+            await LoadMyMetrics();
+
+            await NotificationService.Notify("Your impact has been logged!");
+        }, "An error occurred while logging your impact. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task ApproveAllMetrics()
+    {
+        var popup = new Controls.ConfirmPopup(
+            "Approve All Metrics",
+            "Are you sure you want to approve all pending attendee metrics?",
+            "Approve All");
+        var confirmResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+
+        if (confirmResult?.Result != Controls.ConfirmPopup.Confirmed)
+        {
+            return;
+        }
+
+        await ExecuteAsync(async () =>
+        {
+            var count = await eventAttendeeMetricsRestService.ApproveAllPendingAsync(mobEvent.Id);
+            ShowLeadMetricsActions = false;
+            PendingMetricsCount = 0;
+
+            await NotificationService.Notify($"{count} metric submission(s) approved.");
+        }, "An error occurred while approving metrics. Please try again.");
     }
 }

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
@@ -180,6 +180,107 @@
                     Style="{StaticResource SecondarySmallButton}"
                     Margin="5,4" />
 
+            <!-- Log My Impact Button -->
+            <Button Text="Log My Impact"
+                    Command="{Binding LogImpactCommand}"
+                    IsVisible="{Binding ShowLogImpactButton}"
+                    HorizontalOptions="Fill"
+                    Margin="5,4" />
+
+            <!-- My Contribution Card -->
+            <Border Style="{x:StaticResource RoundBorder}"
+                    IsVisible="{Binding ShowMyContribution}">
+                <VerticalStackLayout Spacing="10">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconChartBox}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="My Contribution"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small" />
+                        <Border Padding="6,2"
+                                StrokeShape="RoundRectangle 8"
+                                StrokeThickness="0"
+                                BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                HorizontalOptions="EndAndExpand">
+                            <Label Text="{Binding MyMetricsStatus}"
+                                   FontSize="Micro"
+                                   TextColor="White" />
+                        </Border>
+                    </HorizontalStackLayout>
+
+                    <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                        <VerticalStackLayout Grid.Column="0" HorizontalOptions="Center">
+                            <Label Text="{Binding MyBagsCollected}"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Medium"
+                                   HorizontalTextAlignment="Center" />
+                            <Label Text="Bags"
+                                   FontSize="Micro"
+                                   HorizontalTextAlignment="Center"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1" HorizontalOptions="Center">
+                            <Label Text="{Binding MyWeightDisplay}"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Medium"
+                                   HorizontalTextAlignment="Center" />
+                            <Label Text="Weight"
+                                   FontSize="Micro"
+                                   HorizontalTextAlignment="Center"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="2" HorizontalOptions="Center">
+                            <Label Text="{Binding MyDurationMinutes, StringFormat='{0} min'}"
+                                   FontFamily="LexendSemibold"
+                                   FontSize="Medium"
+                                   HorizontalTextAlignment="Center" />
+                            <Label Text="Duration"
+                                   FontSize="Micro"
+                                   HorizontalTextAlignment="Center"
+                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                        </VerticalStackLayout>
+                    </Grid>
+
+                    <Button Text="Update My Impact"
+                            Command="{Binding LogImpactCommand}"
+                            Style="{StaticResource SecondarySmallButton}"
+                            HorizontalOptions="Fill" />
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Lead Metrics Actions -->
+            <Border Style="{x:StaticResource RoundBorder}"
+                    IsVisible="{Binding ShowLeadMetricsActions}">
+                <VerticalStackLayout Spacing="8">
+                    <HorizontalStackLayout Spacing="8">
+                        <Image MaximumWidthRequest="20" MaximumHeightRequest="20" VerticalOptions="Center">
+                            <Image.Source>
+                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                 Glyph="{StaticResource IconClipboardCheck}"
+                                                 Size="20"
+                                                 Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            </Image.Source>
+                        </Image>
+                        <Label Text="Attendee Metrics"
+                               FontFamily="LexendSemibold"
+                               FontSize="Small" />
+                    </HorizontalStackLayout>
+                    <Label Text="{Binding PendingMetricsCount, StringFormat='{0} submission(s) pending review'}"
+                           FontSize="Micro"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <Button Text="Approve All"
+                            Command="{Binding ApproveAllMetricsCommand}"
+                            Style="{StaticResource SecondarySmallButton}"
+                            HorizontalOptions="Fill" />
+                </VerticalStackLayout>
+            </Border>
+
         </VerticalStackLayout>
     </ScrollView>
 </ContentView>


### PR DESCRIPTION
## Summary
- **Move POCOs** (`AttendeeMetricsTotals`, `PublicAttendeeMetrics`, `UserImpactStats`) from `TrashMob.Shared.Poco` to `TrashMob.Models.Poco` so the mobile project can reference them
- **Add REST service** (`IEventAttendeeMetricsRestService` + implementation) for mobile to call attendee metrics API endpoints (submit, get my metrics, public summary, approve all, user impact)
- **Add LogImpactPopup** form for attendees to enter bags, weight, duration, and notes after completed events
- **Integrate into ViewEventViewModel/TabDetails** — "Log My Impact" button, "My Contribution" card with status badge, "Update My Impact" option, and lead "Approve All" metrics section
- **Enhance ImpactPage** with "My Event Contributions" section showing per-event metrics breakdown with navigation to event details
- **Update Project 38 planning doc** — Phase 5 status changed from Blocked to In Progress

## Test plan
- [ ] View a completed event you attended — "Log My Impact" button should appear
- [ ] Tap "Log My Impact" — popup form with bags, weight (lbs/kg), duration, notes fields
- [ ] Submit metrics — "My Contribution" card should appear showing values + "Pending" status
- [ ] Tap "Update My Impact" — popup pre-fills with previously submitted values
- [ ] View completed event as lead with pending submissions — "Attendee Metrics" card with "Approve All" button
- [ ] Tap "Approve All" — confirmation popup, then success notification
- [ ] Impact page — "My Event Contributions" section shows events with submitted metrics
- [ ] Tap a contribution row — navigates to ViewEventPage
- [ ] View future/active event — no metrics UI shown
- [ ] View completed event you didn't attend — no metrics UI shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)