### PR TITLE
Add Partners v2 endpoint with pagination

### DIFF
--- a/TrashMob.Models/Extensions/V2/PartnerMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/PartnerMappingsV2.cs
@@ -1,0 +1,52 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping Partner entities to V2 DTOs.
+    /// </summary>
+    public static class PartnerMappingsV2
+    {
+        /// <summary>
+        /// Maps a Partner entity to a V2 PartnerDto, excluding admin-only fields.
+        /// </summary>
+        /// <param name="entity">The Partner entity to map.</param>
+        /// <returns>A PartnerDto with public-safe properties.</returns>
+        public static PartnerDto ToV2Dto(this Partner entity)
+        {
+            return new PartnerDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                Website = entity.Website,
+                PublicNotes = entity.PublicNotes,
+                LogoUrl = entity.LogoUrl,
+                PartnerStatusId = entity.PartnerStatusId,
+                PartnerTypeId = entity.PartnerTypeId,
+                Slug = entity.Slug,
+                HomePageEnabled = entity.HomePageEnabled,
+                IsFeatured = entity.IsFeatured,
+                BrandingPrimaryColor = entity.BrandingPrimaryColor,
+                BrandingSecondaryColor = entity.BrandingSecondaryColor,
+                BannerImageUrl = entity.BannerImageUrl,
+                Tagline = entity.Tagline,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+                City = entity.City,
+                Region = entity.Region,
+                Country = entity.Country,
+                PhysicalAddress = entity.PhysicalAddress,
+                BoundsNorth = entity.BoundsNorth,
+                BoundsSouth = entity.BoundsSouth,
+                BoundsEast = entity.BoundsEast,
+                BoundsWest = entity.BoundsWest,
+                BoundaryGeoJson = entity.BoundaryGeoJson,
+                RegionType = entity.RegionType,
+                CountyName = entity.CountyName,
+                CreatedByUserId = entity.CreatedByUserId,
+                CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerDto.cs
@@ -1,0 +1,162 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a partner. Excludes admin-only fields (PrivateNotes, contact info, adoptable area defaults).
+    /// </summary>
+    public class PartnerDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the partner.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the partner organization.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the website URL.
+        /// </summary>
+        public string Website { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets publicly visible notes about the partner.
+        /// </summary>
+        public string PublicNotes { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the URL of the partner's logo.
+        /// </summary>
+        public string LogoUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the partner status identifier (Active=1, Inactive=2).
+        /// </summary>
+        public int PartnerStatusId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the partner type identifier (Government=1, Business=2, Community=3).
+        /// </summary>
+        public int PartnerTypeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL-friendly slug for the community page.
+        /// </summary>
+        public string Slug { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets whether the community home page is enabled.
+        /// </summary>
+        public bool HomePageEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this community is featured.
+        /// </summary>
+        public bool IsFeatured { get; set; }
+
+        /// <summary>
+        /// Gets or sets the primary branding color (hex format).
+        /// </summary>
+        public string BrandingPrimaryColor { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the secondary branding color (hex format).
+        /// </summary>
+        public string BrandingSecondaryColor { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the URL of the community banner image.
+        /// </summary>
+        public string BannerImageUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the tagline displayed on the community page.
+        /// </summary>
+        public string Tagline { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the latitude of the partner's location.
+        /// </summary>
+        public double? Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude of the partner's location.
+        /// </summary>
+        public double? Longitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the city.
+        /// </summary>
+        public string City { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the region (state/province).
+        /// </summary>
+        public string Region { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the country.
+        /// </summary>
+        public string Country { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the physical address for display.
+        /// </summary>
+        public string PhysicalAddress { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the northern latitude bound for bounding-box filtering.
+        /// </summary>
+        public double? BoundsNorth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the southern latitude bound.
+        /// </summary>
+        public double? BoundsSouth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the eastern longitude bound.
+        /// </summary>
+        public double? BoundsEast { get; set; }
+
+        /// <summary>
+        /// Gets or sets the western longitude bound.
+        /// </summary>
+        public double? BoundsWest { get; set; }
+
+        /// <summary>
+        /// Gets or sets the GeoJSON polygon representing the community boundary.
+        /// </summary>
+        public string BoundaryGeoJson { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the type of geographic region (City, County, State, etc.).
+        /// </summary>
+        public int? RegionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the county name for county-level communities.
+        /// </summary>
+        public string CountyName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who created the partner.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the partner was created.
+        /// </summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the partner was last updated.
+        /// </summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerQueryParameters.cs
+++ b/TrashMob.Models/Poco/V2/PartnerQueryParameters.cs
@@ -1,0 +1,40 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// Query parameters for filtering and paginating partners in V2 API.
+    /// </summary>
+    public class PartnerQueryParameters : QueryParameters
+    {
+        /// <summary>
+        /// Gets or sets an optional partner type filter (Government=1, Business=2, Community=3).
+        /// </summary>
+        public int? PartnerTypeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional city filter.
+        /// </summary>
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional region (state/province) filter.
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional country filter.
+        /// </summary>
+        public string? Country { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional filter for partners with an enabled community home page.
+        /// </summary>
+        public bool? HomePageEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional filter for featured partners.
+        /// </summary>
+        public bool? IsFeatured { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnersV2ControllerTests.cs
@@ -1,0 +1,162 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class PartnersV2ControllerTests
+    {
+        private readonly Mock<IPartnerManager> partnerManager = new();
+        private readonly Mock<ILogger<PartnersV2Controller>> logger = new();
+        private readonly PartnersV2Controller controller;
+
+        public PartnersV2ControllerTests()
+        {
+            controller = new PartnersV2Controller(partnerManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetPartners_ReturnsOkWithPagedResponse()
+        {
+            var partners = new List<Partner>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Seattle Parks",
+                    PartnerStatusId = 1,
+                    PartnerTypeId = 3,
+                    City = "Seattle",
+                    Region = "WA",
+                    Country = "US",
+                    HomePageEnabled = true,
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Portland Green",
+                    PartnerStatusId = 1,
+                    PartnerTypeId = 3,
+                    City = "Portland",
+                    Region = "OR",
+                    Country = "US",
+                },
+            };
+
+            var queryable = new TestAsyncEnumerable<Partner>(partners);
+            var filter = new PartnerQueryParameters { Page = 1, PageSize = 25 };
+
+            partnerManager
+                .Setup(m => m.GetFilteredPartnersQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetPartners(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<PartnerDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal("Seattle Parks", response.Items[0].Name);
+        }
+
+        [Fact]
+        public async Task GetPartners_ReturnsEmptyPagedResponse_WhenNoPartners()
+        {
+            var queryable = new TestAsyncEnumerable<Partner>(Enumerable.Empty<Partner>());
+            var filter = new PartnerQueryParameters { Page = 1, PageSize = 25 };
+
+            partnerManager
+                .Setup(m => m.GetFilteredPartnersQueryable(filter))
+                .Returns(queryable);
+
+            var result = await controller.GetPartners(filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<PartnerDto>>(okResult.Value);
+            Assert.Empty(response.Items);
+            Assert.Equal(0, response.Pagination.TotalCount);
+        }
+
+        [Fact]
+        public async Task GetPartner_ReturnsOkWithDto()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner
+            {
+                Id = partnerId,
+                Name = "Community Cleanup Co",
+                Website = "https://cleanup.example.com",
+                PartnerStatusId = 1,
+                PartnerTypeId = 2,
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                Slug = "community-cleanup",
+                HomePageEnabled = true,
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = new DateTimeOffset(2025, 3, 1, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            var result = await controller.GetPartner(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerDto>(okResult.Value);
+            Assert.Equal(partnerId, dto.Id);
+            Assert.Equal("Community Cleanup Co", dto.Name);
+            Assert.Equal("community-cleanup", dto.Slug);
+        }
+
+        [Fact]
+        public async Task GetPartner_ReturnsNotFound_WhenPartnerDoesNotExist()
+        {
+            var partnerId = Guid.NewGuid();
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.GetPartner(partnerId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetPartner_ReturnsNotFound_WhenPartnerIsInactive()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner
+            {
+                Id = partnerId,
+                Name = "Defunct Partner",
+                PartnerStatusId = 2, // Inactive
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            var result = await controller.GetPartner(partnerId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/PartnerMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/PartnerMappingsV2Tests.cs
@@ -1,0 +1,113 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class PartnerMappingsV2Tests
+    {
+        [Fact]
+        public void ToV2Dto_MapsAllProperties()
+        {
+            var entity = new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = "Seattle Parks",
+                Website = "https://seattle.gov/parks",
+                PublicNotes = "Great partner",
+                LogoUrl = "https://example.com/logo.png",
+                PartnerStatusId = 1,
+                PartnerTypeId = 3,
+                Slug = "seattle-wa",
+                HomePageEnabled = true,
+                IsFeatured = true,
+                BrandingPrimaryColor = "#3B82F6",
+                BrandingSecondaryColor = "#1E40AF",
+                BannerImageUrl = "https://example.com/banner.jpg",
+                Tagline = "Keep Seattle Clean",
+                Latitude = 47.6062,
+                Longitude = -122.3321,
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                PhysicalAddress = "123 Main St",
+                BoundsNorth = 47.7,
+                BoundsSouth = 47.5,
+                BoundsEast = -122.2,
+                BoundsWest = -122.4,
+                BoundaryGeoJson = "{\"type\":\"Polygon\"}",
+                RegionType = 1,
+                CountyName = "King County",
+                CreatedByUserId = Guid.NewGuid(),
+                CreatedDate = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                LastUpdatedDate = new DateTimeOffset(2026, 2, 15, 0, 0, 0, TimeSpan.Zero),
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.Id, dto.Id);
+            Assert.Equal(entity.Name, dto.Name);
+            Assert.Equal(entity.Website, dto.Website);
+            Assert.Equal(entity.PublicNotes, dto.PublicNotes);
+            Assert.Equal(entity.LogoUrl, dto.LogoUrl);
+            Assert.Equal(entity.PartnerStatusId, dto.PartnerStatusId);
+            Assert.Equal(entity.PartnerTypeId, dto.PartnerTypeId);
+            Assert.Equal(entity.Slug, dto.Slug);
+            Assert.Equal(entity.HomePageEnabled, dto.HomePageEnabled);
+            Assert.Equal(entity.IsFeatured, dto.IsFeatured);
+            Assert.Equal(entity.BrandingPrimaryColor, dto.BrandingPrimaryColor);
+            Assert.Equal(entity.BrandingSecondaryColor, dto.BrandingSecondaryColor);
+            Assert.Equal(entity.BannerImageUrl, dto.BannerImageUrl);
+            Assert.Equal(entity.Tagline, dto.Tagline);
+            Assert.Equal(entity.Latitude, dto.Latitude);
+            Assert.Equal(entity.Longitude, dto.Longitude);
+            Assert.Equal(entity.City, dto.City);
+            Assert.Equal(entity.Region, dto.Region);
+            Assert.Equal(entity.Country, dto.Country);
+            Assert.Equal(entity.PhysicalAddress, dto.PhysicalAddress);
+            Assert.Equal(entity.BoundsNorth, dto.BoundsNorth);
+            Assert.Equal(entity.BoundsSouth, dto.BoundsSouth);
+            Assert.Equal(entity.BoundsEast, dto.BoundsEast);
+            Assert.Equal(entity.BoundsWest, dto.BoundsWest);
+            Assert.Equal(entity.BoundaryGeoJson, dto.BoundaryGeoJson);
+            Assert.Equal(entity.RegionType, dto.RegionType);
+            Assert.Equal(entity.CountyName, dto.CountyName);
+            Assert.Equal(entity.CreatedByUserId, dto.CreatedByUserId);
+            Assert.Equal(entity.CreatedDate, dto.CreatedDate);
+            Assert.Equal(entity.LastUpdatedDate, dto.LastUpdatedDate);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullDates()
+        {
+            var entity = new Partner
+            {
+                CreatedDate = null,
+                LastUpdatedDate = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(default, dto.CreatedDate);
+            Assert.Equal(default, dto.LastUpdatedDate);
+        }
+
+        [Fact]
+        public void ToV2Dto_DoesNotExposeAdminFields()
+        {
+            var dto = new Partner().ToV2Dto();
+
+            var dtoType = dto.GetType();
+            Assert.Null(dtoType.GetProperty("PrivateNotes"));
+            Assert.Null(dtoType.GetProperty("ContactEmail"));
+            Assert.Null(dtoType.GetProperty("ContactPhone"));
+            Assert.Null(dtoType.GetProperty("DefaultCleanupFrequencyDays"));
+            Assert.Null(dtoType.GetProperty("DefaultMinEventsPerYear"));
+            Assert.Null(dtoType.GetProperty("DefaultSafetyRequirements"));
+            Assert.Null(dtoType.GetProperty("DefaultAllowCoAdoption"));
+            Assert.Null(dtoType.GetProperty("HomePageStartDate"));
+            Assert.Null(dtoType.GetProperty("HomePageEndDate"));
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/IPartnerManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IPartnerManager.cs
@@ -1,0 +1,20 @@
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System.Linq;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Defines operations for managing partners.
+    /// </summary>
+    public interface IPartnerManager : IKeyedManager<Partner>
+    {
+        /// <summary>
+        /// Gets a queryable of filtered active partners for V2 API pagination. The returned IQueryable
+        /// is not materialized, allowing the caller to apply ToPagedAsync() for database-side pagination.
+        /// </summary>
+        /// <param name="filter">The V2 query parameters with partner-specific filters.</param>
+        /// <returns>An unmaterialized queryable of active partners matching the filter.</returns>
+        IQueryable<Partner> GetFilteredPartnersQueryable(PartnerQueryParameters filter);
+    }
+}

--- a/TrashMob.Shared/Managers/Partners/PartnerManager.cs
+++ b/TrashMob.Shared/Managers/Partners/PartnerManager.cs
@@ -1,0 +1,54 @@
+namespace TrashMob.Shared.Managers.Partners
+{
+    using System.Linq;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// Manager for partner operations.
+    /// </summary>
+    public class PartnerManager(IKeyedRepository<Partner> repository)
+        : KeyedManager<Partner>(repository), IPartnerManager
+    {
+        /// <inheritdoc />
+        public IQueryable<Partner> GetFilteredPartnersQueryable(PartnerQueryParameters filter)
+        {
+            var query = Repo.Get()
+                .Where(p => p.PartnerStatusId == (int)PartnerStatusEnum.Active);
+
+            if (filter.PartnerTypeId != null)
+            {
+                query = query.Where(p => p.PartnerTypeId == filter.PartnerTypeId.Value);
+            }
+
+            if (filter.City != null)
+            {
+                query = query.Where(p => p.City == filter.City);
+            }
+
+            if (filter.Region != null)
+            {
+                query = query.Where(p => p.Region == filter.Region);
+            }
+
+            if (filter.Country != null)
+            {
+                query = query.Where(p => p.Country == filter.Country);
+            }
+
+            if (filter.HomePageEnabled != null)
+            {
+                query = query.Where(p => p.HomePageEnabled == filter.HomePageEnabled.Value);
+            }
+
+            if (filter.IsFeatured != null)
+            {
+                query = query.Where(p => p.IsFeatured == filter.IsFeatured.Value);
+            }
+
+            return query.OrderBy(p => p.Name);
+        }
+    }
+}

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -39,7 +39,7 @@
             services.AddScoped<ILookupManager<EventType>, LookupManager<EventType>>();
             services.AddScoped<ILookupManager<InvitationStatus>, LookupManager<InvitationStatus>>();
             services.AddScoped<IKeyedManager<JobOpportunity>, KeyedManager<JobOpportunity>>();
-            services.AddScoped<IKeyedManager<Partner>, KeyedManager<Partner>>();
+            services.AddScoped<IKeyedManager<Partner>, PartnerManager>();
             services.AddScoped<IKeyedManager<PartnerDocument>, PartnerDocumentManager>();
             services.AddScoped<IKeyedManager<PartnerContact>, KeyedManager<PartnerContact>>();
             services.AddScoped<IKeyedManager<PartnerLocation>, KeyedManager<PartnerLocation>>();
@@ -72,6 +72,7 @@
             services.AddScoped<IEventAttendeeMetricsManager, EventAttendeeMetricsManager>();
             services.AddScoped<IEventManager, EventManager>();
             services.AddScoped<IEventPartnerLocationServiceManager, EventPartnerLocationServiceManager>();
+            services.AddScoped<IPartnerManager, PartnerManager>();
             services.AddScoped<IPartnerAdminManager, PartnerAdminManager>();
             services.AddScoped<IPartnerAdminInvitationManager, PartnerAdminInvitationManager>();
             services.AddScoped<IPartnerContactManager, PartnerContactManager>();

--- a/TrashMob/Controllers/V2/PartnersV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnersV2Controller.cs
@@ -1,0 +1,78 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Extensions;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for partners with server-side pagination and filtering.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partners")]
+    public class PartnersV2Controller(
+        IPartnerManager partnerManager,
+        ILogger<PartnersV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets a paginated list of active partners with optional filtering.
+        /// </summary>
+        /// <param name="filter">Query parameters for pagination and filtering.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A paginated list of partners.</returns>
+        /// <response code="200">Returns the paginated partner list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(PagedResponse<PartnerDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetPartners(
+            [FromQuery] PartnerQueryParameters filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartners requested with Page={Page}, PageSize={PageSize}",
+                filter.Page, filter.PageSize);
+
+            var query = partnerManager.GetFilteredPartnersQueryable(filter);
+            var result = await query.ToPagedAsync(filter, p => p.ToV2Dto(), cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a single partner by its identifier.
+        /// </summary>
+        /// <param name="id">The partner identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The partner details.</returns>
+        /// <response code="200">Returns the partner.</response>
+        /// <response code="404">Partner not found or inactive.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(PartnerDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetPartner(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartner requested for {PartnerId}", id);
+
+            var partner = await partnerManager.GetAsync(id, cancellationToken);
+
+            if (partner is null || partner.PartnerStatusId == (int)PartnerStatusEnum.Inactive)
+            {
+                return NotFound();
+            }
+
+            return Ok(partner.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v2/partners` with server-side pagination and filtering by PartnerTypeId, City/Region/Country, HomePageEnabled, IsFeatured (active partners only)
- Adds `GET /api/v2/partners/{id}` to retrieve a single partner (returns 404 for inactive)
- Creates `PartnerDto` (public-safe flat DTO — excludes PrivateNotes, ContactEmail, ContactPhone, adoptable area defaults)
- Creates `IPartnerManager`/`PartnerManager` (previously Partner used only generic `IKeyedManager<Partner>`)
- Updates `ServiceBuilder.cs` to register the new custom manager (v1 `PartnerController` continues to work via `IKeyedManager<Partner>` resolution)

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors
- [x] `dotnet test TrashMob.Shared.Tests` — 537 passed (2 pre-existing failures unrelated)
- [ ] Verify `GET /api/v2/partners` returns `PagedResponse<PartnerDto>`
- [ ] Verify `GET /api/v2/partners?partnerTypeId=3&homePageEnabled=true` filters community partners
- [ ] Verify `GET /api/v2/partners/{id}` returns partner details
- [ ] Verify `GET /api/v2/partners/{nonexistent}` returns 404
- [ ] Verify DTO excludes PrivateNotes, ContactEmail, ContactPhone

🤖 Generated with [Claude Code](https://claude.com/claude-code)