### PR TITLE
Use first name instead of username in outbound emails

### DIFF
--- a/Planning/Projects/Project_12_In_App_Messaging.md
+++ b/Planning/Projects/Project_12_In_App_Messaging.md
@@ -492,12 +492,75 @@ public async Task<ActionResult> ReviewReport(Guid reportId, [FromBody] ReviewReq
 - Message history with delivery stats
 - Same rate limits as web
 
-### Push Notification Behavior
+### Push Notification Infrastructure & Delivery Scenarios
 
-- **Delivery:** Push notifications appear on device lock screen/notification tray even when app is closed
-- **Opt-in:** Users must grant push notification permission on first message-enabled action
-- **Content preview:** Show subject line in notification; tap to open full message
-- **Badge count:** Show unread message count on app icon
+Delivering messages to users requires different technology depending on whether the app is in the foreground, backgrounded, or completely closed. The table below maps each scenario to the required infrastructure.
+
+#### Scenario Matrix
+
+| Scenario | Mobile (Android) | Mobile (iOS) | Web Browser | Technology Required |
+|----------|------------------|--------------|-------------|---------------------|
+| **App in foreground** | In-app toast/banner | In-app toast/banner | In-app toast/banner | SignalR (real-time WebSocket) or React Query poll |
+| **App backgrounded** | System notification tray | System notification tray | Browser notification (if tab open) | FCM / APNs via Azure Notification Hub |
+| **App closed / device locked** | System notification tray + badge | System notification tray + badge | N/A (no delivery until next visit) | FCM / APNs via Azure Notification Hub |
+| **User offline (no connectivity)** | Queued by FCM/APNs, delivered when online | Queued by FCM/APNs, delivered when online | N/A | FCM / APNs built-in queuing (up to ~28 days) |
+
+#### Required Azure Infrastructure
+
+| Resource | Purpose | Estimated Cost |
+|----------|---------|----------------|
+| **Azure Notification Hub** (Free or Basic tier) | Unified push notification broker — abstracts FCM, APNs, WNS behind a single API | Free tier: 1M pushes/month; Basic ~$10/mo |
+| **Azure SignalR Service** (optional) | Real-time in-app delivery when app is in foreground; avoids polling | Free tier: 20 concurrent connections, 20K messages/day; Standard ~$50/mo |
+
+#### Required External Platform Setup
+
+| Platform | Service | Setup Required |
+|----------|---------|----------------|
+| **Google / Android** | Firebase Cloud Messaging (FCM v1) | Create Firebase project, generate service account JSON, configure in Azure Notification Hub under "Google (FCM V1)" |
+| **Apple / iOS** | Apple Push Notification Service (APNs) | Create APNs signing key or certificate in Apple Developer portal, configure in Azure Notification Hub under "Apple (APNS)" |
+| **Windows (optional)** | Windows Notification Service (WNS) | Register app in Partner Center, configure in Azure Notification Hub (low priority — most users are mobile) |
+
+#### .NET MAUI Mobile App Changes
+
+The mobile app currently has **no push notification infrastructure**. Required additions:
+
+1. **Device registration:** On app startup (after login), register with FCM (Android) / APNs (iOS) to get a device token, then register that token with Azure Notification Hub via our backend API
+2. **Token refresh handling:** FCM/APNs tokens can rotate — handle `OnNewToken` callback to re-register
+3. **Notification handler:** Process incoming push notifications:
+   - **Foreground:** Show in-app banner (existing `NotificationService` toast pattern)
+   - **Background/closed:** System handles display automatically; app handles tap-to-open navigation
+4. **Permission request:** Prompt user for notification permission (required on both iOS and Android 13+)
+5. **NuGet packages:** `Microsoft.Azure.NotificationHubs`, platform-specific Firebase/APNs bindings via `Plugin.Firebase.CloudMessaging` or similar
+
+#### Backend API for Device Registration
+
+```
+POST /api/notifications/register     — Register device token (deviceId, platform, pushToken)
+DELETE /api/notifications/register   — Unregister on logout
+POST /api/notifications/send         — Internal: send push via Azure Notification Hub
+```
+
+The backend calls `NotificationHubClient.SendNotificationAsync()` with platform-specific payloads (FCM JSON, APNs alert) when an event lead sends a message.
+
+#### Web App Considerations
+
+For the **web app**, push notifications while the browser tab is closed require a **Service Worker** and the **Web Push API** (VAPID keys). This is significantly more complex and has lower adoption than mobile push. Recommended approach:
+
+- **Phase 1:** No web push — users see messages in their inbox on next visit; rely on mobile push + optional email digest
+- **Future:** Add Web Push API with Service Worker if demand warrants it
+
+#### Delivery Flow Summary
+
+```
+Event Lead sends message
+    → Backend saves to DB (EventMessage + EventMessageRecipient rows)
+    → Backend calls Azure Notification Hub with message payload
+        → Hub fans out to FCM (Android) and APNs (iOS)
+            → Device receives system notification (background/closed)
+            → OR app receives foreground callback (in-app banner)
+    → (Optional) SignalR broadcasts to connected web/mobile clients for instant in-app update
+    → (Optional) Email digest job picks up unread messages on daily/weekly schedule
+```
 
 ### User Notification Preferences
 
@@ -593,7 +656,7 @@ The following GitHub issues are tracked as part of this project:
 
 ---
 
-**Last Updated:** January 31, 2026
+**Last Updated:** March 6, 2026
 **Owner:** Product Lead
 **Status:** Not Started
 **Next Review:** When prioritized

--- a/TrashMob.Models/User.cs
+++ b/TrashMob.Models/User.cs
@@ -66,6 +66,15 @@ namespace TrashMob.Models
         public string UserName { get; set; }
 
         /// <summary>
+        /// Returns the user's given name if available, otherwise falls back to UserName.
+        /// Use this for email greetings and personalized content.
+        /// </summary>
+        [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+        [System.Text.Json.Serialization.JsonIgnore]
+        public string DisplayFirstName =>
+            !string.IsNullOrWhiteSpace(GivenName) ? GivenName : UserName;
+
+        /// <summary>
         /// Gets or sets the email address of the user.
         /// </summary>
         public string Email { get; set; }

--- a/TrashMob.Shared/Engine/NotificationEngineBase.cs
+++ b/TrashMob.Shared/Engine/NotificationEngineBase.cs
@@ -169,7 +169,7 @@
 
                     var dynamicTemplateData = new
                     {
-                        username = user.UserName,
+                        username = user.DisplayFirstName,
                         eventName = mobEvent.Name,
                         eventDate = localDate.Date,
                         eventTime = localDate.Time,
@@ -183,7 +183,7 @@
 
                     List<EmailAddress> recipients =
                     [
-                        new() { Name = user.UserName, Email = user.Email },
+                        new() { Name = user.DisplayFirstName, Email = user.Email },
                     ];
 
                     Logger.LogInformation("Sending email to {Email}, Subject {Subject}", user.Email, EmailSubject);
@@ -222,14 +222,14 @@
 
             var dynamicTemplateData = new
             {
-                username = user.UserName,
+                username = user.DisplayFirstName,
                 emailCopy,
                 subject = EmailSubject,
             };
 
             List<EmailAddress> recipients =
             [
-                new() { Name = user.UserName, Email = user.Email },
+                new() { Name = user.DisplayFirstName, Email = user.Email },
             ];
 
             Logger.LogInformation("Sending email to {Email}, Subject {Subject}", user.Email, EmailSubject);

--- a/TrashMob.Shared/Engine/UpcomingTeamEventsBaseNotifier.cs
+++ b/TrashMob.Shared/Engine/UpcomingTeamEventsBaseNotifier.cs
@@ -127,7 +127,7 @@ namespace TrashMob.Shared.Engine
 
             var dynamicTemplateData = new
             {
-                username = user.UserName,
+                username = user.DisplayFirstName,
                 eventName = mobEvent.Name,
                 eventDate = localDate.Date,
                 eventTime = localDate.Time,
@@ -141,7 +141,7 @@ namespace TrashMob.Shared.Engine
 
             List<EmailAddress> recipients =
             [
-                new() { Name = user.UserName, Email = user.Email },
+                new() { Name = user.DisplayFirstName, Email = user.Email },
             ];
 
             Logger.LogInformation("Sending team event email to {Email}, Subject {Subject}", user.Email,

--- a/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
+++ b/TrashMob.Shared/Engine/WeeklyLitterReportsInYourAreaNotifier.cs
@@ -146,12 +146,12 @@ namespace TrashMob.Shared.Engine
 
                 List<EmailAddress> recipients =
                 [
-                    new() { Name = user.UserName, Email = user.Email },
+                    new() { Name = user.DisplayFirstName, Email = user.Email },
                 ];
 
                 var dynamicTemplateData = new
                 {
-                    username = user.UserName,
+                    username = user.DisplayFirstName,
                     emailCopy,
                     subject,
                 };

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -219,12 +219,12 @@ namespace TrashMob.Shared.Managers.Events
 
             List<EmailAddress> recipients =
             [
-                new() { Name = user.UserName ?? "TrashMob User", Email = user.Email },
+                new() { Name = user.DisplayFirstName, Email = user.Email },
             ];
 
             var dynamicTemplateData = new
             {
-                username = user.UserName ?? "TrashMob User",
+                username = user.DisplayFirstName,
                 emailCopy = message,
                 subject
             };

--- a/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventPartnerLocationServiceManager.cs
@@ -139,19 +139,19 @@ namespace TrashMob.Shared.Managers.Events
             var partnerMessage = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.EventPartnerResponse.ToString());
             var partnerSubject = "A TrashMob.eco Partner has responded to your request!";
 
-            partnerMessage = partnerMessage.Replace("{UserName}", user.UserName);
+            partnerMessage = partnerMessage.Replace("{UserName}", user.DisplayFirstName);
 
             var dashboardLink = $"https://www.trashmob.eco/events/{existingService.EventId}/edit";
             partnerMessage = partnerMessage.Replace("{PartnerResponseUrl}", dashboardLink);
 
             List<EmailAddress> partnerRecipients =
             [
-                new() { Name = user.UserName, Email = user.Email },
+                new() { Name = user.DisplayFirstName, Email = user.Email },
             ];
 
             var dynamicTemplateData = new
             {
-                username = user.UserName,
+                username = user.DisplayFirstName,
                 emailCopy = partnerMessage,
                 subject,
             };

--- a/TrashMob.Shared/Managers/UserManager.cs
+++ b/TrashMob.Shared/Managers/UserManager.cs
@@ -103,14 +103,14 @@ namespace TrashMob.Shared.Managers
 
             var userDynamicTemplateData = new
             {
-                username = user.UserName,
+                username = user.DisplayFirstName,
                 emailCopy = welcomeMessage,
                 subject = welcomeSubject,
             };
 
             List<EmailAddress> welcomeRecipients =
             [
-                new() { Name = user.UserName, Email = user.Email },
+                new() { Name = user.DisplayFirstName, Email = user.Email },
             ];
 
             await emailManager.SendTemplatedEmailAsync(welcomeSubject, SendGridEmailTemplateId.GenericEmail,


### PR DESCRIPTION
## Summary
- Add `DisplayFirstName` computed property to `User` model — returns `GivenName` if available, falls back to `UserName`
- Update all 6 email-sending files (13 occurrences) to use `DisplayFirstName` for personalized greetings
- Property is `[NotMapped]` + `[JsonIgnore]` — server-side only, no API or DB impact
- Also adds push notification infrastructure & delivery scenario details to Project 12 plan

## Files changed
- `TrashMob.Models/User.cs` — new `DisplayFirstName` property
- `NotificationEngineBase.cs`, `UpcomingTeamEventsBaseNotifier.cs`, `WeeklyLitterReportsInYourAreaNotifier.cs`, `UserManager.cs`, `EventAttendeeManager.cs`, `EventPartnerLocationServiceManager.cs` — use `DisplayFirstName`
- `Planning/Projects/Project_12_In_App_Messaging.md` — infrastructure docs

## Test plan
- [ ] Verify `dotnet build` passes
- [ ] User with `GivenName` set receives email addressed by first name
- [ ] User without `GivenName` receives email addressed by `UserName` (fallback)
- [ ] Verify `DisplayFirstName` does not appear in API responses (`[JsonIgnore]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)