### PR TITLE
Fix page layout overflow causing gaps between sections

### DIFF
--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -534,7 +534,7 @@ const AppContent: FC = () => {
     const { currentUser, isUserLoaded } = useLogin();
 
     return (
-        <div className='flex flex-col h-100'>
+        <div className='flex flex-col min-h-screen'>
             <BrowserRouter>
                 <ScrollToTop />
                 <DefaultPageHead />

--- a/TrashMob/client-app/src/pages/_home/index.tsx
+++ b/TrashMob/client-app/src/pages/_home/index.tsx
@@ -8,7 +8,7 @@ import { WhatIsTrashmobSection } from './whatistrashmob-section';
 
 export const Home = () => {
     return (
-        <div className='bg-card'>
+        <>
             <HeroSection />
             <WhatIsTrashmobSection />
             <StatsSection />
@@ -16,6 +16,6 @@ export const Home = () => {
             <LatestNewsSection />
             <EventSection />
             <GettingStartSection />
-        </div>
+        </>
     );
 };


### PR DESCRIPTION
## Summary
- The root layout div in `App.tsx` used `h-100` — a Bootstrap class meaning `height: 100%`, but in Tailwind CSS v4 it means `height: 25rem` (400px)
- This capped the flex container at 400px while page content was ~2100px+, causing overflow
- The body's `#eee` background showed through behind overflowing sections, creating visible gaps
- Changed to `min-h-screen` which fills the viewport and grows with content
- Reverted the `bg-card` wrapper from PR #2996 since it was just masking this root cause

## Test plan
- [ ] Home page has no visible gap between stats and events sections
- [ ] All pages render with correct backgrounds (no gray bleed-through)
- [ ] Footer sticks to the bottom on short pages
- [ ] Layout looks correct on all screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)