### PR TITLE
Auto-approve lead metrics and add individual review in mobile

### DIFF
--- a/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeMetricsManager.cs
@@ -48,6 +48,9 @@ namespace TrashMob.Shared.Managers.Events
                 return ServiceResult<EventAttendeeMetrics>.Failure("You must be registered as an attendee for this event to submit metrics.");
             }
 
+            // Auto-approve if the submitter is an event lead (creator or co-lead)
+            var isLead = await eventAttendeeManager.IsEventLeadAsync(eventId, userId, cancellationToken);
+
             // Check for existing submission
             var existingMetrics = await GetMyMetricsAsync(eventId, userId, cancellationToken);
 
@@ -67,6 +70,13 @@ namespace TrashMob.Shared.Managers.Events
                 existingMetrics.LastUpdatedByUserId = userId;
                 existingMetrics.LastUpdatedDate = DateTimeOffset.UtcNow;
 
+                if (isLead)
+                {
+                    existingMetrics.Status = EventAttendeeMetricsStatus.Approved;
+                    existingMetrics.ReviewedByUserId = userId;
+                    existingMetrics.ReviewedDate = DateTimeOffset.UtcNow;
+                }
+
                 var updatedResult = await base.UpdateAsync(existingMetrics, userId, cancellationToken);
                 return ServiceResult<EventAttendeeMetrics>.Success(updatedResult);
             }
@@ -82,7 +92,9 @@ namespace TrashMob.Shared.Managers.Events
                 PickedWeightUnitId = metrics.PickedWeightUnitId,
                 DurationMinutes = metrics.DurationMinutes,
                 Notes = metrics.Notes,
-                Status = EventAttendeeMetricsStatus.Pending,
+                Status = isLead ? EventAttendeeMetricsStatus.Approved : EventAttendeeMetricsStatus.Pending,
+                ReviewedByUserId = isLead ? userId : null,
+                ReviewedDate = isLead ? DateTimeOffset.UtcNow : null,
                 CreatedByUserId = userId,
                 CreatedDate = DateTimeOffset.UtcNow,
                 LastUpdatedByUserId = userId,

--- a/TrashMobMobile/Controls/ReviewMetricsPopup.xaml
+++ b/TrashMobMobile/Controls/ReviewMetricsPopup.xaml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.ReviewMetricsPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="320">
+        <VerticalStackLayout Spacing="16">
+
+            <Label Text="Review Submission"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Label x:Name="attendeeLabel"
+                   FontFamily="LexendSemibold"
+                   FontSize="14"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <!-- Stats -->
+            <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                <VerticalStackLayout HorizontalOptions="Center">
+                    <Label x:Name="bagsLabel"
+                           FontFamily="LexendSemibold"
+                           FontSize="20"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+                    <Label Text="Bags"
+                           FontSize="Micro"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+
+                <VerticalStackLayout Grid.Column="1" HorizontalOptions="Center">
+                    <Label x:Name="weightLabel"
+                           FontFamily="LexendSemibold"
+                           FontSize="20"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+                    <Label Text="Weight"
+                           FontSize="Micro"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+
+                <VerticalStackLayout Grid.Column="2" HorizontalOptions="Center">
+                    <Label x:Name="durationLabel"
+                           FontFamily="LexendSemibold"
+                           FontSize="20"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+                    <Label Text="Minutes"
+                           FontSize="Micro"
+                           HorizontalTextAlignment="Center"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                </VerticalStackLayout>
+            </Grid>
+
+            <!-- Notes -->
+            <VerticalStackLayout x:Name="notesSection" Spacing="4" IsVisible="False">
+                <Label Text="Notes"
+                       FontSize="Small"
+                       FontFamily="LexendSemibold"
+                       TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+                <Label x:Name="notesLabel"
+                       FontSize="Small"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+            </VerticalStackLayout>
+
+            <!-- Rejection reason (hidden by default) -->
+            <VerticalStackLayout x:Name="rejectionSection" Spacing="4" IsVisible="False">
+                <Label Text="Reason for Rejection"
+                       FontSize="Small"
+                       FontFamily="LexendSemibold"
+                       TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+                <Editor x:Name="rejectionEditor"
+                        Placeholder="Why are you rejecting this submission?"
+                        HeightRequest="60"
+                        MaxLength="500" />
+            </VerticalStackLayout>
+
+            <Button Text="Approve"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    Clicked="OnApproveClicked" />
+
+            <Button x:Name="rejectButton"
+                    Text="Reject"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnRejectClicked" />
+
+            <Button Text="Cancel"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnCancelClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/ReviewMetricsPopup.xaml.cs
+++ b/TrashMobMobile/Controls/ReviewMetricsPopup.xaml.cs
@@ -1,0 +1,68 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Extensions;
+using TrashMob.Models;
+
+public partial class ReviewMetricsPopup : ContentView
+{
+    public const string ApprovedResult = "Approved";
+    public const string RejectedPrefix = "Rejected:";
+
+    private bool isRejecting;
+
+    public ReviewMetricsPopup(EventAttendeeMetrics metrics)
+    {
+        InitializeComponent();
+
+        attendeeLabel.Text = metrics.User?.UserName ?? "Unknown";
+        bagsLabel.Text = (metrics.BagsCollected ?? 0).ToString();
+        durationLabel.Text = (metrics.DurationMinutes ?? 0).ToString();
+
+        if (metrics.PickedWeight.HasValue && metrics.PickedWeight.Value > 0)
+        {
+            var unit = metrics.PickedWeightUnitId == 2 ? "kg" : "lbs";
+            weightLabel.Text = $"{metrics.PickedWeight.Value:0.##} {unit}";
+        }
+        else
+        {
+            weightLabel.Text = "—";
+        }
+
+        if (!string.IsNullOrWhiteSpace(metrics.Notes))
+        {
+            notesSection.IsVisible = true;
+            notesLabel.Text = metrics.Notes;
+        }
+    }
+
+    private async void OnApproveClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync(ApprovedResult);
+    }
+
+    private async void OnRejectClicked(object? sender, EventArgs e)
+    {
+        if (!isRejecting)
+        {
+            // First click: show the reason editor
+            isRejecting = true;
+            rejectionSection.IsVisible = true;
+            rejectButton.Text = "Confirm Rejection";
+            return;
+        }
+
+        var reason = rejectionEditor.Text?.Trim();
+        if (string.IsNullOrEmpty(reason))
+        {
+            rejectionEditor.Placeholder = "Please enter a reason";
+            return;
+        }
+
+        await Shell.Current.ClosePopupAsync(RejectedPrefix + reason);
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+}

