### PR TITLE
Fix 8 failing Playwright E2E tests

### DIFF
--- a/TrashMob/client-app/e2e/tests/home-page.spec.ts
+++ b/TrashMob/client-app/e2e/tests/home-page.spec.ts
@@ -51,8 +51,8 @@ test.describe('Home Page Content', () => {
             // Should have the heading
             await expect(page.getByRole('heading', { name: /what is a trashmob/i })).toBeVisible();
 
-            // Should have CTA buttons
-            await expect(page.getByRole('link', { name: /learn more/i })).toBeVisible();
+            // Should have CTA buttons (scoped to intro section to avoid strict mode violation with Getting Started's "Learn more")
+            await expect(introSection.getByRole('link', { name: /learn more/i })).toBeVisible();
         });
     });
 

--- a/TrashMob/client-app/e2e/tests/mobile.spec.ts
+++ b/TrashMob/client-app/e2e/tests/mobile.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect, devices } from '@playwright/test';
 
-// Mobile-specific tests using iPhone 13 viewport
-test.use({ ...devices['iPhone 13'] });
+// Mobile-specific tests using iPhone 13 viewport settings.
+// Destructure out defaultBrowserType so the test uses the project's browser (chromium in CI)
+// instead of webkit, which may not be installed.
+const { defaultBrowserType: _, ...mobileDevice } = devices['iPhone 13'];
+test.use(mobileDevice);
 
 test.describe('Mobile Responsiveness', () => {
     test('should display hamburger menu on mobile', async ({ page }) => {

--- a/TrashMob/client-app/src/components/Shop.tsx
+++ b/TrashMob/client-app/src/components/Shop.tsx
@@ -11,8 +11,11 @@ export const Shop: React.FC = () => {
     });
 
     return (
-        <div id='myShop'>
-            <a href='https://trashmobeco.myspreadshop.com'>trashmobeco</a>
+        <div className='container py-4'>
+            <h1 className='text-3xl font-semibold mb-4'>Shop</h1>
+            <div id='myShop'>
+                <a href='https://trashmobeco.myspreadshop.com'>trashmobeco</a>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- **home-page.spec.ts**: Scope "Learn more" link assertion to `#introduction` section to fix strict mode violation (two "Learn more" links exist on the page — one in the intro section, one in Getting Started)
- **mobile.spec.ts**: Strip `defaultBrowserType` from iPhone 13 device descriptor so tests use the project's chromium browser instead of webkit, which is not installed in CI
- **Shop.tsx**: Add `<h1>` heading to the Shop page component so the static page test can find the expected heading element

## Test plan
- [ ] Verify Playwright E2E Tests pass in CI (all 8 previously failing tests should now pass)
- [ ] Verify no regressions in the 47 previously passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)