### PR TITLE
Add mobile UX for dependent management (Phase 5d)

### DIFF
--- a/Planning/Projects/Project_08_Waivers_V3.md
+++ b/Planning/Projects/Project_08_Waivers_V3.md
@@ -309,9 +309,9 @@ The minor waiver must contain language beyond the standard adult waiver:
 - Select from existing dependents or add new inline
 - Sign waiver inline if needed (extend existing multi-waiver popup flow)
 
-- ☐ Add dependents management to mobile profile
-- ☐ Extend mobile event registration with dependent selection
-- ☐ Extend mobile waiver popup for minor waiver signing
+- ✅ Add dependents management to mobile profile — "My Dependents" button in MorePage navigating to existing MyDependentsPage
+- ✅ Extend mobile event registration with dependent selection — SelectDependentsPopup shown after registration in ViewEventViewModel
+- ☐ Extend mobile waiver popup for minor waiver signing — deferred pending legal approval of minor waiver text
 
 #### Phase 5e - Event Headcount & Safety
 

--- a/TrashMobMobile/Controls/SelectDependentsPopup.xaml
+++ b/TrashMobMobile/Controls/SelectDependentsPopup.xaml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.SelectDependentsPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="320"
+            MaximumHeightRequest="500">
+        <VerticalStackLayout Spacing="16">
+
+            <Label x:Name="titleLabel"
+                   Text="Bring Dependents?"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Label Text="Select dependents you plan to bring to this event."
+                   FontSize="14"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <CollectionView x:Name="dependentsList"
+                            MaximumHeightRequest="250">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Border Padding="12,10"
+                                Margin="0,3"
+                                StrokeShape="RoundRectangle 8"
+                                BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}"
+                                Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+                                StrokeThickness="1">
+                            <HorizontalStackLayout Spacing="12">
+                                <CheckBox IsChecked="{Binding IsSelected}"
+                                          CheckedChanged="OnCheckChanged"
+                                          Color="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                <VerticalStackLayout VerticalOptions="Center">
+                                    <Label Text="{Binding DisplayName}"
+                                           FontSize="14"
+                                           FontFamily="LexendSemibold"
+                                           TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+                                    <Label Text="{Binding Relationship}"
+                                           FontSize="12"
+                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                </VerticalStackLayout>
+                            </HorizontalStackLayout>
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <Button x:Name="registerButton"
+                    Text="Register Selected"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    IsEnabled="False"
+                    Clicked="OnRegisterClicked" />
+
+            <Button Text="Skip"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnSkipClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/SelectDependentsPopup.xaml.cs
+++ b/TrashMobMobile/Controls/SelectDependentsPopup.xaml.cs
@@ -1,0 +1,61 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Extensions;
+using TrashMob.Models;
+
+public partial class SelectDependentsPopup : ContentView
+{
+    private readonly List<DependentSelectItem> items;
+
+    public SelectDependentsPopup(List<Dependent> dependents)
+    {
+        InitializeComponent();
+        items = dependents.Select(d => new DependentSelectItem(d)).ToList();
+        dependentsList.ItemsSource = items;
+    }
+
+    private void OnCheckChanged(object? sender, CheckedChangedEventArgs e)
+    {
+        var selectedCount = items.Count(i => i.IsSelected);
+        registerButton.IsEnabled = selectedCount > 0;
+        registerButton.Text = selectedCount > 0
+            ? $"Register Selected ({selectedCount})"
+            : "Register Selected";
+    }
+
+    private async void OnRegisterClicked(object? sender, EventArgs e)
+    {
+        var selectedIds = items
+            .Where(i => i.IsSelected)
+            .Select(i => i.Id)
+            .ToList();
+
+        await Shell.Current.ClosePopupAsync(selectedIds);
+    }
+
+    private async void OnSkipClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+}
+
+/// <summary>
+/// Bindable wrapper for dependent selection in the popup.
+/// </summary>
+public class DependentSelectItem
+{
+    public DependentSelectItem(Dependent dependent)
+    {
+        Id = dependent.Id;
+        DisplayName = $"{dependent.FirstName} {dependent.LastName}";
+        Relationship = dependent.Relationship;
+    }
+
+    public Guid Id { get; }
+
+    public string DisplayName { get; }
+
+    public string Relationship { get; }
+
+    public bool IsSelected { get; set; }
+}

--- a/TrashMobMobile/Pages/MorePage.xaml
+++ b/TrashMobMobile/Pages/MorePage.xaml
@@ -23,6 +23,11 @@
                     ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconSignatureText}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
             <Button Style="{StaticResource SecondaryLargeButton}"
                     ContentLayout="Left, 12"
