### PR TITLE
Project 24 Phase 2: Users v2 endpoint with PII-safe DTO

### DIFF
--- a/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
@@ -1,0 +1,36 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping User entities to V2 DTOs.
+    /// </summary>
+    public static class UserMappingsV2
+    {
+        /// <summary>
+        /// Maps a User entity to a V2 UserDto, excluding PII fields.
+        /// </summary>
+        /// <param name="entity">The User entity to map.</param>
+        /// <returns>A UserDto containing only public-safe properties.</returns>
+        public static UserDto ToV2Dto(this User entity)
+        {
+            return new UserDto
+            {
+                Id = entity.Id,
+                UserName = entity.UserName,
+                City = entity.City,
+                Region = entity.Region,
+                Country = entity.Country,
+                PostalCode = entity.PostalCode,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+                PrefersMetric = entity.PrefersMetric,
+                GivenName = entity.GivenName,
+                Surname = entity.Surname,
+                ProfilePhotoUrl = entity.ProfilePhotoUrl,
+                MemberSince = entity.MemberSince,
+                IsMinor = entity.IsMinor,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserDto.cs
+++ b/TrashMob.Models/Poco/V2/UserDto.cs
@@ -1,0 +1,82 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a user. Excludes PII (email, date of birth, identity provider fields).
+    /// </summary>
+    public class UserDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the user.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display username.
+        /// </summary>
+        public string UserName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's city.
+        /// </summary>
+        public string City { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's region (state/province).
+        /// </summary>
+        public string Region { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's country.
+        /// </summary>
+        public string Country { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's postal code.
+        /// </summary>
+        public string PostalCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the latitude of the user's location.
+        /// </summary>
+        public double? Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude of the user's location.
+        /// </summary>
+        public double? Longitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the user prefers metric units.
+        /// </summary>
+        public bool PrefersMetric { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's given (first) name.
+        /// </summary>
+        public string GivenName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's surname (last name).
+        /// </summary>
+        public string Surname { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the URL of the user's profile photo.
+        /// </summary>
+        public string ProfilePhotoUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the date when the user became a member.
+        /// </summary>
+        public DateTimeOffset? MemberSince { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the user is a minor (13-17).
+        /// </summary>
+        public bool IsMinor { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserQueryParameters.cs
+++ b/TrashMob.Models/Poco/V2/UserQueryParameters.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// Query parameters for filtering and paginating users in V2 API.
+    /// </summary>
+    public class UserQueryParameters : QueryParameters
+    {
+        /// <summary>
+        /// Gets or sets an optional city filter.
+        /// </summary>
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional region (state/province) filter.
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional country filter.
+        /// </summary>
+        public string? Country { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
@@ -1,0 +1,164 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class UsersV2ControllerTests
+    {
+        private readonly Mock<IUserManager> userManager = new();
+        private readonly Mock<ILogger<UsersV2Controller>> logger = new();
+        private readonly UsersV2Controller controller;
+
+        public UsersV2ControllerTests()
+        {
+            controller = new UsersV2Controller(userManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetUsers_ReturnsOkWithPagedResponse()
+        {
+            var users = new List<User>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    UserName = "alice",
+                    City = "Seattle",
+                    Region = "WA",
+                    Country = "US",
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    UserName = "bob",
+                    City = "Portland",
+                    Region = "OR",
+                    Country = "US",
+                },
+            };
+
+            var queryable = new TestAsyncEnumerable<User>(users);
+            var filter = new UserQueryParameters { Page = 1, PageSize = 25 };
+
+            userManager
+                .Setup(m => m.GetFilteredUsersQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetUsers(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<UserDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal(2, response.Pagination.TotalCount);
+            Assert.Equal("alice", response.Items[0].UserName);
+            Assert.Equal("bob", response.Items[1].UserName);
+        }
+
+        [Fact]
+        public async Task GetUsers_ReturnsEmptyPagedResponse_WhenNoUsers()
+        {
+            var queryable = new TestAsyncEnumerable<User>(Enumerable.Empty<User>());
+            var filter = new UserQueryParameters { Page = 1, PageSize = 25 };
+
+            userManager
+                .Setup(m => m.GetFilteredUsersQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetUsers(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<UserDto>>(okResult.Value);
+            Assert.Empty(response.Items);
+            Assert.Equal(0, response.Pagination.TotalCount);
+        }
+
+        [Fact]
+        public async Task GetUsers_AppliesPagination()
+        {
+            var users = Enumerable.Range(1, 5).Select(i => new User
+            {
+                Id = Guid.NewGuid(),
+                UserName = $"user{i}",
+            }).ToList();
+
+            var queryable = new TestAsyncEnumerable<User>(users);
+            var filter = new UserQueryParameters { Page = 2, PageSize = 2 };
+
+            userManager
+                .Setup(m => m.GetFilteredUsersQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetUsers(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<UserDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal(5, response.Pagination.TotalCount);
+            Assert.Equal(2, response.Pagination.Page);
+            Assert.True(response.Pagination.HasPrevious);
+            Assert.True(response.Pagination.HasNext);
+        }
+
+        [Fact]
+        public async Task GetUser_ReturnsOkWithUserDto()
+        {
+            var userId = Guid.NewGuid();
+            var user = new User
+            {
+                Id = userId,
+                UserName = "testuser",
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                GivenName = "Test",
+                Surname = "User",
+                PrefersMetric = false,
+                MemberSince = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            userManager
+                .Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(user);
+
+            var result = await controller.GetUser(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserDto>(okResult.Value);
+            Assert.Equal(userId, dto.Id);
+            Assert.Equal("testuser", dto.UserName);
+            Assert.Equal("Seattle", dto.City);
+            Assert.Equal("Test", dto.GivenName);
+        }
+
+        [Fact]
+        public async Task GetUser_ReturnsNotFound_WhenUserDoesNotExist()
+        {
+            var userId = Guid.NewGuid();
+
+            userManager
+                .Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((User)null);
+
+            var result = await controller.GetUser(userId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/UserMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/UserMappingsV2Tests.cs
@@ -1,0 +1,84 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class UserMappingsV2Tests
+    {
+        [Fact]
+        public void ToV2Dto_MapsAllProperties()
+        {
+            var entity = new User
+            {
+                Id = Guid.NewGuid(),
+                UserName = "testuser",
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                PostalCode = "98101",
+                Latitude = 47.6062,
+                Longitude = -122.3321,
+                PrefersMetric = true,
+                GivenName = "Test",
+                Surname = "User",
+                ProfilePhotoUrl = "https://example.com/photo.jpg",
+                MemberSince = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                IsMinor = false,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.Id, dto.Id);
+            Assert.Equal(entity.UserName, dto.UserName);
+            Assert.Equal(entity.City, dto.City);
+            Assert.Equal(entity.Region, dto.Region);
+            Assert.Equal(entity.Country, dto.Country);
+            Assert.Equal(entity.PostalCode, dto.PostalCode);
+            Assert.Equal(entity.Latitude, dto.Latitude);
+            Assert.Equal(entity.Longitude, dto.Longitude);
+            Assert.Equal(entity.PrefersMetric, dto.PrefersMetric);
+            Assert.Equal(entity.GivenName, dto.GivenName);
+            Assert.Equal(entity.Surname, dto.Surname);
+            Assert.Equal(entity.ProfilePhotoUrl, dto.ProfilePhotoUrl);
+            Assert.Equal(entity.MemberSince, dto.MemberSince);
+            Assert.Equal(entity.IsMinor, dto.IsMinor);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullMemberSince()
+        {
+            var entity = new User
+            {
+                MemberSince = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Null(dto.MemberSince);
+        }
+
+        [Fact]
+        public void ToV2Dto_DoesNotExposePiiFields()
+        {
+            var entity = new User
+            {
+                Email = "secret@example.com",
+                ObjectId = Guid.NewGuid(),
+                NameIdentifier = "secret-identifier",
+                DateOfBirth = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                IsSiteAdmin = true,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            var dtoType = dto.GetType();
+            Assert.Null(dtoType.GetProperty("Email"));
+            Assert.Null(dtoType.GetProperty("ObjectId"));
+            Assert.Null(dtoType.GetProperty("NameIdentifier"));
+            Assert.Null(dtoType.GetProperty("DateOfBirth"));
+            Assert.Null(dtoType.GetProperty("IsSiteAdmin"));
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/IUserManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IUserManager.cs
@@ -1,9 +1,11 @@
 namespace TrashMob.Shared.Managers.Interfaces
 {
     using System;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
 
     /// <summary>
     /// Defines operations for managing users.
@@ -65,5 +67,14 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>The user if they exist; otherwise, null.</returns>
         Task<User> UserExistsAsync(string nameIdentifier, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a queryable of filtered users for V2 API pagination. The returned IQueryable
+        /// is not materialized, allowing the caller to apply ToPagedAsync() for database-side pagination.
+        /// </summary>
+        /// <param name="filter">The V2 query parameters with user-specific filters.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>An unmaterialized queryable of users matching the filter.</returns>
+        IQueryable<User> GetFilteredUsersQueryable(UserQueryParameters filter);
     }
 }

--- a/TrashMob.Shared/Managers/UserManager.cs
+++ b/TrashMob.Shared/Managers/UserManager.cs
@@ -2,10 +2,12 @@ namespace TrashMob.Shared.Managers
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Engine;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Persistence.Interfaces;
@@ -129,6 +131,17 @@ namespace TrashMob.Shared.Managers
         public async Task<User> UserExistsAsync(string nameIdentifier, CancellationToken cancellationToken = default)
         {
             return await Repository.Get(u => u.NameIdentifier == nameIdentifier).FirstOrDefaultAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public IQueryable<User> GetFilteredUsersQueryable(UserQueryParameters filter)
+        {
+            var query = Repo.Get(u =>
+                (filter.Country == null || u.Country == filter.Country) &&
+                (filter.Region == null || u.Region == filter.Region) &&
+                (filter.City == null || u.City == filter.City));
+
+            return query.OrderBy(u => u.UserName);
         }
     }
 }

--- a/TrashMob/Controllers/V2/UsersV2Controller.cs
+++ b/TrashMob/Controllers/V2/UsersV2Controller.cs
@@ -1,0 +1,78 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Extensions;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for users with server-side pagination and filtering.
+    /// Returns PII-safe UserDto (no email, identity provider fields, or date of birth).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/users")]
+    public class UsersV2Controller(
+        IUserManager userManager,
+        ILogger<UsersV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets a paginated list of users with optional filtering.
+        /// </summary>
+        /// <param name="filter">Query parameters for pagination and filtering.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A paginated list of users.</returns>
+        /// <response code="200">Returns the paginated user list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(PagedResponse<UserDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetUsers(
+            [FromQuery] UserQueryParameters filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUsers requested with Page={Page}, PageSize={PageSize}",
+                filter.Page, filter.PageSize);
+
+            var query = userManager.GetFilteredUsersQueryable(filter);
+            var result = await query.ToPagedAsync(filter, u => u.ToV2Dto(), cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a single user by their identifier.
+        /// </summary>
+        /// <param name="id">The user identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The user details (PII-safe).</returns>
+        /// <response code="200">Returns the user.</response>
+        /// <response code="404">User not found.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetUser(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUser requested for {UserId}", id);
+
+            var user = await userManager.GetAsync(id, cancellationToken);
+
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(user.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/v2/users` endpoint with server-side pagination and location filtering (city, region, country)
- Adds `GET /api/v2/users/{id}` endpoint returning PII-safe `UserDto`
- `UserDto` deliberately **excludes**: Email, ObjectId, NameIdentifier, DateOfBirth, IsSiteAdmin, ParentUserId, DependentId, waiver fields
- Adds `GetFilteredUsersQueryable` to `UserManager` returning unmaterialized `IQueryable<User>` for database-side Skip/Take
- 8 new tests (5 controller + 3 mapping, including PII exclusion verification)

## Changes

### New Files
| File | Purpose |
|------|---------|
| `TrashMob.Models/Poco/V2/UserDto.cs` | PII-safe user DTO |
| `TrashMob.Models/Poco/V2/UserQueryParameters.cs` | User filter extending `QueryParameters` |
| `TrashMob.Models/Extensions/V2/UserMappingsV2.cs` | `User.ToV2Dto()` extension method |
| `TrashMob/Controllers/V2/UsersV2Controller.cs` | V2 users endpoints |
| `TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs` | Controller tests (5) |
| `TrashMob.Shared.Tests/Extensions/V2/UserMappingsV2Tests.cs` | Mapping tests (3) |

### Modified Files
| File | Change |
|------|--------|
| `TrashMob.Shared/Managers/Interfaces/IUserManager.cs` | Added `GetFilteredUsersQueryable` |
| `TrashMob.Shared/Managers/UserManager.cs` | Implemented queryable filter method |

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 511 passed, 2 pre-existing failures
- [ ] Verify `GET /api/v2/users` returns `PagedResponse<UserDto>` with no PII fields
- [ ] Verify `GET /api/v2/users?city=Seattle` applies filter
- [ ] Verify `GET /api/v2/users/{id}` returns single `UserDto`
- [ ] Verify `GET /api/v2/users/{nonexistent}` returns 404
- [ ] Verify UserDto does NOT contain Email, ObjectId, DateOfBirth, IsSiteAdmin

🤖 Generated with [Claude Code](https://claude.com/claude-code)