### PR TITLE
Fix crash when switching tabs on ViewEventPage

### DIFF
--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -250,26 +250,29 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     /// </summary>
     public async Task OnTabSelected(int tabIndex)
     {
-        switch (tabIndex)
+        await ExecuteAsync(async () =>
         {
-            case 1 when !partnersLoaded:
-                partnersLoaded = true;
-                await LoadPartners();
-                break;
-            case 3 when !litterLoaded:
-                litterLoaded = true;
-                await LoadLitterReports();
-                break;
-            case 4 when !photosLoaded:
-                photosLoaded = true;
-                await LoadPhotos();
-                break;
-            case 5 when !routesLoaded:
-                routesLoaded = true;
-                var routes = await eventAttendeeRouteRestService.GetEventAttendeeRoutesForEventAsync(EventViewModel.Id);
-                LoadRouteViewModels(routes);
-                break;
-        }
+            switch (tabIndex)
+            {
+                case 1 when !partnersLoaded:
+                    partnersLoaded = true;
+                    await LoadPartners();
+                    break;
+                case 3 when !litterLoaded:
+                    litterLoaded = true;
+                    await LoadLitterReports();
+                    break;
+                case 4 when !photosLoaded:
+                    photosLoaded = true;
+                    await LoadPhotos();
+                    break;
+                case 5 when !routesLoaded:
+                    routesLoaded = true;
+                    var routes = await eventAttendeeRouteRestService.GetEventAttendeeRoutesForEventAsync(EventViewModel.Id);
+                    LoadRouteViewModels(routes);
+                    break;
+            }
+        }, "Failed to load tab data. Please try again.");
     }
     
     [RelayCommand]


### PR DESCRIPTION
## Summary
- Wrap `OnTabSelected` in `ExecuteAsync` to prevent unhandled exceptions from crashing the app
- The `OnSwitcherPropertyChanged` handler is `async void`, so any exception (e.g. a 500 from the routes API) was fatal
- Now shows a user-friendly error message instead of crashing

## Test plan
- [ ] Open an event, switch between all tabs — no crash
- [ ] If routes API returns an error, app shows toast instead of crashing
- [ ] Verify other tabs (Partners, Litter Reports, Photos) still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)