### PR TITLE
Add In Pipeline indicator to Geographic Gaps table

### DIFF
--- a/TrashMob.Models/Poco/GeographicGap.cs
+++ b/TrashMob.Models/Poco/GeographicGap.cs
@@ -25,5 +25,11 @@ namespace TrashMob.Models.Poco
 
         /// <summary>Gets or sets the average longitude of events in this area.</summary>
         public double? AverageLongitude { get; set; }
+
+        /// <summary>Gets or sets the ID of an existing prospect in the pipeline for this area, if any.</summary>
+        public Guid? ExistingProspectId { get; set; }
+
+        /// <summary>Gets or sets the name of an existing prospect in the pipeline for this area, if any.</summary>
+        public string? ExistingProspectName { get; set; }
     }
 }

--- a/TrashMob.Shared/Managers/Prospects/ProspectScoringManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectScoringManager.cs
@@ -95,6 +95,11 @@ namespace TrashMob.Shared.Managers.Prospects
                 .Where(p => p.PartnerStatusId == (int)PartnerStatusEnum.Active && p.HomePageEnabled)
                 .ToListAsync(cancellationToken);
 
+            // Get existing prospects (not yet converted to partners)
+            var existingProspects = await prospectRepository.Get()
+                .Where(p => p.ConvertedPartnerId == null)
+                .ToListAsync(cancellationToken);
+
             List<GeographicGap> gaps = [];
 
             foreach (var group in eventGroups)
@@ -129,6 +134,11 @@ namespace TrashMob.Shared.Managers.Prospects
                     }
                 }
 
+                // Check if a prospect already exists for this city/region
+                var matchingProspect = existingProspects.FirstOrDefault(p =>
+                    string.Equals(p.City?.Trim(), group.City?.Trim(), StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(p.Region?.Trim(), group.Region?.Trim(), StringComparison.OrdinalIgnoreCase));
+
                 gaps.Add(new GeographicGap
                 {
                     City = group.City,
@@ -138,6 +148,8 @@ namespace TrashMob.Shared.Managers.Prospects
                     NearestPartnerDistanceMiles = nearestDistance.HasValue ? Math.Round(nearestDistance.Value, 1) : null,
                     AverageLatitude = group.HasCoordinates ? Math.Round(group.AverageLatitude, 4) : null,
                     AverageLongitude = group.HasCoordinates ? Math.Round(group.AverageLongitude, 4) : null,
+                    ExistingProspectId = matchingProspect?.Id,
+                    ExistingProspectName = matchingProspect?.Name,
                 });
             }
 

--- a/TrashMob/client-app/src/components/Models/GeographicGapData.ts
+++ b/TrashMob/client-app/src/components/Models/GeographicGapData.ts
@@ -6,6 +6,8 @@ class GeographicGapData {
     nearestPartnerDistanceMiles: number | null = null;
     averageLatitude: number | null = null;
     averageLongitude: number | null = null;
+    existingProspectId: string | null = null;
+    existingProspectName: string | null = null;
 }
 
 export default GeographicGapData;

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/discovery.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/discovery.tsx
@@ -161,6 +161,22 @@ const gapColumns: ColumnDef<GeographicGapData>[] = [
         },
     },
     {
+        id: 'status',
+        header: 'Status',
+        cell: ({ row }) => {
+            const gap = row.original;
+            if (!gap.existingProspectId) return null;
+            return (
+                <Link
+                    to={`/siteadmin/prospects/${gap.existingProspectId}`}
+                    className='inline-flex items-center rounded-full bg-teal-100 px-2.5 py-0.5 text-xs font-medium text-teal-800 hover:bg-teal-200'
+                >
+                    In Pipeline
+                </Link>
+            );
+        },
+    },
+    {
         id: 'actions',
         header: '',
         cell: ({ row }) => <GapResearchButton gap={row.original} />,


### PR DESCRIPTION
## Summary
- Geographic Gaps table now shows an **"In Pipeline"** badge when a city already has a `CommunityProspect` record (not yet converted to a Partner)
- Badge links directly to the existing prospect for quick access
- Prevents admins from accidentally duplicating research on cities already in the pipeline
- "Research & Add" button remains functional regardless, in case the admin wants to re-research

## Test plan
- [ ] Go to Site Admin > Prospects > Discovery > Geographic Gaps
- [ ] Verify gaps with no existing prospect show no status indicator
- [ ] Create a prospect for a gap city, refresh — verify "In Pipeline" badge appears
- [ ] Click the badge — verify it navigates to the prospect detail page
- [ ] Verify `dotnet build` and `npx tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)