### PR TITLE
Add v2 endpoints for lookups, app version, contact request, and maps

### DIFF
--- a/TrashMob.Models/Extensions/V2/AddressMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/AddressMappingsV2.cs
@@ -1,0 +1,26 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for addresses.
+    /// </summary>
+    public static class AddressMappingsV2
+    {
+        /// <summary>
+        /// Maps an <see cref="Address"/> to an <see cref="AddressDto"/>.
+        /// </summary>
+        public static AddressDto ToV2Dto(this Address entity)
+        {
+            return new AddressDto
+            {
+                StreetAddress = entity.StreetAddress ?? string.Empty,
+                City = entity.City ?? string.Empty,
+                Region = entity.Region ?? string.Empty,
+                PostalCode = entity.PostalCode ?? string.Empty,
+                Country = entity.Country ?? string.Empty,
+                County = entity.County ?? string.Empty,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/ContactRequestMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/ContactRequestMappingsV2.cs
@@ -1,0 +1,23 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for contact requests.
+    /// </summary>
+    public static class ContactRequestMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="ContactRequestDto"/> to a <see cref="ContactRequest"/> entity.
+        /// </summary>
+        public static ContactRequest ToEntity(this ContactRequestDto dto)
+        {
+            return new ContactRequest
+            {
+                Name = dto.Name,
+                Email = dto.Email,
+                Message = dto.Message,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/LookupMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/LookupMappingsV2.cs
@@ -1,0 +1,24 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for lookup models.
+    /// </summary>
+    public static class LookupMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="LookupModel"/> to a <see cref="LookupItemDto"/>.
+        /// </summary>
+        public static LookupItemDto ToV2Dto(this LookupModel entity)
+        {
+            return new LookupItemDto
+            {
+                Id = entity.Id,
+                Name = entity.Name ?? string.Empty,
+                Description = entity.Description ?? string.Empty,
+                DisplayOrder = entity.DisplayOrder ?? 0,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/AddressDto.cs
+++ b/TrashMob.Models/Poco/V2/AddressDto.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a physical address returned from geocoding.
+/// </summary>
+public class AddressDto
+{
+    /// <summary>
+    /// Gets or sets the street address.
+    /// </summary>
+    public string StreetAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the city name.
+    /// </summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the region or state.
+    /// </summary>
+    public string Region { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the postal or ZIP code.
+    /// </summary>
+    public string PostalCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the country name.
+    /// </summary>
+    public string Country { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the county name.
+    /// </summary>
+    public string County { get; set; } = string.Empty;
+}

--- a/TrashMob.Models/Poco/V2/ContactRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/ContactRequestDto.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a contact request submission.
+/// </summary>
+public class ContactRequestDto
+{
+    /// <summary>
+    /// Gets or sets the name of the person making the contact request.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the email address.
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the message content.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+}

--- a/TrashMob.Models/Poco/V2/LookupItemDto.cs
+++ b/TrashMob.Models/Poco/V2/LookupItemDto.cs
@@ -1,0 +1,29 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a lookup/reference data item (e.g., event type, service type).
+/// </summary>
+public class LookupItemDto
+{
+    /// <summary>
+    /// Gets or sets the unique identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the display order for sorting.
+    /// </summary>
+    public int DisplayOrder { get; set; }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/AppVersionV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/AppVersionV2ControllerTests.cs
@@ -1,0 +1,56 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models.Poco;
+    using Xunit;
+
+    public class AppVersionV2ControllerTests
+    {
+        [Fact]
+        public void GetAppVersion_ReturnsOkWithVersionInfo()
+        {
+            var configValues = new Dictionary<string, string>
+            {
+                { "AppVersion:MinimumVersion", "2.0.0" },
+                { "AppVersion:RecommendedVersion", "2.5.0" },
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            var logger = new Mock<ILogger<AppVersionV2Controller>>();
+            var controller = new AppVersionV2Controller(configuration, logger.Object);
+
+            var result = controller.GetAppVersion();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var info = Assert.IsType<AppVersionInfo>(okResult.Value);
+            Assert.Equal("2.0.0", info.MinimumVersion);
+            Assert.Equal("2.5.0", info.RecommendedVersion);
+        }
+
+        [Fact]
+        public void GetAppVersion_ReturnsFallbackWhenConfigMissing()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>())
+                .Build();
+
+            var logger = new Mock<ILogger<AppVersionV2Controller>>();
+            var controller = new AppVersionV2Controller(configuration, logger.Object);
+
+            var result = controller.GetAppVersion();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var info = Assert.IsType<AppVersionInfo>(okResult.Value);
+            Assert.Equal("1.0.0", info.MinimumVersion);
+            Assert.Equal("1.0.0", info.RecommendedVersion);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ContactRequestV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ContactRequestV2ControllerTests.cs
@@ -1,0 +1,54 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class ContactRequestV2ControllerTests
+    {
+        private readonly Mock<IKeyedManager<ContactRequest>> contactRequestManager = new();
+        private readonly Mock<ILogger<ContactRequestV2Controller>> logger = new();
+        private readonly ContactRequestV2Controller controller;
+
+        public ContactRequestV2ControllerTests()
+        {
+            controller = new ContactRequestV2Controller(contactRequestManager.Object, logger.Object);
+        }
+
+        [Fact]
+        public async Task Add_Returns201Created()
+        {
+            var dto = new ContactRequestDto
+            {
+                Name = "Jane Doe",
+                Email = "jane@example.com",
+                Message = "I want to help!",
+            };
+
+            contactRequestManager
+                .Setup(m => m.AddAsync(It.IsAny<ContactRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ContactRequest());
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var statusResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(201, statusResult.StatusCode);
+
+            contactRequestManager.Verify(
+                m => m.AddAsync(
+                    It.Is<ContactRequest>(e =>
+                        e.Name == "Jane Doe" &&
+                        e.Email == "jane@example.com" &&
+                        e.Message == "I want to help!"),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/LookupsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/LookupsV2ControllerTests.cs
@@ -1,0 +1,89 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class LookupsV2ControllerTests
+    {
+        private readonly Mock<ILookupManager<EventType>> eventTypeManager = new();
+        private readonly Mock<ILookupManager<ServiceType>> serviceTypeManager = new();
+        private readonly Mock<ILookupManager<EventPartnerLocationServiceStatus>> partnerServiceStatusManager = new();
+        private readonly Mock<ILogger<LookupsV2Controller>> logger = new();
+        private readonly LookupsV2Controller controller;
+
+        public LookupsV2ControllerTests()
+        {
+            controller = new LookupsV2Controller(
+                eventTypeManager.Object,
+                serviceTypeManager.Object,
+                partnerServiceStatusManager.Object,
+                logger.Object);
+        }
+
+        [Fact]
+        public async Task GetEventTypes_ReturnsOkWithList()
+        {
+            var types = new List<EventType>
+            {
+                new() { Id = 1, Name = "Park Cleanup", Description = "Clean up a park", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Beach Cleanup", Description = "Clean up a beach", DisplayOrder = 2 },
+            };
+
+            eventTypeManager.Setup(m => m.GetAsync()).ReturnsAsync(types);
+
+            var result = await controller.GetEventTypes();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Park Cleanup", dtos[0].Name);
+            Assert.Equal("Beach Cleanup", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetServiceTypes_ReturnsOkWithList()
+        {
+            var types = new List<ServiceType>
+            {
+                new() { Id = 1, Name = "Hauling", Description = "Waste hauling service", DisplayOrder = 1 },
+            };
+
+            serviceTypeManager.Setup(m => m.GetAsync()).ReturnsAsync(types);
+
+            var result = await controller.GetServiceTypes();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Single(dtos);
+            Assert.Equal("Hauling", dtos[0].Name);
+        }
+
+        [Fact]
+        public async Task GetPartnerServiceStatuses_ReturnsOkWithList()
+        {
+            var statuses = new List<EventPartnerLocationServiceStatus>
+            {
+                new() { Id = 1, Name = "Requested", Description = "Service requested", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Accepted", Description = "Service accepted", DisplayOrder = 2 },
+            };
+
+            partnerServiceStatusManager.Setup(m => m.GetAsync()).ReturnsAsync(statuses);
+
+            var result = await controller.GetPartnerServiceStatuses();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Requested", dtos[0].Name);
+            Assert.Equal("Accepted", dtos[1].Name);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/MapsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/MapsV2ControllerTests.cs
@@ -1,0 +1,53 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class MapsV2ControllerTests
+    {
+        private readonly Mock<IMapManager> mapManager = new();
+        private readonly Mock<ILogger<MapsV2Controller>> logger = new();
+        private readonly MapsV2Controller controller;
+
+        public MapsV2ControllerTests()
+        {
+            controller = new MapsV2Controller(mapManager.Object, logger.Object);
+        }
+
+        [Fact]
+        public async Task GetAddress_ReturnsOkWithAddressDto()
+        {
+            var address = new Address
+            {
+                StreetAddress = "123 Main St",
+                City = "Seattle",
+                Region = "Washington",
+                PostalCode = "98101",
+                Country = "United States",
+                County = "King",
+            };
+
+            mapManager
+                .Setup(m => m.GetAddressAsync(47.6, -122.3))
+                .ReturnsAsync(address);
+
+            var result = await controller.GetAddress(47.6, -122.3);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<AddressDto>(okResult.Value);
+            Assert.Equal("123 Main St", dto.StreetAddress);
+            Assert.Equal("Seattle", dto.City);
+            Assert.Equal("Washington", dto.Region);
+            Assert.Equal("98101", dto.PostalCode);
+            Assert.Equal("United States", dto.Country);
+            Assert.Equal("King", dto.County);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/AddressMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/AddressMappingsV2Tests.cs
@@ -1,0 +1,55 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class AddressMappingsV2Tests
+    {
+        [Fact]
+        public void Address_ToV2Dto_MapsAllProperties()
+        {
+            var entity = new Address
+            {
+                StreetAddress = "123 Main St",
+                City = "Seattle",
+                Region = "Washington",
+                PostalCode = "98101",
+                Country = "United States",
+                County = "King",
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal("123 Main St", dto.StreetAddress);
+            Assert.Equal("Seattle", dto.City);
+            Assert.Equal("Washington", dto.Region);
+            Assert.Equal("98101", dto.PostalCode);
+            Assert.Equal("United States", dto.Country);
+            Assert.Equal("King", dto.County);
+        }
+
+        [Fact]
+        public void Address_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new Address
+            {
+                StreetAddress = null,
+                City = null,
+                Region = null,
+                PostalCode = null,
+                Country = null,
+                County = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.StreetAddress);
+            Assert.Equal(string.Empty, dto.City);
+            Assert.Equal(string.Empty, dto.Region);
+            Assert.Equal(string.Empty, dto.PostalCode);
+            Assert.Equal(string.Empty, dto.Country);
+            Assert.Equal(string.Empty, dto.County);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/ContactRequestMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/ContactRequestMappingsV2Tests.cs
@@ -1,0 +1,38 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using Xunit;
+
+    public class ContactRequestMappingsV2Tests
+    {
+        [Fact]
+        public void ContactRequestDto_ToEntity_MapsAllProperties()
+        {
+            var dto = new ContactRequestDto
+            {
+                Name = "Jane Doe",
+                Email = "jane@example.com",
+                Message = "I'd like to volunteer!",
+            };
+
+            var entity = dto.ToEntity();
+
+            Assert.Equal("Jane Doe", entity.Name);
+            Assert.Equal("jane@example.com", entity.Email);
+            Assert.Equal("I'd like to volunteer!", entity.Message);
+        }
+
+        [Fact]
+        public void ContactRequestDto_ToEntity_HandlesEmptyStrings()
+        {
+            var dto = new ContactRequestDto();
+
+            var entity = dto.ToEntity();
+
+            Assert.Equal(string.Empty, entity.Name);
+            Assert.Equal(string.Empty, entity.Email);
+            Assert.Equal(string.Empty, entity.Message);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/LookupMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/LookupMappingsV2Tests.cs
@@ -1,0 +1,48 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class LookupMappingsV2Tests
+    {
+        [Fact]
+        public void LookupModel_ToV2Dto_MapsAllProperties()
+        {
+            var entity = new EventType
+            {
+                Id = 3,
+                Name = "Park Cleanup",
+                Description = "Clean up a local park",
+                DisplayOrder = 2,
+                IsActive = true,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(3, dto.Id);
+            Assert.Equal("Park Cleanup", dto.Name);
+            Assert.Equal("Clean up a local park", dto.Description);
+            Assert.Equal(2, dto.DisplayOrder);
+        }
+
+        [Fact]
+        public void LookupModel_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new ServiceType
+            {
+                Id = 1,
+                Name = null,
+                Description = null,
+                DisplayOrder = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(1, dto.Id);
+            Assert.Equal(string.Empty, dto.Name);
+            Assert.Equal(string.Empty, dto.Description);
+            Assert.Equal(0, dto.DisplayOrder);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/AppVersionV2Controller.cs
+++ b/TrashMob/Controllers/V2/AppVersionV2Controller.cs
@@ -1,0 +1,42 @@
+namespace TrashMob.Controllers.V2
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Poco;
+
+    /// <summary>
+    /// V2 controller for app version requirements.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/appversion")]
+    public class AppVersionV2Controller(
+        IConfiguration configuration,
+        ILogger<AppVersionV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets the minimum and recommended app version requirements.
+        /// </summary>
+        /// <returns>The app version info.</returns>
+        /// <response code="200">Returns the version requirements.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(AppVersionInfo), StatusCodes.Status200OK)]
+        public IActionResult GetAppVersion()
+        {
+            logger.LogInformation("V2 GetAppVersion requested");
+
+            var appVersionInfo = new AppVersionInfo
+            {
+                MinimumVersion = configuration["AppVersion:MinimumVersion"] ?? "1.0.0",
+                RecommendedVersion = configuration["AppVersion:RecommendedVersion"] ?? "1.0.0",
+            };
+
+            return Ok(appVersionInfo);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ContactRequestV2Controller.cs
+++ b/TrashMob/Controllers/V2/ContactRequestV2Controller.cs
@@ -1,0 +1,49 @@
+namespace TrashMob.Controllers.V2
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for contact request submissions.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/contactrequest")]
+    public class ContactRequestV2Controller(
+        IKeyedManager<ContactRequest> contactRequestManager,
+        ILogger<ContactRequestV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Submits a new contact request.
+        /// </summary>
+        /// <param name="dto">The contact request details.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>201 Created on success.</returns>
+        /// <response code="201">Contact request submitted.</response>
+        /// <response code="400">Invalid request.</response>
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Add(
+            [FromBody] ContactRequestDto dto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddContactRequest requested");
+
+            var entity = dto.ToEntity();
+            await contactRequestManager.AddAsync(entity, cancellationToken);
+
+            return StatusCode(StatusCodes.Status201Created);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/LookupsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LookupsV2Controller.cs
@@ -1,0 +1,83 @@
+namespace TrashMob.Controllers.V2
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for lookup/reference data endpoints.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/lookups")]
+    public class LookupsV2Controller(
+        ILookupManager<EventType> eventTypeManager,
+        ILookupManager<ServiceType> serviceTypeManager,
+        ILookupManager<EventPartnerLocationServiceStatus> partnerServiceStatusManager,
+        ILogger<LookupsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets all event types.
+        /// </summary>
+        /// <returns>A list of event types.</returns>
+        /// <response code="200">Returns the event type list.</response>
+        [HttpGet("event-types")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEventTypes()
+        {
+            logger.LogInformation("V2 GetEventTypes requested");
+
+            var types = await eventTypeManager.GetAsync();
+            var dtos = types.Select(t => t.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all service types.
+        /// </summary>
+        /// <returns>A list of service types.</returns>
+        /// <response code="200">Returns the service type list.</response>
+        [HttpGet("service-types")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetServiceTypes()
+        {
+            logger.LogInformation("V2 GetServiceTypes requested");
+
+            var types = await serviceTypeManager.GetAsync();
+            var dtos = types.Select(t => t.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all event partner location service statuses.
+        /// </summary>
+        /// <returns>A list of partner service statuses.</returns>
+        /// <response code="200">Returns the status list.</response>
+        [HttpGet("partner-service-statuses")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetPartnerServiceStatuses()
+        {
+            logger.LogInformation("V2 GetPartnerServiceStatuses requested");
+
+            var statuses = await partnerServiceStatusManager.GetAsync();
+            var dtos = statuses.Select(s => s.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/MapsV2Controller.cs
+++ b/TrashMob/Controllers/V2/MapsV2Controller.cs
@@ -1,0 +1,54 @@
+namespace TrashMob.Controllers.V2
+{
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for map/geocoding operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/maps")]
+    public class MapsV2Controller(
+        IMapManager mapManager,
+        ILogger<MapsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets the address for a given latitude and longitude.
+        /// </summary>
+        /// <param name="latitude">The latitude.</param>
+        /// <param name="longitude">The longitude.</param>
+        /// <returns>The address at the specified coordinates.</returns>
+        /// <response code="200">Returns the address.</response>
+        /// <response code="401">Authentication required.</response>
+        [HttpGet("address")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(AddressDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetAddress(
+            [FromQuery] double latitude,
+            [FromQuery] double longitude)
+        {
+            logger.LogInformation("V2 GetAddress requested Lat={Latitude}, Lon={Longitude}",
+                latitude, longitude);
+
+            var address = await mapManager.GetAddressAsync(latitude, longitude);
+
+            return Ok(address.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Batch 6 simple mobile-used v1 controllers into v2 with proper DTOs
- **LookupsV2Controller** — consolidated endpoint for event types, service types, and partner service statuses (shared `LookupItemDto`)
- **AppVersionV2Controller** — app version requirements (reuses existing `AppVersionInfo` POCO)
- **ContactRequestV2Controller** — contact form submission with `ContactRequestDto`
- **MapsV2Controller** — authenticated reverse geocoding with `AddressDto`

## New Endpoints
| Method | Route | Auth | Description |
|--------|-------|------|-------------|
| GET | `/api/v2/lookups/event-types` | public (24h cache) | Event type lookup |
| GET | `/api/v2/lookups/service-types` | public (24h cache) | Service type lookup |
| GET | `/api/v2/lookups/partner-service-statuses` | public (24h cache) | Partner service status lookup |
| GET | `/api/v2/appversion` | public | App version requirements |
| POST | `/api/v2/contactrequest` | public | Submit contact request |
| GET | `/api/v2/maps/address` | ValidUser | Reverse geocode to address |

## New Files (17)
- 3 DTOs: `LookupItemDto`, `ContactRequestDto`, `AddressDto`
- 3 mapping extensions + 3 mapping tests
- 4 controllers + 4 controller tests

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 594 passed (2 pre-existing failures in ProspectScoringManager)
- [ ] Verify endpoints via Swagger

🤖 Generated with [Claude Code](https://claude.com/claude-code)