### PR TITLE
Add mobile invite flow for dependents

### DIFF
--- a/TrashMobMobile/Controls/InviteEmailPopup.xaml
+++ b/TrashMobMobile/Controls/InviteEmailPopup.xaml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TrashMobMobile.Controls.InviteEmailPopup">
+
+    <Border Padding="24"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+            StrokeShape="RoundRectangle 16"
+            Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+            StrokeThickness="1"
+            WidthRequest="320">
+        <VerticalStackLayout Spacing="16">
+
+            <Label x:Name="titleLabel"
+                   FontFamily="LexendSemibold"
+                   FontSize="18"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}" />
+
+            <Label Text="Enter the email address where the invitation will be sent. They'll use this email to create their TrashMob account."
+                   FontSize="14"
+                   HorizontalTextAlignment="Center"
+                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <Entry x:Name="emailEntry"
+                   Placeholder="Email address"
+                   Keyboard="Email"
+                   TextChanged="OnEmailTextChanged"
+                   BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}"
+                   TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}"
+                   PlaceholderColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+            <Button x:Name="sendButton"
+                    Text="Send Invitation"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    IsEnabled="False"
+                    Clicked="OnSendClicked" />
+
+            <Button Text="Cancel"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    Clicked="OnCancelClicked" />
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/TrashMobMobile/Controls/InviteEmailPopup.xaml.cs
+++ b/TrashMobMobile/Controls/InviteEmailPopup.xaml.cs
@@ -1,0 +1,32 @@
+namespace TrashMobMobile.Controls;
+
+using CommunityToolkit.Maui.Extensions;
+
+public partial class InviteEmailPopup : ContentView
+{
+    public InviteEmailPopup(string dependentFirstName)
+    {
+        InitializeComponent();
+        titleLabel.Text = $"Invite {dependentFirstName} to Create Account";
+    }
+
+    private void OnEmailTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        var text = e.NewTextValue?.Trim() ?? string.Empty;
+        sendButton.IsEnabled = text.Contains('@') && text.Contains('.');
+    }
+
+    private async void OnSendClicked(object? sender, EventArgs e)
+    {
+        var email = emailEntry.Text?.Trim();
+        if (!string.IsNullOrWhiteSpace(email))
+        {
+            await Shell.Current.ClosePopupAsync(email);
+        }
+    }
+
+    private async void OnCancelClicked(object? sender, EventArgs e)
+    {
+        await Shell.Current.ClosePopupAsync();
+    }
+}

--- a/TrashMobMobile/Pages/MyDependentsPage.xaml
+++ b/TrashMobMobile/Pages/MyDependentsPage.xaml
@@ -39,40 +39,114 @@
                                 SelectionMode="None"
                                 IsVisible="{Binding AreDependentsFound}">
                     <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="models:Dependent">
+                        <DataTemplate x:DataType="viewModels:DependentWithInvitation">
                             <Border Padding="16"
                                     Margin="0,0,0,8"
                                     BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
                                     StrokeShape="RoundRectangle 12"
                                     Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
                                     StrokeThickness="1">
-                                <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto">
+                                <VerticalStackLayout Spacing="8">
+                                    <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto">
 
-                                    <Label Grid.Row="0" Grid.Column="0"
-                                           FontFamily="LexendSemibold"
-                                           FontSize="16"
-                                           TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}">
-                                        <Label.Text>
-                                            <MultiBinding StringFormat="{}{0} {1}">
-                                                <Binding Path="FirstName" />
-                                                <Binding Path="LastName" />
-                                            </MultiBinding>
-                                        </Label.Text>
-                                    </Label>
+                                        <Label Grid.Row="0" Grid.Column="0"
+                                               FontFamily="LexendSemibold"
+                                               FontSize="16"
+                                               TextColor="{AppThemeBinding Light={StaticResource ContentPrimary}, Dark={StaticResource ContentPrimaryDark}}">
+                                            <Label.Text>
+                                                <MultiBinding StringFormat="{}{0} {1}">
+                                                    <Binding Path="Dependent.FirstName" />
+                                                    <Binding Path="Dependent.LastName" />
+                                                </MultiBinding>
+                                            </Label.Text>
+                                        </Label>
 
