### PR TITLE
Add 28 new E2E tests for broader UI coverage

### DIFF
--- a/TrashMob/client-app/e2e/tests/error-pages.spec.ts
+++ b/TrashMob/client-app/e2e/tests/error-pages.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '../fixtures/base.fixture';
+
+test.describe('Error Pages', () => {
+    test('should display 404 page for non-existent routes', async ({ page }) => {
+        await page.goto('/this-page-does-not-exist');
+
+        // Should display 404 heading
+        await expect(page.getByText('404')).toBeVisible();
+        await expect(page.getByText('Page Not Found')).toBeVisible();
+
+        // Should show the attempted path
+        await expect(page.getByText('/this-page-does-not-exist')).toBeVisible();
+    });
+
+    test('should have Back to Home link on 404 page', async ({ page }) => {
+        await page.goto('/nonexistent-route');
+
+        const homeLink = page.getByRole('link', { name: /back to home/i });
+        await expect(homeLink).toBeVisible();
+
+        await homeLink.click();
+        await expect(page).toHaveURL('/');
+    });
+
+    test('should have Go Back button on 404 page', async ({ page }) => {
+        // Navigate to home first, then to a non-existent page
+        await page.goto('/');
+        await page.goto('/nonexistent-route');
+
+        await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+    });
+
+    test('should have contact link on 404 page', async ({ page }) => {
+        await page.goto('/nonexistent-route');
+
+        const contactLink = page.getByRole('link', { name: /let us know/i });
+        await expect(contactLink).toBeVisible();
+
+        await contactLink.click();
+        await expect(page).toHaveURL('/contactus');
+    });
+});

--- a/TrashMob/client-app/e2e/tests/footer.spec.ts
+++ b/TrashMob/client-app/e2e/tests/footer.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../fixtures/base.fixture';
+
+test.describe('Footer', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        // Scroll to footer
+        await page.locator('footer').scrollIntoViewIfNeeded();
+    });
+
+    test('should display footer with copyright', async ({ page }) => {
+        const footer = page.locator('footer');
+        await expect(footer).toBeVisible();
+
+        // Should show copyright text
+        await expect(footer.getByText(/copyright/i)).toBeVisible();
+        await expect(footer.getByText(/trashmob\.eco/i)).toBeVisible();
+    });
+
+    test('should display footer navigation links', async ({ page }) => {
+        const footer = page.locator('footer');
+
+        // Key navigation links should be present
+        await expect(footer.getByRole('link', { name: /about us/i })).toBeVisible();
+        await expect(footer.getByRole('link', { name: /faq/i })).toBeVisible();
+        await expect(footer.getByRole('link', { name: /contact us/i })).toBeVisible();
+        await expect(footer.getByRole('link', { name: /privacy policy/i })).toBeVisible();
+        await expect(footer.getByRole('link', { name: /terms of service/i })).toBeVisible();
+    });
+
+    test('should display social media links', async ({ page }) => {
+        const footer = page.locator('footer');
+
+        // Social media links should have correct hrefs
+        await expect(footer.locator('a[href*="instagram.com"]')).toBeVisible();
+        await expect(footer.locator('a[href*="youtube.com"]')).toBeVisible();
+        await expect(footer.locator('a[href*="facebook.com"]')).toBeVisible();
+        await expect(footer.locator('a[href*="twitter.com"]')).toBeVisible();
+    });
+
+    test('should have working footer navigation links', async ({ page }) => {
+        const footer = page.locator('footer');
+
+        // Click About Us link in footer and verify navigation
+        await footer.getByRole('link', { name: /about us/i }).click();
+        await expect(page).toHaveURL('/aboutus');
+
+        // Go back and click FAQ
+        await page.goto('/');
+        await page.locator('footer').scrollIntoViewIfNeeded();
+        await page.locator('footer').getByRole('link', { name: /faq/i }).click();
+        await expect(page).toHaveURL('/faq');
+    });
+
+    test('should display non-profit disclosure', async ({ page }) => {
+        const footer = page.locator('footer');
+
+        // Should mention 501(c)(3) status
+        await expect(footer.getByText(/501\(c\)\(3\)/)).toBeVisible();
+    });
+});

