### PR TITLE
Add Achievements v2 endpoints

### DIFF
--- a/TrashMob.Models/Poco/V2/AchievementNotificationDto.cs
+++ b/TrashMob.Models/Poco/V2/AchievementNotificationDto.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a newly earned achievement notification.
+    /// </summary>
+    public class AchievementNotificationDto
+    {
+        /// <summary>
+        /// Gets or sets the achievement that was earned.
+        /// </summary>
+        public UserAchievementDto Achievement { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets when the achievement was earned.
+        /// </summary>
+        public DateTimeOffset EarnedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/AchievementTypeDto.cs
+++ b/TrashMob.Models/Poco/V2/AchievementTypeDto.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// V2 API representation of an achievement type from the catalog.
+    /// </summary>
+    public class AchievementTypeDto
+    {
+        /// <summary>
+        /// Gets or sets the achievement type identifier.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the machine name of the achievement.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user-facing display name.
+        /// </summary>
+        public string DisplayName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the description of the achievement.
+        /// </summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the category (e.g., Participation, Impact, Special).
+        /// </summary>
+        public string Category { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the URL of the achievement's badge icon.
+        /// </summary>
+        public string IconUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the points awarded for earning this achievement.
+        /// </summary>
+        public int Points { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display order for sorting in lists.
+        /// </summary>
+        public int DisplayOrder { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserAchievementDto.cs
+++ b/TrashMob.Models/Poco/V2/UserAchievementDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of an individual achievement with the user's earned status.
+    /// </summary>
+    public class UserAchievementDto
+    {
+        /// <summary>
+        /// Gets or sets the achievement type identifier.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the machine name of the achievement.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user-facing display name.
+        /// </summary>
+        public string DisplayName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the description of the achievement.
+        /// </summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the category (e.g., Participation, Impact, Special).
+        /// </summary>
+        public string Category { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the URL of the achievement's badge icon.
+        /// </summary>
+        public string IconUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the points awarded for this achievement.
+        /// </summary>
+        public int Points { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this achievement has been earned by the user.
+        /// </summary>
+        public bool IsEarned { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the achievement was earned. Null if not earned.
+        /// </summary>
+        public DateTimeOffset? EarnedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserAchievementsResponseDto.cs
+++ b/TrashMob.Models/Poco/V2/UserAchievementsResponseDto.cs
@@ -1,0 +1,38 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// V2 API representation of a user's complete achievements summary.
+    /// </summary>
+    public class UserAchievementsResponseDto
+    {
+        /// <summary>
+        /// Gets or sets the user identifier.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total points earned from all achievements.
+        /// </summary>
+        public int TotalPoints { get; set; }
+
+        /// <summary>
+        /// Gets or sets the count of achievements earned.
+        /// </summary>
+        public int EarnedCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total count of available achievements.
+        /// </summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of achievements with earned status.
+        /// </summary>
+        public IReadOnlyList<UserAchievementDto> Achievements { get; set; } = [];
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/AchievementsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/AchievementsV2ControllerTests.cs
@@ -1,0 +1,199 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class AchievementsV2ControllerTests
+    {
+        private readonly Mock<IAchievementManager> achievementManager = new();
+        private readonly Mock<ILogger<AchievementsV2Controller>> logger = new();
+        private readonly AchievementsV2Controller controller;
+
+        public AchievementsV2ControllerTests()
+        {
+            controller = new AchievementsV2Controller(achievementManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetAchievementTypes_ReturnsOkWithTypes()
+        {
+            var types = new List<AchievementType>
+            {
+                new()
+                {
+                    Id = 1,
+                    Name = "first_cleanup",
+                    DisplayName = "First Cleanup",
+                    Description = "Attend your first event",
+                    Category = "Participation",
+                    IconUrl = "https://example.com/first.png",
+                    Points = 10,
+                    DisplayOrder = 1,
+                },
+                new()
+                {
+                    Id = 2,
+                    Name = "bag_collector",
+                    DisplayName = "Bag Collector",
+                    Description = "Collect 100 bags",
+                    Category = "Impact",
+                    IconUrl = "https://example.com/bags.png",
+                    Points = 50,
+                    DisplayOrder = 2,
+                },
+            };
+
+            achievementManager
+                .Setup(m => m.GetAchievementTypesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(types);
+
+            var result = await controller.GetAchievementTypes(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IReadOnlyList<AchievementTypeDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("First Cleanup", dtos[0].DisplayName);
+            Assert.Equal("Bag Collector", dtos[1].DisplayName);
+        }
+
+        [Fact]
+        public async Task GetUserAchievements_ReturnsOkWithResponse()
+        {
+            var userId = Guid.NewGuid();
+            var response = new UserAchievementsResponse
+            {
+                UserId = userId,
+                TotalPoints = 60,
+                EarnedCount = 2,
+                TotalCount = 10,
+                Achievements = new List<AchievementDto>
+                {
+                    new()
+                    {
+                        Id = 1,
+                        Name = "first_cleanup",
+                        DisplayName = "First Cleanup",
+                        Points = 10,
+                        IsEarned = true,
+                        EarnedDate = DateTimeOffset.UtcNow,
+                    },
+                },
+            };
+
+            achievementManager
+                .Setup(m => m.GetUserAchievementsAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await controller.GetUserAchievements(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserAchievementsResponseDto>(okResult.Value);
+            Assert.Equal(userId, dto.UserId);
+            Assert.Equal(60, dto.TotalPoints);
+            Assert.Equal(2, dto.EarnedCount);
+            Assert.Single(dto.Achievements);
+        }
+
+        [Fact]
+        public async Task GetMyAchievements_ReturnsOkWithResponse()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var response = new UserAchievementsResponse
+            {
+                UserId = userId,
+                TotalPoints = 100,
+                EarnedCount = 5,
+                TotalCount = 10,
+                Achievements = new List<AchievementDto>(),
+            };
+
+            achievementManager
+                .Setup(m => m.GetUserAchievementsAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await controller.GetMyAchievements(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserAchievementsResponseDto>(okResult.Value);
+            Assert.Equal(userId, dto.UserId);
+            Assert.Equal(100, dto.TotalPoints);
+            Assert.Equal(5, dto.EarnedCount);
+        }
+
+        [Fact]
+        public async Task GetUnreadAchievements_ReturnsOkWithNotifications()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var earnedDate = new DateTimeOffset(2026, 3, 5, 14, 0, 0, TimeSpan.Zero);
+            var notifications = new List<NewAchievementNotification>
+            {
+                new()
+                {
+                    Achievement = new AchievementDto
+                    {
+                        Id = 3,
+                        Name = "team_player",
+                        DisplayName = "Team Player",
+                        Points = 25,
+                        IsEarned = true,
+                        EarnedDate = earnedDate,
+                    },
+                    EarnedDate = earnedDate,
+                },
+            };
+
+            achievementManager
+                .Setup(m => m.GetUnreadAchievementsAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(notifications);
+
+            var result = await controller.GetUnreadAchievements(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<AchievementNotificationDto>>(okResult.Value);
+            Assert.Single(dtos);
+            Assert.Equal("Team Player", dtos[0].Achievement.DisplayName);
+            Assert.Equal(earnedDate, dtos[0].EarnedDate);
+        }
+
+        [Fact]
+        public async Task MarkAchievementsAsRead_ReturnsNoContent()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var achievementTypeIds = new List<int> { 1, 3, 5 };
+
+            achievementManager
+                .Setup(m => m.MarkAchievementsAsReadAsync(userId, It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.MarkAchievementsAsRead(achievementTypeIds, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            achievementManager.Verify(
+                m => m.MarkAchievementsAsReadAsync(userId, It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/AchievementMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/AchievementMappingsV2Tests.cs
@@ -1,0 +1,195 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using TrashMob.Models;
+    using TrashMob.Shared.Extensions.V2;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class AchievementMappingsV2Tests
+    {
+        [Fact]
+        public void AchievementType_ToV2Dto_MapsAllProperties()
+        {
+            var entity = new AchievementType
+            {
+                Id = 5,
+                Name = "first_cleanup",
+                DisplayName = "First Cleanup",
+                Description = "Attend your first cleanup event",
+                Category = "Participation",
+                IconUrl = "https://example.com/badge.png",
+                Points = 10,
+                DisplayOrder = 1,
+                IsActive = true,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(5, dto.Id);
+            Assert.Equal("first_cleanup", dto.Name);
+            Assert.Equal("First Cleanup", dto.DisplayName);
+            Assert.Equal("Attend your first cleanup event", dto.Description);
+            Assert.Equal("Participation", dto.Category);
+            Assert.Equal("https://example.com/badge.png", dto.IconUrl);
+            Assert.Equal(10, dto.Points);
+            Assert.Equal(1, dto.DisplayOrder);
+        }
+
+        [Fact]
+        public void AchievementType_ToV2Dto_HandlesNullProperties()
+        {
+            var entity = new AchievementType
+            {
+                Id = 1,
+                Name = null,
+                DisplayName = null,
+                Description = null,
+                Category = null,
+                IconUrl = null,
+                DisplayOrder = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.Name);
+            Assert.Equal(string.Empty, dto.DisplayName);
+            Assert.Equal(string.Empty, dto.Description);
+            Assert.Equal(string.Empty, dto.Category);
+            Assert.Equal(string.Empty, dto.IconUrl);
+            Assert.Equal(0, dto.DisplayOrder);
+        }
+
+        [Fact]
+        public void AchievementDto_ToV2Dto_MapsAllProperties()
+        {
+            var dto = new AchievementDto
+            {
+                Id = 3,
+                Name = "bag_collector",
+                DisplayName = "Bag Collector",
+                Description = "Collect 100 bags",
+                Category = "Impact",
+                IconUrl = "https://example.com/bags.png",
+                Points = 50,
+                IsEarned = true,
+                EarnedDate = new DateTimeOffset(2026, 2, 15, 10, 0, 0, TimeSpan.Zero),
+            };
+
+            var v2Dto = dto.ToV2Dto();
+
+            Assert.Equal(3, v2Dto.Id);
+            Assert.Equal("bag_collector", v2Dto.Name);
+            Assert.Equal("Bag Collector", v2Dto.DisplayName);
+            Assert.Equal("Collect 100 bags", v2Dto.Description);
+            Assert.Equal("Impact", v2Dto.Category);
+            Assert.Equal("https://example.com/bags.png", v2Dto.IconUrl);
+            Assert.Equal(50, v2Dto.Points);
+            Assert.True(v2Dto.IsEarned);
+            Assert.Equal(dto.EarnedDate, v2Dto.EarnedDate);
+        }
+
+        [Fact]
+        public void AchievementDto_ToV2Dto_HandlesUnearnedAchievement()
+        {
+            var dto = new AchievementDto
+            {
+                Id = 1,
+                Name = "event_leader",
+                IsEarned = false,
+                EarnedDate = null,
+            };
+
+            var v2Dto = dto.ToV2Dto();
+
+            Assert.False(v2Dto.IsEarned);
+            Assert.Null(v2Dto.EarnedDate);
+        }
+
+        [Fact]
+        public void UserAchievementsResponse_ToV2Dto_MapsAllProperties()
+        {
+            var userId = Guid.NewGuid();
+            var response = new UserAchievementsResponse
+            {
+                UserId = userId,
+                TotalPoints = 60,
+                EarnedCount = 2,
+                TotalCount = 10,
+                Achievements = new List<AchievementDto>
+                {
+                    new()
+                    {
+                        Id = 1,
+                        Name = "first_cleanup",
+                        DisplayName = "First Cleanup",
+                        Points = 10,
+                        IsEarned = true,
+                        EarnedDate = DateTimeOffset.UtcNow,
+                    },
+                    new()
+                    {
+                        Id = 2,
+                        Name = "team_player",
+                        DisplayName = "Team Player",
+                        Points = 50,
+                        IsEarned = true,
+                        EarnedDate = DateTimeOffset.UtcNow,
+                    },
+                },
+            };
+
+            var v2Dto = response.ToV2Dto();
+
+            Assert.Equal(userId, v2Dto.UserId);
+            Assert.Equal(60, v2Dto.TotalPoints);
+            Assert.Equal(2, v2Dto.EarnedCount);
+            Assert.Equal(10, v2Dto.TotalCount);
+            Assert.Equal(2, v2Dto.Achievements.Count);
+            Assert.Equal("First Cleanup", v2Dto.Achievements[0].DisplayName);
+            Assert.Equal("Team Player", v2Dto.Achievements[1].DisplayName);
+        }
+
+        [Fact]
+        public void NewAchievementNotification_ToV2Dto_MapsAllProperties()
+        {
+            var earnedDate = new DateTimeOffset(2026, 3, 5, 14, 0, 0, TimeSpan.Zero);
+            var notification = new NewAchievementNotification
+            {
+                Achievement = new AchievementDto
+                {
+                    Id = 7,
+                    Name = "weight_champion",
+                    DisplayName = "Weight Champion",
+                    Points = 100,
+                    IsEarned = true,
+                    EarnedDate = earnedDate,
+                },
+                EarnedDate = earnedDate,
+            };
+
+            var v2Dto = notification.ToV2Dto();
+
+            Assert.Equal(7, v2Dto.Achievement.Id);
+            Assert.Equal("Weight Champion", v2Dto.Achievement.DisplayName);
+            Assert.Equal(100, v2Dto.Achievement.Points);
+            Assert.Equal(earnedDate, v2Dto.EarnedDate);
+        }
+
+        [Fact]
+        public void NewAchievementNotification_ToV2Dto_HandlesNullAchievement()
+        {
+            var notification = new NewAchievementNotification
+            {
+                Achievement = null,
+                EarnedDate = DateTimeOffset.UtcNow,
+            };
+
+            var v2Dto = notification.ToV2Dto();
+
+            Assert.NotNull(v2Dto.Achievement);
+            Assert.Equal(0, v2Dto.Achievement.Id);
+        }
+    }
+}

--- a/TrashMob.Shared/Extensions/V2/AchievementMappingsV2.cs
+++ b/TrashMob.Shared/Extensions/V2/AchievementMappingsV2.cs
@@ -1,0 +1,85 @@
+namespace TrashMob.Shared.Extensions.V2
+{
+    using System.Linq;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 mapping extensions for achievement types.
+    /// </summary>
+    public static class AchievementMappingsV2
+    {
+        /// <summary>
+        /// Maps an <see cref="AchievementType"/> entity to an <see cref="AchievementTypeDto"/>.
+        /// </summary>
+        /// <param name="entity">The achievement type entity.</param>
+        /// <returns>A V2 achievement type DTO.</returns>
+        public static AchievementTypeDto ToV2Dto(this AchievementType entity)
+        {
+            return new AchievementTypeDto
+            {
+                Id = entity.Id,
+                Name = entity.Name ?? string.Empty,
+                DisplayName = entity.DisplayName ?? string.Empty,
+                Description = entity.Description ?? string.Empty,
+                Category = entity.Category ?? string.Empty,
+                IconUrl = entity.IconUrl ?? string.Empty,
+                Points = entity.Points,
+                DisplayOrder = entity.DisplayOrder.GetValueOrDefault(),
+            };
+        }
+
+        /// <summary>
+        /// Maps an <see cref="AchievementDto"/> to a <see cref="UserAchievementDto"/>.
+        /// </summary>
+        /// <param name="dto">The achievement DTO.</param>
+        /// <returns>A V2 user achievement DTO.</returns>
+        public static UserAchievementDto ToV2Dto(this AchievementDto dto)
+        {
+            return new UserAchievementDto
+            {
+                Id = dto.Id,
+                Name = dto.Name ?? string.Empty,
+                DisplayName = dto.DisplayName ?? string.Empty,
+                Description = dto.Description ?? string.Empty,
+                Category = dto.Category ?? string.Empty,
+                IconUrl = dto.IconUrl ?? string.Empty,
+                Points = dto.Points,
+                IsEarned = dto.IsEarned,
+                EarnedDate = dto.EarnedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="UserAchievementsResponse"/> to a <see cref="UserAchievementsResponseDto"/>.
+        /// </summary>
+        /// <param name="response">The user achievements response.</param>
+        /// <returns>A V2 user achievements response DTO.</returns>
+        public static UserAchievementsResponseDto ToV2Dto(this UserAchievementsResponse response)
+        {
+            return new UserAchievementsResponseDto
+            {
+                UserId = response.UserId,
+                TotalPoints = response.TotalPoints,
+                EarnedCount = response.EarnedCount,
+                TotalCount = response.TotalCount,
+                Achievements = response.Achievements?.Select(a => a.ToV2Dto()).ToList() ?? [],
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="NewAchievementNotification"/> to an <see cref="AchievementNotificationDto"/>.
+        /// </summary>
+        /// <param name="notification">The achievement notification.</param>
+        /// <returns>A V2 achievement notification DTO.</returns>
+        public static AchievementNotificationDto ToV2Dto(this NewAchievementNotification notification)
+        {
+            return new AchievementNotificationDto
+            {
+                Achievement = notification.Achievement?.ToV2Dto() ?? new UserAchievementDto(),
+                EarnedDate = notification.EarnedDate,
+            };
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/AchievementsV2Controller.cs
+++ b/TrashMob/Controllers/V2/AchievementsV2Controller.cs
@@ -1,0 +1,145 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Extensions.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for achievement operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/achievements")]
+    public class AchievementsV2Controller(
+        IAchievementManager achievementManager,
+        ILogger<AchievementsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets all available achievement types.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The list of achievement types.</returns>
+        /// <response code="200">Returns the achievement types.</response>
+        [HttpGet("types")]
+        [ProducesResponseType(typeof(IReadOnlyList<AchievementTypeDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetAchievementTypes(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAchievementTypes requested");
+
+            var types = await achievementManager.GetAchievementTypesAsync(cancellationToken);
+            var dtos = types.Select(t => t.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a specific user's achievements (public profile view).
+        /// </summary>
+        /// <param name="userId">The user identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The user's achievements summary.</returns>
+        /// <response code="200">Returns the user's achievements.</response>
+        [HttpGet("user/{userId}")]
+        [ProducesResponseType(typeof(UserAchievementsResponseDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetUserAchievements(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUserAchievements requested for User={UserId}", userId);
+
+            var response = await achievementManager.GetUserAchievementsAsync(userId, cancellationToken);
+
+            return Ok(response.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the current authenticated user's achievements.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The current user's achievements summary.</returns>
+        /// <response code="200">Returns the user's achievements.</response>
+        /// <response code="401">Authentication required.</response>
+        [HttpGet("my")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(UserAchievementsResponseDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetMyAchievements(CancellationToken cancellationToken)
+        {
+            var userId = new Guid(HttpContext.Items["UserId"].ToString());
+
+            logger.LogInformation("V2 GetMyAchievements requested for User={UserId}", userId);
+
+            var response = await achievementManager.GetUserAchievementsAsync(userId, cancellationToken);
+
+            return Ok(response.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the current user's unread (newly earned) achievement notifications.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The list of unread achievement notifications.</returns>
+        /// <response code="200">Returns unread notifications.</response>
+        /// <response code="401">Authentication required.</response>
+        [HttpGet("my/unread")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<AchievementNotificationDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetUnreadAchievements(CancellationToken cancellationToken)
+        {
+            var userId = new Guid(HttpContext.Items["UserId"].ToString());
+
+            logger.LogInformation("V2 GetUnreadAchievements requested for User={UserId}", userId);
+
+            var notifications = await achievementManager.GetUnreadAchievementsAsync(userId, cancellationToken);
+            var dtos = notifications.Select(n => n.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Marks achievements as read/notified for the current user.
+        /// </summary>
+        /// <param name="achievementTypeIds">The achievement type IDs to mark as read.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Achievements marked as read.</response>
+        /// <response code="401">Authentication required.</response>
+        [HttpPost("my/mark-read")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> MarkAchievementsAsRead(
+            [FromBody] IEnumerable<int> achievementTypeIds,
+            CancellationToken cancellationToken)
+        {
+            var userId = new Guid(HttpContext.Items["UserId"].ToString());
+
+            logger.LogInformation("V2 MarkAchievementsAsRead requested for User={UserId}", userId);
+
+            await achievementManager.MarkAchievementsAsReadAsync(userId, achievementTypeIds, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Achievements v2**: 5 endpoints under `/api/v2/achievements` covering the full mobile workflow
  - `GET types` — public achievement type catalog
  - `GET user/{userId}` — public profile view of a user's achievements
  - `GET my` — authenticated user's own achievements with earned status
  - `GET my/unread` — authenticated unread achievement notifications
  - `POST my/mark-read` — authenticated write endpoint to dismiss notifications (first v2 write endpoint)
- V2 DTOs decouple API contract from internal POCOs (`AchievementDto` → `UserAchievementDto`, etc.)
- Mappings in `TrashMob.Shared/Extensions/V2/` since source POCOs live in `TrashMob.Shared`
- No manager changes needed — thin wrapper over existing `IAchievementManager`
- 8 new files, 0 modified. Build: 0 errors. Tests: 572 passed (2 pre-existing failures).

## Test plan
- [ ] `dotnet build TrashMob.sln` — zero errors
- [ ] `dotnet test TrashMob.Shared.Tests` — all new tests pass (7 mapping + 5 controller)
- [ ] Verify `GET /api/v2/achievements/types` returns achievement type catalog
- [ ] Verify `GET /api/v2/achievements/user/{userId}` returns user's achievements
- [ ] Verify `GET /api/v2/achievements/my` returns 401 without auth, achievements with auth
- [ ] Verify `GET /api/v2/achievements/my/unread` returns unread notifications
- [ ] Verify `POST /api/v2/achievements/my/mark-read` returns 204 with valid body

🤖 Generated with [Claude Code](https://claude.com/claude-code)