### PR TITLE
Fix required field indicators and validation in siteadmin pages

### DIFF
--- a/TrashMob/client-app/src/components/ui/custom/form.tsx
+++ b/TrashMob/client-app/src/components/ui/custom/form.tsx
@@ -41,7 +41,15 @@ const EnhancedFormLabel = React.forwardRef<React.ElementRef<typeof LabelPrimitiv
         }
 
         return (
-            <Label ref={ref} className={cn(error && 'text-destructive', className)} htmlFor={formItemId} {...props} />
+            <>
+                <Label
+                    ref={ref}
+                    className={cn(error && 'text-destructive', className)}
+                    htmlFor={formItemId}
+                    {...props}
+                />
+                {required ? <span className='text-destructive'>*</span> : ''}
+            </>
         );
     },
 );

--- a/TrashMob/client-app/src/pages/siteadmin/contacts/note-dialog.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/contacts/note-dialog.tsx
@@ -6,7 +6,8 @@ import { z } from 'zod';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { EnhancedFormLabel as FormLabel } from '@/components/ui/custom/form';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
@@ -151,7 +152,7 @@ export const NoteDialog = ({ open, onOpenChange, contactId, editingNote }: NoteD
                             name='body'
                             render={({ field }) => (
                                 <FormItem>
-                                    <FormLabel>Note</FormLabel>
+                                    <FormLabel required>Note</FormLabel>
                                     <FormControl>
                                         <Textarea {...field} placeholder='Write your note...' rows={5} />
                                     </FormControl>

--- a/TrashMob/client-app/src/pages/siteadmin/job-opportunities/$jobId.edit.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/job-opportunities/$jobId.edit.tsx
@@ -11,7 +11,7 @@ import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import * as ToolTips from '@/store/ToolTips';
-import { useLogin } from '@/hooks/useLogin';
+
 import { GetJobOpportunityById, UpdateJobOpportunity } from '@/services/opportunities';
 import { Checkbox } from '@/components/ui/checkbox';
 import { GetAllJobOpportunities } from '@/services/opportunities';
@@ -26,14 +26,13 @@ interface FormInputs {
 }
 
 const formSchema = z.object({
-    title: z.string({ required_error: 'Title cannot be blank.' }),
-    tagLine: z.string(),
-    fullDescription: z.string(),
+    title: z.string().min(1, 'Title cannot be blank.'),
+    tagLine: z.string().min(1, 'Tag line cannot be blank.'),
+    fullDescription: z.string().min(1, 'Full description cannot be blank.'),
     isActive: z.boolean(),
 });
 
 export const SiteAdminJobOpportunityEdit = () => {
-    const { currentUser } = useLogin();
     const { jobId } = useParams<{ jobId: string }>() as { jobId: string };
 
     const { data: jobOpportunity } = useQuery({
@@ -94,7 +93,6 @@ export const SiteAdminJobOpportunityEdit = () => {
         body.tagLine = formValues.tagLine;
         body.fullDescription = formValues.fullDescription;
         body.isActive = formValues.isActive;
-        body.lastUpdatedByUserId = currentUser.id;
         updateJobOpportunity.mutate(body);
     }, []);
 

--- a/TrashMob/client-app/src/pages/siteadmin/job-opportunities/create.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/job-opportunities/create.tsx
@@ -1,18 +1,18 @@
-import { useCallback, useEffect } from 'react';
-import { Link, useNavigate, useParams } from 'react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
 import { EnhancedFormLabel as FormLabel } from '@/components/ui/custom/form';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import * as ToolTips from '@/store/ToolTips';
-import { useLogin } from '@/hooks/useLogin';
+
 import { CreateJobOpportunity } from '@/services/opportunities';
 import { Checkbox } from '@/components/ui/checkbox';
 import { GetAllJobOpportunities } from '@/services/opportunities';
@@ -27,15 +27,13 @@ interface FormInputs {
 }
 
 const formSchema = z.object({
-    title: z.string({ required_error: 'Title cannot be blank.' }),
-    tagLine: z.string(),
-    fullDescription: z.string(),
+    title: z.string().min(1, 'Title cannot be blank.'),
+    tagLine: z.string().min(1, 'Tag line cannot be blank.'),
+    fullDescription: z.string().min(1, 'Full description cannot be blank.'),
     isActive: z.boolean(),
 });
 
 export const SiteAdminJobOpportunityCreate = () => {
-    const { currentUser } = useLogin();
-
     const { toast } = useToast();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
@@ -76,8 +74,6 @@ export const SiteAdminJobOpportunityCreate = () => {
         body.tagLine = formValues.tagLine;
         body.fullDescription = formValues.fullDescription;
         body.isActive = formValues.isActive;
-        body.createdByUserId = currentUser.id;
-        body.lastUpdatedByUserId = currentUser.id;
         createJobOpportunity.mutate(body);
     }, []);
 


### PR DESCRIPTION
## Summary
- Fix `EnhancedFormLabel` component bug where the required asterisk (`*`) only rendered when a tooltip was also present — now shows in both code paths
- Add proper Zod `.min(1)` validation to job-opportunities create/edit for `title`, `tagLine`, and `fullDescription` (labels already showed `required` but the schema didn't enforce it)
- Switch contact note dialog to use `EnhancedFormLabel` with `required` indicator on the Note (body) field
- Remove redundant frontend audit field assignments (`createdByUserId`, `lastUpdatedByUserId`) from job-opportunities — backend handles these via `BaseManager`

## Test plan
- [ ] Verify required asterisks appear on all siteadmin form labels that have `required` prop (contacts, donations, grants, pledges, prospects, waivers, job-opportunities, send-notification, note dialog)
- [ ] Verify job-opportunities create/edit show validation errors when title, tag line, or full description are left empty
- [ ] Verify contact note dialog shows required indicator on the Note field
- [ ] Verify job-opportunities create/edit still save correctly without frontend setting audit fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)