### PR TITLE
Project 24 Phase 2: Events v2 endpoint with server-side pagination

### DIFF
--- a/TrashMob.Models/Extensions/V2/EventMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventMappingsV2.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping Event entities to V2 DTOs.
+    /// </summary>
+    public static class EventMappingsV2
+    {
+        /// <summary>
+        /// Maps an Event entity to a V2 EventDto.
+        /// </summary>
+        public static EventDto ToV2Dto(this Event entity)
+        {
+            return new EventDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                Description = entity.Description,
+                EventDate = entity.EventDate,
+                DurationHours = entity.DurationHours,
+                DurationMinutes = entity.DurationMinutes,
+                EventTypeId = entity.EventTypeId,
+                EventStatusId = entity.EventStatusId,
+                StreetAddress = entity.StreetAddress,
+                City = entity.City,
+                Region = entity.Region,
+                Country = entity.Country,
+                PostalCode = entity.PostalCode,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+                MaxNumberOfParticipants = entity.MaxNumberOfParticipants,
+                IsEventPublic = entity.EventVisibilityId == (int)EventVisibilityEnum.Public,
+                CreatedByUserId = entity.CreatedByUserId,
+                CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/EventQueryParameters.cs
+++ b/TrashMob.Models/Poco/V2/EventQueryParameters.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// Query parameters for filtering and paginating events in the V2 API.
+    /// </summary>
+    public class EventQueryParameters : QueryParameters
+    {
+        /// <summary>
+        /// Gets or sets the optional event status identifier to filter by.
+        /// </summary>
+        public int? EventStatusId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional event type identifier to filter by.
+        /// </summary>
+        public int? EventTypeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional city to filter by.
+        /// </summary>
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional region (state/province) to filter by.
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional country to filter by.
+        /// </summary>
+        public string? Country { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start of the date range to filter events.
+        /// </summary>
+        public DateTimeOffset? FromDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end of the date range to filter events.
+        /// </summary>
+        public DateTimeOffset? ToDate { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
@@ -1,0 +1,174 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class EventsV2ControllerTests
+    {
+        private readonly Mock<IEventManager> eventManager = new();
+        private readonly Mock<ILogger<EventsV2Controller>> logger = new();
+        private readonly EventsV2Controller controller;
+
+        public EventsV2ControllerTests()
+        {
+            controller = new EventsV2Controller(eventManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetEvents_ReturnsOkWithPagedResponse()
+        {
+            var events = new List<Event>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Park Cleanup",
+                    EventDate = DateTimeOffset.UtcNow.AddDays(1),
+                    EventStatusId = (int)EventStatusEnum.Active,
+                    EventVisibilityId = (int)EventVisibilityEnum.Public,
+                    CreatedByUserId = Guid.NewGuid(),
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Beach Cleanup",
+                    EventDate = DateTimeOffset.UtcNow.AddDays(2),
+                    EventStatusId = (int)EventStatusEnum.Active,
+                    EventVisibilityId = (int)EventVisibilityEnum.Public,
+                    CreatedByUserId = Guid.NewGuid(),
+                },
+            };
+
+            var queryable = new TestAsyncEnumerable<Event>(events);
+            var filter = new EventQueryParameters { Page = 1, PageSize = 25 };
+
+            eventManager
+                .Setup(m => m.GetFilteredEventsQueryableAsync(filter, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(queryable);
+
+            var result = await controller.GetEvents(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<EventDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal(2, response.Pagination.TotalCount);
+            Assert.Equal("Park Cleanup", response.Items[0].Name);
+            Assert.Equal("Beach Cleanup", response.Items[1].Name);
+        }
+
+        [Fact]
+        public async Task GetEvents_ReturnsEmptyPagedResponse_WhenNoEvents()
+        {
+            var queryable = new TestAsyncEnumerable<Event>(Enumerable.Empty<Event>());
+            var filter = new EventQueryParameters { Page = 1, PageSize = 25 };
+
+            eventManager
+                .Setup(m => m.GetFilteredEventsQueryableAsync(filter, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(queryable);
+
+            var result = await controller.GetEvents(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<EventDto>>(okResult.Value);
+            Assert.Empty(response.Items);
+            Assert.Equal(0, response.Pagination.TotalCount);
+        }
+
+        [Fact]
+        public async Task GetEvents_AppliesPagination()
+        {
+            var events = Enumerable.Range(1, 5).Select(i => new Event
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Event {i}",
+                EventDate = DateTimeOffset.UtcNow.AddDays(i),
+                EventStatusId = (int)EventStatusEnum.Active,
+                EventVisibilityId = (int)EventVisibilityEnum.Public,
+                CreatedByUserId = Guid.NewGuid(),
+            }).ToList();
+
+            var queryable = new TestAsyncEnumerable<Event>(events);
+            var filter = new EventQueryParameters { Page = 2, PageSize = 2 };
+
+            eventManager
+                .Setup(m => m.GetFilteredEventsQueryableAsync(filter, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(queryable);
+
+            var result = await controller.GetEvents(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<EventDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal(5, response.Pagination.TotalCount);
+            Assert.Equal(2, response.Pagination.Page);
+            Assert.True(response.Pagination.HasPrevious);
+            Assert.True(response.Pagination.HasNext);
+        }
+
+        [Fact]
+        public async Task GetEvent_ReturnsOkWithEventDto()
+        {
+            var eventId = Guid.NewGuid();
+            var mobEvent = new Event
+            {
+                Id = eventId,
+                Name = "Trail Cleanup",
+                Description = "Clean up the hiking trail",
+                EventDate = new DateTimeOffset(2026, 6, 15, 10, 0, 0, TimeSpan.Zero),
+                DurationHours = 3,
+                DurationMinutes = 0,
+                EventTypeId = 1,
+                EventStatusId = (int)EventStatusEnum.Active,
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                EventVisibilityId = (int)EventVisibilityEnum.Public,
+                CreatedByUserId = Guid.NewGuid(),
+            };
+
+            eventManager
+                .Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+
+            var result = await controller.GetEvent(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventDto>(okResult.Value);
+            Assert.Equal(eventId, dto.Id);
+            Assert.Equal("Trail Cleanup", dto.Name);
+            Assert.Equal("Seattle", dto.City);
+            Assert.True(dto.IsEventPublic);
+        }
+
+        [Fact]
+        public async Task GetEvent_ReturnsNotFound_WhenEventDoesNotExist()
+        {
+            var eventId = Guid.NewGuid();
+
+            eventManager
+                .Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Event)null);
+
+            var result = await controller.GetEvent(eventId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/EventMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventMappingsV2Tests.cs
@@ -1,0 +1,106 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class EventMappingsV2Tests
+    {
+        [Fact]
+        public void ToV2Dto_MapsAllProperties()
+        {
+            var entity = new Event
+            {
+                Id = Guid.NewGuid(),
+                Name = "Park Cleanup",
+                Description = "Clean up the local park",
+                EventDate = new DateTimeOffset(2026, 6, 15, 10, 0, 0, TimeSpan.Zero),
+                DurationHours = 2,
+                DurationMinutes = 30,
+                EventTypeId = 1,
+                EventStatusId = (int)EventStatusEnum.Active,
+                StreetAddress = "123 Main St",
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                PostalCode = "98101",
+                Latitude = 47.6062,
+                Longitude = -122.3321,
+                MaxNumberOfParticipants = 50,
+                EventVisibilityId = (int)EventVisibilityEnum.Public,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                LastUpdatedDate = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.Id, dto.Id);
+            Assert.Equal(entity.Name, dto.Name);
+            Assert.Equal(entity.Description, dto.Description);
+            Assert.Equal(entity.EventDate, dto.EventDate);
+            Assert.Equal(entity.DurationHours, dto.DurationHours);
+            Assert.Equal(entity.DurationMinutes, dto.DurationMinutes);
+            Assert.Equal(entity.EventTypeId, dto.EventTypeId);
+            Assert.Equal(entity.EventStatusId, dto.EventStatusId);
+            Assert.Equal(entity.StreetAddress, dto.StreetAddress);
+            Assert.Equal(entity.City, dto.City);
+            Assert.Equal(entity.Region, dto.Region);
+            Assert.Equal(entity.Country, dto.Country);
+            Assert.Equal(entity.PostalCode, dto.PostalCode);
+            Assert.Equal(entity.Latitude, dto.Latitude);
+            Assert.Equal(entity.Longitude, dto.Longitude);
+            Assert.Equal(entity.MaxNumberOfParticipants, dto.MaxNumberOfParticipants);
+            Assert.True(dto.IsEventPublic);
+            Assert.Equal(entity.CreatedByUserId, dto.CreatedByUserId);
+            Assert.Equal(entity.CreatedDate, dto.CreatedDate);
+            Assert.Equal(entity.LastUpdatedDate, dto.LastUpdatedDate);
+        }
+
+        [Fact]
+        public void ToV2Dto_IsEventPublic_TrueForPublicVisibility()
+        {
+            var entity = new Event { EventVisibilityId = (int)EventVisibilityEnum.Public };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.True(dto.IsEventPublic);
+        }
+
+        [Fact]
+        public void ToV2Dto_IsEventPublic_FalseForTeamOnlyVisibility()
+        {
+            var entity = new Event { EventVisibilityId = (int)EventVisibilityEnum.TeamOnly };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.False(dto.IsEventPublic);
+        }
+
+        [Fact]
+        public void ToV2Dto_IsEventPublic_FalseForPrivateVisibility()
+        {
+            var entity = new Event { EventVisibilityId = (int)EventVisibilityEnum.Private };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.False(dto.IsEventPublic);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullDates()
+        {
+            var entity = new Event
+            {
+                CreatedDate = null,
+                LastUpdatedDate = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(default, dto.CreatedDate);
+            Assert.Equal(default, dto.LastUpdatedDate);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -9,6 +9,7 @@ namespace TrashMob.Shared.Managers.Events
     using TrashMob.Models;
     using TrashMob.Models.Extensions;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Engine;
     using TrashMob.Shared.Extensions;
     using TrashMob.Shared.Managers.Interfaces;
@@ -150,6 +151,32 @@ namespace TrashMob.Shared.Managers.Events
                 .ToListAsync(cancellationToken);
 
             return locations;
+        }
+
+        /// <inheritdoc />
+        public async Task<IQueryable<Event>> GetFilteredEventsQueryableAsync(EventQueryParameters filter,
+            Guid? userId = null, CancellationToken cancellationToken = default)
+        {
+            var userTeamIds = await GetUserTeamIdsAsync(userId, cancellationToken);
+
+            var query = Repo.Get(e =>
+                e.EventStatusId != (int)EventStatusEnum.Canceled &&
+                (filter.EventStatusId == null || e.EventStatusId == filter.EventStatusId) &&
+                (filter.EventTypeId == null || e.EventTypeId == filter.EventTypeId) &&
+                (filter.FromDate == null || e.EventDate >= filter.FromDate) &&
+                (filter.ToDate == null || e.EventDate <= filter.ToDate) &&
+                (filter.Country == null || e.Country == filter.Country) &&
+                (filter.Region == null || e.Region == filter.Region) &&
+                (filter.City == null || e.City == filter.City) &&
+                (
+                    e.EventVisibilityId == (int)EventVisibilityEnum.Public
+                    || (e.EventVisibilityId == (int)EventVisibilityEnum.TeamOnly
+                        && e.TeamId != null
+                        && userTeamIds.Contains(e.TeamId.Value))
+                    || (userId != null && e.CreatedByUserId == userId.Value)
+                ));
+
+            return query.OrderByDescending(e => e.EventDate);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
@@ -2,10 +2,12 @@ namespace TrashMob.Shared.Managers.Interfaces
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using TrashMob.Models;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
 
     /// <summary>
     /// Defines operations for managing events.
@@ -84,6 +86,17 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A collection of event locations within the time range.</returns>
         Task<IEnumerable<Location>> GetEventLocationsByTimeRangeAsync(DateTimeOffset? startTime, DateTimeOffset? endTime,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a queryable of filtered events for V2 API pagination. The returned IQueryable
+        /// is not materialized, allowing the caller to apply ToPagedAsync() for database-side pagination.
+        /// </summary>
+        /// <param name="filter">The V2 query parameters with event-specific filters.</param>
+        /// <param name="userId">Optional user ID to include team-only events visible to this user.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>An unmaterialized queryable of events matching the filter.</returns>
+        Task<IQueryable<Event>> GetFilteredEventsQueryableAsync(EventQueryParameters filter, Guid? userId = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/TrashMob/Controllers/V2/EventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventsV2Controller.cs
@@ -1,0 +1,81 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Extensions;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for events with server-side pagination and filtering.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/events")]
+    public class EventsV2Controller(
+        IEventManager eventManager,
+        ILogger<EventsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets a paginated list of events with optional filtering.
+        /// </summary>
+        /// <param name="filter">Query parameters for pagination and filtering.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A paginated list of events.</returns>
+        /// <response code="200">Returns the paginated event list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(PagedResponse<EventDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetEvents(
+            [FromQuery] EventQueryParameters filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEvents requested with Page={Page}, PageSize={PageSize}",
+                filter.Page, filter.PageSize);
+
+            Guid? userId = User.Identity?.IsAuthenticated == true
+                ? new Guid(HttpContext.Items["UserId"]?.ToString() ?? string.Empty)
+                : null;
+
+            var query = await eventManager.GetFilteredEventsQueryableAsync(filter, userId, cancellationToken);
+            var result = await query.ToPagedAsync(filter, e => e.ToV2Dto(), cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a single event by its identifier.
+        /// </summary>
+        /// <param name="id">The event identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The event details.</returns>
+        /// <response code="200">Returns the event.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(EventDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetEvent(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEvent requested for {EventId}", id);
+
+            var mobEvent = await eventManager.GetAsync(id, cancellationToken);
+
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(mobEvent.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/v2/events` endpoint with server-side pagination and filtering (city, region, country, status, type, date range)
- Adds `GET /api/v2/events/{id}` endpoint returning a flat `EventDto` (no navigation properties)
- Implements `GetFilteredEventsQueryableAsync` in `EventManager` returning unmaterialized `IQueryable<Event>` for database-side Skip/Take, replacing v1's in-memory pagination pattern
- Includes `EventQueryParameters`, `EventMappingsV2` (entity-to-DTO), and full test coverage (10 new tests)

## Changes

### New Files
| File | Purpose |
|------|---------|
| `TrashMob.Models/Poco/V2/EventQueryParameters.cs` | Event filter extending `QueryParameters` |
| `TrashMob.Models/Extensions/V2/EventMappingsV2.cs` | `Event.ToV2Dto()` extension method |
| `TrashMob/Controllers/V2/EventsV2Controller.cs` | V2 events endpoints |
| `TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs` | Controller tests (5) |
| `TrashMob.Shared.Tests/Extensions/V2/EventMappingsV2Tests.cs` | Mapping tests (5) |

### Modified Files
| File | Change |
|------|--------|
| `TrashMob.Shared/Managers/Interfaces/IEventManager.cs` | Added `GetFilteredEventsQueryableAsync` |
| `TrashMob.Shared/Managers/Events/EventManager.cs` | Implemented queryable filter method |

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 503 passed, 2 pre-existing failures (ProspectScoringManager)
- [ ] Verify `GET /api/v2/events` returns `PagedResponse<EventDto>` with pagination metadata
- [ ] Verify `GET /api/v2/events?city=Seattle&page=2&pageSize=10` applies filters
- [ ] Verify `GET /api/v2/events/{id}` returns single `EventDto`
- [ ] Verify `GET /api/v2/events/{nonexistent}` returns 404 ProblemDetails
- [ ] Verify Swagger v2 doc shows Events endpoints
- [ ] Verify v1 `GET /api/events` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)