### PR TITLE
Remove obsolete SQL Server steps from Strapi deploy workflows

### DIFF
--- a/.claude/commands/upload-article.md
+++ b/.claude/commands/upload-article.md
@@ -1,0 +1,88 @@
+Upload a news article to the TrashMob Strapi CMS.
+
+## Arguments
+- `$ARGUMENTS` - Path to the markdown article file (e.g., `Planning/NewsArticles/2026-02-24_article.md`) and target environment (`dev` or `prod`)
+
+## Instructions
+
+1. **Parse the arguments** to get the article file path and environment (default to `dev` if not specified).
+
+2. **Read the article markdown file**. It should have frontmatter in this format:
+   ```
+   # Title
+   **Slug:** article-slug
+   **Author:** Author Name
+   **Category:** Announcements | Community Stories | Tips & Guides
+   **Tags:** ["tag1", "tag2"]
+   **Featured:** true/false
+   **Estimated Read Time:** N
+   ---
+   ## Excerpt
+   Excerpt text here
+   ---
+   ## Body
+   Article body in markdown...
+   ```
+
+3. **Determine the Strapi URL** based on environment:
+   - `dev`: Get FQDN via `az containerapp show --name ca-strapi-tm-dev-westus2 --resource-group rg-trashmob-dev-westus2 --query "properties.configuration.ingress.fqdn" -o tsv`
+   - `prod`: Get FQDN via `az containerapp show --name ca-strapi-tm-pr-westus2 --resource-group rg-trashmob-pr-westus2 --subscription 5ea21946-8cb1-413f-9005-0ab10bfa839d --query "properties.configuration.ingress.fqdn" -o tsv`
+
+4. **Convert the markdown body to Strapi Blocks format**. The body field uses Strapi's block editor format:
+   - Paragraphs → `{ "type": "paragraph", "children": [{ "type": "text", "text": "..." }] }`
+   - H2 headings → `{ "type": "heading", "level": 2, "children": [{ "type": "text", "text": "..." }] }`
+   - H3 headings → `{ "type": "heading", "level": 3, "children": [{ "type": "text", "text": "..." }] }`
+   - Bold text → `{ "type": "text", "bold": true, "text": "..." }`
+   - Italic text → `{ "type": "text", "italic": true, "text": "..." }`
+   - Links → `{ "type": "link", "url": "https://...", "children": [{ "type": "text", "text": "..." }] }`
+   - Mixed formatting in a paragraph: multiple children in the paragraph's children array
+
+5. **Look up the category ID**. Query `GET /api/news-categories` and find the matching category by name. Default categories (auto-seeded):
+   - ID 1: "Announcements"
+   - ID 2: "Community Stories"
+   - ID 3: "Tips & Guides"
+
+6. **Build the JSON payload**:
+   ```json
+   {
+     "data": {
+       "title": "...",
+       "slug": "...",
+       "excerpt": "...",
+       "author": "...",
+       "isFeatured": true/false,
+       "estimatedReadTime": N,
+       "tags": ["tag1", "tag2"],
+       "category": { "connect": [CATEGORY_ID] },
+       "body": [ ...blocks... ]
+     }
+   }
+   ```
+
+7. **Authenticate with Strapi**:
+   - Try `POST /admin/login` with admin credentials (ask user if not known)
+   - Create or reuse an API token via `POST /admin/api-tokens`
+   - Use `Authorization: Bearer <token>` for the upload
+
+8. **Upload the article**:
+   ```bash
+   curl -X POST "$STRAPI_URL/api/news-posts" \
+     -H "Authorization: Bearer $API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d @article.json
+   ```
+
+9. **Publish the article** (Strapi creates as draft by default in v5):
+   - Get the article ID from the POST response
+   - `PUT /api/news-posts/{id}` with `{ "data": { "publishedAt": "2026-01-01T00:00:00.000Z" } }` to publish
+
+10. **Save the upload JSON** to `Planning/NewsArticles/` alongside the markdown file for reference (e.g., `strapi-upload.json`).
+
+11. **Verify** by hitting `GET /api/news-posts?filters[slug][$eq]=SLUG` and confirming the article appears.
+
+## Example Usage
+```
+/upload-article Planning/NewsArticles/2026-02-24_trashmob-2026-launch.md prod
+/upload-article Planning/NewsArticles/my-article.md dev
+/upload-article Planning/NewsArticles/my-article.md  (defaults to dev)
+```

--- a/.github/workflows/container_strapi-tm-dev-westus2.yml
+++ b/.github/workflows/container_strapi-tm-dev-westus2.yml
@@ -71,43 +71,6 @@ jobs:
           docker push $IMAGE_TAG
           docker push $IMAGE_TAG_LATEST
 
