### PR TITLE
Add dependent waiver PDF generation (Project 8 Phase 5b)

### DIFF
--- a/Planning/Projects/Project_08_Waivers_V3.md
+++ b/Planning/Projects/Project_08_Waivers_V3.md
@@ -259,10 +259,10 @@ The minor waiver must contain language beyond the standard adult waiver:
 6. **Supervision acknowledgment:** "I understand that I am responsible for supervising [minor's name] during this activity" (for parent/guardian) or "I confirm I have been authorized by the parent/legal guardian of [minor's name] to supervise this child" (for authorized supervisors)
 7. **Activity acknowledgment:** "I understand that this activity involves outdoor litter cleanup which may include walking on uneven surfaces, handling litter and debris, exposure to weather conditions, and proximity to traffic"
 
-- ☐ Draft minor waiver text (requires legal review)
-- ☐ Draft "authorized supervisor" variant waiver text
-- ☐ Create WaiverVersion record with minor scope
-- ☐ PDF generation for dependent waivers (extend existing QuestPDF template)
+- ✅ Draft minor waiver text (requires legal review) — `TrashMob.Shared/Engine/WaiverContent/MinorWaiverText.cs`
+- ✅ Draft "authorized supervisor" variant waiver text — included in `MinorWaiverText.cs`
+- ☐ Create WaiverVersion record with minor scope (pending legal approval of waiver text)
+- ✅ PDF generation for dependent waivers (extend existing QuestPDF template) — `WaiverDocumentManager` + download endpoint
 
 #### Phase 5c - Web UX
 

