### PR TITLE
Add EventSummary and Leaderboards v2 endpoints

### DIFF
--- a/TrashMob.Models/Extensions/V2/EventSummaryMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventSummaryMappingsV2.cs
@@ -1,0 +1,33 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for <see cref="EventSummary"/>.
+    /// </summary>
+    public static class EventSummaryMappingsV2
+    {
+        /// <summary>
+        /// Maps an <see cref="EventSummary"/> entity to a <see cref="EventSummaryDto"/>.
+        /// </summary>
+        /// <param name="entity">The event summary entity.</param>
+        /// <returns>A V2 event summary DTO.</returns>
+        public static EventSummaryDto ToV2Dto(this EventSummary entity)
+        {
+            return new EventSummaryDto
+            {
+                EventId = entity.EventId,
+                NumberOfBuckets = entity.NumberOfBuckets,
+                NumberOfBags = entity.NumberOfBags,
+                DurationInMinutes = entity.DurationInMinutes,
+                ActualNumberOfAttendees = entity.ActualNumberOfAttendees,
+                PickedWeight = entity.PickedWeight,
+                PickedWeightUnitId = entity.PickedWeightUnitId,
+                IsFromRouteData = entity.IsFromRouteData,
+                Notes = entity.Notes ?? string.Empty,
+                CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/EventSummaryDto.cs
+++ b/TrashMob.Models/Poco/V2/EventSummaryDto.cs
@@ -1,0 +1,67 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of an event's post-completion summary metrics.
+    /// </summary>
+    public class EventSummaryDto
+    {
+        /// <summary>
+        /// Gets or sets the event identifier.
+        /// </summary>
+        public Guid EventId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of buckets filled during the event.
+        /// </summary>
+        public int NumberOfBuckets { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of bags filled during the event.
+        /// </summary>
+        public int NumberOfBags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actual duration of the event in minutes.
+        /// </summary>
+        public int DurationInMinutes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the actual number of attendees who participated.
+        /// </summary>
+        public int ActualNumberOfAttendees { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total weight of trash collected.
+        /// </summary>
+        public decimal PickedWeight { get; set; }
+
+        /// <summary>
+        /// Gets or sets the weight unit identifier (Pound or Kilogram).
+        /// </summary>
+        public int PickedWeightUnitId { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this summary was auto-populated from route data.
+        /// </summary>
+        public bool IsFromRouteData { get; set; }
+
+        /// <summary>
+        /// Gets or sets any additional notes about the event.
+        /// </summary>
+        public string Notes { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets when the summary was created.
+        /// </summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the summary was last updated.
+        /// </summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/LeaderboardEntryDto.cs
+++ b/TrashMob.Models/Poco/V2/LeaderboardEntryDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a single leaderboard entry.
+    /// </summary>
+    public class LeaderboardEntryDto
+    {
+        /// <summary>
+        /// Gets or sets the entity identifier (user, team, or community).
+        /// </summary>
+        public Guid EntityId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display name for the entity.
+        /// </summary>
+        public string EntityName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the entity type (User, Team, Community).
+        /// </summary>
+        public string EntityType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the rank position on the leaderboard.
+        /// </summary>
+        public int Rank { get; set; }
+
+        /// <summary>
+        /// Gets or sets the score value.
+        /// </summary>
+        public decimal Score { get; set; }
+
+        /// <summary>
+        /// Gets or sets the formatted score for display (e.g., "42 events", "150 lbs").
+        /// </summary>
+        public string FormattedScore { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the region for location-based filtering.
+        /// </summary>
+        public string Region { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the city for location-based filtering.
+        /// </summary>
+        public string City { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the profile photo URL for the entity.
+        /// </summary>
+        public string ProfilePhotoUrl { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Models/Poco/V2/LeaderboardOptionsDto.cs
+++ b/TrashMob.Models/Poco/V2/LeaderboardOptionsDto.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// V2 API representation of available leaderboard query options.
+    /// </summary>
+    public class LeaderboardOptionsDto
+    {
+        /// <summary>
+        /// Gets or sets the available leaderboard types (e.g., Events, Bags, Weight, Hours).
+        /// </summary>
+        public string[] Types { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets the available time ranges (e.g., Week, Month, Year, AllTime).
+        /// </summary>
+        public string[] TimeRanges { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets the available location scopes (e.g., Global, Region, City).
+        /// </summary>
+        public string[] LocationScopes { get; set; } = [];
+    }
+}

--- a/TrashMob.Models/Poco/V2/LeaderboardResponseDto.cs
+++ b/TrashMob.Models/Poco/V2/LeaderboardResponseDto.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// V2 API representation of a leaderboard query response.
+    /// </summary>
+    public class LeaderboardResponseDto
+    {
+        /// <summary>
+        /// Gets or sets the leaderboard type (Events, Bags, Weight, Hours).
+        /// </summary>
+        public string LeaderboardType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the time range (Week, Month, Year, AllTime).
+        /// </summary>
+        public string TimeRange { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the location scope (Global, Region, City).
+        /// </summary>
+        public string LocationScope { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the location value (region or city name).
+        /// </summary>
+        public string LocationValue { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets when this leaderboard data was last computed.
+        /// </summary>
+        public DateTimeOffset ComputedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total number of entries available.
+        /// </summary>
+        public int TotalEntries { get; set; }
+
+        /// <summary>
+        /// Gets or sets the leaderboard entries.
+        /// </summary>
+        public IReadOnlyList<LeaderboardEntryDto> Entries { get; set; } = [];
+    }
+}

--- a/TrashMob.Models/Poco/V2/TeamRankDto.cs
+++ b/TrashMob.Models/Poco/V2/TeamRankDto.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a team's rank on a leaderboard.
+    /// </summary>
+    public class TeamRankDto
+    {
+        /// <summary>
+        /// Gets or sets the team identifier.
+        /// </summary>
+        public Guid TeamId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the team name.
+        /// </summary>
+        public string TeamName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the leaderboard type.
+        /// </summary>
+        public string LeaderboardType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the time range.
+        /// </summary>
+        public string TimeRange { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the team's current rank. Null if not ranked.
+        /// </summary>
+        public int? Rank { get; set; }
+
+        /// <summary>
+        /// Gets or sets the team's score. Null if not ranked.
+        /// </summary>
+        public decimal? Score { get; set; }
+
+        /// <summary>
+        /// Gets or sets the formatted score for display.
+        /// </summary>
+        public string FormattedScore { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the total number of ranked teams.
+        /// </summary>
+        public int TotalRanked { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the team is eligible to appear on leaderboards.
+        /// </summary>
+        public bool IsEligible { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason if not eligible.
+        /// </summary>
+        public string IneligibleReason { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserRankDto.cs
+++ b/TrashMob.Models/Poco/V2/UserRankDto.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// V2 API representation of the current user's rank on a leaderboard.
+    /// </summary>
+    public class UserRankDto
+    {
+        /// <summary>
+        /// Gets or sets the leaderboard type.
+        /// </summary>
+        public string LeaderboardType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the time range.
+        /// </summary>
+        public string TimeRange { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's current rank. Null if not ranked.
+        /// </summary>
+        public int? Rank { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's score. Null if not ranked.
+        /// </summary>
+        public decimal? Score { get; set; }
+
+        /// <summary>
+        /// Gets or sets the formatted score for display.
+        /// </summary>
+        public string FormattedScore { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the total number of ranked users.
+        /// </summary>
+        public int TotalRanked { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the user is eligible to appear on leaderboards.
+        /// </summary>
+        public bool IsEligible { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason if not eligible.
+        /// </summary>
+        public string IneligibleReason { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventSummaryV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventSummaryV2ControllerTests.cs
@@ -1,0 +1,86 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class EventSummaryV2ControllerTests
+    {
+        private readonly Mock<IEventSummaryManager> eventSummaryManager = new();
+        private readonly Mock<ILogger<EventSummaryV2Controller>> logger = new();
+        private readonly EventSummaryV2Controller controller;
+
+        public EventSummaryV2ControllerTests()
+        {
+            controller = new EventSummaryV2Controller(eventSummaryManager.Object, logger.Object);
+        }
+
+        [Fact]
+        public async Task GetEventSummary_ReturnsSummary_WhenExists()
+        {
+            var eventId = Guid.NewGuid();
+            var summary = new EventSummary
+            {
+                EventId = eventId,
+                NumberOfBuckets = 3,
+                NumberOfBags = 10,
+                DurationInMinutes = 90,
+                ActualNumberOfAttendees = 6,
+                PickedWeight = 25.5m,
+                PickedWeightUnitId = 1,
+                IsFromRouteData = false,
+                Notes = "Good turnout",
+                CreatedDate = new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero),
+                LastUpdatedDate = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero),
+            };
+
+            eventSummaryManager
+                .Setup(m => m.GetAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<EventSummary, bool>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventSummary> { summary });
+
+            var result = await controller.GetEventSummary(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventSummaryDto>(okResult.Value);
+            Assert.Equal(eventId, dto.EventId);
+            Assert.Equal(3, dto.NumberOfBuckets);
+            Assert.Equal(10, dto.NumberOfBags);
+            Assert.Equal(90, dto.DurationInMinutes);
+            Assert.Equal(6, dto.ActualNumberOfAttendees);
+            Assert.Equal(25.5m, dto.PickedWeight);
+            Assert.Equal(1, dto.PickedWeightUnitId);
+            Assert.False(dto.IsFromRouteData);
+            Assert.Equal("Good turnout", dto.Notes);
+        }
+
+        [Fact]
+        public async Task GetEventSummary_ReturnsEmptySummary_WhenNoneExists()
+        {
+            var eventId = Guid.NewGuid();
+
+            eventSummaryManager
+                .Setup(m => m.GetAsync(It.IsAny<System.Linq.Expressions.Expression<System.Func<EventSummary, bool>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventSummary>());
+
+            var result = await controller.GetEventSummary(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventSummaryDto>(okResult.Value);
+            Assert.Equal(eventId, dto.EventId);
+            Assert.Equal(0, dto.NumberOfBags);
+            Assert.Equal(0, dto.NumberOfBuckets);
+            Assert.Equal(0, dto.DurationInMinutes);
+            Assert.Equal(0, dto.ActualNumberOfAttendees);
+            Assert.Equal(0m, dto.PickedWeight);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/LeaderboardsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/LeaderboardsV2ControllerTests.cs
@@ -1,0 +1,217 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class LeaderboardsV2ControllerTests
+    {
+        private readonly Mock<ILeaderboardManager> leaderboardManager = new();
+        private readonly Mock<ILogger<LeaderboardsV2Controller>> logger = new();
+        private readonly LeaderboardsV2Controller controller;
+
+        public LeaderboardsV2ControllerTests()
+        {
+            controller = new LeaderboardsV2Controller(leaderboardManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetLeaderboard_ReturnsOkWithEntries()
+        {
+            var response = new LeaderboardResponse
+            {
+                LeaderboardType = "Events",
+                TimeRange = "Month",
+                LocationScope = "Global",
+                ComputedDate = DateTimeOffset.UtcNow,
+                TotalEntries = 2,
+                Entries = new List<LeaderboardEntry>
+                {
+                    new()
+                    {
+                        EntityId = Guid.NewGuid(),
+                        EntityName = "TopUser",
+                        EntityType = "User",
+                        Rank = 1,
+                        Score = 10,
+                        FormattedScore = "10 events",
+                    },
+                    new()
+                    {
+                        EntityId = Guid.NewGuid(),
+                        EntityName = "RunnerUp",
+                        EntityType = "User",
+                        Rank = 2,
+                        Score = 8,
+                        FormattedScore = "8 events",
+                    },
+                },
+            };
+
+            leaderboardManager
+                .Setup(m => m.GetLeaderboardAsync("Events", "Month", "Global", null, 50, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await controller.GetLeaderboard(cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<LeaderboardResponseDto>(okResult.Value);
+            Assert.Equal("Events", dto.LeaderboardType);
+            Assert.Equal(2, dto.Entries.Count);
+            Assert.Equal("TopUser", dto.Entries[0].EntityName);
+            Assert.Equal(1, dto.Entries[0].Rank);
+        }
+
+        [Fact]
+        public async Task GetTeamLeaderboard_ReturnsOkWithEntries()
+        {
+            var response = new LeaderboardResponse
+            {
+                LeaderboardType = "Bags",
+                TimeRange = "Year",
+                LocationScope = "Global",
+                TotalEntries = 1,
+                Entries = new List<LeaderboardEntry>
+                {
+                    new()
+                    {
+                        EntityId = Guid.NewGuid(),
+                        EntityName = "Eco Warriors",
+                        EntityType = "Team",
+                        Rank = 1,
+                        Score = 500,
+                        FormattedScore = "500 bags",
+                    },
+                },
+            };
+
+            leaderboardManager
+                .Setup(m => m.GetTeamLeaderboardAsync("Bags", "Year", "Global", null, 50, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await controller.GetTeamLeaderboard(type: "Bags", timeRange: "Year", cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<LeaderboardResponseDto>(okResult.Value);
+            Assert.Equal("Bags", dto.LeaderboardType);
+            Assert.Single(dto.Entries);
+            Assert.Equal("Team", dto.Entries[0].EntityType);
+        }
+
+        [Fact]
+        public async Task GetTeamRank_ReturnsOk_WhenTeamFound()
+        {
+            var teamId = Guid.NewGuid();
+            var response = new TeamRankResponse
+            {
+                TeamId = teamId,
+                TeamName = "Green Team",
+                LeaderboardType = "Events",
+                TimeRange = "AllTime",
+                Rank = 3,
+                Score = 25,
+                FormattedScore = "25 events",
+                TotalRanked = 50,
+                IsEligible = true,
+            };
+
+            leaderboardManager
+                .Setup(m => m.GetTeamRankAsync(teamId, "Events", "AllTime", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await controller.GetTeamRank(teamId, cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<TeamRankDto>(okResult.Value);
+            Assert.Equal(teamId, dto.TeamId);
+            Assert.Equal("Green Team", dto.TeamName);
+            Assert.Equal(3, dto.Rank);
+        }
+
+        [Fact]
+        public async Task GetTeamRank_ReturnsNotFound_WhenTeamNotFound()
+        {
+            var teamId = Guid.NewGuid();
+            var response = new TeamRankResponse
+            {
+                TeamId = teamId,
+                IsEligible = false,
+                IneligibleReason = "Team not found.",
+            };
+
+            leaderboardManager
+                .Setup(m => m.GetTeamRankAsync(teamId, "Events", "AllTime", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await controller.GetTeamRank(teamId, cancellationToken: CancellationToken.None);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetMyRank_ReturnsOkWithUserRank()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var response = new UserRankResponse
+            {
+                LeaderboardType = "Events",
+                TimeRange = "AllTime",
+                Rank = 7,
+                Score = 15,
+                FormattedScore = "15 events",
+                TotalRanked = 200,
+                IsEligible = true,
+            };
+
+            leaderboardManager
+                .Setup(m => m.GetUserRankAsync(userId, "Events", "AllTime", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await controller.GetMyRank(cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserRankDto>(okResult.Value);
+            Assert.Equal(7, dto.Rank);
+            Assert.Equal(15, dto.Score);
+            Assert.True(dto.IsEligible);
+        }
+
+        [Fact]
+        public void GetOptions_ReturnsOkWithOptions()
+        {
+            leaderboardManager
+                .Setup(m => m.GetAvailableLeaderboardTypes())
+                .Returns(new[] { "Events", "Bags", "Weight", "Hours" });
+            leaderboardManager
+                .Setup(m => m.GetAvailableTimeRanges())
+                .Returns(new[] { "Week", "Month", "Year", "AllTime" });
+            leaderboardManager
+                .Setup(m => m.GetAvailableLocationScopes())
+                .Returns(new[] { "Global", "Region", "City" });
+
+            var result = controller.GetOptions();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<LeaderboardOptionsDto>(okResult.Value);
+            Assert.Equal(4, dto.Types.Length);
+            Assert.Equal(4, dto.TimeRanges.Length);
+            Assert.Equal(3, dto.LocationScopes.Length);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/EventSummaryMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventSummaryMappingsV2Tests.cs
@@ -1,0 +1,73 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class EventSummaryMappingsV2Tests
+    {
+        [Fact]
+        public void ToV2Dto_MapsAllProperties()
+        {
+            var entity = new EventSummary
+            {
+                EventId = Guid.NewGuid(),
+                NumberOfBuckets = 5,
+                NumberOfBags = 12,
+                DurationInMinutes = 120,
+                ActualNumberOfAttendees = 8,
+                PickedWeight = 45.5m,
+                PickedWeightUnitId = 1,
+                IsFromRouteData = true,
+                Notes = "Great cleanup!",
+                CreatedDate = new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero),
+                LastUpdatedDate = new DateTimeOffset(2026, 3, 2, 14, 0, 0, TimeSpan.Zero),
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(entity.EventId, dto.EventId);
+            Assert.Equal(5, dto.NumberOfBuckets);
+            Assert.Equal(12, dto.NumberOfBags);
+            Assert.Equal(120, dto.DurationInMinutes);
+            Assert.Equal(8, dto.ActualNumberOfAttendees);
+            Assert.Equal(45.5m, dto.PickedWeight);
+            Assert.Equal(1, dto.PickedWeightUnitId);
+            Assert.True(dto.IsFromRouteData);
+            Assert.Equal("Great cleanup!", dto.Notes);
+            Assert.Equal(entity.CreatedDate, dto.CreatedDate);
+            Assert.Equal(entity.LastUpdatedDate, dto.LastUpdatedDate);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullNotes()
+        {
+            var entity = new EventSummary
+            {
+                EventId = Guid.NewGuid(),
+                Notes = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.Notes);
+        }
+
+        [Fact]
+        public void ToV2Dto_HandlesNullAuditDates()
+        {
+            var entity = new EventSummary
+            {
+                EventId = Guid.NewGuid(),
+                CreatedDate = null,
+                LastUpdatedDate = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(default, dto.CreatedDate);
+            Assert.Equal(default, dto.LastUpdatedDate);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/LeaderboardMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/LeaderboardMappingsV2Tests.cs
@@ -1,0 +1,183 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using TrashMob.Shared.Extensions.V2;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class LeaderboardMappingsV2Tests
+    {
+        [Fact]
+        public void LeaderboardResponse_ToV2Dto_MapsAllProperties()
+        {
+            var response = new LeaderboardResponse
+            {
+                LeaderboardType = "Events",
+                TimeRange = "Month",
+                LocationScope = "Global",
+                LocationValue = null,
+                ComputedDate = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
+                TotalEntries = 100,
+                Entries = new List<LeaderboardEntry>
+                {
+                    new()
+                    {
+                        EntityId = Guid.NewGuid(),
+                        EntityName = "CleanupKing",
+                        EntityType = "User",
+                        Rank = 1,
+                        Score = 42,
+                        FormattedScore = "42 events",
+                        Region = "Washington",
+                        City = "Seattle",
+                        ProfilePhotoUrl = "https://example.com/photo.jpg",
+                    },
+                },
+            };
+
+            var dto = response.ToV2Dto();
+
+            Assert.Equal("Events", dto.LeaderboardType);
+            Assert.Equal("Month", dto.TimeRange);
+            Assert.Equal("Global", dto.LocationScope);
+            Assert.Equal(string.Empty, dto.LocationValue);
+            Assert.Equal(response.ComputedDate, dto.ComputedDate);
+            Assert.Equal(100, dto.TotalEntries);
+            Assert.Single(dto.Entries);
+            Assert.Equal("CleanupKing", dto.Entries[0].EntityName);
+            Assert.Equal(1, dto.Entries[0].Rank);
+            Assert.Equal(42, dto.Entries[0].Score);
+            Assert.Equal("42 events", dto.Entries[0].FormattedScore);
+        }
+
+        [Fact]
+        public void LeaderboardEntry_ToV2Dto_MapsAllProperties()
+        {
+            var entityId = Guid.NewGuid();
+            var entry = new LeaderboardEntry
+            {
+                EntityId = entityId,
+                EntityName = "TrashTeam",
+                EntityType = "Team",
+                Rank = 3,
+                Score = 150.5m,
+                FormattedScore = "150 lbs",
+                Region = "Oregon",
+                City = "Portland",
+                ProfilePhotoUrl = "https://example.com/team.jpg",
+            };
+
+            var dto = entry.ToV2Dto();
+
+            Assert.Equal(entityId, dto.EntityId);
+            Assert.Equal("TrashTeam", dto.EntityName);
+            Assert.Equal("Team", dto.EntityType);
+            Assert.Equal(3, dto.Rank);
+            Assert.Equal(150.5m, dto.Score);
+            Assert.Equal("150 lbs", dto.FormattedScore);
+            Assert.Equal("Oregon", dto.Region);
+            Assert.Equal("Portland", dto.City);
+            Assert.Equal("https://example.com/team.jpg", dto.ProfilePhotoUrl);
+        }
+
+        [Fact]
+        public void UserRankResponse_ToV2Dto_MapsAllProperties()
+        {
+            var response = new UserRankResponse
+            {
+                LeaderboardType = "Bags",
+                TimeRange = "AllTime",
+                Rank = 5,
+                Score = 200m,
+                FormattedScore = "200 bags",
+                TotalRanked = 500,
+                IsEligible = true,
+                IneligibleReason = null,
+            };
+
+            var dto = response.ToV2Dto();
+
+            Assert.Equal("Bags", dto.LeaderboardType);
+            Assert.Equal("AllTime", dto.TimeRange);
+            Assert.Equal(5, dto.Rank);
+            Assert.Equal(200m, dto.Score);
+            Assert.Equal("200 bags", dto.FormattedScore);
+            Assert.Equal(500, dto.TotalRanked);
+            Assert.True(dto.IsEligible);
+            Assert.Equal(string.Empty, dto.IneligibleReason);
+        }
+
+        [Fact]
+        public void UserRankResponse_ToV2Dto_HandlesIneligibleUser()
+        {
+            var response = new UserRankResponse
+            {
+                LeaderboardType = "Events",
+                TimeRange = "Month",
+                Rank = null,
+                Score = null,
+                FormattedScore = null,
+                TotalRanked = 100,
+                IsEligible = false,
+                IneligibleReason = "Fewer than 3 events",
+            };
+
+            var dto = response.ToV2Dto();
+
+            Assert.Null(dto.Rank);
+            Assert.Null(dto.Score);
+            Assert.Equal(string.Empty, dto.FormattedScore);
+            Assert.False(dto.IsEligible);
+            Assert.Equal("Fewer than 3 events", dto.IneligibleReason);
+        }
+
+        [Fact]
+        public void TeamRankResponse_ToV2Dto_MapsAllProperties()
+        {
+            var teamId = Guid.NewGuid();
+            var response = new TeamRankResponse
+            {
+                TeamId = teamId,
+                TeamName = "Eco Warriors",
+                LeaderboardType = "Weight",
+                TimeRange = "Year",
+                Rank = 2,
+                Score = 500m,
+                FormattedScore = "500 lbs",
+                TotalRanked = 50,
+                IsEligible = true,
+                IneligibleReason = null,
+            };
+
+            var dto = response.ToV2Dto();
+
+            Assert.Equal(teamId, dto.TeamId);
+            Assert.Equal("Eco Warriors", dto.TeamName);
+            Assert.Equal("Weight", dto.LeaderboardType);
+            Assert.Equal("Year", dto.TimeRange);
+            Assert.Equal(2, dto.Rank);
+            Assert.Equal(500m, dto.Score);
+            Assert.Equal("500 lbs", dto.FormattedScore);
+            Assert.Equal(50, dto.TotalRanked);
+            Assert.True(dto.IsEligible);
+            Assert.Equal(string.Empty, dto.IneligibleReason);
+        }
+
+        [Fact]
+        public void LeaderboardResponse_ToV2Dto_HandlesNullEntries()
+        {
+            var response = new LeaderboardResponse
+            {
+                LeaderboardType = "Events",
+                TimeRange = "Week",
+                LocationScope = "Global",
+                Entries = null,
+            };
+
+            var dto = response.ToV2Dto();
+
+            Assert.Empty(dto.Entries);
+        }
+    }
+}

--- a/TrashMob.Shared/Extensions/V2/LeaderboardMappingsV2.cs
+++ b/TrashMob.Shared/Extensions/V2/LeaderboardMappingsV2.cs
@@ -1,0 +1,94 @@
+namespace TrashMob.Shared.Extensions.V2
+{
+    using System.Linq;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 mapping extensions for leaderboard response types.
+    /// </summary>
+    public static class LeaderboardMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="LeaderboardResponse"/> to a <see cref="LeaderboardResponseDto"/>.
+        /// </summary>
+        /// <param name="response">The leaderboard response.</param>
+        /// <returns>A V2 leaderboard response DTO.</returns>
+        public static LeaderboardResponseDto ToV2Dto(this LeaderboardResponse response)
+        {
+            return new LeaderboardResponseDto
+            {
+                LeaderboardType = response.LeaderboardType ?? string.Empty,
+                TimeRange = response.TimeRange ?? string.Empty,
+                LocationScope = response.LocationScope ?? string.Empty,
+                LocationValue = response.LocationValue ?? string.Empty,
+                ComputedDate = response.ComputedDate,
+                TotalEntries = response.TotalEntries,
+                Entries = response.Entries?.Select(e => e.ToV2Dto()).ToList() ?? [],
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="LeaderboardEntry"/> to a <see cref="LeaderboardEntryDto"/>.
+        /// </summary>
+        /// <param name="entry">The leaderboard entry.</param>
+        /// <returns>A V2 leaderboard entry DTO.</returns>
+        public static LeaderboardEntryDto ToV2Dto(this LeaderboardEntry entry)
+        {
+            return new LeaderboardEntryDto
+            {
+                EntityId = entry.EntityId,
+                EntityName = entry.EntityName ?? string.Empty,
+                EntityType = entry.EntityType ?? string.Empty,
+                Rank = entry.Rank,
+                Score = entry.Score,
+                FormattedScore = entry.FormattedScore ?? string.Empty,
+                Region = entry.Region ?? string.Empty,
+                City = entry.City ?? string.Empty,
+                ProfilePhotoUrl = entry.ProfilePhotoUrl ?? string.Empty,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="UserRankResponse"/> to a <see cref="UserRankDto"/>.
+        /// </summary>
+        /// <param name="response">The user rank response.</param>
+        /// <returns>A V2 user rank DTO.</returns>
+        public static UserRankDto ToV2Dto(this UserRankResponse response)
+        {
+            return new UserRankDto
+            {
+                LeaderboardType = response.LeaderboardType ?? string.Empty,
+                TimeRange = response.TimeRange ?? string.Empty,
+                Rank = response.Rank,
+                Score = response.Score,
+                FormattedScore = response.FormattedScore ?? string.Empty,
+                TotalRanked = response.TotalRanked,
+                IsEligible = response.IsEligible,
+                IneligibleReason = response.IneligibleReason ?? string.Empty,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="TeamRankResponse"/> to a <see cref="TeamRankDto"/>.
+        /// </summary>
+        /// <param name="response">The team rank response.</param>
+        /// <returns>A V2 team rank DTO.</returns>
+        public static TeamRankDto ToV2Dto(this TeamRankResponse response)
+        {
+            return new TeamRankDto
+            {
+                TeamId = response.TeamId,
+                TeamName = response.TeamName ?? string.Empty,
+                LeaderboardType = response.LeaderboardType ?? string.Empty,
+                TimeRange = response.TimeRange ?? string.Empty,
+                Rank = response.Rank,
+                Score = response.Score,
+                FormattedScore = response.FormattedScore ?? string.Empty,
+                TotalRanked = response.TotalRanked,
+                IsEligible = response.IsEligible,
+                IneligibleReason = response.IneligibleReason ?? string.Empty,
+            };
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventSummaryV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventSummaryV2Controller.cs
@@ -1,0 +1,54 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for event summaries as a nested resource under events.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/events/{eventId}/summary")]
+    public class EventSummaryV2Controller(
+        IEventSummaryManager eventSummaryManager,
+        ILogger<EventSummaryV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets the post-completion summary for an event.
+        /// Returns an empty summary with just the EventId if none exists yet.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The event summary.</returns>
+        /// <response code="200">Returns the event summary.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(EventSummaryDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetEventSummary(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventSummary requested for Event={EventId}", eventId);
+
+            var eventSummary =
+                (await eventSummaryManager.GetAsync(es => es.EventId == eventId, cancellationToken)).FirstOrDefault();
+
+            if (eventSummary is null)
+            {
+                return Ok(new EventSummaryDto { EventId = eventId });
+            }
+
+            return Ok(eventSummary.ToV2Dto());
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/LeaderboardsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LeaderboardsV2Controller.cs
@@ -1,0 +1,176 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Extensions.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for leaderboard operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/leaderboards")]
+    public class LeaderboardsV2Controller(
+        ILeaderboardManager leaderboardManager,
+        ILogger<LeaderboardsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets the user leaderboard for the specified parameters.
+        /// </summary>
+        /// <param name="type">The leaderboard type (Events, Bags, Weight, Hours). Default: Events.</param>
+        /// <param name="timeRange">The time range (Week, Month, Year, AllTime). Default: Month.</param>
+        /// <param name="scope">The location scope (Global, Region, City). Default: Global.</param>
+        /// <param name="location">The location value (required if scope is not Global).</param>
+        /// <param name="limit">Maximum entries to return (1-100). Default: 50.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The leaderboard response.</returns>
+        /// <response code="200">Returns the leaderboard.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(LeaderboardResponseDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetLeaderboard(
+            [FromQuery] string type = "Events",
+            [FromQuery] string timeRange = "Month",
+            [FromQuery] string scope = "Global",
+            [FromQuery] string location = null,
+            [FromQuery] int limit = 50,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetLeaderboard requested Type={Type}, TimeRange={TimeRange}, Scope={Scope}, Limit={Limit}",
+                type, timeRange, scope, limit);
+
+            var response = await leaderboardManager.GetLeaderboardAsync(
+                type, timeRange, scope, location, limit, cancellationToken);
+
+            return Ok(response.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the team leaderboard for the specified parameters.
+        /// </summary>
+        /// <param name="type">The leaderboard type (Events, Bags, Weight, Hours). Default: Events.</param>
+        /// <param name="timeRange">The time range (Week, Month, Year, AllTime). Default: Month.</param>
+        /// <param name="scope">The location scope (Global, Region, City). Default: Global.</param>
+        /// <param name="location">The location value (required if scope is not Global).</param>
+        /// <param name="limit">Maximum entries to return (1-100). Default: 50.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The team leaderboard response.</returns>
+        /// <response code="200">Returns the team leaderboard.</response>
+        [HttpGet("teams")]
+        [ProducesResponseType(typeof(LeaderboardResponseDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetTeamLeaderboard(
+            [FromQuery] string type = "Events",
+            [FromQuery] string timeRange = "Month",
+            [FromQuery] string scope = "Global",
+            [FromQuery] string location = null,
+            [FromQuery] int limit = 50,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetTeamLeaderboard requested Type={Type}, TimeRange={TimeRange}, Scope={Scope}, Limit={Limit}",
+                type, timeRange, scope, limit);
+
+            var response = await leaderboardManager.GetTeamLeaderboardAsync(
+                type, timeRange, scope, location, limit, cancellationToken);
+
+            return Ok(response.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets a specific team's rank on a leaderboard.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="type">The leaderboard type. Default: Events.</param>
+        /// <param name="timeRange">The time range. Default: AllTime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The team's rank information.</returns>
+        /// <response code="200">Returns the team's rank.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpGet("teams/{teamId}/rank")]
+        [ProducesResponseType(typeof(TeamRankDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetTeamRank(
+            Guid teamId,
+            [FromQuery] string type = "Events",
+            [FromQuery] string timeRange = "AllTime",
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetTeamRank requested Team={TeamId}, Type={Type}, TimeRange={TimeRange}",
+                teamId, type, timeRange);
+
+            var response = await leaderboardManager.GetTeamRankAsync(
+                teamId, type, timeRange, cancellationToken);
+
+            if (response.IneligibleReason == "Team not found.")
+            {
+                return NotFound(response.ToV2Dto());
+            }
+
+            return Ok(response.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the current authenticated user's rank on a leaderboard.
+        /// </summary>
+        /// <param name="type">The leaderboard type. Default: Events.</param>
+        /// <param name="timeRange">The time range. Default: AllTime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The user's rank information.</returns>
+        /// <response code="200">Returns the user's rank.</response>
+        /// <response code="401">Authentication required.</response>
+        [HttpGet("my-rank")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(UserRankDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetMyRank(
+            [FromQuery] string type = "Events",
+            [FromQuery] string timeRange = "AllTime",
+            CancellationToken cancellationToken = default)
+        {
+            var userId = new Guid(HttpContext.Items["UserId"].ToString());
+
+            logger.LogInformation("V2 GetMyRank requested User={UserId}, Type={Type}, TimeRange={TimeRange}",
+                userId, type, timeRange);
+
+            var response = await leaderboardManager.GetUserRankAsync(
+                userId, type, timeRange, cancellationToken);
+
+            return Ok(response.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the available leaderboard options (types, time ranges, scopes).
+        /// </summary>
+        /// <returns>Available leaderboard options.</returns>
+        /// <response code="200">Returns the available options.</response>
+        [HttpGet("options")]
+        [ProducesResponseType(typeof(LeaderboardOptionsDto), StatusCodes.Status200OK)]
+        public IActionResult GetOptions()
+        {
+            logger.LogInformation("V2 GetOptions requested");
+
+            return Ok(new LeaderboardOptionsDto
+            {
+                Types = leaderboardManager.GetAvailableLeaderboardTypes(),
+                TimeRanges = leaderboardManager.GetAvailableTimeRanges(),
+                LocationScopes = leaderboardManager.GetAvailableLocationScopes(),
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **EventSummary v2**: `GET /api/v2/events/{eventId}/summary` — public nested endpoint returning post-completion event metrics (bags, buckets, weight, duration, attendees). Returns empty DTO when no summary exists yet, matching existing mobile app behavior.
- **Leaderboards v2**: 5 endpoints under `/api/v2/leaderboards` — user leaderboard, team leaderboard, team rank lookup, authenticated `my-rank` (first v2 endpoint extracting UserId from HttpContext), and available options. V2 DTOs decouple API contract from internal POCOs.
- No manager interface or implementation changes needed — both endpoints use existing manager methods.
- 14 new files, 0 modified. Build: 0 errors. Tests: 560 passed (2 pre-existing failures).

## Test plan
- [ ] `dotnet build TrashMob.sln` — zero errors
- [ ] `dotnet test TrashMob.Shared.Tests` — all new tests pass (9 mapping + 8 controller)
- [ ] Verify `GET /api/v2/events/{eventId}/summary` returns summary or empty DTO
- [ ] Verify `GET /api/v2/leaderboards?type=Events&timeRange=Month` returns leaderboard
- [ ] Verify `GET /api/v2/leaderboards/teams` returns team leaderboard
- [ ] Verify `GET /api/v2/leaderboards/my-rank` returns 401 without auth, rank data with auth
- [ ] Verify `GET /api/v2/leaderboards/options` returns available types/ranges/scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)