### PR TITLE
Update Project 8 status: Phases 5a-5e complete

### DIFF
--- a/Planning/Projects/Project_08_Waivers_V3.md
+++ b/Planning/Projects/Project_08_Waivers_V3.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 1-4, 6 Complete; Phase 5 Ready for Development) |
+| **Status** | In Progress (Phases 1-4, 5a-5e, 6 Complete; Phase 5 minor waiver signing pending legal review) |
 | **Priority** | High |
 | **Risk** | Very High |
 | **Size** | Very Large |
@@ -240,12 +240,12 @@ Covers the scenario where a registered adult brings children to events — child
 | GET | /events/{eventId}/dependents | EventLead | List dependents attending event |
 | GET | /events/{eventId}/dependent-count | ValidUser | Count of dependents registered |
 
-- ☐ Create Dependent model, repository, manager
-- ☐ Create EventDependent model, repository, manager
-- ☐ Create DependentWaiver model, repository, manager
-- ☐ Add migration for new tables with proper indexes and FKs
-- ☐ Create API controllers with authorization
-- ☐ Create minor-specific waiver text (add to WaiverVersion with a MinorWaiver flag or separate scope)
+- ✅ Create Dependent model, repository, manager
+- ✅ Create EventDependent model, repository, manager
+- ✅ Create DependentWaiver model, repository, manager
+- ✅ Add migration for new tables with proper indexes and FKs
+- ✅ Create API controllers with authorization
+- ☐ Create minor-specific waiver text (add to WaiverVersion with a MinorWaiver flag or separate scope) — pending legal approval
 
 #### Phase 5b - Minor Waiver Content
 
@@ -902,9 +902,9 @@ The following GitHub issues are tracked as part of this project:
 
 ---
 
-**Last Updated:** March 3, 2026
+**Last Updated:** March 4, 2026
 **Owner:** Product Lead + Legal Counsel
-**Status:** In Progress (Phases 1-4, 6 Complete; Phase 5 Ready for Development — no longer blocked on Project 23)
+**Status:** In Progress (Phases 1-4, 5a-5e, 6 Complete; Phase 5 minor waiver signing pending legal review)
 **Next Review:** After legal review of minor waiver text
 
 **?? CRITICAL:** No development work begins until legal team provides written approval of approach.

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -32,7 +32,7 @@
 | [Project 2 - Home Page Improvements](./Projects/Project_02_Home_Page.md) | Dynamic content, ads, sponsors | Ready for Design Review |
 | [Project 3 - Litter Reporting Web](./Projects/Project_03_Litter_Reporting_Web.md) | Complete web parity for litter reports | ✅ Complete |
 | [Project 7 - Event Weights](./Projects/Project_07_Event_Weights.md) | Track weight metrics | ✅ Complete |
-| [Project 8 - Waivers V3](./Projects/Project_08_Waivers_V3.md) | Community waivers, minors coverage | In Progress (Phases 1-4, 6 Complete; Phase 5 Ready) |
+| [Project 8 - Waivers V3](./Projects/Project_08_Waivers_V3.md) | Community waivers, minors coverage | In Progress (Phases 1-4, 5a-5e, 6 Complete; minor waiver signing pending legal) |
 | [Project 9 - Teams](./Projects/Project_09_Teams.md) | User-created teams MVP | ✅ Complete |
 | [Project 10 - Community Pages](./Projects/Project_10_Community_Pages.md) | Branded partner community pages | ✅ Complete |
 | [Project 13 - Bulk Email Invites](./Projects/Project_13_Bulk_Email_Invites.md) | Scale email invitations | ✅ Complete |
@@ -182,7 +182,7 @@
 | [Project 4 - Mobile Robustness](./Projects/Project_04_Mobile_Robustness.md) | Phases 3-5: Manual test matrix on physical devices, regression testing, load testing, accessibility audit (TalkBack/VoiceOver), supported device docs |
 | [Project 5 - Deployment Pipelines](./Projects/Project_05_Deployment_Pipelines.md) | Phase 4: Deployment health dashboards; Phase 5: Cost optimization & auto-scaling; Phase 6: Security scanning (OWASP ZAP, CodeQL, Trivy) |
 | [Project 6 - Backend Standards](./Projects/Project_06_Backend_Standards.md) | Phase 3: Security audit — review remaining API endpoints for authorization, input validation, rate limiting |
-| [Project 8 - Waivers V3](./Projects/Project_08_Waivers_V3.md) | Phase 5: Dependent minors & guardian waivers — dependent profiles, minor waiver signing, per-event dependent selection, event headcount (no longer blocked on Project 23; requires legal review of minor waiver text) |
+| [Project 8 - Waivers V3](./Projects/Project_08_Waivers_V3.md) | Phase 5 remaining: Minor waiver signing dialog (web + mobile), WaiverVersion record with minor scope, compliance export with dependent waivers — all pending legal review of minor waiver text |
 | [Project 15 - Route Tracing](./Projects/Project_15_Route_Tracing.md) | Mobile app route recording/upload device testing on iOS and Android |
 | [Project 25 - Automated Testing](./Projects/Project_25_Automated_Testing.md) | Phase 2: Core web flow E2E tests (event CRUD, litter reports, partner management); Phase 3: Mobile test foundation; Phase 4: Remaining tests & perf baseline |
 | [Project 30 - Azure Billing Alerts](./Projects/Project_30_Azure_Billing_Alerts.md) | Operational monitoring and alert tuning |
@@ -288,6 +288,6 @@ All new features should consider adding feature usage tracking. See [Project 29 
 
 ---
 
-**Last Updated:** March 1, 2026
+**Last Updated:** March 4, 2026
 **Maintained By:** Product & Engineering Team
 **Next Review:** End of Q1 2026


### PR DESCRIPTION
## Summary
- Mark Project 8 (Waivers V3) Phase 5a checklist items as complete
- Update project status across Project 8 doc and Planning README to reflect Phases 5a-5e done
- Remaining Phase 5 work (minor waiver signing dialog, WaiverVersion record, compliance export) is pending legal review of minor waiver text

## Test plan
- [ ] Verify planning docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)