### PR TITLE
Fix Android Google Maps API key not resolving from environment secrets

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -31,14 +31,14 @@ on:
                 required: true
                 type: string
         secrets:
-            android_keystore:
-                required: true
-            android_keystore_password:
-                required: true
-            appsettings:
-                required: true
-            android_google_apikey:
-                required: true
+            ANDROID_KEYSTORE:
+                required: false
+            ANDROID_KEYSTORE_PASSWORD:
+                required: false
+            MOBILE_APPSETTINGS:
+                required: false
+            ANDROID_GOOGLE_APIKEY:
+                required: false
         outputs:
             artifact_name:
                 value: artifacts-android-${{ inputs.build_number }}
@@ -100,7 +100,7 @@ jobs:
           run: |
               $content = Get-Content TrashMobMobile/Platforms/Android/AndroidManifest.xml -Raw
   
-              $newContent = $content -replace '<meta-data android:name="com.google.android.geo.API_KEY" android:value=".*" />', '<meta-data android:name="com.google.android.geo.API_KEY" android:value="${{secrets.android_google_apikey}}" />'
+              $newContent = $content -replace '<meta-data android:name="com.google.android.geo.API_KEY" android:value=".*" />', '<meta-data android:name="com.google.android.geo.API_KEY" android:value="${{secrets.ANDROID_GOOGLE_APIKEY}}" />'
   
               Set-Content TrashMobMobile/Platforms/Android/AndroidManifest.xml -Value $newContent
   
@@ -173,14 +173,14 @@ jobs:
           run: |
             cd TrashMobMobile
             mkdir android
-            echo "${{ secrets.android_keystore }}" > android/trashmobmobileapp.jks.base64
+            echo "${{ secrets.ANDROID_KEYSTORE }}" > android/trashmobmobileapp.jks.base64
             base64 -d android/trashmobmobileapp.jks.base64 > android/trashmobmobileapp.decrypted.jks
         # check android SDK paths etc in installed VM : https://github.com/actions/virtual-environments#available-environments
         - name: Sign dev build
           shell: bash
           run: |
             cd TrashMobMobile
-            jarsigner -keystore android/trashmobmobileapp.decrypted.jks -storepass "${{ secrets.android_keystore_password }}" -signedjar bin/${{ inputs.configuration }}/net10.0-android/publish/${{ inputs.bundle_id }}-Signed.aab bin/${{ inputs.configuration }}/net10.0-android/publish/${{ inputs.bundle_id }}.aab ${{ inputs.android_key_name }}
+            jarsigner -keystore android/trashmobmobileapp.decrypted.jks -storepass "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" -signedjar bin/${{ inputs.configuration }}/net10.0-android/publish/${{ inputs.bundle_id }}-Signed.aab bin/${{ inputs.configuration }}/net10.0-android/publish/${{ inputs.bundle_id }}.aab ${{ inputs.android_key_name }}
 
         - name: Stage artifacts into flat directory
           shell: pwsh

--- a/.github/workflows/main_trashmobmobileapp.yml
+++ b/.github/workflows/main_trashmobmobileapp.yml
@@ -105,11 +105,7 @@ jobs:
       bundle_id: ${{ needs.exposeEnvironmentVariables.outputs.android_bundle_id }}
       android_key_name: "upload"
       define_constants: "USETEST"
-    secrets:
-      android_keystore: ${{ secrets.ANDROID_KEYSTORE }}
-      android_keystore_password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-      appsettings: ${{ secrets.MOBILE_APPSETTINGS }}
-      android_google_apikey: ${{ secrets.ANDROID_GOOGLE_APIKEY }}
+    secrets: inherit
 
 
   calliOSBuild:

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -102,11 +102,7 @@ jobs:
       version: ${{ github.event.inputs.version }}
       android_key_name: "key"
       define_constants: "USEPROD"
-    secrets:
-      android_keystore: ${{ secrets.ANDROID_KEYSTORE }}
-      android_keystore_password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-      appsettings: ${{ secrets.MOBILE_APPSETTINGS }}
-      android_google_apikey: ${{ secrets.ANDROID_GOOGLE_APIKEY }}
+    secrets: inherit
 
   calliOSBuild:
     name: Call iOS build workflow


### PR DESCRIPTION
## Summary
- Google Maps showing blank on production Android app because the API key wasn't being injected during builds
- Root cause: `ANDROID_GOOGLE_APIKEY` only exists as **environment-scoped** secrets (dev/test/production), not as a repo-level secret. The caller workflows resolved `${{ secrets.ANDROID_GOOGLE_APIKEY }}` in their own context (no environment set), resulting in an empty string
- Fix: Switch `callBuildAndroid` to `secrets: inherit` so the called workflow resolves secrets from its own `environment:` context (test or production)
- Updated `build-android.yml` secret references to match actual environment secret names (uppercase)

## Files changed
- `.github/workflows/build-android.yml` — Secret input names and references updated to match environment secret names
- `.github/workflows/release_trashmobmobileapp.yml` — Explicit secrets block → `secrets: inherit`
- `.github/workflows/main_trashmobmobileapp.yml` — Explicit secrets block → `secrets: inherit`

## Test plan
- [ ] Merge to main → verify dev Android build succeeds and `ANDROID_GOOGLE_APIKEY` is injected (check "Update GoogleMaps Key" step output)
- [ ] Merge main to release → verify prod Android build succeeds
- [ ] Install prod build and verify Google Maps loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)