-                                    <Label Grid.Row="1" Grid.Column="0"
-                                           FontSize="Small"
-                                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}">
-                                        <Label.Text>
-                                            <MultiBinding StringFormat="{}{0} · Born {1:MMM d, yyyy}">
-                                                <Binding Path="Relationship" />
-                                                <Binding Path="DateOfBirth" />
-                                            </MultiBinding>
-                                        </Label.Text>
-                                    </Label>
+                                        <Label Grid.Row="1" Grid.Column="0"
+                                               FontSize="Small"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}">
+                                            <Label.Text>
+                                                <MultiBinding StringFormat="{}{0} · Born {1:MMM d, yyyy}">
+                                                    <Binding Path="Dependent.Relationship" />
+                                                    <Binding Path="Dependent.DateOfBirth" />
+                                                </MultiBinding>
+                                            </Label.Text>
+                                        </Label>
 
-                                    <HorizontalStackLayout Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
-                                                           VerticalOptions="Center" Spacing="8">
+                                        <!-- Status badge -->
+                                        <Border Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                                VerticalOptions="Center"
+                                                Padding="8,4"
+                                                StrokeShape="RoundRectangle 8"
+                                                StrokeThickness="0"
+                                                IsVisible="{Binding ShowStatusBadge}">
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Style.Triggers>
+                                                        <DataTrigger TargetType="Border" Binding="{Binding HasAcceptedInvitation}" Value="True">
+                                                            <Setter Property="BackgroundColor" Value="#dcfce7" />
+                                                        </DataTrigger>
+                                                        <DataTrigger TargetType="Border" Binding="{Binding HasActiveInvitation}" Value="True">
+                                                            <Setter Property="BackgroundColor" Value="#dbeafe" />
+                                                        </DataTrigger>
+                                                        <DataTrigger TargetType="Border" Binding="{Binding IsEligibleForInvite}" Value="True">
+                                                            <Setter Property="BackgroundColor" Value="#fef3c7" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
+                                            <Label Text="{Binding InvitationStatusText}"
+                                                   FontSize="12"
+                                                   FontFamily="LexendSemibold">
+                                                <Label.Style>
+                                                    <Style TargetType="Label">
+                                                        <Style.Triggers>
+                                                            <DataTrigger TargetType="Label" Binding="{Binding HasAcceptedInvitation}" Value="True">
+                                                                <Setter Property="TextColor" Value="#166534" />
+                                                            </DataTrigger>
+                                                            <DataTrigger TargetType="Label" Binding="{Binding HasActiveInvitation}" Value="True">
+                                                                <Setter Property="TextColor" Value="#1e40af" />
+                                                            </DataTrigger>
+                                                            <DataTrigger TargetType="Label" Binding="{Binding IsEligibleForInvite}" Value="True">
+                                                                <Setter Property="TextColor" Value="#92400e" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Label.Style>
+                                            </Label>
+                                        </Border>
+                                    </Grid>
+
+                                    <!-- Action buttons -->
+                                    <HorizontalStackLayout Spacing="8" HorizontalOptions="End">
+                                        <!-- Invite button (eligible dependents) -->
+                                        <Button Text="Invite"
+                                                Style="{StaticResource PrimaryLargeButton}"
+                                                HeightRequest="36"
+                                                Padding="12,0"
+                                                FontSize="Small"
+                                                IsVisible="{Binding IsEligibleForInvite}"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:MyDependentsViewModel}}, Path=InviteDependentCommand}"
+                                                CommandParameter="{Binding .}" />
+
+                                        <!-- Resend / Cancel buttons (active invitations) -->
+                                        <Button Text="Resend"
+                                                Style="{StaticResource SecondaryLargeButton}"
+                                                HeightRequest="36"
+                                                Padding="12,0"
+                                                FontSize="Small"
+                                                IsVisible="{Binding HasActiveInvitation}"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:MyDependentsViewModel}}, Path=ResendInvitationCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        <Button Text="Cancel Invite"
+                                                Style="{StaticResource SecondaryLargeButton}"
+                                                HeightRequest="36"
+                                                Padding="12,0"
+                                                FontSize="Small"
+                                                IsVisible="{Binding HasActiveInvitation}"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:MyDependentsViewModel}}, Path=CancelInvitationCommand}"
+                                                CommandParameter="{Binding .}" />
+
+                                        <!-- Edit / Remove buttons (always shown) -->
                                         <Button Text="Edit"
                                                 Style="{StaticResource SecondaryLargeButton}"
                                                 HeightRequest="36"
