### PR TITLE
Fix GitHub environment name in DB least-privilege workflow

### DIFF
--- a/.github/workflows/setup-db-least-privilege.yml
+++ b/.github/workflows/setup-db-least-privilege.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment == 'pr' && 'production' || 'development' }}
+    environment: ${{ github.event.inputs.environment == 'pr' && 'production' || 'test' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- Fix Azure login failure (AADSTS700213) in the DB least-privilege setup workflow
- Changed GitHub environment from `development` to `test` for the dev input, matching all other dev-environment workflows

## Root cause
The Azure OIDC federated identity credential is configured for `repo:TrashMob-eco/TrashMob:environment:test`, but the workflow was using `environment: development`. All other dev workflows (container deploys, exception monitor, PR checks) correctly use `test`.

## Test plan
- [ ] After merge: re-run setup workflow against dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)