### PR TITLE
Fix Strapi SQLite locking on Azure Files

### DIFF
--- a/Deploy/containerAppStrapi.bicep
+++ b/Deploy/containerAppStrapi.bicep
@@ -147,12 +147,11 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           env: [
             {
               name: 'DATABASE_CLIENT'
-              value: 'sqlite'  // Strapi v5 dropped MSSQL support; SQLite on persistent Azure Files
+              value: 'sqlite'  // Strapi v5 dropped MSSQL support
             }
-            {
-              name: 'DATABASE_FILENAME'
-              value: '/app/data/strapi.db'  // Persistent storage via Azure Files mount
-            }
+            // DATABASE_FILENAME is set by docker-entrypoint.sh to local ephemeral storage
+            // The entrypoint copies DB from Azure Files (/app/data) to local (/app/.tmp) on startup
+            // and syncs back periodically, avoiding SMB file locking issues with SQLite
             {
               name: 'ADMIN_JWT_SECRET'
               secretRef: 'admin-jwt-secret'

--- a/Strapi/.gitattributes
+++ b/Strapi/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts have Unix line endings for Docker
+*.sh text eol=lf

--- a/Strapi/Dockerfile
+++ b/Strapi/Dockerfile
@@ -38,13 +38,17 @@ COPY --from=build /app/tsconfig.json ./tsconfig.json
 # SQLite uses local ephemeral storage (Azure Files SMB has locking issues)
 RUN mkdir -p /app/public/uploads /app/.tmp
 
+# Copy entrypoint script that handles DB persistence via Azure Files
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+
 # Create non-root user for security
 RUN addgroup -g 1001 -S strapi && \
     adduser -S strapi -u 1001 -G strapi && \
-    chown -R strapi:strapi /app
+    chown -R strapi:strapi /app && \
+    chmod +x /app/docker-entrypoint.sh
 
 USER strapi
 
 EXPOSE 1337
 
-CMD ["npm", "run", "start"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Strapi/config/database.ts
+++ b/Strapi/config/database.ts
@@ -4,9 +4,9 @@ export default ({ env }) => {
   const connections = {
     sqlite: {
       connection: {
-        // Deployed: DATABASE_FILENAME=/app/data/strapi.db (persistent Azure Files mount)
-        // Local dev: defaults to /app/.tmp/data.db (ephemeral)
-        // maxReplicas=1 in Bicep avoids SQLite locking issues with SMB
+        // Deployed: docker-entrypoint.sh sets DATABASE_FILENAME=/app/.tmp/strapi.db (local ephemeral)
+        // and handles persistence by copying to/from Azure Files mount at /app/data/
+        // Local dev: defaults to /app/.tmp/data.db
         filename: env('DATABASE_FILENAME', '/app/.tmp/data.db'),
       },
       useNullAsDefault: true,

--- a/Strapi/docker-entrypoint.sh
+++ b/Strapi/docker-entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Entrypoint script that copies SQLite DB from Azure Files (persistent)
+# to local ephemeral storage (where SQLite locking works properly),
+# runs Strapi, and syncs the DB back periodically.
+#
+# Azure Files uses SMB which doesn't support the POSIX file locking
+# that SQLite requires, causing "database is locked" errors.
+
+PERSISTENT_DIR="/app/data"
+LOCAL_DIR="/app/.tmp"
+DB_NAME="strapi.db"
+
+# Ensure local directory exists
+mkdir -p "$LOCAL_DIR"
+
+# Restore DB from persistent storage if it exists and is non-empty
+if [ -f "$PERSISTENT_DIR/$DB_NAME" ] && [ -s "$PERSISTENT_DIR/$DB_NAME" ]; then
+  echo "Restoring database from persistent storage..."
+  cp "$PERSISTENT_DIR/$DB_NAME" "$LOCAL_DIR/$DB_NAME"
+  echo "Database restored ($(wc -c < "$PERSISTENT_DIR/$DB_NAME") bytes)"
+else
+  echo "No existing database found, Strapi will create a fresh one."
+fi
+
+# Background sync: copy local DB back to persistent storage every 5 minutes
+sync_db() {
+  if [ -f "$LOCAL_DIR/$DB_NAME" ] && [ -s "$LOCAL_DIR/$DB_NAME" ]; then
+    cp "$LOCAL_DIR/$DB_NAME" "$PERSISTENT_DIR/$DB_NAME" 2>/dev/null && \
+      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Database synced to persistent storage"
+  fi
+}
+
+(
+  while true; do
+    sleep 300
+    sync_db
+  done
+) &
+SYNC_PID=$!
+
+# Override DATABASE_FILENAME to use local storage
+export DATABASE_FILENAME="$LOCAL_DIR/$DB_NAME"
+
+# Start Strapi in the background so we can handle signals
+echo "Starting Strapi with local database at $DATABASE_FILENAME"
+npm run start &
+STRAPI_PID=$!
+
+# Trap shutdown signals to sync DB before exit
+cleanup() {
+  echo "Shutting down - syncing database to persistent storage..."
+  sync_db
+  kill $SYNC_PID 2>/dev/null
+  kill $STRAPI_PID 2>/dev/null
+  wait $STRAPI_PID 2>/dev/null
+  exit 0
+}
+trap cleanup SIGTERM SIGINT
+
+# Wait for Strapi to exit
+wait $STRAPI_PID
+EXIT_CODE=$?
+
+# Sync on normal exit too
+sync_db
+kill $SYNC_PID 2>/dev/null
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Both dev and prod Strapi containers are in CrashLoopBackOff due to SQLite "database is locked" errors
- Azure Files (SMB) doesn't support POSIX file locking that SQLite requires
- Add `docker-entrypoint.sh` that copies DB from Azure Files to local ephemeral storage on startup, runs Strapi against the local copy, and syncs back every 5 minutes + on shutdown
- Remove `DATABASE_FILENAME` env var from Bicep (entrypoint script sets it)

## Test plan
- [ ] Verify CI builds the Docker image successfully
- [ ] Deploy to DEV and confirm Strapi starts without "database is locked" errors
- [ ] Verify admin panel is accessible and categories are seeded
- [ ] Confirm DB persists after container restart (check Azure Files share has non-empty strapi.db)

🤖 Generated with [Claude Code](https://claude.com/claude-code)