--- a/TrashMobMobile/Services/EventAttendeeMetricsRestService.cs
+++ b/TrashMobMobile/Services/EventAttendeeMetricsRestService.cs
@@ -48,6 +48,16 @@ namespace TrashMobMobile.Services
             return JsonConvert.DeserializeObject<EventMetricsPublicSummary>(content) ?? new EventMetricsPublicSummary();
         }
 
+        public async Task<List<EventAttendeeMetrics>> GetPendingMetricsAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/attendee-metrics/pending";
+
+            using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<List<EventAttendeeMetrics>>(content) ?? [];
+        }
+
         public async Task<int> ApproveAllPendingAsync(Guid eventId, CancellationToken cancellationToken = default)
         {
             var requestUri = eventId + "/attendee-metrics/approve-all";
@@ -56,6 +66,27 @@ namespace TrashMobMobile.Services
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
             return JsonConvert.DeserializeObject<int>(content);
+        }
+
+        public async Task<EventAttendeeMetrics> ApproveMetricsAsync(Guid eventId, Guid metricsId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/attendee-metrics/" + metricsId + "/approve";
+
+            using var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content)!;
+        }
+
+        public async Task<EventAttendeeMetrics> RejectMetricsAsync(Guid eventId, Guid metricsId, string reason, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/attendee-metrics/" + metricsId + "/reject";
+            var body = JsonContent.Create(new { RejectionReason = reason }, null, SerializerOptions);
+
+            using var response = await AuthorizedHttpClient.PostAsync(requestUri, body, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content)!;
         }
 
         public async Task<UserImpactStats> GetUserImpactAsync(Guid userId, CancellationToken cancellationToken = default)

--- a/TrashMobMobile/Services/IEventAttendeeMetricsRestService.cs
+++ b/TrashMobMobile/Services/IEventAttendeeMetricsRestService.cs
@@ -11,7 +11,13 @@ namespace TrashMobMobile.Services
 
         Task<EventMetricsPublicSummary> GetPublicMetricsAsync(Guid eventId, CancellationToken cancellationToken = default);
 
+        Task<List<EventAttendeeMetrics>> GetPendingMetricsAsync(Guid eventId, CancellationToken cancellationToken = default);
+
         Task<int> ApproveAllPendingAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+        Task<EventAttendeeMetrics> ApproveMetricsAsync(Guid eventId, Guid metricsId, CancellationToken cancellationToken = default);
+
+        Task<EventAttendeeMetrics> RejectMetricsAsync(Guid eventId, Guid metricsId, string reason, CancellationToken cancellationToken = default);
 
         Task<UserImpactStats> GetUserImpactAsync(Guid userId, CancellationToken cancellationToken = default);
     }

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -197,6 +197,8 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
     public ObservableCollection<LitterImageViewModel> LitterImages { get; set; } = [];
 
+    public ObservableCollection<EventAttendeeMetrics> PendingMetricsList { get; set; } = [];
+
     public ObservableCollection<EventAttendeeViewModel> EventAttendees { get; set; } = [];
 
     public ObservableCollection<DisplayEventAttendeeRoute> EventAttendeeRoutes { get; set; } = [];
@@ -1257,8 +1259,14 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
         if (isLead)
         {
-            var publicMetrics = await eventAttendeeMetricsRestService.GetPublicMetricsAsync(mobEvent.Id);
-            PendingMetricsCount = publicMetrics.Contributors.Count(c => c.Status == "Pending");
+            var pendingMetrics = await eventAttendeeMetricsRestService.GetPendingMetricsAsync(mobEvent.Id);
+            PendingMetricsList.Clear();
+            foreach (var m in pendingMetrics)
+            {
+                PendingMetricsList.Add(m);
+            }
+
+            PendingMetricsCount = PendingMetricsList.Count;
             ShowLeadMetricsActions = PendingMetricsCount > 0;
         }
     }
