### PR TITLE
Add Sentry breadcrumb for Android map initialization

### DIFF
--- a/TrashMobMobile/Platforms/Android/CustomMapHandler.cs
+++ b/TrashMobMobile/Platforms/Android/CustomMapHandler.cs
@@ -170,6 +170,11 @@ public class CustomMapHandler : MapHandler
         public void OnMapReady(GoogleMap googleMap)
         {
             mapHandler.UpdateValue(nameof(IMap.Pins));
+
+            Sentry.SentrySdk.AddBreadcrumb(
+                message: $"GoogleMap ready — MapType={googleMap.MapType}",
+                category: "maps",
+                level: Sentry.BreadcrumbLevel.Info);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a Sentry breadcrumb when `GoogleMap.OnMapReady` fires, logging the map type
- Provides diagnostic data to help debug blank map tile issues on Android
- Triggers a version number bump for the next mobile build

## Test plan
- [ ] Merge to main and verify the mobile CI build triggers with a new version number
- [ ] Deploy to device and check Sentry breadcrumbs when viewing a map screen
- [ ] Verify Google Maps tiles render (maps debugging in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)