### PR TITLE
Fix gpg dearmor TTY error in sqlcmd installation

### DIFF
--- a/.github/workflows/setup-db-least-privilege.yml
+++ b/.github/workflows/setup-db-least-privilege.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Install sqlcmd
         run: |
-          curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list
+          curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --batch --yes --dearmor | sudo tee /usr/share/keyrings/microsoft-prod.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/microsoft-prod.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y sqlcmd
 


### PR DESCRIPTION
## Summary
- Fix `gpg: cannot open '/dev/tty': No such device or address` error
- Add `--batch --yes` flags to `gpg --dearmor` and pipe through `tee` instead of using `-o` directly

## Test plan
- [ ] After merge: re-run setup workflow against dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)