-      - name: Deploy Strapi Database
-        run: |
-          az deployment group create \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
-            --template-file Deploy/sqlDatabaseStrapi.bicep \
-            --parameters \
-              environment=dev \
-              region=${{ env.REGION }}
-
-      - name: Install SQL Server tools
-        run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
-          sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev
-          echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
-
-      - name: Create Strapi SQL User
-        run: |
-          export PATH="$PATH:/opt/mssql-tools18/bin"
-
-          # Get admin credentials from the main app connection string (format: Server=...;User ID=dbadmin;Password=<pw>;...)
-          SQL_SERVER="sql-tm-dev-${{ env.REGION }}"
-          CONN_STR=$(az keyvault secret show --name TMDBServerConnectionString --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
-          SQL_ADMIN=$(echo "$CONN_STR" | grep -oP '(?<=User ID=)[^;]+')
-          SQL_ADMIN_PASSWORD=$(echo "$CONN_STR" | grep -oP '(?<=Password=)[^;]+')
-          STRAPI_PASSWORD=$(az keyvault secret show --name strapi-db-password --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
-
-          # Create user if not exists (idempotent)
-          sqlcmd -S "${SQL_SERVER}.database.windows.net" -d "db-strapi-dev-${{ env.REGION }}" \
-            -U "$SQL_ADMIN" -P "$SQL_ADMIN_PASSWORD" -C \
-            -Q "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = 'strapi-dev')
-                BEGIN
-                  CREATE USER [strapi-dev] WITH PASSWORD = '$STRAPI_PASSWORD';
-                  ALTER ROLE db_owner ADD MEMBER [strapi-dev];
-                END"
-
       - name: Get Strapi secrets from Key Vault
         id: get-secrets
         run: |

--- a/.github/workflows/release_strapi-tm-pr-westus2.yml
+++ b/.github/workflows/release_strapi-tm-pr-westus2.yml
@@ -71,43 +71,6 @@ jobs:
           docker push $IMAGE_TAG
           docker push $IMAGE_TAG_LATEST
 
-      - name: Deploy Strapi Database
-        run: |
-          az deployment group create \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
-            --template-file Deploy/sqlDatabaseStrapi.bicep \
-            --parameters \
-              environment=pr \
-              region=${{ env.REGION }}
-
-      - name: Install SQL Server tools
-        run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
-          sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev
-          echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
-
-      - name: Create Strapi SQL User
-        run: |
-          export PATH="$PATH:/opt/mssql-tools18/bin"
-
-          # Get admin credentials from the main app connection string (format: Server=...;User ID=dbadmin;Password=<pw>;...)
-          SQL_SERVER="sql-tm-pr-${{ env.REGION }}"
-          CONN_STR=$(az keyvault secret show --name TMDBServerConnectionString --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
-          SQL_ADMIN=$(echo "$CONN_STR" | grep -oP '(?<=User ID=)[^;]+')
-          SQL_ADMIN_PASSWORD=$(echo "$CONN_STR" | grep -oP '(?<=Password=)[^;]+')
-          STRAPI_PASSWORD=$(az keyvault secret show --name strapi-db-password --vault-name ${{ env.KEY_VAULT_NAME }} --query value -o tsv)
-
-          # Create user if not exists (idempotent)
-          sqlcmd -S "${SQL_SERVER}.database.windows.net" -d "db-strapi-pr-${{ env.REGION }}" \
-            -U "$SQL_ADMIN" -P "$SQL_ADMIN_PASSWORD" -C \
-            -Q "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = 'strapi-pr')
-                BEGIN
-                  CREATE USER [strapi-pr] WITH PASSWORD = '$STRAPI_PASSWORD';
-                  ALTER ROLE db_owner ADD MEMBER [strapi-pr];
-                END"
-
       - name: Get Strapi secrets from Key Vault
         id: get-secrets
         run: |


### PR DESCRIPTION
## Summary
- Remove "Deploy Strapi Database", "Install SQL Server tools", and "Create Strapi SQL User" steps from both dev and prod Strapi workflows
- These steps reference a `sqlDatabaseStrapi.bicep` template and try to create a `db-strapi-*` database that doesn't exist since Strapi switched to SQLite
- This was causing the DEV deployment to fail after #2923 merged
- Also includes the `/upload-article` Claude command file

## Test plan
- [ ] Merge and verify the DEV Strapi workflow runs successfully
- [ ] Confirm Strapi container starts and is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)