### PR TITLE
Fix CookieConsent crash from missing router context

### DIFF
--- a/TrashMob/client-app/src/components/CookieConsent/CookieConsent.tsx
+++ b/TrashMob/client-app/src/components/CookieConsent/CookieConsent.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { getConsent, setConsent, loadClarity, loadAppInsights } from '@/lib/analytics';
 
@@ -25,9 +24,9 @@ export function CookieConsent() {
             <div className='mx-auto flex max-w-4xl flex-col items-center gap-3 sm:flex-row sm:justify-between'>
                 <p className='text-sm text-muted-foreground'>
                     We use cookies for analytics and to improve your experience.{' '}
-                    <Link to='/privacypolicy' className='underline hover:text-foreground'>
+                    <a href='/privacypolicy' className='underline hover:text-foreground'>
                         Privacy Policy
-                    </Link>
+                    </a>
                 </p>
                 <div className='flex shrink-0 gap-2'>
                     <Button variant='outline' size='sm' onClick={handleReject}>


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot destructure property 'basename' of useContext(...)` crash caused by `CookieConsent` using react-router `<Link>` while rendered outside `BrowserRouter`
- Replace `<Link to='/privacypolicy'>` with plain `<a href='/privacypolicy'>` since the component is at the App root level alongside `<Toaster />`

## Test plan
- [ ] Verify no console errors on page load
- [ ] Verify cookie consent banner appears and Privacy Policy link works
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)