### PR TITLE
Add year/month dropdowns to birth date picker

### DIFF
--- a/TrashMob/client-app/src/components/AgeGate/AgeGateDialog.tsx
+++ b/TrashMob/client-app/src/components/AgeGate/AgeGateDialog.tsx
@@ -61,7 +61,17 @@ export function AgeGateDialog({ open, onOpenChange, onConfirm }: AgeGateDialogPr
                 ) : (
                     <>
                         <div className='py-2'>
-                            <DatePicker value={dob as Date} onChange={(value) => setDob(value)} />
+                            <DatePicker
+                                value={dob as Date}
+                                onChange={(value) => setDob(value)}
+                                placeholder='Select your date of birth'
+                                calendarProps={{
+                                    captionLayout: 'dropdown-buttons',
+                                    fromYear: 1920,
+                                    toYear: new Date().getFullYear(),
+                                    defaultMonth: new Date(2000, 0),
+                                }}
+                            />
                         </div>
                         <DialogFooter>
                             <Button variant='outline' onClick={() => handleOpenChange(false)}>

--- a/TrashMob/client-app/src/components/ui/calendar.tsx
+++ b/TrashMob/client-app/src/components/ui/calendar.tsx
@@ -17,6 +17,12 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
                 month: 'space-y-4',
                 caption: 'flex justify-center pt-1 relative items-center',
                 caption_label: 'text-sm font-medium',
+                caption_dropdowns: 'flex items-center gap-2',
+                dropdown:
+                    'appearance-none rounded-md border border-input bg-background px-2 py-1 text-sm font-medium shadow-xs focus:outline-none focus:ring-1 focus:ring-ring',
+                dropdown_month: '[&>span]:sr-only',
+                dropdown_year: '[&>span]:sr-only',
+                vhidden: 'sr-only',
                 nav: 'space-x-1 flex items-center',
                 nav_button: cn(
                     buttonVariants({ variant: 'outline-solid' }),

--- a/TrashMob/client-app/src/components/ui/datepicker.tsx
+++ b/TrashMob/client-app/src/components/ui/datepicker.tsx
@@ -4,16 +4,17 @@ import { CalendarIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { Calendar } from '@/components/ui/calendar';
+import { Calendar, type CalendarProps } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 interface DatePickerProps {
     value: Date;
     onChange: (value?: Date) => void;
+    placeholder?: string;
+    calendarProps?: Omit<CalendarProps, 'mode' | 'selected' | 'onSelect'>;
 }
 
-export function DatePicker(props: DatePickerProps) {
-    const date = props.value;
+export function DatePicker({ value, onChange, placeholder = 'Pick a date', calendarProps }: DatePickerProps) {
     return (
         <Popover>
             <PopoverTrigger asChild>
@@ -21,15 +22,15 @@ export function DatePicker(props: DatePickerProps) {
                     variant='outline'
                     className={cn(
                         'w-full justify-start text-left font-normal border-input shadow-xs',
-                        !date && 'text-muted-foreground',
+                        !value && 'text-muted-foreground',
                     )}
                 >
                     <CalendarIcon />
-                    {date ? moment(date).format('L') : <span>Pick a date</span>}
+                    {value ? moment(value).format('L') : <span>{placeholder}</span>}
                 </Button>
             </PopoverTrigger>
             <PopoverContent className='w-auto p-0'>
-                <Calendar mode='single' selected={date} onSelect={props.onChange} initialFocus />
+                <Calendar mode='single' selected={value} onSelect={onChange} initialFocus {...calendarProps} />
             </PopoverContent>
         </Popover>
     );


### PR DESCRIPTION
## Summary
- Switches the age gate date picker from month-by-month arrow navigation to **year/month dropdown menus**, so users can jump directly to their birth year instead of scrolling through hundreds of months
- Extends the `DatePicker` component with `placeholder` and `calendarProps` pass-through props for reuse
- Adds Tailwind styling for the dropdown `<select>` elements in the `Calendar` component

## Test plan
- [ ] Open the Create Account flow and verify the date picker shows year and month dropdowns
- [ ] Select a birth date using the dropdowns and confirm age verification works correctly
- [ ] Verify the calendar defaults to January 2000 and allows years from 1920 to current year
- [ ] Confirm other DatePicker usages in the app are unaffected (no `calendarProps` = same behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)