### PR TITLE
Fix Android deploy to use correct environment

### DIFF
--- a/.github/workflows/main_trashmobmobileapp.yml
+++ b/.github/workflows/main_trashmobmobileapp.yml
@@ -130,11 +130,12 @@ jobs:
 
   callAndroidDeploy:
     name: Call Android deploy workflow
-    needs: callBuildAndroid
+    needs: [callBuildAndroid, exposeEnvironmentVariables]
     uses: ./.github/workflows/publish-android.yml
     with:
       artifact_name: ${{ needs.callBuildAndroid.outputs.artifact_name }}
       bundle_id: ${{ needs.callBuildAndroid.outputs.bundle_id }}
+      environment: ${{ needs.exposeEnvironmentVariables.outputs.environment }}
     secrets:
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -9,6 +9,10 @@ on:
             artifact_name:
                 required: true
                 type: string
+            environment:
+                required: false
+                type: string
+                default: 'production'
             promote_to_production:
                 required: false
                 type: boolean
@@ -26,7 +30,7 @@ jobs:
     deploy-android:
         name: Deploy Android to Google Play
         runs-on: ubuntu-latest
-        environment: production
+        environment: ${{ inputs.environment }}
         steps:
             - name: Download artifact
               uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- The `publish-android.yml` workflow hardcoded `environment: production`, so dev builds pulled `GCP_SERVICE_ACCOUNT` from the production environment secrets
- Added `environment` input to `publish-android.yml` (defaults to `production` for backwards compatibility)
- Dev workflow now passes `environment: test` so it uses the correct service account

## Test plan
- [ ] Merge and verify dev mobile build deploys successfully to Google Play internal track
- [ ] Verify production (release) workflow still defaults to `production` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)