@@ -1348,10 +1356,41 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
         await ExecuteAsync(async () =>
         {
             var count = await eventAttendeeMetricsRestService.ApproveAllPendingAsync(mobEvent.Id);
+            PendingMetricsList.Clear();
             ShowLeadMetricsActions = false;
             PendingMetricsCount = 0;
 
             await NotificationService.Notify($"{count} metric submission(s) approved.");
         }, "An error occurred while approving metrics. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task ReviewMetrics(EventAttendeeMetrics metrics)
+    {
+        var popup = new Controls.ReviewMetricsPopup(metrics);
+        var result = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+        var value = result?.Result;
+
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        await ExecuteAsync(async () =>
+        {
+            if (value == Controls.ReviewMetricsPopup.ApprovedResult)
+            {
+                await eventAttendeeMetricsRestService.ApproveMetricsAsync(mobEvent.Id, metrics.Id);
+                await NotificationService.Notify("Submission approved.");
+            }
+            else if (value.StartsWith(Controls.ReviewMetricsPopup.RejectedPrefix))
+            {
+                var reason = value[Controls.ReviewMetricsPopup.RejectedPrefix.Length..];
+                await eventAttendeeMetricsRestService.RejectMetricsAsync(mobEvent.Id, metrics.Id, reason);
+                await NotificationService.Notify("Submission rejected.");
+            }
+
+            await LoadMyMetrics();
+        }, "An error occurred while reviewing the submission. Please try again.");
     }
 }

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             xmlns:models="clr-namespace:TrashMob.Models;assembly=TrashMob.Models"
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
              x:Class="TrashMobMobile.Views.ViewEvent.TabDetails">
     <ScrollView>
@@ -274,6 +275,50 @@
                     <Label Text="{Binding PendingMetricsCount, StringFormat='{0} submission(s) pending review'}"
                            FontSize="Micro"
                            TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                    <!-- Pending submissions list -->
+                    <CollectionView ItemsSource="{Binding PendingMetricsList}">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="models:EventAttendeeMetrics">
+                                <Border Padding="12,8"
+                                        Margin="0,2"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource BackgroundLight}, Dark={StaticResource BackgroundDark}}"
+                                        StrokeShape="RoundRectangle 8"
+                                        Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+                                        StrokeThickness="1">
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:ViewEventViewModel}}, Path=ReviewMetricsCommand}"
+                                                              CommandParameter="{Binding .}" />
+                                    </Border.GestureRecognizers>
+                                    <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="12">
+                                        <Label Text="{Binding User.UserName}"
+                                               FontSize="Small"
+                                               VerticalOptions="Center"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Grid.Column="1"
+                                               Text="{Binding BagsCollected, StringFormat='{0} bags'}"
+                                               FontSize="Micro"
+                                               VerticalOptions="Center"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Label Grid.Column="2"
+                                               Text="{Binding DurationMinutes, StringFormat='{0} min'}"
+                                               FontSize="Micro"
+                                               VerticalOptions="Center"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                        <Image Grid.Column="3" MaximumWidthRequest="16" MaximumHeightRequest="16" VerticalOptions="Center">
+                                            <Image.Source>
+                                                <FontImageSource FontFamily="{StaticResource GoogleMaterialIcons}"
+                                                                 Glyph="{StaticResource IconChevronRight}"
+                                                                 Size="16"
+                                                                 Color="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                            </Image.Source>
+                                        </Image>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+
                     <Button Text="Approve All"
                             Command="{Binding ApproveAllMetricsCommand}"
                             Style="{StaticResource SecondarySmallButton}"


### PR DESCRIPTION
## Summary
- **Auto-approve lead metrics (backend):** Event leads' own metrics submissions are now automatically approved in `SubmitMetricsAsync` — no more pointless self-approval step. Covers both event creators and co-leads via `IsEventLeadAsync`. Fixes both web and mobile.
- **Fix pending count bug (mobile):** `LoadMyMetrics()` was using `GetPublicMetricsAsync` which only returns Approved/Adjusted metrics, so pending count was always 0. Now uses `GetPendingMetricsAsync`.
- **Individual metrics review (mobile):** Event leads can now tap individual pending submissions to review them (approve or reject with reason), instead of only having a bulk "Approve All" button.

## Test plan
- [ ] `dotnet test TrashMob.Shared.Tests` — 470 tests pass
- [ ] `dotnet build TrashMobMobile -f net10.0-android` — 0 errors
- [ ] Deploy to emulator, sign in as event lead, submit own metrics → verify status shows "Approved" immediately
- [ ] Verify pending list shows other attendees' submissions with tap-to-review
- [ ] Test approve and reject flows from ReviewMetricsPopup
- [ ] Verify "Approve All" still works and clears the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)