### PR TITLE
Fix race condition in dependent event registration

### DIFF
--- a/TrashMob.Shared/Managers/EventDependentManager.cs
+++ b/TrashMob.Shared/Managers/EventDependentManager.cs
@@ -5,6 +5,7 @@ namespace TrashMob.Shared.Managers
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Data.SqlClient;
     using Microsoft.EntityFrameworkCore;
     using TrashMob.Models;
     using TrashMob.Shared.Managers.Interfaces;
@@ -70,8 +71,17 @@ namespace TrashMob.Shared.Managers
                     DependentWaiverId = currentWaiver.Id,
                 };
 
-                var created = await AddAsync(eventDependent, parentUserId, cancellationToken);
-                results.Add(created);
+                try
+                {
+                    var created = await AddAsync(eventDependent, parentUserId, cancellationToken);
+                    results.Add(created);
+                }
+                catch (DbUpdateException ex) when (ex.InnerException is SqlException { Number: 2627 or 2601 })
+                {
+                    // Unique constraint violation — another concurrent request already registered
+                    // this dependent for the event. The desired end state is achieved, so continue.
+                    continue;
+                }
             }
 
             return ServiceResult<IEnumerable<EventDependent>>.Success(results);


### PR DESCRIPTION
## Summary

- Fixes a race condition in `EventDependentManager.RegisterDependentsAsync()` where two concurrent requests can both pass the existence check and attempt to insert, causing a unique constraint violation (`SqlException` 2627/2601) on `IX_EventDependents_EventId_DependentId`
- The fix catches `DbUpdateException` with unique constraint `SqlException` and treats it as a no-op — the desired end state (dependent registered for the event) is already achieved by the concurrent request

## Root Cause

The check-then-insert pattern on lines 49-73 is not atomic:
1. Request A checks if dependent is registered → `false`
2. Request B checks if dependent is registered → `false`
3. Request A inserts → succeeds
4. Request B inserts → **fails with unique constraint violation**

This was observed once in PROD on 2026-03-03, ~3 hours after the dependent minors feature was deployed.

Fixes #2998

## Test plan

- [ ] All 455 existing unit tests pass
- [ ] Verify the fix handles concurrent registration gracefully (no exception, no duplicate)
- [ ] Verify single registration still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)