### PR TITLE
Fix flaky keyboard accessibility E2E test

### DIFF
--- a/TrashMob/client-app/e2e/tests/public-pages.spec.ts
+++ b/TrashMob/client-app/e2e/tests/public-pages.spec.ts
@@ -163,6 +163,9 @@ test.describe('Public Pages', () => {
         test('navigation should be keyboard accessible', async ({ page }) => {
             await page.goto('/');
 
+            // Wait for header to be visible before testing keyboard navigation
+            await expect(page.locator('header')).toBeVisible();
+
             // Tab through navigation elements
             await page.keyboard.press('Tab');
 


### PR DESCRIPTION
## Summary
- The "navigation should be keyboard accessible" E2E test was failing because it pressed Tab before the page header was fully rendered
- Added `await expect(page.locator('header')).toBeVisible()` before the Tab press to ensure focusable elements are present in the DOM
- This was exposed after PR #2996 replaced the home page `<>` fragment with a `<div>` wrapper

## Test plan
- [ ] E2E tests pass in CI (the keyboard accessibility test specifically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)