### PR TITLE
Add EventAttendees v2 endpoint with count and list

### DIFF
--- a/TrashMob.Models/Extensions/V2/EventAttendeeMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventAttendeeMappingsV2.cs
@@ -1,0 +1,29 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping EventAttendee entities to V2 DTOs.
+    /// </summary>
+    public static class EventAttendeeMappingsV2
+    {
+        /// <summary>
+        /// Maps an EventAttendee entity to a V2 EventAttendeeDto, including basic user info.
+        /// Requires the User navigation property to be loaded.
+        /// </summary>
+        /// <param name="entity">The EventAttendee entity to map.</param>
+        /// <returns>An EventAttendeeDto with attendee and user info.</returns>
+        public static EventAttendeeDto ToV2Dto(this EventAttendee entity)
+        {
+            return new EventAttendeeDto
+            {
+                UserId = entity.UserId,
+                UserName = entity.User?.UserName ?? string.Empty,
+                GivenName = entity.User?.GivenName ?? string.Empty,
+                ProfilePhotoUrl = entity.User?.ProfilePhotoUrl ?? string.Empty,
+                SignUpDate = entity.SignUpDate,
+                IsEventLead = entity.IsEventLead,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/EventAttendeeCountDto.cs
+++ b/TrashMob.Models/Poco/V2/EventAttendeeCountDto.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of an event's active attendee count.
+    /// </summary>
+    public class EventAttendeeCountDto
+    {
+        /// <summary>
+        /// Gets or sets the event identifier.
+        /// </summary>
+        public Guid EventId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of active attendees.
+        /// </summary>
+        public int Count { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/EventAttendeeDto.cs
+++ b/TrashMob.Models/Poco/V2/EventAttendeeDto.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of an event attendee with basic user info.
+    /// </summary>
+    public class EventAttendeeDto
+    {
+        /// <summary>
+        /// Gets or sets the identifier of the attending user.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display username of the attendee.
+        /// </summary>
+        public string UserName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the given (first) name of the attendee.
+        /// </summary>
+        public string GivenName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the URL of the attendee's profile photo.
+        /// </summary>
+        public string ProfilePhotoUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the date and time when the user signed up.
+        /// </summary>
+        public DateTimeOffset SignUpDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this attendee is an event lead.
+        /// </summary>
+        public bool IsEventLead { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeesV2ControllerTests.cs
@@ -1,0 +1,138 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class EventAttendeesV2ControllerTests
+    {
+        private readonly Mock<IEventAttendeeManager> eventAttendeeManager = new();
+        private readonly Mock<ILogger<EventAttendeesV2Controller>> logger = new();
+        private readonly EventAttendeesV2Controller controller;
+
+        public EventAttendeesV2ControllerTests()
+        {
+            controller = new EventAttendeesV2Controller(eventAttendeeManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetAttendeeCount_ReturnsOkWithCount()
+        {
+            var eventId = Guid.NewGuid();
+
+            eventAttendeeManager
+                .Setup(m => m.GetActiveAttendeeCountAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(15);
+
+            var result = await controller.GetAttendeeCount(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventAttendeeCountDto>(okResult.Value);
+            Assert.Equal(eventId, dto.EventId);
+            Assert.Equal(15, dto.Count);
+        }
+
+        [Fact]
+        public async Task GetAttendeeCount_ReturnsZero_WhenNoAttendees()
+        {
+            var eventId = Guid.NewGuid();
+
+            eventAttendeeManager
+                .Setup(m => m.GetActiveAttendeeCountAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(0);
+
+            var result = await controller.GetAttendeeCount(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventAttendeeCountDto>(okResult.Value);
+            Assert.Equal(0, dto.Count);
+        }
+
+        [Fact]
+        public async Task GetAttendees_ReturnsOkWithPagedResponse()
+        {
+            var eventId = Guid.NewGuid();
+            var attendees = new List<EventAttendee>
+            {
+                new()
+                {
+                    EventId = eventId,
+                    UserId = Guid.NewGuid(),
+                    SignUpDate = new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero),
+                    IsEventLead = true,
+                    User = new User
+                    {
+                        UserName = "leaduser",
+                        GivenName = "Lead",
+                        ProfilePhotoUrl = "https://example.com/lead.jpg",
+                    },
+                },
+                new()
+                {
+                    EventId = eventId,
+                    UserId = Guid.NewGuid(),
+                    SignUpDate = new DateTimeOffset(2026, 3, 2, 10, 0, 0, TimeSpan.Zero),
+                    IsEventLead = false,
+                    User = new User
+                    {
+                        UserName = "volunteer1",
+                        GivenName = "Alex",
+                        ProfilePhotoUrl = "https://example.com/alex.jpg",
+                    },
+                },
+            };
+
+            var queryable = new TestAsyncEnumerable<EventAttendee>(attendees);
+            var filter = new QueryParameters { Page = 1, PageSize = 25 };
+
+            eventAttendeeManager
+                .Setup(m => m.GetEventAttendeesQueryable(eventId))
+                .Returns(queryable);
+
+            var result = await controller.GetAttendees(eventId, filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<EventAttendeeDto>>(okResult.Value);
+            Assert.Equal(2, response.Items.Count);
+            Assert.Equal("leaduser", response.Items[0].UserName);
+            Assert.True(response.Items[0].IsEventLead);
+            Assert.Equal("volunteer1", response.Items[1].UserName);
+            Assert.False(response.Items[1].IsEventLead);
+        }
+
+        [Fact]
+        public async Task GetAttendees_ReturnsEmptyPagedResponse_WhenNoAttendees()
+        {
+            var eventId = Guid.NewGuid();
+            var queryable = new TestAsyncEnumerable<EventAttendee>(Enumerable.Empty<EventAttendee>());
+            var filter = new QueryParameters { Page = 1, PageSize = 25 };
+
+            eventAttendeeManager
+                .Setup(m => m.GetEventAttendeesQueryable(eventId))
+                .Returns(queryable);
+
+            var result = await controller.GetAttendees(eventId, filter, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var response = Assert.IsType<PagedResponse<EventAttendeeDto>>(okResult.Value);
+            Assert.Empty(response.Items);
+            Assert.Equal(0, response.Pagination.TotalCount);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/EventAttendeeMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventAttendeeMappingsV2Tests.cs
@@ -1,0 +1,55 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class EventAttendeeMappingsV2Tests
+    {
+        [Fact]
+        public void ToV2Dto_MapsAllProperties()
+        {
+            var entity = new EventAttendee
+            {
+                UserId = Guid.NewGuid(),
+                SignUpDate = new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero),
+                IsEventLead = true,
+                User = new User
+                {
+                    UserName = "cleanupking",
+                    GivenName = "Alex",
+                    ProfilePhotoUrl = "https://example.com/photo.jpg",
+                },
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.UserId, dto.UserId);
+            Assert.Equal("cleanupking", dto.UserName);
+            Assert.Equal("Alex", dto.GivenName);
+            Assert.Equal("https://example.com/photo.jpg", dto.ProfilePhotoUrl);
+            Assert.Equal(entity.SignUpDate, dto.SignUpDate);
+            Assert.True(dto.IsEventLead);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullUser()
+        {
+            var entity = new EventAttendee
+            {
+                UserId = Guid.NewGuid(),
+                SignUpDate = DateTimeOffset.UtcNow,
+                IsEventLead = false,
+                User = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.UserId, dto.UserId);
+            Assert.Equal(string.Empty, dto.UserName);
+            Assert.Equal(string.Empty, dto.GivenName);
+            Assert.Equal(string.Empty, dto.ProfilePhotoUrl);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -248,5 +248,22 @@ namespace TrashMob.Shared.Managers.Events
                 recipients,
                 cancellationToken);
         }
+
+        /// <inheritdoc />
+        public IQueryable<EventAttendee> GetEventAttendeesQueryable(Guid eventId)
+        {
+            return Repository.Get()
+                .Where(ea => ea.EventId == eventId && ea.CanceledDate == null)
+                .Include(ea => ea.User)
+                .OrderBy(ea => ea.SignUpDate);
+        }
+
+        /// <inheritdoc />
+        public async Task<int> GetActiveAttendeeCountAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            return await Repository.Get()
+                .Where(ea => ea.EventId == eventId && ea.CanceledDate == null)
+                .CountAsync(cancellationToken);
+        }
     }
 }

--- a/TrashMob.Shared/Managers/Interfaces/IEventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IEventAttendeeManager.cs
@@ -2,6 +2,7 @@ namespace TrashMob.Shared.Managers.Interfaces
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using TrashMob.Models;
@@ -78,5 +79,21 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>The updated event attendee without lead status.</returns>
         Task<EventAttendee> DemoteFromLeadAsync(Guid eventId, Guid userId, Guid demotedByUserId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a queryable of active attendees for an event, including User navigation.
+        /// The returned IQueryable is not materialized, allowing the caller to apply ToPagedAsync().
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <returns>An unmaterialized queryable of active event attendees with User included.</returns>
+        IQueryable<EventAttendee> GetEventAttendeesQueryable(Guid eventId);
+
+        /// <summary>
+        /// Gets the count of active (non-canceled) attendees for an event.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The number of active attendees.</returns>
+        Task<int> GetActiveAttendeeCountAsync(Guid eventId, CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
@@ -1,0 +1,80 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared.Extensions;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for event attendees as a nested resource under events.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/events/{eventId}/attendees")]
+    public class EventAttendeesV2Controller(
+        IEventAttendeeManager eventAttendeeManager,
+        ILogger<EventAttendeesV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets the count of active attendees for an event.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The attendee count.</returns>
+        /// <response code="200">Returns the attendee count.</response>
+        [HttpGet("count")]
+        [ProducesResponseType(typeof(EventAttendeeCountDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetAttendeeCount(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAttendeeCount requested for Event={EventId}", eventId);
+
+            var count = await eventAttendeeManager.GetActiveAttendeeCountAsync(eventId, cancellationToken);
+
+            return Ok(new EventAttendeeCountDto
+            {
+                EventId = eventId,
+                Count = count,
+            });
+        }
+
+        /// <summary>
+        /// Gets a paginated list of active attendees for an event. Requires authentication.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="filter">Query parameters for pagination.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A paginated list of event attendees with user info.</returns>
+        /// <response code="200">Returns the paginated attendee list.</response>
+        /// <response code="401">Authentication required.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PagedResponse<EventAttendeeDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetAttendees(
+            Guid eventId,
+            [FromQuery] QueryParameters filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAttendees requested for Event={EventId}, Page={Page}, PageSize={PageSize}",
+                eventId, filter.Page, filter.PageSize);
+
+            var query = eventAttendeeManager.GetEventAttendeesQueryable(eventId);
+            var result = await query.ToPagedAsync(filter, ea => ea.ToV2Dto(), cancellationToken);
+
+            return Ok(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v2/events/{eventId}/attendees/count` — **public** endpoint returning active attendee count (no auth needed)
- Adds `GET /api/v2/events/{eventId}/attendees` — **authenticated** endpoint returning paginated attendee list with user info (UserName, GivenName, ProfilePhotoUrl, SignUpDate, IsEventLead)
- Creates `EventAttendeeDto` and `EventAttendeeCountDto` DTOs
- Creates `EventAttendeeMappingsV2` extension (maps attendee + User navigation)
- Adds `GetEventAttendeesQueryable` and `GetActiveAttendeeCountAsync` to `IEventAttendeeManager`/`EventAttendeeManager`
- First v2 endpoint using nested route pattern (`/api/v2/events/{eventId}/attendees`)
- First v2 endpoint requiring authentication (`[Authorize(Policy = ValidUser)]`)

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors
- [x] `dotnet test TrashMob.Shared.Tests` — 543 passed (2 pre-existing failures unrelated)
- [ ] Verify `GET /api/v2/events/{eventId}/attendees/count` returns count without auth
- [ ] Verify `GET /api/v2/events/{eventId}/attendees` returns 401 without auth
- [ ] Verify `GET /api/v2/events/{eventId}/attendees` returns `PagedResponse<EventAttendeeDto>` with auth
- [ ] Verify canceled attendees excluded from both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)