@@ -88,7 +162,7 @@
                                                 Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:MyDependentsViewModel}}, Path=DeleteDependentCommand}"
                                                 CommandParameter="{Binding .}" />
                                     </HorizontalStackLayout>
-                                </Grid>
+                                </VerticalStackLayout>
                             </Border>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>

--- a/TrashMobMobile/Services/DependentRestService.cs
+++ b/TrashMobMobile/Services/DependentRestService.cs
@@ -52,6 +52,53 @@ namespace TrashMobMobile.Services
             response.EnsureSuccessStatusCode();
         }
 
+        // Dependent Invitations
+
+        public async Task<List<DependentInvitation>> GetDependentInvitationsAsync(
+            Guid userId, Guid dependentId, CancellationToken cancellationToken = default)
+        {
+            using var client = CreateHttpClient("dependentinvitations/");
+            var requestUri = $"users/{userId}/dependents/{dependentId}";
+
+            using var response = await client.GetAsync(requestUri, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<List<DependentInvitation>>(content) ?? [];
+        }
+
+        public async Task<DependentInvitation> CreateDependentInvitationAsync(
+            Guid userId, Guid dependentId, string email, CancellationToken cancellationToken = default)
+        {
+            using var client = CreateHttpClient("dependentinvitations/");
+            var requestUri = $"users/{userId}/dependents/{dependentId}";
+            var body = JsonContent.Create(new { Email = email }, options: SerializerOptions);
+
+            using var response = await client.PostAsync(requestUri, body, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<DependentInvitation>(content)!;
+        }
+
+        public async Task CancelDependentInvitationAsync(Guid invitationId, CancellationToken cancellationToken = default)
+        {
+            using var client = CreateHttpClient("dependentinvitations/");
+            var requestUri = $"{invitationId}/cancel";
+
+            using var response = await client.PostAsync(requestUri, null, cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task<DependentInvitation> ResendDependentInvitationAsync(Guid invitationId, CancellationToken cancellationToken = default)
+        {
+            using var client = CreateHttpClient("dependentinvitations/");
+            var requestUri = $"{invitationId}/resend";
+
+            using var response = await client.PostAsync(requestUri, null, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<DependentInvitation>(content)!;
+        }
+
         // Dependent Waivers
 
         public async Task<DependentWaiver> SignWaiverAsync(

--- a/TrashMobMobile/Services/IDependentRestService.cs
+++ b/TrashMobMobile/Services/IDependentRestService.cs
@@ -13,6 +13,15 @@ namespace TrashMobMobile.Services
 
         Task DeleteDependentAsync(Guid userId, Guid dependentId, CancellationToken cancellationToken = default);
 
+        // Dependent Invitations (api/dependentinvitations)
+        Task<List<DependentInvitation>> GetDependentInvitationsAsync(Guid userId, Guid dependentId, CancellationToken cancellationToken = default);
+
+        Task<DependentInvitation> CreateDependentInvitationAsync(Guid userId, Guid dependentId, string email, CancellationToken cancellationToken = default);
+
+        Task CancelDependentInvitationAsync(Guid invitationId, CancellationToken cancellationToken = default);
+
+        Task<DependentInvitation> ResendDependentInvitationAsync(Guid invitationId, CancellationToken cancellationToken = default);
+
         // Dependent Waivers (api/dependents/{dependentId}/waiver)
         Task<DependentWaiver> SignWaiverAsync(Guid dependentId, Guid waiverVersionId, string typedLegalName, CancellationToken cancellationToken = default);
 

--- a/TrashMobMobile/ViewModels/DependentWithInvitation.cs
+++ b/TrashMobMobile/ViewModels/DependentWithInvitation.cs
@@ -1,0 +1,55 @@
+namespace TrashMobMobile.ViewModels
+{
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Wraps a Dependent with its active invitation (if any) for display in the My Dependents page.
+    /// </summary>
+    public class DependentWithInvitation
+    {
+        public DependentWithInvitation(Dependent dependent, DependentInvitation? activeInvitation = null)
+        {
+            Dependent = dependent;
+            ActiveInvitation = activeInvitation;
+        }
+
+        public Dependent Dependent { get; }
+
+        public DependentInvitation? ActiveInvitation { get; set; }
+
+        public int Age
+        {
+            get
+            {
+                var today = DateOnly.FromDateTime(DateTime.UtcNow);
+                var dob = Dependent.DateOfBirth;
+                var age = today.Year - dob.Year;
+                if (dob > today.AddYears(-age)) age--;
+                return age;
+            }
+        }
+
+        public bool IsEligibleForInvite => Age >= 13 && !HasActiveInvitation && !HasAcceptedInvitation;
+
+        public bool HasActiveInvitation =>
+            ActiveInvitation != null &&
+            ActiveInvitation.InvitationStatusId == (int)InvitationStatusEnum.Sent;
+
+        public bool HasAcceptedInvitation =>
+            ActiveInvitation != null &&
+            ActiveInvitation.InvitationStatusId == (int)InvitationStatusEnum.Accepted;
+
+        public string InvitationStatusText
+        {
+            get
+            {
+                if (HasAcceptedInvitation) return "Account Created";
+                if (HasActiveInvitation) return "Invited";
+                if (IsEligibleForInvite) return "Eligible";
+                return string.Empty;
+            }
+        }
+
+        public bool ShowStatusBadge => !string.IsNullOrEmpty(InvitationStatusText);
+    }
+}

--- a/TrashMobMobile/ViewModels/MyDependentsViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDependentsViewModel.cs
@@ -1,9 +1,11 @@
 namespace TrashMobMobile.ViewModels
 {
     using System.Collections.ObjectModel;
+    using CommunityToolkit.Maui.Extensions;
     using CommunityToolkit.Mvvm.ComponentModel;
     using CommunityToolkit.Mvvm.Input;
     using TrashMob.Models;
+    using TrashMobMobile.Controls;
     using TrashMobMobile.Services;
 
     public partial class MyDependentsViewModel(
@@ -18,7 +20,7 @@ namespace TrashMobMobile.ViewModels
         [ObservableProperty]
         private bool areNoDependentsFound = true;
 
-        public ObservableCollection<Dependent> Dependents { get; } = [];
+        public ObservableCollection<DependentWithInvitation> Dependents { get; } = [];
 
         public async Task Init()
         {
@@ -27,9 +29,30 @@ namespace TrashMobMobile.ViewModels
                 var userId = userManager.CurrentUser.Id;
                 var dependents = await dependentRestService.GetDependentsAsync(userId);
                 Dependents.Clear();
+
                 foreach (var d in dependents.OrderBy(x => x.FirstName))
                 {
-                    Dependents.Add(d);
+                    DependentInvitation? activeInvitation = null;
+
+                    var wrapper = new DependentWithInvitation(d);
+                    if (wrapper.Age >= 13)
+                    {
+                        try
+                        {
+                            var invitations = await dependentRestService.GetDependentInvitationsAsync(userId, d.Id);
+                            activeInvitation = invitations
+                                .OrderByDescending(i => i.DateInvited)
+                                .FirstOrDefault(i =>
+                                    i.InvitationStatusId == (int)InvitationStatusEnum.Sent ||
+                                    i.InvitationStatusId == (int)InvitationStatusEnum.Accepted);
+                        }
+                        catch
+                        {
+                            // Non-critical — just show the dependent without invitation info
+                        }
+                    }
+
+                    Dependents.Add(new DependentWithInvitation(d, activeInvitation));
                 }
 
                 AreDependentsFound = Dependents.Count > 0;
@@ -44,20 +67,20 @@ namespace TrashMobMobile.ViewModels
         }
 
         [RelayCommand]
-        private async Task EditDependent(Dependent dependent)
+        private async Task EditDependent(DependentWithInvitation item)
         {
-            if (dependent == null) return;
-            await Shell.Current.GoToAsync($"{nameof(Pages.EditDependentPage)}?DependentId={dependent.Id}");
+            if (item == null) return;
+            await Shell.Current.GoToAsync($"{nameof(Pages.EditDependentPage)}?DependentId={item.Dependent.Id}");
         }
 
         [RelayCommand]
-        private async Task DeleteDependent(Dependent dependent)
+        private async Task DeleteDependent(DependentWithInvitation item)
         {
-            if (dependent == null) return;
+            if (item == null) return;
 
             var confirmed = await Shell.Current.DisplayAlertAsync(
                 "Remove Dependent",
-                $"Are you sure you want to remove {dependent.FirstName} {dependent.LastName}?",
+                $"Are you sure you want to remove {item.Dependent.FirstName} {item.Dependent.LastName}?",
                 "Remove", "Cancel");
 
             if (!confirmed) return;
@@ -65,12 +88,65 @@ namespace TrashMobMobile.ViewModels
             await ExecuteAsync(async () =>
             {
                 var userId = userManager.CurrentUser.Id;
-                await dependentRestService.DeleteDependentAsync(userId, dependent.Id);
-                Dependents.Remove(dependent);
+                await dependentRestService.DeleteDependentAsync(userId, item.Dependent.Id);
+                Dependents.Remove(item);
                 AreDependentsFound = Dependents.Count > 0;
                 AreNoDependentsFound = !AreDependentsFound;
                 await NotificationService.Notify("Dependent removed.");
             }, "Failed to remove dependent. Please try again.");
+        }
+
+        [RelayCommand]
+        private async Task InviteDependent(DependentWithInvitation item)
+        {
+            if (item == null) return;
+
+            var popup = new InviteEmailPopup(item.Dependent.FirstName);
+            var popupResult = await Shell.Current.CurrentPage.ShowPopupAsync<string>(popup);
+            var email = popupResult?.Result;
+
+            if (string.IsNullOrWhiteSpace(email)) return;
+
+            await ExecuteAsync(async () =>
+            {
+                var userId = userManager.CurrentUser.Id;
+                await dependentRestService.CreateDependentInvitationAsync(userId, item.Dependent.Id, email);
+                await NotificationService.Notify($"Invitation sent to {email}.");
+                await Init();
+            }, "Failed to send invitation. Please try again.");
+        }
+
+        [RelayCommand]
+        private async Task CancelInvitation(DependentWithInvitation item)
+        {
+            if (item?.ActiveInvitation == null) return;
+
+            var confirmed = await Shell.Current.DisplayAlertAsync(
+                "Cancel Invitation",
+                $"Cancel the invitation for {item.Dependent.FirstName}?",
+                "Cancel Invitation", "Keep");
+
+            if (!confirmed) return;
+
+            await ExecuteAsync(async () =>
+            {
+                await dependentRestService.CancelDependentInvitationAsync(item.ActiveInvitation.Id);
+                await NotificationService.Notify("Invitation canceled.");
+                await Init();
+            }, "Failed to cancel invitation. Please try again.");
+        }
+
+        [RelayCommand]
+        private async Task ResendInvitation(DependentWithInvitation item)
+        {
+            if (item?.ActiveInvitation == null) return;
+
+            await ExecuteAsync(async () =>
+            {
+                await dependentRestService.ResendDependentInvitationAsync(item.ActiveInvitation.Id);
+                await NotificationService.Notify($"Invitation resent to {item.ActiveInvitation.Email}.");
+                await Init();
+            }, "Failed to resend invitation. Please try again.");
         }
 
         [RelayCommand]


### PR DESCRIPTION
## Summary
- Adds dependent invitation API methods to the MAUI mobile REST service (get, create, cancel, resend)
- Creates `InviteEmailPopup` control for entering the invitation email address
- Creates `DependentWithInvitation` wrapper model with age calculation, eligibility checks, and status text
- Updates `MyDependentsViewModel` with invite/cancel/resend commands and invitation status fetching for 13+ dependents
- Updates `MyDependentsPage.xaml` with color-coded status badges (green=Account Created, blue=Invited, amber=Eligible) and conditional action buttons

## Test plan
- [ ] Build succeeds: `dotnet build TrashMobMobile -f net10.0-android`
- [ ] My Dependents page shows status badges for 13+ dependents
- [ ] Tapping "Invite" shows email popup, sending creates invitation and shows "Invited" badge
- [ ] "Resend" and "Cancel Invite" buttons appear for active invitations
- [ ] "Account Created" badge appears for accepted invitations
- [ ] Edit/Remove buttons continue to work for all dependents

🤖 Generated with [Claude Code](https://claude.com/claude-code)