### PR TITLE
Add PRIVO consent webhook endpoint

### DIFF
--- a/TrashMob.Models/Poco/PrivoConsentEvent.cs
+++ b/TrashMob.Models/Poco/PrivoConsentEvent.cs
@@ -1,0 +1,31 @@
+namespace TrashMob.Models.Poco
+{
+    using System;
+
+    /// <summary>
+    /// Placeholder model for PRIVO consent webhook payloads.
+    /// Will be updated when the official PRIVO payload specification is available.
+    /// </summary>
+    public class PrivoConsentEvent
+    {
+        /// <summary>
+        /// Gets or sets the type of consent status update.
+        /// </summary>
+        public string EventType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the identifier for the consent request.
+        /// </summary>
+        public string ConsentRequestId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the consent status (e.g., approved, denied).
+        /// </summary>
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets when the event occurred.
+        /// </summary>
+        public DateTimeOffset? Timestamp { get; set; }
+    }
+}

--- a/TrashMob/Controllers/PrivoWebhooksController.cs
+++ b/TrashMob/Controllers/PrivoWebhooksController.cs
@@ -1,0 +1,42 @@
+namespace TrashMob.Controllers
+{
+    using System.Threading;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+
+    /// <summary>
+    /// Controller for processing PRIVO consent webhook events.
+    /// </summary>
+    [Route("api/webhooks/privo")]
+    [ApiController]
+    [TypeFilter(typeof(PrivoApiKeyAuthenticationFilter))]
+    public class PrivoWebhooksController(
+        ILogger<PrivoWebhooksController> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Receives consent status updates from PRIVO.
+        /// </summary>
+        /// <param name="consentEvent">The consent event payload.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>200 OK on successful receipt.</returns>
+        [HttpPost("consent")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public IActionResult ProcessConsentEvent([FromBody] PrivoConsentEvent consentEvent, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation(
+                "Received PRIVO consent event: Type={EventType}, ConsentRequestId={ConsentRequestId}, Status={Status}",
+                consentEvent.EventType,
+                consentEvent.ConsentRequestId,
+                consentEvent.Status);
+
+            // TODO: Process consent status update when PRIVO payload spec is finalized
+            // Will update DependentInvitation status based on consent result
+
+            return Ok();
+        }
+    }
+}

--- a/TrashMob/Security/PrivoApiKeyAuthenticationFilter.cs
+++ b/TrashMob/Security/PrivoApiKeyAuthenticationFilter.cs
@@ -1,0 +1,64 @@
+namespace TrashMob.Security
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// Authentication filter that validates API key for PRIVO webhook requests.
+    /// </summary>
+    public class PrivoApiKeyAuthenticationFilter(
+        IKeyVaultManager keyVaultManager,
+        ILogger<PrivoApiKeyAuthenticationFilter> logger) : IAsyncAuthorizationFilter
+    {
+        private const string ApiKeyHeaderName = "X-Api-Key";
+        private const string KeyVaultSecretName = "Privo-ApiKey";
+
+        public Task OnAuthorizationAsync(AuthorizationFilterContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            try
+            {
+                if (!context.HttpContext.Request.Headers.TryGetValue(ApiKeyHeaderName, out var apiKeyHeader))
+                {
+                    context.Result = new JsonResult(new { error = "API key header not found." })
+                    {
+                        StatusCode = StatusCodes.Status401Unauthorized,
+                    };
+
+                    return Task.CompletedTask;
+                }
+
+                var expectedKey = keyVaultManager.GetSecret(KeyVaultSecretName);
+
+                if (!string.Equals(apiKeyHeader, expectedKey, StringComparison.Ordinal))
+                {
+                    context.Result = new JsonResult(new { error = "Invalid API key." })
+                    {
+                        StatusCode = StatusCodes.Status401Unauthorized,
+                    };
+
+                    return Task.CompletedTask;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error occurred while validating PRIVO API key");
+                context.Result = new JsonResult(new { error = "A server error has occurred." })
+                {
+                    StatusCode = StatusCodes.Status401Unauthorized,
+                };
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/webhooks/privo/consent` endpoint for receiving PRIVO parental consent status updates
- Adds `PrivoApiKeyAuthenticationFilter` that validates `X-Api-Key` header against `Privo-ApiKey` Key Vault secret
- Adds placeholder `PrivoConsentEvent` POCO (to be updated when official payload spec arrives)

## Notes
- Requires `Privo-ApiKey` secret to be added to Key Vault before deployment
- Controller logs received events; actual consent processing will be added in a follow-up when PRIVO payload spec is finalized

## Test plan
- [ ] Verify `dotnet build` succeeds with 0 errors
- [ ] Verify `dotnet test TrashMob.Shared.Tests` passes (470/472, 2 pre-existing failures)
- [ ] Verify endpoint returns 401 without valid `X-Api-Key` header
- [ ] Verify endpoint returns 200 with valid API key and JSON body

🤖 Generated with [Claude Code](https://claude.com/claude-code)