### PR TITLE
Move route disclosure popup to ViewModel layer

### DIFF
--- a/TrashMobMobile/Platforms/Android/GeolocatorImplementation.cs
+++ b/TrashMobMobile/Platforms/Android/GeolocatorImplementation.cs
@@ -18,23 +18,6 @@ public class GeolocatorImplementation : IGeolocator
         var permission = await Permissions.CheckStatusAsync<Permissions.LocationWhenInUse>();
         if (permission != PermissionStatus.Granted)
         {
-            // Show prominent disclosure before requesting location permission (Google Play policy)
-            var accepted = await MainThread.InvokeOnMainThreadAsync(async () =>
-            {
-                return await App.Current!.Windows[0].Page!.DisplayAlert(
-                    "Location Permission Required",
-                    "TrashMob needs access to your location to record your cleanup route on a map. " +
-                    "Your location will be tracked while the route recording is active and a notification is shown. " +
-                    "You can stop recording at any time.",
-                    "Continue",
-                    "Cancel");
-            });
-
-            if (!accepted)
-            {
-                return;
-            }
-
             permission = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
             if (permission != PermissionStatus.Granted)
             {

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -443,6 +443,26 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
         if (EnableStartTrackEventRoute)
         {
+            // Show prominent disclosure the first time the user starts route tracking (Google Play policy)
+            const string disclosureKey = "RouteTrackingDisclosureShown";
+            if (!Preferences.Default.Get(disclosureKey, false))
+            {
+                var accepted = await Shell.Current.CurrentPage.DisplayAlert(
+                    "Location Permission Required",
+                    "TrashMob needs access to your location to record your cleanup route on a map. " +
+                    "Your location will be tracked while the route recording is active and a notification is shown. " +
+                    "You can stop recording at any time.",
+                    "Continue",
+                    "Cancel");
+
+                if (!accepted)
+                {
+                    return;
+                }
+
+                Preferences.Default.Set(disclosureKey, true);
+            }
+
             RouteStartTime = DateTimeOffset.Now;
             RouteEndTime = DateTimeOffset.Now;
             EnableStopTrackEventRoute = true;


### PR DESCRIPTION
## Summary
- Moved the Google Play prominent disclosure popup from `GeolocatorImplementation` to `ViewEventViewModel.RealTimeLocationTracker`
- The popup was previously inside a permission check in `GeolocatorImplementation`, so it never appeared when location permission was already granted by map controls (`IsShowingUser="True"`)
- Now uses `Preferences` to show the disclosure once on first "Start Route" tap, regardless of current permission state
- Works on both emulator and real devices (previous location was skipped on emulator due to `DeviceType.Virtual` check)

## Test plan
- [ ] Fresh install: tap "Start Route" → disclosure popup appears → tap "Continue" → route starts
- [ ] Tap "Start Route" again → disclosure does NOT appear (already shown)
- [ ] Fresh install: tap "Start Route" → disclosure popup → tap "Cancel" → route does not start
- [ ] Maps still show user location (blue dot) without triggering disclosure

🤖 Generated with [Claude Code](https://claude.com/claude-code)