### PR TITLE
Fix Google Play location permission rejection

### DIFF
--- a/TrashMobMobile/Platforms/Android/AndroidManifest.xml
+++ b/TrashMobMobile/Platforms/Android/AndroidManifest.xml
@@ -10,7 +10,6 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:description="@string/LocationPermission" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:description="@string/LocationPermission" />
-  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
   <uses-permission android:name="android.permission.CAMERA" android:description="@string/CameraPermission" />

--- a/TrashMobMobile/Platforms/Android/GeolocatorImplementation.cs
+++ b/TrashMobMobile/Platforms/Android/GeolocatorImplementation.cs
@@ -15,13 +15,30 @@ public class GeolocatorImplementation : IGeolocator
 
     public async Task StartListening(IProgress<Microsoft.Maui.Devices.Sensors.Location> positionChangedProgress, CancellationToken cancellationToken)
     {
-        var permission = await Permissions.CheckStatusAsync<Permissions.LocationAlways>();
+        var permission = await Permissions.CheckStatusAsync<Permissions.LocationWhenInUse>();
         if (permission != PermissionStatus.Granted)
         {
-            permission = await Permissions.RequestAsync<Permissions.LocationAlways>();
+            // Show prominent disclosure before requesting location permission (Google Play policy)
+            var accepted = await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                return await App.Current!.Windows[0].Page!.DisplayAlert(
+                    "Location Permission Required",
+                    "TrashMob needs access to your location to record your cleanup route on a map. " +
+                    "Your location will be tracked while the route recording is active and a notification is shown. " +
+                    "You can stop recording at any time.",
+                    "Continue",
+                    "Cancel");
+            });
+
+            if (!accepted)
+            {
+                return;
+            }
+
+            permission = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
             if (permission != PermissionStatus.Granted)
             {
-                await Toast.Make("No permission").Show(CancellationToken.None);
+                await Toast.Make("Location permission is required to record routes.").Show(CancellationToken.None);
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- **Remove `ACCESS_BACKGROUND_LOCATION`** from AndroidManifest.xml — the app uses a foreground service for route tracking, which only requires `ACCESS_FINE_LOCATION` + `FOREGROUND_SERVICE_LOCATION`
- **Downgrade permission request** from `LocationAlways` to `LocationWhenInUse` in `GeolocatorImplementation.cs` — the foreground service handles the "app backgrounded while tracking" case
- **Add prominent disclosure dialog** before the system permission prompt — explains what location data is collected, why, and how the user can stop it

## Context
Google Play rejected the app video review for foreground location service, citing missing prominent disclosure and issues with the background location permission declaration. The `ACCESS_BACKGROUND_LOCATION` permission was unnecessary since the app exclusively uses a foreground service with persistent notification for route tracking.

## Test plan
- [ ] Open an event → Routes tab → tap "Start Route"
- [ ] Prominent disclosure dialog appears explaining location usage → tap "Continue"
- [ ] System location permission dialog appears → grant permission
- [ ] Foreground notification shows "Recording your cleanup route..."
- [ ] Tap "Stop Route" → route saved, notification dismissed
- [ ] Tap "Start Route" again (permission already granted) → no disclosure dialog, tracking starts immediately
- [ ] Tap "Start Route" → disclosure dialog → tap "Cancel" → tracking does not start
- [ ] Deny system permission → toast "Location permission is required to record routes."

🤖 Generated with [Claude Code](https://claude.com/claude-code)