### PR TITLE
Fix mobile auth: CurrentUser not set after CIAM sign-in

### DIFF
--- a/TrashMobMobile/Authentication/AuthService.cs
+++ b/TrashMobMobile/Authentication/AuthService.cs
@@ -365,17 +365,25 @@ public class AuthService : IAuthService
         accessToken = result.AccessToken;
         expiresOn = result.ExpiresOn;
 
-        var emailClaim = result.ClaimsPrincipal.Claims.FirstOrDefault(c => c.Type == "email");
         var context = GetUserContext(result);
 
         // Set user context first so AuthHandler can use the token for the API call below
         UserState.UserContext = context;
 
-        if (emailClaim != null)
+        // Try email lookup first (CIAM id_tokens may lack email claim)
+        if (!string.IsNullOrWhiteSpace(context.EmailAddress))
         {
-            userEmail = emailClaim.Value;
+            userEmail = context.EmailAddress;
             var user = await userManager.GetUserByEmailAsync(context.EmailAddress);
+            App.CurrentUser = user;
+            return;
+        }
 
+        // Fall back to ObjectId lookup (CIAM tokens always include oid)
+        var oidClaim = result.ClaimsPrincipal.Claims.FirstOrDefault(c => c.Type == "oid");
+        if (oidClaim != null)
+        {
+            var user = await userManager.GetUserByObjectIdAsync(oidClaim.Value);
             App.CurrentUser = user;
         }
     }

--- a/TrashMobMobile/Services/IUserManager.cs
+++ b/TrashMobMobile/Services/IUserManager.cs
@@ -11,6 +11,9 @@
         Task<User> GetUserByEmailAsync(string email,
             CancellationToken cancellationToken = default);
 
+        Task<User?> GetUserByObjectIdAsync(string objectId,
+            CancellationToken cancellationToken = default);
+
         Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default);
 
         Task<User> UpdateUserAsync(User user, CancellationToken cancellationToken = default);

--- a/TrashMobMobile/Services/IUserRestService.cs
+++ b/TrashMobMobile/Services/IUserRestService.cs
@@ -9,6 +9,9 @@
         Task<User> GetUserByEmailAsync(string email,
             CancellationToken cancellationToken = default);
 
+        Task<User?> GetUserByObjectIdAsync(string objectId,
+            CancellationToken cancellationToken = default);
+
         Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default);
 
         Task<User> UpdateUserAsync(User user, CancellationToken cancellationToken = default);

--- a/TrashMobMobile/Services/UserManager.cs
+++ b/TrashMobMobile/Services/UserManager.cs
@@ -28,6 +28,12 @@
             return userRestService.GetUserByEmailAsync(email, cancellationToken);
         }
 
+        public Task<User?> GetUserByObjectIdAsync(string objectId,
+            CancellationToken cancellationToken = default)
+        {
+            return userRestService.GetUserByObjectIdAsync(objectId, cancellationToken);
+        }
+
         public Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default)
         {
             return userRestService.AddUserAsync(user, cancellationToken);

--- a/TrashMobMobile/Services/UserRestService.cs
+++ b/TrashMobMobile/Services/UserRestService.cs
@@ -35,6 +35,19 @@ public class UserRestService(IHttpClientFactory httpClientFactory) : RestService
         }
     }
 
+    public async Task<User?> GetUserByObjectIdAsync(string objectId,
+        CancellationToken cancellationToken = default)
+    {
+        var requestUri = Controller + "/getbyobjectid/" + objectId;
+
+        using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
+
+        if (!response.IsSuccessStatusCode) return null;
+
+        var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<User>(responseString);
+    }
+
     public async Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default)
     {
         var content = JsonContent.Create(user, typeof(User), null, SerializerOptions);

--- a/TrashMobMobile/ViewModels/ImpactViewModel.cs
+++ b/TrashMobMobile/ViewModels/ImpactViewModel.cs
@@ -36,7 +36,10 @@ public partial class ImpactViewModel(
 
     private async Task RefreshPersonalStats()
     {
-        var stats = await statsRestService.GetUserStatsAsync(userManager.CurrentUser.Id);
+        var currentUser = userManager.CurrentUser;
+        if (currentUser == null) return;
+
+        var stats = await statsRestService.GetUserStatsAsync(currentUser.Id);
 
         PersonalStats = new StatisticsViewModel
         {
@@ -79,7 +82,10 @@ public partial class ImpactViewModel(
 
     private async Task RefreshEventContributions()
     {
-        var impact = await eventAttendeeMetricsRestService.GetUserImpactAsync(userManager.CurrentUser.Id);
+        var currentUser = userManager.CurrentUser;
+        if (currentUser == null) return;
+
+        var impact = await eventAttendeeMetricsRestService.GetUserImpactAsync(currentUser.Id);
 
         EventContributions.Clear();
 


### PR DESCRIPTION
## Summary
- **Root cause**: CIAM id_tokens lack the `email` claim, so `SetAuthenticated` checked `ClaimsPrincipal.Claims` for `email`, got null, and skipped the user lookup — `App.CurrentUser` was never set
- **Fix**: Use `GetUserContext`'s parsed email (which tries both `email` and `emailAddress` from raw id_token), then fall back to ObjectId (`oid` claim) lookup via new `/Users/getbyobjectid/{oid}` endpoint — same approach the web app uses
- **Sentry fix**: Added null guards in `ImpactViewModel.RefreshPersonalStats` and `RefreshEventContributions` to prevent `NullReferenceException` when `CurrentUser` is null

### Files changed
- `AuthService.cs` — Fixed `SetAuthenticated` to use email from context + OID fallback
- `IUserRestService.cs` / `UserRestService.cs` — Added `GetUserByObjectIdAsync`
- `IUserManager.cs` / `UserManager.cs` — Added `GetUserByObjectIdAsync`
- `ImpactViewModel.cs` — Null guards for `CurrentUser`

## Test plan
- [ ] Sign in on Android — verify CurrentUser is set and user data loads
- [ ] Navigate to Impact tab — verify stats load without crash
- [ ] Sign out and back in — verify user context is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)