### PR TITLE
Install sqlcmd in DB least-privilege workflow

### DIFF
--- a/.github/workflows/setup-db-least-privilege.yml
+++ b/.github/workflows/setup-db-least-privilege.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install sqlcmd
+        run: |
+          curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc > /dev/null
+          sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list)"
+          sudo apt-get update
+          sudo apt-get install -y sqlcmd
+
       - name: Login to Azure
         uses: azure/login@v2
         with:


### PR DESCRIPTION
## Summary
- Add step to install `sqlcmd` from the Microsoft apt repository before running SQL scripts
- The `ubuntu-latest` runner doesn't have `sqlcmd` pre-installed, causing the workflow to fail with `command not found`

## Test plan
- [ ] After merge: re-run setup workflow against dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)