### PR TITLE
Project 24 Phase 2: LitterReports v2 endpoint with image DTOs

### DIFF
--- a/TrashMob.Models/Extensions/V2/LitterReportMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/LitterReportMappingsV2.cs
@@ -1,0 +1,57 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping LitterReport and LitterImage entities to V2 DTOs.
+    /// </summary>
+    public static class LitterReportMappingsV2
+    {
+        /// <summary>
+        /// Maps a LitterReport entity to a V2 LitterReportDto, including non-cancelled images.
+        /// </summary>
+        /// <param name="entity">The LitterReport entity to map.</param>
+        /// <returns>A LitterReportDto with associated image DTOs.</returns>
+        public static LitterReportDto ToV2Dto(this LitterReport entity)
+        {
+            return new LitterReportDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                Description = entity.Description,
+                LitterReportStatusId = entity.LitterReportStatusId,
+                CreatedByUserId = entity.CreatedByUserId,
+                CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
+                Images = entity.LitterImages?
+                    .Where(li => !li.IsCancelled)
+                    .Select(li => li.ToV2Dto())
+                    .ToList()
+                    ?? (IReadOnlyList<LitterImageDto>)[],
+            };
+        }
+
+        /// <summary>
+        /// Maps a LitterImage entity to a V2 LitterImageDto, excluding moderation fields.
+        /// </summary>
+        /// <param name="entity">The LitterImage entity to map.</param>
+        /// <returns>A LitterImageDto with image URL and location data.</returns>
+        public static LitterImageDto ToV2Dto(this LitterImage entity)
+        {
+            return new LitterImageDto
+            {
+                Id = entity.Id,
+                ImageUrl = entity.AzureBlobURL,
+                StreetAddress = entity.StreetAddress,
+                City = entity.City,
+                Region = entity.Region,
+                Country = entity.Country,
+                PostalCode = entity.PostalCode,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/LitterImageDto.cs
+++ b/TrashMob.Models/Poco/V2/LitterImageDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a litter image. Excludes moderation internals.
+    /// </summary>
+    public class LitterImageDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the image.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the image.
+        /// </summary>
+        public string ImageUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the street address where the litter was photographed.
+        /// </summary>
+        public string StreetAddress { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the city.
+        /// </summary>
+        public string City { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the region (state/province).
+        /// </summary>
+        public string Region { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the country.
+        /// </summary>
+        public string Country { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the postal code.
+        /// </summary>
+        public string PostalCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the latitude.
+        /// </summary>
+        public double? Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude.
+        /// </summary>
+        public double? Longitude { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/LitterReportDto.cs
+++ b/TrashMob.Models/Poco/V2/LitterReportDto.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// V2 API representation of a litter report with associated images.
+    /// </summary>
+    public class LitterReportDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the litter report.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name or title of the litter report.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the description of the litter report.
+        /// </summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the status identifier (New=1, Assigned=2, Cleaned=3, Cancelled=4).
+        /// </summary>
+        public int LitterReportStatusId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who created the report.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the report was created.
+        /// </summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the report was last updated.
+        /// </summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the associated images for this litter report.
+        /// </summary>
+        public IReadOnlyList<LitterImageDto> Images { get; set; } = [];
+    }
+}

--- a/TrashMob.Models/Poco/V2/LitterReportQueryParameters.cs
+++ b/TrashMob.Models/Poco/V2/LitterReportQueryParameters.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// Query parameters for filtering and paginating litter reports in V2 API.
+    /// </summary>
+    public class LitterReportQueryParameters : QueryParameters
+    {
+        /// <summary>
+        /// Gets or sets an optional litter report status filter (New=1, Assigned=2, Cleaned=3, Cancelled=4).
+        /// </summary>
+        public int? LitterReportStatusId { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional city filter (matches against litter image locations).
+        /// </summary>
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional region (state/province) filter.
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional country filter.
+        /// </summary>
+        public string? Country { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start of the date range filter.
+        /// </summary>
+        public DateTimeOffset? FromDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end of the date range filter.
+        /// </summary>
+        public DateTimeOffset? ToDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional filter for reports created by a specific user.
+        /// </summary>
+        public Guid? CreatedByUserId { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/LitterReportsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/LitterReportsV2ControllerTests.cs
@@ -1,0 +1,150 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class LitterReportsV2ControllerTests
+    {
+        private readonly Mock<ILitterReportManager> litterReportManager = new();
+        private readonly Mock<ILogger<LitterReportsV2Controller>> logger = new();
+        private readonly LitterReportsV2Controller controller;
+
+        public LitterReportsV2ControllerTests()
+        {
+            controller = new LitterReportsV2Controller(litterReportManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetLitterReports_ReturnsOkWithPagedResponse()
+        {
+            var reports = new List<LitterReport>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Park Litter",
+                    LitterReportStatusId = 1,
+                    CreatedByUserId = Guid.NewGuid(),
+                    LitterImages = new List<LitterImage>
+                    {
+                        new() { Id = Guid.NewGuid(), AzureBlobURL = "img1.jpg", City = "Seattle" },
+                    },
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Beach Litter",
+                    LitterReportStatusId = 1,
+                    CreatedByUserId = Guid.NewGuid(),
+                    LitterImages = new List<LitterImage>
+                    {
+                        new() { Id = Guid.NewGuid(), AzureBlobURL = "img2.jpg", City = "Portland" },
+                    },
+                },
+            };
+
+            var queryable = new TestAsyncEnumerable<LitterReport>(reports);
+            var filter = new LitterReportQueryParameters { Page = 1, PageSize = 25 };
+
+            litterReportManager
+                .Setup(m => m.GetFilteredLitterReportsQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetLitterReports(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<LitterReportDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal("Park Litter", response.Items[0].Name);
+            Assert.Single(response.Items[0].Images);
+        }
+
+        [Fact]
+        public async Task GetLitterReports_ReturnsEmptyPagedResponse_WhenNoReports()
+        {
+            var queryable = new TestAsyncEnumerable<LitterReport>(Enumerable.Empty<LitterReport>());
+            var filter = new LitterReportQueryParameters { Page = 1, PageSize = 25 };
+
+            litterReportManager
+                .Setup(m => m.GetFilteredLitterReportsQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetLitterReports(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<LitterReportDto>>(okResult.Value);
+            Assert.Empty(response.Items);
+            Assert.Equal(0, response.Pagination.TotalCount);
+        }
+
+        [Fact]
+        public async Task GetLitterReport_ReturnsOkWithDto()
+        {
+            var reportId = Guid.NewGuid();
+            var report = new LitterReport
+            {
+                Id = reportId,
+                Name = "Trail Litter",
+                Description = "Trash along the trail",
+                LitterReportStatusId = 2,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
+                LitterImages = new List<LitterImage>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        AzureBlobURL = "https://blob.example.com/trail.jpg",
+                        City = "Seattle",
+                        Region = "WA",
+                        Country = "US",
+                    },
+                },
+            };
+
+            litterReportManager
+                .Setup(m => m.GetAsync(reportId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(report);
+
+            var result = await controller.GetLitterReport(reportId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<LitterReportDto>(okResult.Value);
+            Assert.Equal(reportId, dto.Id);
+            Assert.Equal("Trail Litter", dto.Name);
+            Assert.Single(dto.Images);
+            Assert.Equal("https://blob.example.com/trail.jpg", dto.Images[0].ImageUrl);
+        }
+
+        [Fact]
+        public async Task GetLitterReport_ReturnsNotFound_WhenReportDoesNotExist()
+        {
+            var reportId = Guid.NewGuid();
+
+            litterReportManager
+                .Setup(m => m.GetAsync(reportId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((LitterReport)null);
+
+            var result = await controller.GetLitterReport(reportId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/LitterReportMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/LitterReportMappingsV2Tests.cs
@@ -1,0 +1,158 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class LitterReportMappingsV2Tests
+    {
+        [Fact]
+        public void ToV2Dto_MapsAllProperties()
+        {
+            var imageId = Guid.NewGuid();
+            var entity = new LitterReport
+            {
+                Id = Guid.NewGuid(),
+                Name = "Park Litter",
+                Description = "Litter near the fountain",
+                LitterReportStatusId = 1,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero),
+                LastUpdatedDate = new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
+                LitterImages =
+                [
+                    new LitterImage
+                    {
+                        Id = imageId,
+                        AzureBlobURL = "https://blob.example.com/img1.jpg",
+                        StreetAddress = "123 Main St",
+                        City = "Seattle",
+                        Region = "WA",
+                        Country = "US",
+                        PostalCode = "98101",
+                        Latitude = 47.6062,
+                        Longitude = -122.3321,
+                    },
+                ],
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.Id, dto.Id);
+            Assert.Equal(entity.Name, dto.Name);
+            Assert.Equal(entity.Description, dto.Description);
+            Assert.Equal(entity.LitterReportStatusId, dto.LitterReportStatusId);
+            Assert.Equal(entity.CreatedByUserId, dto.CreatedByUserId);
+            Assert.Equal(entity.CreatedDate, dto.CreatedDate);
+            Assert.Equal(entity.LastUpdatedDate, dto.LastUpdatedDate);
+            Assert.Single(dto.Images);
+            Assert.Equal(imageId, dto.Images[0].Id);
+            Assert.Equal("https://blob.example.com/img1.jpg", dto.Images[0].ImageUrl);
+            Assert.Equal("Seattle", dto.Images[0].City);
+        }
+
+        [Fact]
+        public void ToV2Dto_ExcludesCancelledImages()
+        {
+            var entity = new LitterReport
+            {
+                Id = Guid.NewGuid(),
+                LitterImages = new List<LitterImage>
+                {
+                    new() { Id = Guid.NewGuid(), AzureBlobURL = "img1.jpg", IsCancelled = false },
+                    new() { Id = Guid.NewGuid(), AzureBlobURL = "img2.jpg", IsCancelled = true },
+                    new() { Id = Guid.NewGuid(), AzureBlobURL = "img3.jpg", IsCancelled = false },
+                },
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(2, dto.Images.Count);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullImages()
+        {
+            var entity = new LitterReport
+            {
+                Id = Guid.NewGuid(),
+                LitterImages = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Empty(dto.Images);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullDates()
+        {
+            var entity = new LitterReport
+            {
+                CreatedDate = null,
+                LastUpdatedDate = null,
+                LitterImages = [],
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(default, dto.CreatedDate);
+            Assert.Equal(default, dto.LastUpdatedDate);
+        }
+
+        [Fact]
+        public void LitterImage_ToV2Dto_MapsAllProperties()
+        {
+            var entity = new LitterImage
+            {
+                Id = Guid.NewGuid(),
+                AzureBlobURL = "https://blob.example.com/photo.jpg",
+                StreetAddress = "456 Oak Ave",
+                City = "Portland",
+                Region = "OR",
+                Country = "US",
+                PostalCode = "97201",
+                Latitude = 45.5152,
+                Longitude = -122.6784,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.Id, dto.Id);
+            Assert.Equal(entity.AzureBlobURL, dto.ImageUrl);
+            Assert.Equal(entity.StreetAddress, dto.StreetAddress);
+            Assert.Equal(entity.City, dto.City);
+            Assert.Equal(entity.Region, dto.Region);
+            Assert.Equal(entity.Country, dto.Country);
+            Assert.Equal(entity.PostalCode, dto.PostalCode);
+            Assert.Equal(entity.Latitude, dto.Latitude);
+            Assert.Equal(entity.Longitude, dto.Longitude);
+        }
+
+        [Fact]
+        public void LitterImage_ToV2Dto_DoesNotExposeModerationFields()
+        {
+            var entity = new LitterImage
+            {
+                Id = Guid.NewGuid(),
+                ModerationStatus = PhotoModerationStatus.Rejected,
+                InReview = true,
+                ReviewRequestedByUserId = Guid.NewGuid(),
+                ModeratedByUserId = Guid.NewGuid(),
+                ModerationReason = "Inappropriate",
+            };
+
+            var dto = entity.ToV2Dto();
+
+            var dtoType = dto.GetType();
+            Assert.Null(dtoType.GetProperty("ModerationStatus"));
+            Assert.Null(dtoType.GetProperty("InReview"));
+            Assert.Null(dtoType.GetProperty("ReviewRequestedByUserId"));
+            Assert.Null(dtoType.GetProperty("ModeratedByUserId"));
+            Assert.Null(dtoType.GetProperty("ModerationReason"));
+            Assert.Null(dtoType.GetProperty("IsCancelled"));
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/ILitterReportManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/ILitterReportManager.cs
@@ -2,10 +2,12 @@ namespace TrashMob.Shared.Managers.Interfaces
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using TrashMob.Models;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Poco;
 
     /// <summary>
@@ -110,5 +112,14 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>The count of litter reports submitted by the user.</returns>
         Task<int> GetUserLitterReportCountAsync(Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a queryable of filtered litter reports for V2 API pagination. The returned IQueryable
+        /// is not materialized, allowing the caller to apply ToPagedAsync() for database-side pagination.
+        /// Includes LitterImages navigation property.
+        /// </summary>
+        /// <param name="filter">The V2 query parameters with litter report-specific filters.</param>
+        /// <returns>An unmaterialized queryable of litter reports matching the filter.</returns>
+        IQueryable<LitterReport> GetFilteredLitterReportsQueryable(LitterReportQueryParameters filter);
     }
 }

--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -10,6 +10,7 @@ namespace TrashMob.Shared.Managers.LitterReport
     using TrashMob.Models;
     using TrashMob.Models.Extensions;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Engine;
     using TrashMob.Shared.Extensions;
     using TrashMob.Shared.Managers.Interfaces;
@@ -498,6 +499,24 @@ namespace TrashMob.Shared.Managers.LitterReport
         public async Task<int> GetUserLitterReportCountAsync(Guid userId, CancellationToken cancellationToken = default)
         {
             return await Repo.Get(lr => lr.CreatedByUserId == userId).CountAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public IQueryable<LitterReport> GetFilteredLitterReportsQueryable(LitterReportQueryParameters filter)
+        {
+            var query = Repo.Get(lr =>
+                lr.LitterReportStatusId != (int)LitterReportStatusEnum.Cancelled &&
+                (filter.LitterReportStatusId == null || lr.LitterReportStatusId == filter.LitterReportStatusId) &&
+                (filter.FromDate == null || lr.CreatedDate >= filter.FromDate) &&
+                (filter.ToDate == null || lr.CreatedDate <= filter.ToDate) &&
+                (filter.CreatedByUserId == null || lr.CreatedByUserId == filter.CreatedByUserId) &&
+                (filter.Country == null || lr.LitterImages.Any(li => li.Country == filter.Country)) &&
+                (filter.Region == null || lr.LitterImages.Any(li => li.Region == filter.Region)) &&
+                (filter.City == null || lr.LitterImages.Any(li => li.City == filter.City)));
+
+            return query
+                .Include(lr => lr.LitterImages)
+                .OrderByDescending(lr => lr.CreatedDate);
         }
     }
 }

--- a/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
@@ -1,0 +1,77 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Extensions;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for litter reports with server-side pagination and filtering.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/litterreports")]
+    public class LitterReportsV2Controller(
+        ILitterReportManager litterReportManager,
+        ILogger<LitterReportsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets a paginated list of litter reports with optional filtering.
+        /// </summary>
+        /// <param name="filter">Query parameters for pagination and filtering.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A paginated list of litter reports with images.</returns>
+        /// <response code="200">Returns the paginated litter report list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(PagedResponse<LitterReportDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetLitterReports(
+            [FromQuery] LitterReportQueryParameters filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLitterReports requested with Page={Page}, PageSize={PageSize}",
+                filter.Page, filter.PageSize);
+
+            var query = litterReportManager.GetFilteredLitterReportsQueryable(filter);
+            var result = await query.ToPagedAsync(filter, lr => lr.ToV2Dto(), cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a single litter report by its identifier, including images.
+        /// </summary>
+        /// <param name="id">The litter report identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The litter report details with images.</returns>
+        /// <response code="200">Returns the litter report.</response>
+        /// <response code="404">Litter report not found.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(LitterReportDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetLitterReport(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLitterReport requested for {LitterReportId}", id);
+
+            var litterReport = await litterReportManager.GetAsync(id, cancellationToken);
+
+            if (litterReport is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(litterReport.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/v2/litterreports` endpoint with server-side pagination and filtering (status, city/region/country via image locations, date range, creator)
- Adds `GET /api/v2/litterreports/{id}` endpoint returning `LitterReportDto` with nested `LitterImageDto` list
- `LitterImageDto` maps `AzureBlobURL` → `ImageUrl` and excludes all moderation internals (ModerationStatus, InReview, etc.)
- Cancelled images automatically excluded from DTO responses
- Geographic filtering uses `LitterImages.Any()` pattern (same as v1) since reports derive location from their images
- 10 new tests (4 controller + 6 mapping), all passing

## Changes

### New Files
| File | Purpose |
|------|---------|
| `TrashMob.Models/Poco/V2/LitterReportDto.cs` | Litter report DTO with nested images |
| `TrashMob.Models/Poco/V2/LitterImageDto.cs` | Image DTO (URL + location, no moderation) |
| `TrashMob.Models/Poco/V2/LitterReportQueryParameters.cs` | Filter extending `QueryParameters` |
| `TrashMob.Models/Extensions/V2/LitterReportMappingsV2.cs` | Mapping extensions |
| `TrashMob/Controllers/V2/LitterReportsV2Controller.cs` | V2 litter reports endpoints |
| `TrashMob.Shared.Tests/Extensions/V2/LitterReportMappingsV2Tests.cs` | Mapping tests (6) |
| `TrashMob.Shared.Tests/Controllers/V2/LitterReportsV2ControllerTests.cs` | Controller tests (4) |

### Modified Files
| File | Change |
|------|--------|
| `TrashMob.Shared/Managers/Interfaces/ILitterReportManager.cs` | Added `GetFilteredLitterReportsQueryable` |
| `TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs` | Implemented queryable filter method |

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 521 passed, 2 pre-existing failures
- [ ] Verify `GET /api/v2/litterreports` returns `PagedResponse<LitterReportDto>` with images
- [ ] Verify `GET /api/v2/litterreports?litterReportStatusId=1&city=Seattle` applies filters
- [ ] Verify `GET /api/v2/litterreports/{id}` returns single `LitterReportDto`
- [ ] Verify cancelled images excluded from responses
- [ ] Verify image DTOs exclude moderation fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)