--- a/TrashMob/client-app/e2e/tests/home-page.spec.ts
+++ b/TrashMob/client-app/e2e/tests/home-page.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '../fixtures/base.fixture';
+import { HomePage } from '../pages/home.page';
+
+test.describe('Home Page Content', () => {
+    test.describe('Hero Section', () => {
+        test('should display hero section with CTA buttons', async ({ page }) => {
+            const homePage = new HomePage(page);
+            await homePage.goto();
+
+            // Hero should have a "Join us today" or similar CTA link
+            await expect(page.getByRole('link', { name: /join us|get started/i })).toBeVisible();
+        });
+
+        test('should have working Getting Started link in hero', async ({ page }) => {
+            const homePage = new HomePage(page);
+            await homePage.goto();
+
+            const ctaLink = page.getByRole('link', { name: /join us today/i });
+            if (await ctaLink.isVisible()) {
+                await ctaLink.click();
+                await expect(page).toHaveURL('/gettingstarted');
+            }
+        });
+    });
+
+    test.describe('Stats Section', () => {
+        test('should display stats section with counters', async ({ page }) => {
+            const homePage = new HomePage(page);
+            await homePage.goto();
+
+            // Stats section should have a gray background section with stat cards
+            const statsSection = page.locator('section.bg-background');
+            await expect(statsSection).toBeVisible();
+
+            // Should display stat labels
+            await expect(page.getByText('Events Hosted')).toBeVisible();
+            await expect(page.getByText('Bags Collected')).toBeVisible();
+            await expect(page.getByText('Participants')).toBeVisible();
+            await expect(page.getByText('Hours Spent')).toBeVisible();
+        });
+    });
+
+    test.describe('What is TrashMob Section', () => {
+        test('should display introduction section', async ({ page }) => {
+            const homePage = new HomePage(page);
+            await homePage.goto();
+
+            const introSection = page.locator('#introduction');
+            await expect(introSection).toBeVisible();
+
+            // Should have the heading
+            await expect(page.getByRole('heading', { name: /what is a trashmob/i })).toBeVisible();
+
+            // Should have CTA buttons
+            await expect(page.getByRole('link', { name: /learn more/i })).toBeVisible();
+        });
+    });
+
+    test.describe('Events Section', () => {
+        test('should display events section with search', async ({ page }) => {
+            const homePage = new HomePage(page);
+            await homePage.goto();
+
+            // Events section heading
+            await expect(page.getByRole('heading', { name: /events near/i })).toBeVisible();
+
+            // Should have tabs for Upcoming and Completed
+            await expect(page.getByRole('tab', { name: /upcoming/i })).toBeVisible();
+            await expect(page.getByRole('tab', { name: /completed/i })).toBeVisible();
+        });
+    });
+
+    test.describe('Getting Started Section', () => {
+        test('should display getting started section', async ({ page }) => {
+            const homePage = new HomePage(page);
+            await homePage.goto();
+
+            await expect(page.getByRole('heading', { name: /getting started/i })).toBeVisible();
+
+            // Should display the three requirements
+            await expect(page.getByText('Work gloves')).toBeVisible();
+            await expect(page.getByText('A bucket')).toBeVisible();
+            await expect(page.getByText('A good attitude')).toBeVisible();
+        });
+    });
+});

--- a/TrashMob/client-app/e2e/tests/mobile.spec.ts
+++ b/TrashMob/client-app/e2e/tests/mobile.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect, devices } from '@playwright/test';
+
+// Mobile-specific tests using iPhone 13 viewport
+test.use({ ...devices['iPhone 13'] });
+
+test.describe('Mobile Responsiveness', () => {
+    test('should display hamburger menu on mobile', async ({ page }) => {
+        await page.goto('/');
+
+        // Hamburger menu button should be visible on mobile
+        const menuButton = page.getByRole('button', { name: /toggle menu/i });
+        await expect(menuButton).toBeVisible();
+    });
+
+    test('should toggle navigation menu on hamburger click', async ({ page }) => {
+        await page.goto('/');
+
+        const menuButton = page.getByRole('button', { name: /toggle menu/i });
+        await menuButton.click();
+
+        // Navigation items should become visible after clicking hamburger
+        await expect(page.getByRole('button', { name: /explore/i })).toBeVisible();
+        await expect(page.getByRole('button', { name: /about/i })).toBeVisible();
+    });
+
+    test('should display sign in button on mobile', async ({ page }) => {
+        await page.goto('/');
+
+        // Open mobile menu first
+        const menuButton = page.getByRole('button', { name: /toggle menu/i });
+        await menuButton.click();
+
+        await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+    });
+
+    test('should render home page sections on mobile', async ({ page }) => {
+        await page.goto('/');
+
+        // Key sections should still be visible
+        await expect(page.locator('header')).toBeVisible();
+        await expect(page.getByRole('heading', { name: /what is a trashmob/i })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /events near/i })).toBeVisible();
+    });
+
+    test('should load static pages on mobile', async ({ page }) => {
+        // Test a few key pages render correctly on mobile
+        await page.goto('/aboutus');
+        await expect(page.locator('h1')).toBeVisible();
+
+        await page.goto('/faq');
+        await expect(page.locator('h1').first()).toBeVisible();
+
+        await page.goto('/contactus');
+        await expect(page.locator('h1')).toBeVisible();
+    });
+
+    test('should display footer on mobile', async ({ page }) => {
+        await page.goto('/');
+        await page.locator('footer').scrollIntoViewIfNeeded();
+        await expect(page.locator('footer')).toBeVisible();
+        await expect(page.locator('footer').getByText(/copyright/i)).toBeVisible();
+    });
+});

