### PR TITLE
Update prod minimum app version to 2.11.709

### DIFF
--- a/TrashMob/appsettings.json
+++ b/TrashMob/appsettings.json
@@ -22,7 +22,7 @@
   },
   "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb",
   "AppVersion": {
-    "MinimumVersion": "2.11.707",
-    "RecommendedVersion": "2.11.707"
+    "MinimumVersion": "2.11.709",
+    "RecommendedVersion": "2.11.709"
   }
 }


### PR DESCRIPTION
## Summary
- Updates `MinimumVersion` and `RecommendedVersion` in `appsettings.json` (prod) from 2.11.707 to 2.11.709

## Test plan
- [ ] Verify `GET /api/appversion` returns 2.11.709 for MinimumVersion after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)