### PR TITLE
Add Communities v2 endpoints

### DIFF
--- a/TrashMob.Shared.Tests/Controllers/V2/CommunitiesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunitiesV2ControllerTests.cs
@@ -1,0 +1,240 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class CommunitiesV2ControllerTests
+    {
+        private readonly Mock<ICommunityManager> communityManager = new();
+        private readonly Mock<ILogger<CommunitiesV2Controller>> logger = new();
+        private readonly CommunitiesV2Controller controller;
+
+        public CommunitiesV2ControllerTests()
+        {
+            controller = new CommunitiesV2Controller(communityManager.Object, logger.Object);
+        }
+
+        [Fact]
+        public async Task GetCommunities_ReturnsOkWithList()
+        {
+            var communities = new List<Partner>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Seattle Cleanup",
+                    Slug = "seattle-wa",
+                    HomePageEnabled = true,
+                    PartnerStatusId = 2,
+                    City = "Seattle",
+                    Region = "Washington",
+                    Country = "United States",
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Portland Green",
+                    Slug = "portland-or",
+                    HomePageEnabled = true,
+                    PartnerStatusId = 2,
+                },
+            };
+
+            communityManager
+                .Setup(m => m.GetEnabledCommunitiesAsync(null, null, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(communities);
+
+            var result = await controller.GetCommunities(cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<PartnerDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Seattle Cleanup", dtos[0].Name);
+            Assert.Equal("seattle-wa", dtos[0].Slug);
+        }
+
+        [Fact]
+        public async Task GetCommunities_WithGeoFilter_PassesParamsToManager()
+        {
+            communityManager
+                .Setup(m => m.GetEnabledCommunitiesAsync(47.6, -122.3, 25.0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Partner>());
+
+            var result = await controller.GetCommunities(47.6, -122.3, 25.0, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<PartnerDto>>(okResult.Value);
+            Assert.Empty(dtos);
+
+            communityManager.Verify(
+                m => m.GetEnabledCommunitiesAsync(47.6, -122.3, 25.0, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetCommunityBySlug_ReturnsOk_WhenFound()
+        {
+            var community = new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = "Seattle Cleanup",
+                Slug = "seattle-wa",
+                City = "Seattle",
+                Region = "Washington",
+            };
+
+            communityManager
+                .Setup(m => m.GetBySlugAsync("seattle-wa", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(community);
+
+            var result = await controller.GetCommunityBySlug("seattle-wa", CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerDto>(okResult.Value);
+            Assert.Equal("Seattle Cleanup", dto.Name);
+            Assert.Equal("seattle-wa", dto.Slug);
+        }
+
+        [Fact]
+        public async Task GetCommunityBySlug_ReturnsNotFound_WhenMissing()
+        {
+            communityManager
+                .Setup(m => m.GetBySlugAsync("nonexistent", It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.GetCommunityBySlug("nonexistent", CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetCommunityEvents_ReturnsOkWithEvents()
+        {
+            var community = new Partner { Id = Guid.NewGuid(), Slug = "seattle-wa" };
+            var events = new List<Event>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Park Cleanup",
+                    EventDate = new DateTimeOffset(2026, 4, 1, 9, 0, 0, TimeSpan.Zero),
+                    City = "Seattle",
+                    Region = "Washington",
+                    Country = "United States",
+                },
+            };
+
+            communityManager
+                .Setup(m => m.GetBySlugAsync("seattle-wa", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(community);
+            communityManager
+                .Setup(m => m.GetCommunityEventsAsync("seattle-wa", true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(events);
+
+            var result = await controller.GetCommunityEvents("seattle-wa", cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<EventDto>>(okResult.Value);
+            Assert.Single(dtos);
+            Assert.Equal("Park Cleanup", dtos[0].Name);
+        }
+
+        [Fact]
+        public async Task GetCommunityEvents_ReturnsNotFound_WhenSlugMissing()
+        {
+            communityManager
+                .Setup(m => m.GetBySlugAsync("nonexistent", It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.GetCommunityEvents("nonexistent", cancellationToken: CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetCommunityTeams_ReturnsOkWithTeams()
+        {
+            var community = new Partner { Id = Guid.NewGuid(), Slug = "seattle-wa" };
+            var teams = new List<Team>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Green Warriors",
+                    IsPublic = true,
+                    IsActive = true,
+                    City = "Seattle",
+                },
+            };
+
+            communityManager
+                .Setup(m => m.GetBySlugAsync("seattle-wa", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(community);
+            communityManager
+                .Setup(m => m.GetCommunityTeamsAsync("seattle-wa", 50, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(teams);
+
+            var result = await controller.GetCommunityTeams("seattle-wa", cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<TeamDto>>(okResult.Value);
+            Assert.Single(dtos);
+            Assert.Equal("Green Warriors", dtos[0].Name);
+        }
+
+        [Fact]
+        public async Task GetCommunityStats_ReturnsOkWithStats()
+        {
+            var community = new Partner { Id = Guid.NewGuid(), Slug = "seattle-wa" };
+            var stats = new Stats
+            {
+                TotalEvents = 25,
+                TotalBags = 150,
+                TotalHours = 300,
+                TotalParticipants = 200,
+                TotalWeightInPounds = 1500,
+                TotalWeightInKilograms = 680,
+                TotalLitterReportsSubmitted = 50,
+                TotalLitterReportsClosed = 40,
+            };
+
+            communityManager
+                .Setup(m => m.GetBySlugAsync("seattle-wa", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(community);
+            communityManager
+                .Setup(m => m.GetCommunityStatsAsync("seattle-wa", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(stats);
+
+            var result = await controller.GetCommunityStats("seattle-wa", CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<StatsDto>(okResult.Value);
+            Assert.Equal(25, dto.TotalEvents);
+            Assert.Equal(150, dto.TotalBags);
+            Assert.Equal(200, dto.TotalParticipants);
+        }
+
+        [Fact]
+        public async Task GetCommunityStats_ReturnsNotFound_WhenSlugMissing()
+        {
+            communityManager
+                .Setup(m => m.GetBySlugAsync("nonexistent", It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.GetCommunityStats("nonexistent", CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/CommunitiesV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunitiesV2Controller.cs
@@ -1,0 +1,181 @@
+namespace TrashMob.Controllers.V2
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for community discovery and sub-resources.
+    /// Communities are partners with enabled home pages.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities")]
+    public class CommunitiesV2Controller(
+        ICommunityManager communityManager,
+        ILogger<CommunitiesV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets enabled communities, optionally filtered by location.
+        /// </summary>
+        /// <param name="latitude">Optional latitude for location-based filtering.</param>
+        /// <param name="longitude">Optional longitude for location-based filtering.</param>
+        /// <param name="radiusMiles">Optional radius in miles. All three geo params required for filtering.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of enabled communities.</returns>
+        /// <response code="200">Returns the community list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IReadOnlyList<PartnerDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetCommunities(
+            [FromQuery] double? latitude = null,
+            [FromQuery] double? longitude = null,
+            [FromQuery] double? radiusMiles = null,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetCommunities requested Lat={Latitude}, Lon={Longitude}, Radius={RadiusMiles}",
+                latitude, longitude, radiusMiles);
+
+            var communities = await communityManager.GetEnabledCommunitiesAsync(
+                latitude, longitude, radiusMiles, cancellationToken);
+
+            var dtos = communities.Select(c => c.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a community by its URL slug.
+        /// </summary>
+        /// <param name="slug">The URL-friendly slug (e.g., "seattle-wa").</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The community details.</returns>
+        /// <response code="200">Returns the community.</response>
+        /// <response code="404">Community not found or not enabled.</response>
+        [HttpGet("{slug}")]
+        [ProducesResponseType(typeof(PartnerDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetCommunityBySlug(string slug, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetCommunityBySlug requested Slug={Slug}", slug);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(community.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets events in a community.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="upcomingOnly">If true, only returns upcoming events. Default: true.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of events in the community.</returns>
+        /// <response code="200">Returns the event list.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet("{slug}/events")]
+        [ProducesResponseType(typeof(IReadOnlyList<EventDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetCommunityEvents(
+            string slug,
+            [FromQuery] bool upcomingOnly = true,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetCommunityEvents requested Slug={Slug}, UpcomingOnly={UpcomingOnly}",
+                slug, upcomingOnly);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            var events = await communityManager.GetCommunityEventsAsync(slug, upcomingOnly, cancellationToken);
+            var dtos = events.Select(e => e.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets teams near a community by location proximity.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="radiusMiles">The radius in miles to search within. Default: 50.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of nearby teams.</returns>
+        /// <response code="200">Returns the team list.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet("{slug}/teams")]
+        [ProducesResponseType(typeof(IReadOnlyList<TeamDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetCommunityTeams(
+            string slug,
+            [FromQuery] double radiusMiles = 50,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetCommunityTeams requested Slug={Slug}, RadiusMiles={RadiusMiles}",
+                slug, radiusMiles);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            var teams = await communityManager.GetCommunityTeamsAsync(slug, radiusMiles, cancellationToken);
+            var dtos = teams.Select(t => t.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets aggregated impact stats for a community.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Community impact statistics.</returns>
+        /// <response code="200">Returns the community stats.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet("{slug}/stats")]
+        [ProducesResponseType(typeof(StatsDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetCommunityStats(
+            string slug,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetCommunityStats requested Slug={Slug}", slug);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            var stats = await communityManager.GetCommunityStatsAsync(slug, cancellationToken);
+
+            return Ok(stats.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CommunitiesV2Controller` with 5 public endpoints for community discovery (list with geo-filter, detail by slug, events, teams, stats)
- Reuses all existing v2 DTOs from prior PRs — no new DTOs or mappings needed (`PartnerDto`, `EventDto`, `TeamDto`, `StatsDto`)
- Add 9 controller unit tests

## Endpoints
| Method | Route | Description |
|--------|-------|-------------|
| GET | `/api/v2/communities` | List enabled communities (optional lat/lon/radius geo-filter) |
| GET | `/api/v2/communities/{slug}` | Community detail by URL slug |
| GET | `/api/v2/communities/{slug}/events` | Community events (upcomingOnly default true) |
| GET | `/api/v2/communities/{slug}/teams` | Nearby teams (radiusMiles default 50) |
| GET | `/api/v2/communities/{slug}/stats` | Community impact statistics |

## New Files
- `TrashMob/Controllers/V2/CommunitiesV2Controller.cs`
- `TrashMob.Shared.Tests/Controllers/V2/CommunitiesV2ControllerTests.cs`

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 581 passed (2 pre-existing failures in ProspectScoringManager)
- [ ] Verify GET endpoints return correct DTO shapes via Swagger

🤖 Generated with [Claude Code](https://claude.com/claude-code)