### PR TITLE
Add auto-link prompt for dependent invitations

### DIFF
--- a/TrashMob/client-app/src/pages/MyDashboard/MyDependentsCard.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyDependentsCard.tsx
@@ -7,6 +7,7 @@ import { format, parseISO } from 'date-fns';
 import { Baby, Pencil, Trash2, Plus, Mail, RotateCw, X } from 'lucide-react';
 import { AxiosResponse } from 'axios';
 
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -267,6 +268,9 @@ export const MyDependentsCard: FC<MyDependentsCardProps> = ({ userId }) => {
     };
 
     const dependentCount = (dependents || []).length;
+    const eligibleDependents = (dependents || []).filter(
+        (dep) => dep.dateOfBirth && getAge(dep.dateOfBirth) >= 13 && !getActiveInvitation(dep.id),
+    );
     const isSubmitting = addMutation.isPending || updateMutation.isPending;
 
     return (
@@ -283,6 +287,18 @@ export const MyDependentsCard: FC<MyDependentsCardProps> = ({ userId }) => {
                     </div>
                 </CardHeader>
                 <CardContent>
+                    {eligibleDependents.length > 0 && (
+                        <Alert className='mb-4'>
+                            <Mail className='h-4 w-4' />
+                            <AlertTitle>Invitations Available</AlertTitle>
+                            <AlertDescription>
+                                {eligibleDependents.length === 1
+                                    ? `${eligibleDependents[0].firstName} is old enough (13+) to create their own TrashMob account.`
+                                    : `${eligibleDependents.length} of your dependents are old enough (13+) to create their own TrashMob accounts.`}{' '}
+                                Use the <Mail className='inline h-3 w-3' /> button to send them an invitation!
+                            </AlertDescription>
+                        </Alert>
+                    )}
                     {dependentCount === 0 ? (
                         <p className='text-muted-foreground text-center py-4'>
                             No dependents added yet. Add a dependent minor to register them for events.

--- a/TrashMobMobile/Pages/MyDependentsPage.xaml
+++ b/TrashMobMobile/Pages/MyDependentsPage.xaml
@@ -21,6 +21,25 @@
                         Command="{Binding AddDependentCommand}"
                         Margin="0,0,0,16" />
 
+                <!-- Invite prompt -->
+                <Border Padding="12"
+                        Margin="0,0,0,12"
+                        BackgroundColor="{AppThemeBinding Light=#dbeafe, Dark=#1e3a5f}"
+                        StrokeShape="RoundRectangle 10"
+                        Stroke="{AppThemeBinding Light=#93c5fd, Dark=#3b82f6}"
+                        StrokeThickness="1"
+                        IsVisible="{Binding HasEligibleDependents}">
+                    <VerticalStackLayout Spacing="4">
+                        <Label Text="Invitations Available"
+                               FontFamily="LexendSemibold"
+                               FontSize="14"
+                               TextColor="{AppThemeBinding Light=#1e40af, Dark=#93c5fd}" />
+                        <Label Text="{Binding EligibleDependentsMessage}"
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#1e40af, Dark=#bfdbfe}" />
+                    </VerticalStackLayout>
+                </Border>
+
                 <!-- Empty state -->
                 <VerticalStackLayout IsVisible="{Binding AreNoDependentsFound}" Spacing="8">
                     <Label Text="No dependents on file"

--- a/TrashMobMobile/ViewModels/MyDependentsViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDependentsViewModel.cs
@@ -20,6 +20,12 @@ namespace TrashMobMobile.ViewModels
         [ObservableProperty]
         private bool areNoDependentsFound = true;
 
+        [ObservableProperty]
+        private bool hasEligibleDependents;
+
+        [ObservableProperty]
+        private string eligibleDependentsMessage = string.Empty;
+
         public ObservableCollection<DependentWithInvitation> Dependents { get; } = [];
 
         public async Task Init()
@@ -57,6 +63,12 @@ namespace TrashMobMobile.ViewModels
 
                 AreDependentsFound = Dependents.Count > 0;
                 AreNoDependentsFound = !AreDependentsFound;
+
+                var eligibleCount = Dependents.Count(d => d.IsEligibleForInvite);
+                HasEligibleDependents = eligibleCount > 0;
+                EligibleDependentsMessage = eligibleCount == 1
+                    ? $"{Dependents.First(d => d.IsEligibleForInvite).Dependent.FirstName} is old enough (13+) to create their own TrashMob account. Tap Invite to send them an invitation!"
+                    : $"{eligibleCount} of your dependents are old enough (13+) to create their own accounts. Tap Invite to send them invitations!";
             }, "Failed to load dependents. Please try again.");
         }
 


### PR DESCRIPTION
## Summary
- Adds "Invitations Available" alert banner to the web My Dependents card when parents have 13+ dependents without active invitations
- Adds matching blue info banner to the MAUI mobile My Dependents page with personalized messaging
- Banners automatically disappear once all eligible dependents have been invited
- Completes the final item in Project 23 Phase 0 (Parent-First Flow)

## Test plan
- [ ] Web: My Dependents card shows alert when 13+ dependents exist without invitations
- [ ] Web: Alert disappears after all eligible dependents are invited
- [ ] Mobile: Blue info banner appears above dependents list for eligible dependents
- [ ] Mobile: Banner disappears after invitations are sent
- [ ] `npm run build` and `npm run lint` pass
- [ ] `dotnet build TrashMobMobile -f net10.0-android` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)