### PR TITLE
Fix Strapi v5 database and add launch announcement article

### DIFF
--- a/Planning/NewsArticles/2026-02-24_trashmob-2026-launch.md
+++ b/Planning/NewsArticles/2026-02-24_trashmob-2026-launch.md
@@ -1,0 +1,96 @@
+# TrashMob 2026: A New Era for Community Cleanup Programs
+
+**Slug:** trashmob-2026-a-new-era-for-community-cleanup-programs
+**Author:** Joe Beernink
+**Category:** Announcements
+**Tags:** ["communities", "launch", "partnerships", "adopt-a-location"]
+**Featured:** true
+**Estimated Read Time:** 4
+
+---
+
+## Excerpt
+
+TrashMob.eco launches its biggest update ever — a complete platform for cities, counties, and nonprofits to run cleanup and adopt-a-location programs without the spreadsheets, email chains, and manual tracking.
+
+---
+
+## Body
+
+If you manage a community cleanup program, you already know the drill: spreadsheets tracking who adopted which street, email threads coordinating Saturday events, paper waivers stuffed in a filing cabinet, and a quarterly report that takes days to compile from scattered sources.
+
+We built TrashMob to fix that.
+
+### One platform, everything connected
+
+TrashMob.eco started as a simple way for volunteers to find and join litter cleanups. It's grown into something much bigger — an operations platform that handles the full lifecycle of community cleanup programs.
+
+Event coordination. Volunteer teams. Adopt-a-location with interactive maps. Custom waivers. Impact tracking. Reporting. It's all connected and it all works together, so the data flows from the field to your dashboard without anyone re-keying numbers into a spreadsheet.
+
+### Built for the people who run cleanup programs
+
+The 2026 release was designed with community program managers in mind. Here's what changes for you:
+
+**Your own branded community page.** Your logo, your programs, your impact stats — all in one place that volunteers can find and trust. Events, teams, adoptable areas, and litter reports all roll up under your community.
+
+**Adopt-a-location that actually scales.** Define adoptable areas on an interactive map, accept team applications, set maintenance schedules, and track compliance. Import your existing locations from GIS shapefiles, KML, or GeoJSON — or let our AI tools suggest optimal zones.
+
+**No more paper waivers.** Create community-specific digital waivers that volunteers sign before their first event. Every signature tracked, every version managed.
+
+**Impact data you can actually use.** Before/after photos, GPS route traces, weight collected, hours logged, per-volunteer metrics. Export to CSV when your council or board asks for numbers.
+
+### The volunteer experience matters too
+
+Volunteers don't come back if the experience is frustrating. TrashMob gives them reasons to stay engaged: teams they can join with friends, leaderboards that recognize effort, achievement badges, photo galleries that show their impact, and a mobile app that works as well as the website.
+
+When volunteers are happy, your program grows. When your program grows, your community gets cleaner. That's the cycle we're building for.
+
+### We're a nonprofit, and that matters
+
+TrashMob is a 501(c)(3) nonprofit. We're not trying to monetize your volunteer data or build a business on top of your community's goodwill. We exist to make cleanup programs work better, and we're funded by the communities we serve.
+
+Individual volunteers always use TrashMob for free. Communities partner with us for the tools that make program management effortless.
+
+### Let's talk
+
+We're actively looking for community partners — cities, counties, nonprofits, and civic organizations — who are ready to modernize how they run cleanup and adoption programs.
+
+If you're spending staff time on coordination that a platform should handle, we should have a conversation.
+
+**Visit the "For Communities" page at [trashmob.eco](https://www.trashmob.eco) or email [info@trashmob.eco](mailto:info@trashmob.eco) to schedule a 30-minute discovery call.**
+
+---
+
+*TrashMob.eco is a 501(c)(3) nonprofit dedicated to empowering communities to keep their neighborhoods clean.*
+
+---
+
+## Social Posts
+
+### LinkedIn
+
+We just shipped the biggest update in TrashMob's history.
+
+TrashMob.eco is now a full operations platform for community cleanup programs — branded community pages, adopt-a-location with interactive maps, digital waivers, volunteer teams, impact dashboards, and a mobile app that volunteers actually want to use.
+
+If you manage a cleanup or adoption program for a city, county, or nonprofit, and you're still running it on spreadsheets and email threads — let's talk.
+
+We're a 501(c)(3) nonprofit, volunteers always use it free, and we can have your community live in two weeks.
+
+info@trashmob.eco | trashmob.eco
+
+#CommunityCleanup #AdoptAStreet #CivicTech #NonProfit #LitterCleanup #Sustainability
+
+### Bluesky
+
+Big launch day: TrashMob.eco 2026 is live.
+
+Full platform for running community cleanup programs — branded pages, adopt-a-location maps, digital waivers, volunteer teams, impact tracking.
+
+If your city or nonprofit is managing cleanups with spreadsheets, we built the replacement. And we're a nonprofit, so volunteers use it free.
+
+trashmob.eco | info@trashmob.eco
+
+### Newsletter (First Letter intro paragraph)
+
+We're thrilled to announce the launch of TrashMob 2026 — our biggest release ever. This update transforms TrashMob from a volunteer coordination tool into a complete operations platform for community cleanup programs. Branded community pages, adopt-a-location with interactive maps, digital waivers, volunteer teams with leaderboards, and impact dashboards that give you real numbers when your board or council asks. If you know a community leader who's still managing cleanups with spreadsheets, forward this to them — we can have them up and running in two weeks. Read the full announcement on our news page.

--- a/Strapi/src/index.ts
+++ b/Strapi/src/index.ts
@@ -14,5 +14,71 @@ export default {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap(/* { strapi } */) {},
+  async bootstrap({ strapi }) {
+    // Set up public read permissions for content types.
+    // This runs on every startup to ensure permissions are always configured,
+    // especially important when using ephemeral SQLite storage.
+    const publicRole = await strapi
+      .query("plugin::users-permissions.role")
+      .findOne({ where: { type: "public" } });
+
+    if (publicRole) {
+      const publicPermissions = [
+        "api::news-post.news-post.find",
+        "api::news-post.news-post.findOne",
+        "api::news-category.news-category.find",
+        "api::news-category.news-category.findOne",
+        "api::hero-section.hero-section.find",
+        "api::what-is-trashmob.what-is-trashmob.find",
+        "api::getting-started.getting-started.find",
+      ];
+
+      for (const action of publicPermissions) {
+        const existing = await strapi
+          .query("plugin::users-permissions.permission")
+          .findOne({ where: { action, role: publicRole.id } });
+
+        if (!existing) {
+          await strapi
+            .query("plugin::users-permissions.permission")
+            .create({ data: { action, role: publicRole.id, enabled: true } });
+        }
+      }
+
+      strapi.log.info("Public permissions configured for CMS content types");
+    }
+
+    // Seed default news categories if they don't exist
+    const defaultCategories = [
+      {
+        name: "Announcements",
+        slug: "announcements",
+        description: "Official TrashMob announcements and major releases",
+      },
+      {
+        name: "Community Stories",
+        slug: "community-stories",
+        description: "Stories and highlights from TrashMob communities",
+      },
+      {
+        name: "Tips & Guides",
+        slug: "tips-and-guides",
+        description: "How-to guides and best practices for cleanup organizers",
+      },
+    ];
+
+    for (const cat of defaultCategories) {
+      const existing = await strapi
+        .documents("api::news-category.news-category")
+        .findFirst({ filters: { slug: cat.slug } });
+
+      if (!existing) {
+        await strapi
+          .documents("api::news-category.news-category")
+          .create({ data: cat, status: "published" });
+      }
+    }
+
+    strapi.log.info("Default news categories seeded");
+  },
 };


### PR DESCRIPTION
## Summary
- **Strapi v5 MSSQL fix:** Strapi v5 dropped MSSQL support. The dev Strapi container was crashing with `Unknown dialect mssql`. Switched to SQLite with single-replica constraint. The bootstrap function auto-configures public read permissions and seeds default news categories on every startup (important since SQLite is ephemeral).
- **Launch article:** First news article for the site — "TrashMob 2026: A New Era for Community Cleanup Programs". Targets community leaders managing cleanup/adoption programs. Includes LinkedIn, Bluesky, and newsletter social posts.
- **Planning folder:** Created `Planning/NewsArticles/` for article drafts and Strapi upload payloads.

## Files changed
| File | Change |
|------|--------|
| `Deploy/containerAppStrapi.bicep` | Switch DATABASE_CLIENT from mssql to sqlite, remove MSSQL env vars, cap maxReplicas=1 |
| `Strapi/src/index.ts` | Add bootstrap: public permissions + category seeding |
| `Planning/NewsArticles/2026-02-24_trashmob-2026-launch.md` | Article draft with social media posts |

## Test plan
- [ ] Merge triggers Strapi dev deploy — verify bootstrap runs (check container logs for "Public permissions configured" and "Default news categories seeded")
- [ ] Verify `https://dev.trashmob.eco/news` shows the article after content is uploaded
- [ ] Verify Strapi admin panel accessible at container app URL
- [ ] Review article content and social posts for tone/accuracy

## Notes
- Article already uploaded to dev Strapi manually (will need re-upload after container restart since SQLite is ephemeral)
- Dev Strapi admin: `joe@trashmob.eco` / `mBF6IGL08DmPZ8kCNlAb` (change after review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)