### PR TITLE
Fix backfill table name: EventSummaries

### DIFF
--- a/TrashMobDailyJobs/HistoricalMetricsBackfill.cs
+++ b/TrashMobDailyJobs/HistoricalMetricsBackfill.cs
@@ -25,7 +25,7 @@ namespace TrashMobDailyJobs
             // First, check how many events need backfilling
             var countSql = @"
                 SELECT COUNT(DISTINCT es.EventId)
-                FROM dbo.EventSummary es
+                FROM dbo.EventSummaries es
                 INNER JOIN dbo.Events e ON es.EventId = e.Id
                 WHERE e.EventStatusId != 3
                   AND (es.NumberOfBags > 0 OR es.PickedWeight > 0 OR es.DurationInMinutes > 0)
@@ -88,7 +88,7 @@ namespace TrashMobDailyJobs
                         GETUTCDATE()
                     FROM dbo.EventAttendees ea
                     INNER JOIN dbo.Events e ON ea.EventId = e.Id
-                    INNER JOIN dbo.EventSummary es ON e.Id = es.EventId
+                    INNER JOIN dbo.EventSummaries es ON e.Id = es.EventId
                     CROSS APPLY (
                         SELECT COUNT(*) AS AttendeeCount
                         FROM dbo.EventAttendees ea2


### PR DESCRIPTION
## Summary
- Fix `Invalid object name 'dbo.EventSummary'` error in the historical metrics backfill
- The actual table name is `EventSummaries` (plural), not `EventSummary`

## Test plan
- [x] Verified correct table name in database
- [ ] Deploy and re-run daily job

🤖 Generated with [Claude Code](https://claude.com/claude-code)