### PR TITLE
Fix Google Maps blank tiles — API key overwritten in CI

### DIFF
--- a/TrashMobMobile/TrashMobMobile.csproj
+++ b/TrashMobMobile/TrashMobMobile.csproj
@@ -351,9 +351,9 @@
 
   <!-- Inject Google Maps API key into the intermediate AndroidManifest.xml at build time.
        The key is fetched from Azure Key Vault (dev environment) during local builds.
-       CI uses GitHub secrets to replace the placeholder instead.
-       Override: set GOOGLE_MAPS_API_KEY env var to skip the Key Vault lookup. -->
-  <Target Name="InjectGoogleMapsKey" AfterTargets="_ManifestMerger" BeforeTargets="_CreateBaseApk" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+       CI uses GitHub secrets to replace the placeholder in the source manifest instead,
+       so this target is skipped when CI=true to avoid overwriting the injected key. -->
+  <Target Name="InjectGoogleMapsKey" AfterTargets="_ManifestMerger" BeforeTargets="_CreateBaseApk" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' AND '$(CI)' != 'true'">
     <!-- If GOOGLE_MAPS_API_KEY is already set (env var or MSBuild property), use it directly -->
     <!-- Otherwise, fetch from Azure Key Vault (requires 'az login') -->
     <Exec Command="az keyvault secret show --vault-name kv-tm-dev-westus2 --name Android-Google-ApiKey-Dev --query value -o tsv" ConsoleToMsBuild="true" Condition="'$(GOOGLE_MAPS_API_KEY)' == ''" ContinueOnError="true" StandardOutputImportance="low">


### PR DESCRIPTION
## Summary
- The `InjectGoogleMapsKey` MSBuild target was overwriting the CI-injected Google Maps API key with the `az` CLI error message
- The API key baked into every CI-built APK was literally: `ERROR: Please run 'az login' to setup account.`
- Fix: skip the target when `CI=true` (set automatically by GitHub Actions)

## Root cause
1. CI PowerShell step correctly replaces `"fill"` with the real API key in the source manifest
2. During `dotnet publish`, the `InjectGoogleMapsKey` MSBuild target runs
3. `az keyvault secret show` fails (no az login on CI runner), but `ConsoleToMsBuild="true"` captures the error output as the property value
4. `GOOGLE_MAPS_API_KEY` is set to the error message (not empty), so the `XmlPoke` condition passes
5. XmlPoke overwrites the real key with the error message

## Test plan
- [ ] Merge and trigger a dev mobile build
- [ ] Download artifact and verify manifest contains the real API key (not the error message)
- [ ] Install on device and verify Google Maps tiles render

🤖 Generated with [Claude Code](https://claude.com/claude-code)