--- a/TrashMob/client-app/e2e/tests/public-pages.spec.ts
+++ b/TrashMob/client-app/e2e/tests/public-pages.spec.ts
@@ -144,6 +144,48 @@ test.describe('Public Pages', () => {
             await expect(page).toHaveTitle(/terms|trashmob/i);
             await expect(page.locator('h1')).toBeVisible();
         });
+
+        test('should load News page', async ({ page }) => {
+            await page.goto('/news');
+            await expect(page).toHaveTitle(/news|trashmob/i);
+            await expect(page.locator('h1')).toBeVisible();
+        });
+
+        test('should load Board of Directors page', async ({ page }) => {
+            await page.goto('/board');
+            await expect(page).toHaveTitle(/board|trashmob/i);
+            await expect(page.locator('h1')).toBeVisible();
+        });
+
+        test('should load Partnerships page', async ({ page }) => {
+            await page.goto('/partnerships');
+            await expect(page).toHaveTitle(/partner|trashmob/i);
+            await expect(page.locator('h1').first()).toBeVisible();
+        });
+
+        test('should load For Communities page', async ({ page }) => {
+            await page.goto('/for-communities');
+            await expect(page).toHaveTitle(/communit|trashmob/i);
+            await expect(page.locator('h1')).toBeVisible();
+        });
+
+        test('should load Volunteer Opportunities page', async ({ page }) => {
+            await page.goto('/volunteeropportunities');
+            await expect(page).toHaveTitle(/volunteer|trashmob/i);
+            await expect(page.locator('h1').first()).toBeVisible();
+        });
+
+        test('should load Litter Reports page', async ({ page }) => {
+            await page.goto('/litterreports');
+            await expect(page).toHaveTitle(/litter|trashmob/i);
+            await expect(page.locator('h1')).toBeVisible();
+        });
+
+        test('should load Shop page', async ({ page }) => {
+            await page.goto('/shop');
+            await expect(page).toHaveTitle(/shop|trashmob/i);
+            await expect(page.locator('h1').first()).toBeVisible();
+        });
     });
 
     test.describe('Accessibility', () => {


### PR DESCRIPTION
## Summary
- **28 new Playwright E2E tests** across 4 new test files + 7 additions to existing file
- Increases test count from 33 to 59 (~79% increase)
- All tests are public/unauthenticated — no auth setup required

### New test files
- **home-page.spec.ts** (6 tests): Hero CTA buttons, stats section counters, "What is TrashMob" intro, events section tabs, getting started cards
- **footer.spec.ts** (5 tests): Copyright text, navigation links, social media links, link navigation, 501(c)(3) disclosure
- **error-pages.spec.ts** (4 tests): 404 page content, Back to Home link, Go Back button, contact link
- **mobile.spec.ts** (6 tests): Hamburger menu visibility, menu toggle, sign-in on mobile, home sections rendering, static page loading, footer on mobile

### Expanded existing file
- **public-pages.spec.ts** (+7 tests): News, Board of Directors, Partnerships, For Communities, Volunteer Opportunities, Litter Reports, Shop

## Test plan
- [ ] All new E2E tests pass in CI
- [ ] Existing tests continue to pass
- [ ] No flakiness on retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)