### PR TITLE
Make route privacy trim opt-in at route start

### DIFF
--- a/TrashMob.Models/Poco/DisplayEventAttendeeRoute.cs
+++ b/TrashMob.Models/Poco/DisplayEventAttendeeRoute.cs
@@ -61,6 +61,12 @@
         public int TrimEndMeters { get; set; }
 
         /// <summary>
+        /// Gets or sets whether to skip applying the default 100m privacy trim on upload.
+        /// When true, start/end trimming values from the client are used as-is (including 0 for no trim).
+        /// </summary>
+        public bool SkipDefaultTrim { get; set; }
+
+        /// <summary>
         /// Gets or sets bags collected along this route.
         /// </summary>
         public int? BagsCollected { get; set; }

--- a/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeRouteManager.cs
@@ -419,12 +419,21 @@ namespace TrashMob.Shared.Managers.Events
 
         private static void ApplyDefaultTrim(EventAttendeeRoute route)
         {
-            if (route.TrimStartMeters == 0)
+            // Negative values indicate the client explicitly opted out of default trim
+            if (route.TrimStartMeters < 0)
+            {
+                route.TrimStartMeters = 0;
+            }
+            else if (route.TrimStartMeters == 0)
             {
                 route.TrimStartMeters = 100;
             }
 
-            if (route.TrimEndMeters == 0)
+            if (route.TrimEndMeters < 0)
+            {
+                route.TrimEndMeters = 0;
+            }
+            else if (route.TrimEndMeters == 0)
             {
                 route.TrimEndMeters = 100;
             }

--- a/TrashMob/Controllers/EventAttendeeRoutesController.cs
+++ b/TrashMob/Controllers/EventAttendeeRoutesController.cs
@@ -136,6 +136,14 @@ namespace TrashMob.Controllers
         {
             var eventAttendeeRoute = displayEventAttendeeRoute.ToEventAttendeeRoute();
 
+            // When client explicitly opts out of default privacy trim, set trim values to 0
+            // so the manager's ApplyDefaultTrim won't override them with the 100m default.
+            if (displayEventAttendeeRoute.SkipDefaultTrim)
+            {
+                eventAttendeeRoute.TrimStartMeters = -1;
+                eventAttendeeRoute.TrimEndMeters = -1;
+            }
+
             var result = await eventAttendeeRouteManager.AddAsync(eventAttendeeRoute, UserId, cancellationToken);
             TrackEvent(nameof(AddEventAttendeeRoute));
             return CreatedAtAction(nameof(GetEventAttendeeRoute), new { id = result.Id }, result);

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -131,6 +131,8 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     [ObservableProperty]
     private bool isRecordingRoute;
 
+    private bool skipDefaultTrim;
+
     [ObservableProperty]
     private bool areRoutesFound;
 
@@ -463,6 +465,16 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
                 Preferences.Default.Set(disclosureKey, true);
             }
 
+            // Ask user whether to hide start/end location for privacy
+            var hideStartEnd = await Shell.Current.CurrentPage.DisplayAlert(
+                "Privacy Option",
+                "Would you like to hide the first and last 100 meters of your route? " +
+                "This helps protect your home location if you're starting from home.",
+                "Yes, hide",
+                "No, keep full route");
+
+            skipDefaultTrim = !hideStartEnd;
+
             RouteStartTime = DateTimeOffset.Now;
             RouteEndTime = DateTimeOffset.Now;
             EnableStopTrackEventRoute = true;
@@ -534,6 +546,7 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
                 Locations = GetSortableLocations(),
                 StartTime = RouteStartTime,
                 EndTime = RouteEndTime,
+                SkipDefaultTrim = skipDefaultTrim,
             });
         }, "An error occurred while saving your route.");
     }


### PR DESCRIPTION
## Summary
- When tapping "Start Route", the app now asks whether to hide the first/last 100m for privacy
- Default answer ("Yes, hide") preserves existing behavior for users starting from home
- "No, keep full route" sends `SkipDefaultTrim = true`, uploading the complete route
- Backend uses sentinel value (-1) to distinguish "user opted out" from "not set" (0 = apply default)

### Files changed
- `DisplayEventAttendeeRoute.cs` — Added `SkipDefaultTrim` bool to DTO
- `EventAttendeeRoutesController.cs` — Sets trim values to -1 when client opts out
- `EventAttendeeRouteManager.cs` — `ApplyDefaultTrim` now treats negative values as explicit opt-out (sets to 0)
- `ViewEventViewModel.cs` — Added privacy dialog before route recording starts

## Context
The 100m hide was originally designed to protect home locations, but many users start cleanups at parks or event locations where hiding 100m loses valuable data. This makes it opt-in so users can choose.

## Also investigated
- **Route upload failures**: Routes are stored in-memory only during recording. If the upload fails after 3 Polly retries (exponential backoff 2s/4s/8s), the route data is lost. No offline queue exists — this is a known gap for future work.
- **Production logs**: Route uploads trigger `TrackEvent("AddEventAttendeeRoute")` in App Insights — check there for the failed 4-mile walk upload.

## Test plan
- [ ] Start route recording — verify privacy dialog appears
- [ ] Choose "Yes, hide" — verify 100m trimmed from start/end after upload
- [ ] Choose "No, keep full route" — verify full route is preserved
- [ ] Existing routes unaffected (backend only changes behavior on new uploads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)