### PR TITLE
Fix remaining flaky mobile E2E test

### DIFF
--- a/TrashMob/client-app/e2e/tests/mobile.spec.ts
+++ b/TrashMob/client-app/e2e/tests/mobile.spec.ts
@@ -16,15 +16,16 @@ test.describe('Mobile Responsiveness', () => {
     });
 
     test('should toggle navigation menu on hamburger click', async ({ page }) => {
-        await page.goto('/', { waitUntil: 'networkidle' });
+        await page.goto('/');
 
         const menuButton = page.getByRole('button', { name: /toggle menu/i });
         await expect(menuButton).toBeVisible();
         await menuButton.click();
 
         // Mobile nav uses flat links with section headers, not dropdown buttons
-        await expect(page.getByRole('link', { name: /events/i }).first()).toBeVisible({ timeout: 10000 });
-        await expect(page.getByRole('link', { name: /faq/i })).toBeVisible();
+        const nav = page.getByRole('navigation');
+        await expect(nav.getByRole('link', { name: /events/i }).first()).toBeVisible({ timeout: 10000 });
+        await expect(nav.getByRole('link', { name: /faq/i })).toBeVisible();
     });
 
     test('should display sign in button on mobile', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Removed `networkidle` wait from hamburger test — home page has persistent connections that prevent network idle within the 30s test timeout
- Scoped FAQ link assertion to `navigation` role to avoid strict mode violation (FAQ link exists in both nav and footer)
- All 6 mobile E2E tests now pass locally against dev.trashmob.eco

## Test plan
- [x] All 6 mobile.spec.ts tests pass against dev.trashmob.eco
- [ ] CI E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)