### PR TITLE
Fix sqlcmd installation for Ubuntu 24.04

### DIFF
--- a/.github/workflows/setup-db-least-privilege.yml
+++ b/.github/workflows/setup-db-least-privilege.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Install sqlcmd
         run: |
-          curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc > /dev/null
-          sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list)"
+          curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y sqlcmd
 


### PR DESCRIPTION
## Summary
- Fix `sqlcmd` installation in the DB least-privilege workflow
- `add-apt-repository` can't parse the Microsoft prod list format on Ubuntu 24.04 (Noble)
- Use direct apt sources list entry with `signed-by` keyring instead

## Test plan
- [ ] After merge: re-run setup workflow against dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)