--- a/TrashMob.Shared/Engine/WaiverContent/MinorWaiverText.cs
+++ b/TrashMob.Shared/Engine/WaiverContent/MinorWaiverText.cs
@@ -1,0 +1,119 @@
+namespace TrashMob.Shared.Engine.WaiverContent
+{
+    /// <summary>
+    /// Draft minor waiver text for dependents brought to cleanup events by adults.
+    /// DRAFT — Requires legal review and approval before use in production.
+    /// </summary>
+    public static class MinorWaiverText
+    {
+        /// <summary>
+        /// Full waiver text for a parent or legal guardian signing on behalf of a dependent minor.
+        /// Placeholders are NOT used — the waiver is generic and the dependent's details
+        /// are captured separately in the DependentWaiver and Dependent records.
+        /// </summary>
+        public const string ParentGuardianWaiver = """
+            # TrashMob.eco Minor Participant Waiver and Release of Liability
+
+            ## 1. Statement of Guardian Authority
+
+            By signing this waiver, I certify that I am the parent, legal guardian, or person with legal authority over the minor named in this waiver. I have the legal right to consent to the minor's participation in TrashMob.eco cleanup events and to execute this waiver on their behalf.
+
+            ## 2. Assumption of Risk
+
+            I understand that participation in outdoor litter cleanup events involves inherent risks, including but not limited to:
+
+            - Contact with sharp objects, broken glass, or hazardous debris
+            - Walking on uneven terrain, slopes, or near waterways
+            - Proximity to vehicular traffic
+            - Exposure to weather conditions (heat, cold, rain, wind)
+            - Potential contact with hazardous materials, chemicals, or biological waste
+            - Insect bites, stings, or encounters with wildlife
+            - Physical exertion, fatigue, or dehydration
+
+            I acknowledge these risks and voluntarily choose to allow the minor to participate despite them.
+
+            ## 3. Liability Release and Indemnification
+
+            I, on behalf of myself, the minor, and our heirs, executors, and assigns, hereby release, waive, and forever discharge TrashMob.eco, its officers, directors, employees, volunteers, event organizers, community partners, sponsors, and affiliated organizations (collectively, the "Released Parties") from any and all liability, claims, demands, or causes of action arising out of or related to the minor's participation in any TrashMob.eco cleanup event, including but not limited to claims for personal injury, illness, death, or property damage.
+
+            I agree to indemnify and hold harmless the Released Parties from any claims, damages, or expenses (including reasonable attorney's fees) arising from the minor's participation or from any breach of this waiver.
+
+            ## 4. Medical Authorization
+
+            In the event of injury, illness, or medical emergency involving the minor during a TrashMob.eco event, I authorize TrashMob.eco, event organizers, and their designated representatives to arrange emergency medical treatment for the minor at my expense. I understand that TrashMob.eco does not provide medical insurance for participants and that I am responsible for any medical costs incurred.
+
+            I have disclosed any known medical conditions, allergies, or medications relevant to the minor's participation in the medical notes section of the minor's profile.
+
+            ## 5. Photo and Media Release
+
+            I grant TrashMob.eco and its partners permission to photograph, video record, and use the minor's likeness in connection with TrashMob.eco events for promotional, educational, and social media purposes. I waive any right to inspect or approve the finished product or the copy that may be used in connection with these images.
+
+            ## 6. Supervision Acknowledgment
+
+            I understand that I am responsible for the direct supervision of the minor during all TrashMob.eco events. I will ensure that the minor follows all safety instructions provided by event organizers. I understand that TrashMob.eco event organizers are not responsible for supervising individual participants, including minors.
+
+            ## 7. Activity Acknowledgment
+
+            I understand that TrashMob.eco cleanup events involve outdoor litter and debris collection, which may include walking on uneven surfaces, handling litter and debris with provided equipment, exposure to weather conditions, and proximity to traffic or other environmental hazards. I confirm that the minor is physically capable of participating in these activities.
+
+            ---
+
+            **By signing below, I acknowledge that I have read this waiver in its entirety, understand its terms, and agree to be bound by them on behalf of myself and the minor.**
+            """;
+
+        /// <summary>
+        /// Full waiver text for an authorized supervisor (non-parent/guardian) signing on behalf of a dependent minor.
+        /// Includes additional certification that the supervisor has been authorized by the parent/legal guardian.
+        /// </summary>
+        public const string AuthorizedSupervisorWaiver = """
+            # TrashMob.eco Minor Participant Waiver and Release of Liability
+            ## Authorized Supervisor Form
+
+            ## 1. Statement of Authorized Supervision
+
+            By signing this waiver, I certify that I have been expressly authorized by the parent or legal guardian of the minor named in this waiver to supervise the minor during TrashMob.eco cleanup events. I understand that I am assuming responsibility for the minor's safety and well-being during the event.
+
+            I confirm that the parent or legal guardian has provided me with written or verbal authorization to consent to the minor's participation and to execute this waiver on their behalf.
+
+            ## 2. Assumption of Risk
+
+            I understand that participation in outdoor litter cleanup events involves inherent risks, including but not limited to:
+
+            - Contact with sharp objects, broken glass, or hazardous debris
+            - Walking on uneven terrain, slopes, or near waterways
+            - Proximity to vehicular traffic
+            - Exposure to weather conditions (heat, cold, rain, wind)
+            - Potential contact with hazardous materials, chemicals, or biological waste
+            - Insect bites, stings, or encounters with wildlife
+            - Physical exertion, fatigue, or dehydration
+
+            I acknowledge these risks and voluntarily choose to allow the minor to participate despite them.
+
+            ## 3. Liability Release and Indemnification
+
+            I, on behalf of myself and to the extent authorized by the parent or legal guardian, hereby release, waive, and forever discharge TrashMob.eco, its officers, directors, employees, volunteers, event organizers, community partners, sponsors, and affiliated organizations (collectively, the "Released Parties") from any and all liability, claims, demands, or causes of action arising out of or related to the minor's participation in any TrashMob.eco cleanup event, including but not limited to claims for personal injury, illness, death, or property damage.
+
+            ## 4. Medical Authorization
+
+            In the event of injury, illness, or medical emergency involving the minor during a TrashMob.eco event, I authorize TrashMob.eco, event organizers, and their designated representatives to arrange emergency medical treatment for the minor at my expense or the expense of the parent/legal guardian. I have been authorized by the parent or legal guardian to consent to emergency medical treatment on behalf of the minor.
+
+            I have reviewed any known medical conditions, allergies, or medications relevant to the minor's participation as disclosed in the minor's profile.
+
+            ## 5. Photo and Media Release
+
+            On behalf of the parent or legal guardian, I grant TrashMob.eco and its partners permission to photograph, video record, and use the minor's likeness in connection with TrashMob.eco events for promotional, educational, and social media purposes.
+
+            ## 6. Supervision Acknowledgment
+
+            I confirm that I have been authorized by the parent or legal guardian of the minor to supervise this child during TrashMob.eco events. I understand that I am personally responsible for the direct supervision of the minor during all event activities. I will ensure that the minor follows all safety instructions provided by event organizers.
+
+            ## 7. Activity Acknowledgment
+
+            I understand that TrashMob.eco cleanup events involve outdoor litter and debris collection, which may include walking on uneven surfaces, handling litter and debris with provided equipment, exposure to weather conditions, and proximity to traffic or other environmental hazards. I confirm that, to the best of my knowledge, the minor is physically capable of participating in these activities.
+
+            ---
+
+            **By signing below, I acknowledge that I have read this waiver in its entirety, understand its terms, and agree to be bound by them. I further certify that I have been authorized by the minor's parent or legal guardian to sign this waiver and supervise the minor during this event.**
+            """;
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/IWaiverDocumentManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IWaiverDocumentManager.cs
@@ -40,6 +40,29 @@ namespace TrashMob.Shared.Managers.Interfaces
         Task<Stream> GetWaiverPdfAsync(string documentUrl, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Generates a PDF document for a signed dependent waiver and stores it in blob storage.
+        /// </summary>
+        /// <param name="dependentWaiver">The dependent waiver record.</param>
+        /// <param name="dependent">The dependent (minor) the waiver covers.</param>
+        /// <param name="signer">The adult who signed the waiver.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The URL of the stored PDF document.</returns>
+        Task<string> GenerateAndStoreDependentWaiverPdfAsync(
+            DependentWaiver dependentWaiver,
+            Dependent dependent,
+            User signer,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Generates a PDF document for a signed dependent waiver as a byte array.
+        /// </summary>
+        /// <param name="dependentWaiver">The dependent waiver record.</param>
+        /// <param name="dependent">The dependent (minor) the waiver covers.</param>
+        /// <param name="signer">The adult who signed the waiver.</param>
+        /// <returns>The PDF document as a byte array.</returns>
+        byte[] GenerateDependentWaiverPdf(DependentWaiver dependentWaiver, Dependent dependent, User signer);
+
+        /// <summary>
         /// Stores an uploaded paper waiver document in blob storage.
         /// </summary>
         /// <param name="userWaiver">The user waiver record.</param>

--- a/TrashMob.Shared/Managers/WaiverDocumentManager.cs
+++ b/TrashMob.Shared/Managers/WaiverDocumentManager.cs
@@ -135,6 +135,174 @@ namespace TrashMob.Shared.Managers
             return blobClient.Uri.ToString();
         }
 
+        /// <inheritdoc />
+        public async Task<string> GenerateAndStoreDependentWaiverPdfAsync(
+            DependentWaiver dependentWaiver,
+            Dependent dependent,
+            User signer,
+            CancellationToken cancellationToken = default)
+        {
+            var pdfBytes = GenerateDependentWaiverPdf(dependentWaiver, dependent, signer);
+
+            var blobContainer = blobServiceClient.GetBlobContainerClient(WaiversContainerName);
+            await blobContainer.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+
+            var blobName = $"dependents/{dependentWaiver.DependentId}/{dependentWaiver.Id}.pdf";
+            var blobClient = blobContainer.GetBlobClient(blobName);
+
+            using var stream = new MemoryStream(pdfBytes);
+            await blobClient.UploadAsync(
+                stream,
+                new BlobHttpHeaders { ContentType = "application/pdf" },
+                cancellationToken: cancellationToken);
+
+            logger.LogInformation(
+                "Generated and stored dependent waiver PDF for dependent {DependentId}, waiver {DependentWaiverId}",
+                dependentWaiver.DependentId,
+                dependentWaiver.Id);
+
+            return blobClient.Uri.ToString();
+        }
+
+        /// <inheritdoc />
+        public byte[] GenerateDependentWaiverPdf(DependentWaiver dependentWaiver, Dependent dependent, User signer)
+        {
+            var waiverVersion = dependentWaiver.WaiverVersion;
+            var waiverText = dependentWaiver.WaiverTextSnapshot ?? waiverVersion?.WaiverText ?? string.Empty;
+
+            var document = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Size(PageSizes.Letter);
+                    page.Margin(50);
+                    page.DefaultTextStyle(x => x.FontSize(10));
+
+                    page.Header().Element(header => ComposeHeader(header, waiverVersion?.Name ?? "Minor Waiver"));
+                    page.Content().Element(content => ComposeDependentContent(content, waiverText, dependentWaiver, dependent, signer));
+                    page.Footer().Element(ComposeFooter);
+                });
+            });
+
+            return document.GeneratePdf();
+        }
+
+        private static void ComposeDependentContent(
+            IContainer container,
+            string waiverText,
+            DependentWaiver dependentWaiver,
+            Dependent dependent,
+            User signer)
+        {
+            container.PaddingVertical(20).Column(column =>
+            {
+                column.Spacing(10);
+
+                // Dependent information section
+                column.Item().Border(1).BorderColor(Colors.Orange.Lighten2).Background(Colors.Orange.Lighten5).Padding(15).Column(depColumn =>
+                {
+                    depColumn.Item().Text("Dependent Information").Bold().FontSize(12);
+                    depColumn.Item().PaddingTop(10).Row(row =>
+                    {
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Name:").SemiBold();
+                            col.Item().Text($"{dependent.FirstName} {dependent.LastName}");
+                        });
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Date of Birth:").SemiBold();
+                            col.Item().Text($"{dependent.DateOfBirth:MMMM d, yyyy}");
+                        });
+                    });
+                    depColumn.Item().PaddingTop(5).Row(row =>
+                    {
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Relationship:").SemiBold();
+                            col.Item().Text($"{dependent.Relationship}");
+                        });
+                        row.RelativeItem().Column(col =>
+                        {
+                            if (!string.IsNullOrWhiteSpace(dependent.MedicalNotes))
+                            {
+                                col.Item().Text("Medical Notes:").SemiBold();
+                                col.Item().Text($"{dependent.MedicalNotes}");
+                            }
+                        });
+                    });
+                });
+
+                // Waiver text with markdown rendering
+                column.Item().Border(1).BorderColor(Colors.Grey.Lighten2).Padding(15).Column(textColumn =>
+                {
+                    textColumn.Item().Text("Waiver Text").Bold().FontSize(12);
+                    textColumn.Item().PaddingTop(10).Element(e => RenderMarkdown(e, waiverText));
+                });
+
+                // Signature section
+                column.Item().PaddingTop(20).Border(1).BorderColor(Colors.Grey.Lighten2).Padding(15).Column(sigColumn =>
+                {
+                    sigColumn.Item().Text("Electronic Signature (Parent/Guardian)").Bold().FontSize(12);
+                    sigColumn.Item().PaddingTop(10).Row(row =>
+                    {
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Signer Name:").SemiBold();
+                            col.Item().Text($"{signer?.UserName ?? "N/A"}");
+                        });
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Typed Legal Name:").SemiBold();
+                            col.Item().Text($"{dependentWaiver.TypedLegalName}");
+                        });
+                    });
+                });
+
+                // Acceptance details
+                column.Item().PaddingTop(15).Border(1).BorderColor(Colors.Grey.Lighten2).Padding(15).Column(timeColumn =>
+                {
+                    timeColumn.Item().Text("Acceptance Details").Bold().FontSize(12);
+                    timeColumn.Item().PaddingTop(10).Row(row =>
+                    {
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Accepted Date (UTC):").SemiBold();
+                            col.Item().Text($"{dependentWaiver.AcceptedDate:yyyy-MM-dd HH:mm:ss} UTC");
+                        });
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Expiry Date:").SemiBold();
+                            col.Item().Text($"{dependentWaiver.ExpiryDate:yyyy-MM-dd HH:mm:ss} UTC");
+                        });
+                    });
+                    timeColumn.Item().PaddingTop(5).Row(row =>
+                    {
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Document ID:").SemiBold();
+                            col.Item().Text($"{dependentWaiver.Id}");
+                        });
+                        row.RelativeItem().Column(col =>
+                        {
+                            col.Item().Text("Dependent ID:").SemiBold();
+                            col.Item().Text($"{dependentWaiver.DependentId}");
+                        });
+                    });
+                });
+
+                // Audit trail
+                column.Item().PaddingTop(15).Border(1).BorderColor(Colors.Grey.Lighten2).Padding(15).Column(auditColumn =>
+                {
+                    auditColumn.Item().Text("Audit Trail").Bold().FontSize(12);
+                    auditColumn.Item().PaddingTop(10).Text($"IP Address: {dependentWaiver.IPAddress ?? "Not recorded"}")
+                        .FontSize(9).FontColor(Colors.Grey.Darken1);
+                    auditColumn.Item().Text($"User Agent: {TruncateUserAgent(dependentWaiver.UserAgent)}")
+                        .FontSize(9).FontColor(Colors.Grey.Darken1);
+                });
+            });
+        }
+
         private static string GetExtensionFromContentType(string contentType)
         {
             return contentType?.ToLowerInvariant() switch

--- a/TrashMob/Controllers/DependentWaiversController.cs
+++ b/TrashMob/Controllers/DependentWaiversController.cs
@@ -7,6 +7,7 @@ namespace TrashMob.Controllers
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
     using TrashMob.Models;
     using TrashMob.Security;
@@ -19,7 +20,9 @@ namespace TrashMob.Controllers
     [Route("api/dependents/{dependentId}/waiver")]
     public class DependentWaiversController(
         IDependentWaiverManager dependentWaiverManager,
-        IDependentManager dependentManager)
+        IDependentManager dependentManager,
+        IWaiverDocumentManager waiverDocumentManager,
+        IUserManager userManager)
         : SecureController
     {
         /// <summary>
@@ -59,6 +62,21 @@ namespace TrashMob.Controllers
             if (!result.IsSuccess)
             {
                 return BadRequest(result.ErrorMessage);
+            }
+
+            // Generate and store PDF
+            try
+            {
+                var user = await userManager.GetAsync(UserId, cancellationToken);
+                var documentUrl = await waiverDocumentManager
+                    .GenerateAndStoreDependentWaiverPdfAsync(result.Data, dependent, user, cancellationToken);
+                result.Data.DocumentUrl = documentUrl;
+                await dependentWaiverManager.UpdateAsync(result.Data, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // Don't fail waiver acceptance if PDF generation fails
+                Logger?.LogWarning(ex, "PDF generation failed for dependent waiver {WaiverId}", result.Data.Id);
             }
 
             TrackEvent(nameof(SignWaiver));
@@ -115,6 +133,50 @@ namespace TrashMob.Controllers
 
             var waivers = await dependentWaiverManager.GetByDependentIdAsync(dependentId, cancellationToken);
             return Ok(waivers);
+        }
+
+        /// <summary>
+        /// Downloads the PDF for a signed dependent waiver.
+        /// </summary>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="waiverId">The dependent waiver ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The waiver PDF file.</returns>
+        [HttpGet("{waiverId:guid}/download")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DownloadWaiverPdf(
+            Guid dependentId, Guid waiverId, CancellationToken cancellationToken)
+        {
+            var dependent = await dependentManager.GetAsync(dependentId, cancellationToken);
+            if (dependent == null || dependent.ParentUserId != UserId)
+            {
+                return Forbid();
+            }
+
+            var waiver = await dependentWaiverManager.GetAsync(waiverId, cancellationToken);
+            if (waiver == null || waiver.DependentId != dependentId)
+            {
+                return NotFound();
+            }
+
+            // If no stored document, generate one on-the-fly
+            if (string.IsNullOrWhiteSpace(waiver.DocumentUrl))
+            {
+                var user = await userManager.GetAsync(UserId, cancellationToken);
+                var pdfBytes = waiverDocumentManager.GenerateDependentWaiverPdf(waiver, dependent, user);
+
+                TrackEvent(nameof(DownloadWaiverPdf));
+
+                return File(pdfBytes, "application/pdf", $"dependent-waiver-{waiver.Id}.pdf");
+            }
+
+            TrackEvent(nameof(DownloadWaiverPdf));
+
+            return Redirect(waiver.DocumentUrl);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- **PDF generation for dependent waivers**: Extends `WaiverDocumentManager` with QuestPDF-based PDF generation for `DependentWaiver` records, including dependent info (name, DOB, relationship, medical notes), parent/guardian signature, acceptance details, and audit trail
- **Signing flow integration**: PDF auto-generated and stored in blob storage (`waivers/dependents/{id}/`) after waiver signing, with graceful failure (waiver still valid if PDF generation fails)
- **Download endpoint**: `GET /api/dependents/{dependentId}/waiver/{waiverId}/download` with on-the-fly generation fallback
- **Draft minor waiver text**: Parent/guardian and authorized supervisor variants covering all 7 required sections (authority, risk, liability, medical auth, photo release, supervision, activity) — flagged for legal review

## Test plan
- [ ] `dotnet build TrashMob.sln` — 0 errors (verified)
- [ ] `dotnet test TrashMob.Shared.Tests` — 470 tests pass (verified)
- [ ] Confirm Swagger shows new `GET /api/dependents/{dependentId}/waiver/{waiverId}/download` endpoint
- [ ] Test dependent waiver signing generates PDF and stores DocumentUrl
- [ ] Test PDF download endpoint returns valid PDF with dependent info
- [ ] Legal team reviews draft waiver text in `MinorWaiverText.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)