+                    Clicked="OnMyDependentsClicked"
+                    Text="My Dependents"
+                    ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconHumanChild}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
+            <Button Style="{StaticResource SecondaryLargeButton}"
+                    ContentLayout="Left, 12"
                     Clicked="OnContactUsClicked"
                     Text="Contact us"
                     ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmail}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />

--- a/TrashMobMobile/Pages/MorePage.xaml.cs
+++ b/TrashMobMobile/Pages/MorePage.xaml.cs
@@ -25,6 +25,11 @@ public partial class MorePage : ContentPage
         await Shell.Current.GoToAsync(nameof(WaiverPage));
     }
 
+    private async void OnMyDependentsClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync(nameof(MyDependentsPage));
+    }
+
     private async void OnContactUsClicked(object sender, EventArgs e)
     {
         await Shell.Current.GoToAsync(nameof(ContactUsPage));

--- a/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
+++ b/TrashMobMobile/Resources/Styles/GoogleMaterialIcons.xaml
@@ -747,7 +747,7 @@
     <!-- <x:String x:Key="IconBowlMixOutline">&#xf02e4;</x:String> -->
     <!-- <x:String x:Key="IconPot">&#xf02e5;</x:String> -->
     <!-- <x:String x:Key="IconHuman">&#xf02e6;</x:String> -->
-    <!-- <x:String x:Key="IconHumanChild">&#xf02e7;</x:String> -->
+    <x:String x:Key="IconHumanChild">&#xf02e7;</x:String>
     <!-- <x:String x:Key="IconHumanMaleFemale">&#xf02e8;</x:String> -->
     <x:String x:Key="IconImage">&#xf02e9;</x:String>
     <!-- <x:String x:Key="IconImageAlbum">&#xf02ea;</x:String> -->

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -28,7 +28,8 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     IRouteTrackingSessionManager routeTrackingSessionManager,
     IEventAttendeeMetricsRestService eventAttendeeMetricsRestService,
     RoutePointWriter routePointWriter,
-    SyncQueue syncQueue) : BaseViewModel(notificationService)
+    SyncQueue syncQueue,
+    IDependentRestService dependentRestService) : BaseViewModel(notificationService)
 {
     private readonly IEventAttendeeRestService eventAttendeeRestService = eventAttendeeRestService;
     private readonly IEventLitterReportManager eventLitterReportManager = eventLitterReportManager;
@@ -725,6 +726,25 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
             var registerPopup = new ConfirmPopup("Registered!", "You have been registered for this event. We'll see you there!", "OK");
             await Shell.Current.CurrentPage.ShowPopupAsync<string>(registerPopup);
+
+            // Offer to register dependents if user has any
+            var dependents = await dependentRestService.GetDependentsAsync(userManager.CurrentUser.Id);
+            if (dependents.Count > 0)
+            {
+                var dependentPopup = new SelectDependentsPopup(dependents);
+                var popupResult = await Shell.Current.CurrentPage.ShowPopupAsync<List<Guid>>(dependentPopup);
+                var selectedIds = popupResult?.Result;
+
+                if (selectedIds is { Count: > 0 })
+                {
+                    await dependentRestService.RegisterDependentsForEventAsync(
+                        EventViewModel.Id, selectedIds);
+
+                    var countPopup = new ConfirmPopup("Dependents Registered!",
+                        $"{selectedIds.Count} dependent(s) registered for this event.", "OK");
+                    await Shell.Current.CurrentPage.ShowPopupAsync<string>(countPopup);
+                }
+            }
         }, "An error occurred while registering you for this event. Please try again.");
     }
 


### PR DESCRIPTION
## Summary
- Add "My Dependents" button to the More page, navigating to the existing MyDependentsPage for CRUD management
- Create `SelectDependentsPopup` control — checkbox list shown after event registration so users can optionally register their dependents
- Integrate dependent selection into `ViewEventViewModel.Register()` flow: after self-registration, prompt user to select dependents if any exist
- Uncomment `IconHumanChild` font icon resource
- Minor waiver signing deferred pending legal approval of waiver text

## Test plan
- [ ] More page → "My Dependents" button appears and navigates to MyDependentsPage
- [ ] Register for event with dependents → SelectDependentsPopup appears after confirmation
- [ ] Select dependents + "Register Selected" → API call registers them, confirmation shown
- [ ] "Skip" on popup → dismisses without action
- [ ] Register for event with no dependents → no popup shown
- [ ] Android build succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)