### PR TITLE
Set minimum mobile app version to 2.11.707

### DIFF
--- a/TrashMob/appsettings.Development.json
+++ b/TrashMob/appsettings.Development.json
@@ -26,7 +26,7 @@
   "StorageAccountUri": "https://stortmdevwestus2.blob.core.windows.net",
   "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb",
   "AppVersion": {
-    "MinimumVersion": "1.0.0",
-    "RecommendedVersion": "1.0.2"
+    "MinimumVersion": "2.11.707",
+    "RecommendedVersion": "2.11.707"
   }
 }

--- a/TrashMob/appsettings.json
+++ b/TrashMob/appsettings.json
@@ -22,7 +22,7 @@
   },
   "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb",
   "AppVersion": {
-    "MinimumVersion": "1.0.0",
-    "RecommendedVersion": "1.0.2"
+    "MinimumVersion": "2.11.707",
+    "RecommendedVersion": "2.11.707"
   }
 }


### PR DESCRIPTION
## Summary
- Update `MinimumVersion` and `RecommendedVersion` from `1.0.0` to `2.11.707` in both `appsettings.json` (prod) and `appsettings.Development.json` (dev)
- Mobile apps older than 2.11.707 will be force-updated via the `GET /api/appversion` check on startup

## Test plan
- [ ] Deploy to dev and verify `GET https://dev.trashmob.eco/api/appversion` returns `2.11.707`
- [ ] Open an older mobile build and confirm force-update prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)