### PR TITLE
Fix auth extension OIDC authority to use CIAM endpoint

### DIFF
--- a/TrashMob.AuthExtension/Program.cs
+++ b/TrashMob.AuthExtension/Program.cs
@@ -12,7 +12,7 @@ var allowedAppId = builder.Configuration["AuthExtension:AllowedAppId"]
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        options.Authority = $"https://login.microsoftonline.com/{tenantId}/v2.0";
+        options.Authority = $"https://{tenantId}.ciamlogin.com/{tenantId}/v2.0";
         options.Audience = clientId;
         options.TokenValidationParameters.ValidIssuers =
         [


### PR DESCRIPTION
## Summary
- Changed JWT `Authority` from `login.microsoftonline.com` to `{tenantId}.ciamlogin.com`
- The CIAM OIDC discovery endpoint has additional signing keys that `login.microsoftonline.com` does not expose (e.g., kid `z6-fLv223PW4n6R3gxvdvXigZXk`)
- This caused `IDX10503` signature validation failures in production — the token was signed with a key the app couldn't find

## Root cause
The prod CIAM tenant (`b5fc8717`) issues tokens signed by keys only available at `{tenantId}.ciamlogin.com/.../keys`. The `login.microsoftonline.com/.../keys` endpoint for the same tenant returns a subset of keys that doesn't include the one used to sign the custom auth extension token.

## Test plan
- [ ] Merge to main → auto-deploys to dev → test dev sign-up
- [ ] Merge main to release → deploys to prod → test prod sign-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)