### PR TITLE
Add Teams v2 endpoint with pagination

### DIFF
--- a/TrashMob.Models/Extensions/V2/TeamMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamMappingsV2.cs
@@ -1,0 +1,38 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping Team entities to V2 DTOs.
+    /// </summary>
+    public static class TeamMappingsV2
+    {
+        /// <summary>
+        /// Maps a Team entity to a V2 TeamDto.
+        /// </summary>
+        /// <param name="entity">The Team entity to map.</param>
+        /// <returns>A TeamDto with all public-safe properties.</returns>
+        public static TeamDto ToV2Dto(this Team entity)
+        {
+            return new TeamDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                Description = entity.Description,
+                LogoUrl = entity.LogoUrl,
+                IsPublic = entity.IsPublic,
+                RequiresApproval = entity.RequiresApproval,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+                City = entity.City,
+                Region = entity.Region,
+                Country = entity.Country,
+                PostalCode = entity.PostalCode,
+                IsActive = entity.IsActive,
+                CreatedByUserId = entity.CreatedByUserId,
+                CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/TeamDto.cs
+++ b/TrashMob.Models/Poco/V2/TeamDto.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a team. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class TeamDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the team.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the team.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the description of the team.
+        /// </summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the URL of the team's logo image.
+        /// </summary>
+        public string LogoUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets whether the team is publicly visible.
+        /// </summary>
+        public bool IsPublic { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether joining the team requires approval from a lead.
+        /// </summary>
+        public bool RequiresApproval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the latitude of the team's primary location.
+        /// </summary>
+        public double? Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude of the team's primary location.
+        /// </summary>
+        public double? Longitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the city where the team is based.
+        /// </summary>
+        public string City { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the region (state/province) where the team is based.
+        /// </summary>
+        public string Region { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the country where the team is based.
+        /// </summary>
+        public string Country { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the postal code of the team's location.
+        /// </summary>
+        public string PostalCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets whether the team is active.
+        /// </summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who created the team.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the team was created.
+        /// </summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the team was last updated.
+        /// </summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/TeamQueryParameters.cs
+++ b/TrashMob.Models/Poco/V2/TeamQueryParameters.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// Query parameters for filtering and paginating teams in V2 API.
+    /// </summary>
+    public class TeamQueryParameters : QueryParameters
+    {
+        /// <summary>
+        /// Gets or sets an optional city filter.
+        /// </summary>
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional region (state/province) filter.
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional country filter.
+        /// </summary>
+        public string? Country { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamsV2ControllerTests.cs
@@ -1,0 +1,159 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class TeamsV2ControllerTests
+    {
+        private readonly Mock<ITeamManager> teamManager = new();
+        private readonly Mock<ILogger<TeamsV2Controller>> logger = new();
+        private readonly TeamsV2Controller controller;
+
+        public TeamsV2ControllerTests()
+        {
+            controller = new TeamsV2Controller(teamManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetTeams_ReturnsOkWithPagedResponse()
+        {
+            var teams = new List<Team>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Seattle Cleanup Crew",
+                    IsPublic = true,
+                    IsActive = true,
+                    City = "Seattle",
+                    Region = "WA",
+                    Country = "US",
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Portland Green Team",
+                    IsPublic = true,
+                    IsActive = true,
+                    City = "Portland",
+                    Region = "OR",
+                    Country = "US",
+                },
+            };
+
+            var queryable = new TestAsyncEnumerable<Team>(teams);
+            var filter = new TeamQueryParameters { Page = 1, PageSize = 25 };
+
+            teamManager
+                .Setup(m => m.GetFilteredTeamsQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetTeams(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<TeamDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal("Seattle Cleanup Crew", response.Items[0].Name);
+        }
+
+        [Fact]
+        public async Task GetTeams_ReturnsEmptyPagedResponse_WhenNoTeams()
+        {
+            var queryable = new TestAsyncEnumerable<Team>(Enumerable.Empty<Team>());
+            var filter = new TeamQueryParameters { Page = 1, PageSize = 25 };
+
+            teamManager
+                .Setup(m => m.GetFilteredTeamsQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetTeams(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<TeamDto>>(okResult.Value);
+            Assert.Empty(response.Items);
+            Assert.Equal(0, response.Pagination.TotalCount);
+        }
+
+        [Fact]
+        public async Task GetTeam_ReturnsOkWithDto()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team
+            {
+                Id = teamId,
+                Name = "Trail Blazers",
+                Description = "Cleaning trails in the Pacific NW",
+                IsPublic = true,
+                IsActive = true,
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            var result = await controller.GetTeam(teamId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<TeamDto>(okResult.Value);
+            Assert.Equal(teamId, dto.Id);
+            Assert.Equal("Trail Blazers", dto.Name);
+            Assert.Equal("Seattle", dto.City);
+        }
+
+        [Fact]
+        public async Task GetTeam_ReturnsNotFound_WhenTeamDoesNotExist()
+        {
+            var teamId = Guid.NewGuid();
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team)null);
+
+            var result = await controller.GetTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetTeam_ReturnsNotFound_WhenTeamIsInactive()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team
+            {
+                Id = teamId,
+                Name = "Defunct Team",
+                IsActive = false,
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            var result = await controller.GetTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/TeamMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/TeamMappingsV2Tests.cs
@@ -1,0 +1,81 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class TeamMappingsV2Tests
+    {
+        [Fact]
+        public void ToV2Dto_MapsAllProperties()
+        {
+            var entity = new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = "Seattle Cleanup Crew",
+                Description = "Cleaning up Seattle parks",
+                LogoUrl = "https://example.com/logo.png",
+                IsPublic = true,
+                RequiresApproval = false,
+                Latitude = 47.6062,
+                Longitude = -122.3321,
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                PostalCode = "98101",
+                IsActive = true,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero),
+                LastUpdatedDate = new DateTimeOffset(2026, 1, 10, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.Id, dto.Id);
+            Assert.Equal(entity.Name, dto.Name);
+            Assert.Equal(entity.Description, dto.Description);
+            Assert.Equal(entity.LogoUrl, dto.LogoUrl);
+            Assert.Equal(entity.IsPublic, dto.IsPublic);
+            Assert.Equal(entity.RequiresApproval, dto.RequiresApproval);
+            Assert.Equal(entity.Latitude, dto.Latitude);
+            Assert.Equal(entity.Longitude, dto.Longitude);
+            Assert.Equal(entity.City, dto.City);
+            Assert.Equal(entity.Region, dto.Region);
+            Assert.Equal(entity.Country, dto.Country);
+            Assert.Equal(entity.PostalCode, dto.PostalCode);
+            Assert.Equal(entity.IsActive, dto.IsActive);
+            Assert.Equal(entity.CreatedByUserId, dto.CreatedByUserId);
+            Assert.Equal(entity.CreatedDate, dto.CreatedDate);
+            Assert.Equal(entity.LastUpdatedDate, dto.LastUpdatedDate);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullDates()
+        {
+            var entity = new Team
+            {
+                CreatedDate = null,
+                LastUpdatedDate = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(default, dto.CreatedDate);
+            Assert.Equal(default, dto.LastUpdatedDate);
+        }
+
+        [Fact]
+        public void ToV2Dto_DoesNotExposeNavigationProperties()
+        {
+            var dto = new Team().ToV2Dto();
+
+            var dtoType = dto.GetType();
+            Assert.Null(dtoType.GetProperty("Members"));
+            Assert.Null(dtoType.GetProperty("JoinRequests"));
+            Assert.Null(dtoType.GetProperty("TeamEvents"));
+            Assert.Null(dtoType.GetProperty("Photos"));
+            Assert.Null(dtoType.GetProperty("Adoptions"));
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/ITeamManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/ITeamManager.cs
@@ -2,9 +2,11 @@ namespace TrashMob.Shared.Managers.Interfaces
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
 
     /// <summary>
     /// Defines operations for managing teams.
@@ -64,5 +66,13 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A collection of all teams.</returns>
         Task<IEnumerable<Team>> GetAllTeamsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a queryable of filtered public teams for V2 API pagination. The returned IQueryable
+        /// is not materialized, allowing the caller to apply ToPagedAsync() for database-side pagination.
+        /// </summary>
+        /// <param name="filter">The V2 query parameters with team-specific filters.</param>
+        /// <returns>An unmaterialized queryable of public, active teams matching the filter.</returns>
+        IQueryable<Team> GetFilteredTeamsQueryable(TeamQueryParameters filter);
     }
 }

--- a/TrashMob.Shared/Managers/Teams/TeamManager.cs
+++ b/TrashMob.Shared/Managers/Teams/TeamManager.cs
@@ -7,6 +7,7 @@ namespace TrashMob.Shared.Managers.Teams
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Persistence.Interfaces;
 
@@ -102,6 +103,30 @@ namespace TrashMob.Shared.Managers.Teams
         public async Task<IEnumerable<Team>> GetAllTeamsAsync(CancellationToken cancellationToken = default)
         {
             return await Repo.Get().ToListAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public IQueryable<Team> GetFilteredTeamsQueryable(TeamQueryParameters filter)
+        {
+            var query = Repo.Get()
+                .Where(t => t.IsPublic && t.IsActive);
+
+            if (filter.City != null)
+            {
+                query = query.Where(t => t.City == filter.City);
+            }
+
+            if (filter.Region != null)
+            {
+                query = query.Where(t => t.Region == filter.Region);
+            }
+
+            if (filter.Country != null)
+            {
+                query = query.Where(t => t.Country == filter.Country);
+            }
+
+            return query.OrderBy(t => t.Name);
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/TeamsV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamsV2Controller.cs
@@ -1,0 +1,77 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Extensions;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for teams with server-side pagination and filtering.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/teams")]
+    public class TeamsV2Controller(
+        ITeamManager teamManager,
+        ILogger<TeamsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets a paginated list of public, active teams with optional filtering.
+        /// </summary>
+        /// <param name="filter">Query parameters for pagination and filtering.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A paginated list of teams.</returns>
+        /// <response code="200">Returns the paginated team list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(PagedResponse<TeamDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetTeams(
+            [FromQuery] TeamQueryParameters filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetTeams requested with Page={Page}, PageSize={PageSize}",
+                filter.Page, filter.PageSize);
+
+            var query = teamManager.GetFilteredTeamsQueryable(filter);
+            var result = await query.ToPagedAsync(filter, t => t.ToV2Dto(), cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a single team by its identifier.
+        /// </summary>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The team details.</returns>
+        /// <response code="200">Returns the team.</response>
+        /// <response code="404">Team not found or inactive.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(TeamDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetTeam(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetTeam requested for {TeamId}", id);
+
+            var team = await teamManager.GetAsync(id, cancellationToken);
+
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            return Ok(team.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v2/teams` with server-side pagination and City/Region/Country filtering (public + active teams only)
- Adds `GET /api/v2/teams/{id}` to retrieve a single team by ID (returns 404 for inactive teams)
- Creates `TeamDto` (flat DTO excluding navigation properties), `TeamQueryParameters`, and `TeamMappingsV2` extension
- Adds `GetFilteredTeamsQueryable` to `ITeamManager`/`TeamManager` for unmaterialized IQueryable pagination

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors
- [x] `dotnet test TrashMob.Shared.Tests` — 529 passed (2 pre-existing failures unrelated)
- [ ] Verify `GET /api/v2/teams` returns `PagedResponse<TeamDto>`
- [ ] Verify `GET /api/v2/teams?city=Seattle` filters correctly
- [ ] Verify `GET /api/v2/teams/{id}` returns team details
- [ ] Verify `GET /api/v2/teams/{nonexistent}` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)