### PR TITLE
Fix SQLite WAL pragma crash on route start

### DIFF
--- a/TrashMobMobile/Services/Offline/OfflineDatabase.cs
+++ b/TrashMobMobile/Services/Offline/OfflineDatabase.cs
@@ -42,7 +42,9 @@ public class OfflineDatabase
             connection = new SQLiteAsyncConnection(databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.SharedCache);
 
             // Enable WAL mode for crash safety and concurrent read/write
-            await connection.ExecuteAsync("PRAGMA journal_mode=WAL");
+            // Use ExecuteScalarAsync because PRAGMA journal_mode returns a result row;
+            // ExecuteAsync maps to ExecuteNonQuery which throws on result-returning statements
+            await connection.ExecuteScalarAsync<string>("PRAGMA journal_mode=WAL");
 
             // Check and apply schema migrations
             await MigrateSchemaAsync(connection);

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -506,7 +506,16 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
                 IsRecordingRoute = false;
                 RouteEndTime = DateTimeOffset.Now;
                 await routePointWriter.StopAndFlushAsync();
+
+                var sessionId = routeTrackingSessionManager.ActiveSessionId;
                 routeTrackingSessionManager.EndSession();
+
+                // Discard the empty SQLite session since emulator uses server-side simulation
+                if (sessionId != null)
+                {
+                    await syncQueue.DiscardSessionAsync(sessionId);
+                }
+
                 tcs.TrySetResult();
             });
 


### PR DESCRIPTION
## Summary
- Fix crash when starting route recording on Android — `PRAGMA journal_mode=WAL` returns a result row but `ExecuteAsync` uses `ExecuteNonQuery` which throws `SQLiteException: not an error`
- Clean up orphaned SQLite sessions on emulator path — discard the empty session before calling `SimulateRoute()`

## Test plan
- [x] Verified fix on Android emulator — route start no longer crashes
- [ ] Verify on physical Android device

Fixes #2978

🤖 Generated with [Claude Code](https://claude.com/claude-code)