### PR TITLE
Add all remaining v2 API endpoints (Phase 2 batch)

### DIFF
--- a/TrashMob.Models/Extensions/V2/DependentMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/DependentMappingsV2.cs
@@ -1,0 +1,48 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for dependents.
+    /// </summary>
+    public static class DependentMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="Dependent"/> to a <see cref="DependentDto"/>.
+        /// </summary>
+        public static DependentDto ToV2Dto(this Dependent entity)
+        {
+            return new DependentDto
+            {
+                Id = entity.Id,
+                ParentUserId = entity.ParentUserId,
+                FirstName = entity.FirstName ?? string.Empty,
+                LastName = entity.LastName ?? string.Empty,
+                DateOfBirth = entity.DateOfBirth,
+                Relationship = entity.Relationship ?? string.Empty,
+                MedicalNotes = entity.MedicalNotes ?? string.Empty,
+                EmergencyContactPhone = entity.EmergencyContactPhone ?? string.Empty,
+                IsActive = entity.IsActive,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="DependentDto"/> to a <see cref="Dependent"/> entity.
+        /// </summary>
+        public static Dependent ToEntity(this DependentDto dto)
+        {
+            return new Dependent
+            {
+                Id = dto.Id,
+                ParentUserId = dto.ParentUserId,
+                FirstName = dto.FirstName,
+                LastName = dto.LastName,
+                DateOfBirth = dto.DateOfBirth,
+                Relationship = dto.Relationship,
+                MedicalNotes = dto.MedicalNotes,
+                EmergencyContactPhone = dto.EmergencyContactPhone,
+                IsActive = dto.IsActive,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/EventAttendeeMetricsMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventAttendeeMetricsMappingsV2.cs
@@ -1,0 +1,36 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for event attendee metrics.
+    /// </summary>
+    public static class EventAttendeeMetricsMappingsV2
+    {
+        /// <summary>
+        /// Maps an <see cref="EventAttendeeMetrics"/> to an <see cref="EventAttendeeMetricsDto"/>.
+        /// </summary>
+        public static EventAttendeeMetricsDto ToV2Dto(this EventAttendeeMetrics entity)
+        {
+            return new EventAttendeeMetricsDto
+            {
+                Id = entity.Id,
+                EventId = entity.EventId,
+                UserId = entity.UserId,
+                BagsCollected = entity.BagsCollected,
+                PickedWeight = entity.PickedWeight,
+                PickedWeightUnitId = entity.PickedWeightUnitId,
+                DurationMinutes = entity.DurationMinutes,
+                Notes = entity.Notes ?? string.Empty,
+                Status = entity.Status ?? string.Empty,
+                ReviewedDate = entity.ReviewedDate,
+                RejectionReason = entity.RejectionReason ?? string.Empty,
+                AdjustedBagsCollected = entity.AdjustedBagsCollected,
+                AdjustedPickedWeight = entity.AdjustedPickedWeight,
+                AdjustedPickedWeightUnitId = entity.AdjustedPickedWeightUnitId,
+                AdjustedDurationMinutes = entity.AdjustedDurationMinutes,
+                AdjustmentReason = entity.AdjustmentReason ?? string.Empty,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/EventPartnerLocationServiceMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventPartnerLocationServiceMappingsV2.cs
@@ -1,0 +1,24 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for event partner location services.
+    /// </summary>
+    public static class EventPartnerLocationServiceMappingsV2
+    {
+        /// <summary>
+        /// Maps an <see cref="EventPartnerLocationServiceRequestDto"/> to an <see cref="EventPartnerLocationService"/> entity.
+        /// </summary>
+        public static EventPartnerLocationService ToEntity(this EventPartnerLocationServiceRequestDto dto)
+        {
+            return new EventPartnerLocationService
+            {
+                EventId = dto.EventId,
+                PartnerLocationId = dto.PartnerLocationId,
+                ServiceTypeId = dto.ServiceTypeId,
+                EventPartnerLocationServiceStatusId = dto.EventPartnerLocationServiceStatusId,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/EventPhotoMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventPhotoMappingsV2.cs
@@ -1,0 +1,29 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for event photos.
+    /// </summary>
+    public static class EventPhotoMappingsV2
+    {
+        /// <summary>
+        /// Maps an <see cref="EventPhoto"/> to an <see cref="EventPhotoDto"/>.
+        /// </summary>
+        public static EventPhotoDto ToV2Dto(this EventPhoto entity)
+        {
+            return new EventPhotoDto
+            {
+                Id = entity.Id,
+                EventId = entity.EventId,
+                UploadedByUserId = entity.UploadedByUserId,
+                ImageUrl = entity.ImageUrl ?? string.Empty,
+                ThumbnailUrl = entity.ThumbnailUrl ?? string.Empty,
+                PhotoType = entity.PhotoType,
+                Caption = entity.Caption ?? string.Empty,
+                TakenAt = entity.TakenAt,
+                UploadedDate = entity.UploadedDate,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/NewsletterMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/NewsletterMappingsV2.cs
@@ -1,0 +1,24 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for newsletter categories.
+    /// </summary>
+    public static class NewsletterMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="NewsletterCategory"/> to a <see cref="NewsletterCategoryDto"/>.
+        /// </summary>
+        public static NewsletterCategoryDto ToV2Dto(this NewsletterCategory entity)
+        {
+            return new NewsletterCategoryDto
+            {
+                Id = entity.Id,
+                Name = entity.Name ?? string.Empty,
+                Description = entity.Description ?? string.Empty,
+                IsDefault = entity.IsDefault,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/PickupLocationMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/PickupLocationMappingsV2.cs
@@ -1,0 +1,58 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for pickup locations.
+    /// </summary>
+    public static class PickupLocationMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="PickupLocation"/> to a <see cref="PickupLocationDto"/>.
+        /// </summary>
+        public static PickupLocationDto ToV2Dto(this PickupLocation entity)
+        {
+            return new PickupLocationDto
+            {
+                Id = entity.Id,
+                EventId = entity.EventId,
+                Name = entity.Name ?? string.Empty,
+                StreetAddress = entity.StreetAddress ?? string.Empty,
+                City = entity.City ?? string.Empty,
+                Region = entity.Region ?? string.Empty,
+                PostalCode = entity.PostalCode ?? string.Empty,
+                Country = entity.Country ?? string.Empty,
+                County = entity.County ?? string.Empty,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+                HasBeenSubmitted = entity.HasBeenSubmitted,
+                HasBeenPickedUp = entity.HasBeenPickedUp,
+                Notes = entity.Notes ?? string.Empty,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="PickupLocationDto"/> to a <see cref="PickupLocation"/> entity.
+        /// </summary>
+        public static PickupLocation ToEntity(this PickupLocationDto dto)
+        {
+            return new PickupLocation
+            {
+                Id = dto.Id,
+                EventId = dto.EventId,
+                Name = dto.Name,
+                StreetAddress = dto.StreetAddress,
+                City = dto.City,
+                Region = dto.Region,
+                PostalCode = dto.PostalCode,
+                Country = dto.Country,
+                County = dto.County,
+                Latitude = dto.Latitude,
+                Longitude = dto.Longitude,
+                HasBeenSubmitted = dto.HasBeenSubmitted,
+                HasBeenPickedUp = dto.HasBeenPickedUp,
+                Notes = dto.Notes,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/WaiverMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/WaiverMappingsV2.cs
@@ -1,0 +1,49 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for waivers.
+    /// </summary>
+    public static class WaiverMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="WaiverVersion"/> to a <see cref="WaiverVersionDto"/>.
+        /// </summary>
+        public static WaiverVersionDto ToV2Dto(this WaiverVersion entity)
+        {
+            return new WaiverVersionDto
+            {
+                Id = entity.Id,
+                Name = entity.Name ?? string.Empty,
+                Version = entity.Version ?? string.Empty,
+                WaiverText = entity.WaiverText ?? string.Empty,
+                EffectiveDate = entity.EffectiveDate,
+                ExpiryDate = entity.ExpiryDate,
+                IsActive = entity.IsActive,
+                Scope = entity.Scope,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="UserWaiver"/> to a <see cref="UserWaiverDto"/>.
+        /// </summary>
+        public static UserWaiverDto ToV2Dto(this UserWaiver entity)
+        {
+            return new UserWaiverDto
+            {
+                Id = entity.Id,
+                UserId = entity.UserId,
+                WaiverVersionId = entity.WaiverVersionId,
+                AcceptedDate = entity.AcceptedDate,
+                ExpiryDate = entity.ExpiryDate,
+                TypedLegalName = entity.TypedLegalName ?? string.Empty,
+                SigningMethod = entity.SigningMethod ?? string.Empty,
+                DocumentUrl = entity.DocumentUrl ?? string.Empty,
+                IsMinor = entity.IsMinor,
+                GuardianName = entity.GuardianName ?? string.Empty,
+                GuardianRelationship = entity.GuardianRelationship ?? string.Empty,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/AcceptWaiverRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/AcceptWaiverRequestDto.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Request body for accepting a waiver.
+/// </summary>
+public class AcceptWaiverRequestDto
+{
+    /// <summary>Gets or sets the waiver version to accept.</summary>
+    public Guid WaiverVersionId { get; set; }
+
+    /// <summary>Gets or sets the typed legal name.</summary>
+    public string TypedLegalName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether the user is a minor.</summary>
+    public bool IsMinor { get; set; }
+
+    /// <summary>Gets or sets the guardian user ID (if minor and registered guardian).</summary>
+    public Guid? GuardianUserId { get; set; }
+
+    /// <summary>Gets or sets the guardian name (if minor).</summary>
+    public string GuardianName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the guardian relationship (if minor).</summary>
+    public string GuardianRelationship { get; set; } = string.Empty;
+}

--- a/TrashMob.Models/Poco/V2/DependentDto.cs
+++ b/TrashMob.Models/Poco/V2/DependentDto.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a dependent (minor) linked to a parent account.
+/// </summary>
+public class DependentDto
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the parent user identifier.</summary>
+    public Guid ParentUserId { get; set; }
+
+    /// <summary>Gets or sets the first name.</summary>
+    public string FirstName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the last name.</summary>
+    public string LastName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the date of birth.</summary>
+    public DateOnly DateOfBirth { get; set; }
+
+    /// <summary>Gets or sets the relationship (parent, legal guardian, etc.).</summary>
+    public string Relationship { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets optional medical notes.</summary>
+    public string MedicalNotes { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the emergency contact phone.</summary>
+    public string EmergencyContactPhone { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether the dependent is active.</summary>
+    public bool IsActive { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/EventAttendeeMetricsDto.cs
+++ b/TrashMob.Models/Poco/V2/EventAttendeeMetricsDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents metrics submitted by an event attendee.
+/// </summary>
+public class EventAttendeeMetricsDto
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the event identifier.</summary>
+    public Guid EventId { get; set; }
+
+    /// <summary>Gets or sets the user identifier.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>Gets or sets bags collected.</summary>
+    public int? BagsCollected { get; set; }
+
+    /// <summary>Gets or sets picked weight.</summary>
+    public decimal? PickedWeight { get; set; }
+
+    /// <summary>Gets or sets the weight unit identifier.</summary>
+    public int? PickedWeightUnitId { get; set; }
+
+    /// <summary>Gets or sets duration in minutes.</summary>
+    public int? DurationMinutes { get; set; }
+
+    /// <summary>Gets or sets notes.</summary>
+    public string Notes { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the status (Pending, Approved, Rejected, Adjusted).</summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the reviewed date.</summary>
+    public DateTimeOffset? ReviewedDate { get; set; }
+
+    /// <summary>Gets or sets the rejection reason.</summary>
+    public string RejectionReason { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets adjusted bags collected.</summary>
+    public int? AdjustedBagsCollected { get; set; }
+
+    /// <summary>Gets or sets adjusted picked weight.</summary>
+    public decimal? AdjustedPickedWeight { get; set; }
+
+    /// <summary>Gets or sets adjusted weight unit identifier.</summary>
+    public int? AdjustedPickedWeightUnitId { get; set; }
+
+    /// <summary>Gets or sets adjusted duration in minutes.</summary>
+    public int? AdjustedDurationMinutes { get; set; }
+
+    /// <summary>Gets or sets the adjustment reason.</summary>
+    public string AdjustmentReason { get; set; } = string.Empty;
+}

--- a/TrashMob.Models/Poco/V2/EventPartnerLocationServiceRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/EventPartnerLocationServiceRequestDto.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Request body for creating or updating an event partner location service.
+/// </summary>
+public class EventPartnerLocationServiceRequestDto
+{
+    /// <summary>Gets or sets the event identifier.</summary>
+    public Guid EventId { get; set; }
+
+    /// <summary>Gets or sets the partner location identifier.</summary>
+    public Guid PartnerLocationId { get; set; }
+
+    /// <summary>Gets or sets the service type identifier.</summary>
+    public int ServiceTypeId { get; set; }
+
+    /// <summary>Gets or sets the service status identifier.</summary>
+    public int EventPartnerLocationServiceStatusId { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/EventPhotoDto.cs
+++ b/TrashMob.Models/Poco/V2/EventPhotoDto.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents an event photo for public display.
+/// </summary>
+public class EventPhotoDto
+{
+    /// <summary>Gets or sets the photo identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the event identifier.</summary>
+    public Guid EventId { get; set; }
+
+    /// <summary>Gets or sets the identifier of the user who uploaded the photo.</summary>
+    public Guid UploadedByUserId { get; set; }
+
+    /// <summary>Gets or sets the full-size image URL.</summary>
+    public string ImageUrl { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the thumbnail image URL.</summary>
+    public string ThumbnailUrl { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the photo type (Before=0, During=1, After=2).</summary>
+    public EventPhotoType PhotoType { get; set; }
+
+    /// <summary>Gets or sets the caption.</summary>
+    public string Caption { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets when the photo was taken.</summary>
+    public DateTimeOffset? TakenAt { get; set; }
+
+    /// <summary>Gets or sets the upload date.</summary>
+    public DateTimeOffset UploadedDate { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/NewsletterCategoryDto.cs
+++ b/TrashMob.Models/Poco/V2/NewsletterCategoryDto.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a newsletter category.
+/// </summary>
+public class NewsletterCategoryDto
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the description.</summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether new users are auto-subscribed.</summary>
+    public bool IsDefault { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/NewsletterPreferenceDto.cs
+++ b/TrashMob.Models/Poco/V2/NewsletterPreferenceDto.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a user's newsletter preference for a category.
+/// </summary>
+public class NewsletterPreferenceDto
+{
+    /// <summary>Gets or sets the category identifier.</summary>
+    public int CategoryId { get; set; }
+
+    /// <summary>Gets or sets the category name.</summary>
+    public string CategoryName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the category description.</summary>
+    public string CategoryDescription { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether subscribed.</summary>
+    public bool IsSubscribed { get; set; }
+
+    /// <summary>Gets or sets the subscribed date.</summary>
+    public DateTimeOffset? SubscribedDate { get; set; }
+
+    /// <summary>Gets or sets the unsubscribed date.</summary>
+    public DateTimeOffset? UnsubscribedDate { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/PickupLocationDto.cs
+++ b/TrashMob.Models/Poco/V2/PickupLocationDto.cs
@@ -1,0 +1,51 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a pickup location for collected trash.
+/// </summary>
+public class PickupLocationDto
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the event identifier.</summary>
+    public Guid EventId { get; set; }
+
+    /// <summary>Gets or sets the name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the street address.</summary>
+    public string StreetAddress { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the city.</summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the region or state.</summary>
+    public string Region { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the postal code.</summary>
+    public string PostalCode { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the country.</summary>
+    public string Country { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the county.</summary>
+    public string County { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the latitude.</summary>
+    public double? Latitude { get; set; }
+
+    /// <summary>Gets or sets the longitude.</summary>
+    public double? Longitude { get; set; }
+
+    /// <summary>Gets or sets whether locations have been submitted for pickup.</summary>
+    public bool HasBeenSubmitted { get; set; }
+
+    /// <summary>Gets or sets whether the trash has been picked up.</summary>
+    public bool HasBeenPickedUp { get; set; }
+
+    /// <summary>Gets or sets any notes.</summary>
+    public string Notes { get; set; } = string.Empty;
+}

--- a/TrashMob.Models/Poco/V2/RejectMetricsRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/RejectMetricsRequestDto.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Request body for rejecting attendee metrics.
+/// </summary>
+public class RejectMetricsRequestDto
+{
+    /// <summary>Gets or sets the rejection reason.</summary>
+    public string RejectionReason { get; set; } = string.Empty;
+}

--- a/TrashMob.Models/Poco/V2/UpdateNewsletterPreferenceDto.cs
+++ b/TrashMob.Models/Poco/V2/UpdateNewsletterPreferenceDto.cs
@@ -1,0 +1,15 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Request body for updating a newsletter preference.
+/// </summary>
+public class UpdateNewsletterPreferenceDto
+{
+    /// <summary>Gets or sets the newsletter category identifier.</summary>
+    public int CategoryId { get; set; }
+
+    /// <summary>Gets or sets whether subscribed.</summary>
+    public bool IsSubscribed { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/UserWaiverDto.cs
+++ b/TrashMob.Models/Poco/V2/UserWaiverDto.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a user's waiver acceptance record.
+/// </summary>
+public class UserWaiverDto
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the user identifier.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>Gets or sets the waiver version identifier.</summary>
+    public Guid WaiverVersionId { get; set; }
+
+    /// <summary>Gets or sets when the waiver was accepted.</summary>
+    public DateTimeOffset AcceptedDate { get; set; }
+
+    /// <summary>Gets or sets when this acceptance expires.</summary>
+    public DateTimeOffset ExpiryDate { get; set; }
+
+    /// <summary>Gets or sets the typed legal name.</summary>
+    public string TypedLegalName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the signing method.</summary>
+    public string SigningMethod { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the document URL.</summary>
+    public string DocumentUrl { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether the signer was a minor.</summary>
+    public bool IsMinor { get; set; }
+
+    /// <summary>Gets or sets the guardian name.</summary>
+    public string GuardianName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the guardian relationship.</summary>
+    public string GuardianRelationship { get; set; } = string.Empty;
+}

--- a/TrashMob.Models/Poco/V2/WaiverCheckResultDto.cs
+++ b/TrashMob.Models/Poco/V2/WaiverCheckResultDto.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Result of checking whether a user has a valid waiver.
+/// </summary>
+public class WaiverCheckResultDto
+{
+    /// <summary>Gets or sets whether the user has a valid waiver.</summary>
+    public bool HasValidWaiver { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/WaiverVersionDto.cs
+++ b/TrashMob.Models/Poco/V2/WaiverVersionDto.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Represents a waiver version for display.
+/// </summary>
+public class WaiverVersionDto
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the waiver name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the version string.</summary>
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the waiver text (HTML).</summary>
+    public string WaiverText { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the effective date.</summary>
+    public DateTimeOffset EffectiveDate { get; set; }
+
+    /// <summary>Gets or sets the expiry date (null = current version).</summary>
+    public DateTimeOffset? ExpiryDate { get; set; }
+
+    /// <summary>Gets or sets whether active.</summary>
+    public bool IsActive { get; set; }
+
+    /// <summary>Gets or sets the scope (Global=0, Community=1).</summary>
+    public WaiverScope Scope { get; set; }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/DependentsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/DependentsV2ControllerTests.cs
@@ -1,0 +1,120 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class DependentsV2ControllerTests
+    {
+        private readonly Mock<IDependentManager> dependentManager = new();
+        private readonly Mock<ILogger<DependentsV2Controller>> logger = new();
+        private readonly DependentsV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public DependentsV2ControllerTests()
+        {
+            controller = new DependentsV2Controller(dependentManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+        }
+
+        [Fact]
+        public async Task GetDependents_ReturnsOk_WhenOwner()
+        {
+            var dependents = new List<Dependent>
+            {
+                new() { Id = Guid.NewGuid(), ParentUserId = userId, FirstName = "Jane", LastName = "Doe", IsActive = true },
+            };
+
+            dependentManager.Setup(m => m.GetByParentUserIdAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependents);
+
+            var result = await controller.GetDependents(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<DependentDto>>(okResult.Value);
+            Assert.Single(dtos);
+            Assert.Equal("Jane", dtos[0].FirstName);
+        }
+
+        [Fact]
+        public async Task GetDependents_ReturnsForbid_WhenNotOwner()
+        {
+            var result = await controller.GetDependents(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_ReturnsCreated_WhenOwner()
+        {
+            var dto = new DependentDto
+            {
+                FirstName = "John",
+                LastName = "Smith",
+                DateOfBirth = new DateOnly(2015, 1, 1),
+                Relationship = "Child",
+            };
+
+            dependentManager.Setup(m => m.AddAsync(It.IsAny<Dependent>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dependent
+                {
+                    Id = Guid.NewGuid(),
+                    ParentUserId = userId,
+                    FirstName = "John",
+                    LastName = "Smith",
+                    IsActive = true,
+                });
+
+            var result = await controller.Add(userId, dto, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent_WhenOwner()
+        {
+            var dependentId = Guid.NewGuid();
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dependent { Id = dependentId, ParentUserId = userId });
+            dependentManager.Setup(m => m.SoftDeleteAsync(dependentId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(userId, dependentId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNotFound_WhenDependentMissing()
+        {
+            dependentManager.Setup(m => m.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Dependent)null);
+
+            var result = await controller.Delete(userId, Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Update_ReturnsForbid_WhenNotOwner()
+        {
+            var result = await controller.Update(Guid.NewGuid(), Guid.NewGuid(), new DependentDto(), CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeMetricsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeMetricsV2ControllerTests.cs
@@ -1,0 +1,139 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class EventAttendeeMetricsV2ControllerTests
+    {
+        private readonly Mock<IEventAttendeeMetricsManager> metricsManager = new();
+        private readonly Mock<IKeyedManager<Event>> eventManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<EventAttendeeMetricsV2Controller>> logger = new();
+        private readonly EventAttendeeMetricsV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public EventAttendeeMetricsV2ControllerTests()
+        {
+            controller = new EventAttendeeMetricsV2Controller(
+                metricsManager.Object, eventManager.Object, authorizationService.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+        }
+
+        [Fact]
+        public async Task GetMyMetrics_ReturnsOk_WhenFound()
+        {
+            var eventId = Guid.NewGuid();
+            var metrics = new EventAttendeeMetrics
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                UserId = userId,
+                BagsCollected = 3,
+                Status = "Pending",
+            };
+
+            metricsManager.Setup(m => m.GetMyMetricsAsync(eventId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(metrics);
+
+            var result = await controller.GetMyMetrics(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventAttendeeMetricsDto>(okResult.Value);
+            Assert.Equal(3, dto.BagsCollected);
+        }
+
+        [Fact]
+        public async Task GetMyMetrics_ReturnsNotFound_WhenMissing()
+        {
+            metricsManager.Setup(m => m.GetMyMetricsAsync(It.IsAny<Guid>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EventAttendeeMetrics)null);
+
+            var result = await controller.GetMyMetrics(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task SubmitMyMetrics_ReturnsOk_OnSuccess()
+        {
+            var eventId = Guid.NewGuid();
+            var metrics = new EventAttendeeMetrics { BagsCollected = 5 };
+            var resultMetrics = new EventAttendeeMetrics
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                UserId = userId,
+                BagsCollected = 5,
+                Status = "Pending",
+            };
+
+            metricsManager.Setup(m => m.SubmitMetricsAsync(eventId, userId, metrics, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeMetrics>.Success(resultMetrics));
+
+            var result = await controller.SubmitMyMetrics(eventId, metrics, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventAttendeeMetricsDto>(okResult.Value);
+            Assert.Equal(5, dto.BagsCollected);
+        }
+
+        [Fact]
+        public async Task SubmitMyMetrics_ReturnsBadRequest_OnFailure()
+        {
+            var eventId = Guid.NewGuid();
+            metricsManager.Setup(m => m.SubmitMetricsAsync(eventId, userId, It.IsAny<EventAttendeeMetrics>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeMetrics>.Failure("Event not found"));
+
+            var result = await controller.SubmitMyMetrics(eventId, new EventAttendeeMetrics(), CancellationToken.None);
+
+            var badResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Event not found", badResult.Value);
+        }
+
+        [Fact]
+        public async Task GetPublicMetrics_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event { Id = eventId });
+            metricsManager.Setup(m => m.GetPublicMetricsSummaryAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventMetricsPublicSummary { TotalBagsCollected = 50 });
+
+            var result = await controller.GetPublicMetrics(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var summary = Assert.IsType<EventMetricsPublicSummary>(okResult.Value);
+            Assert.Equal(50, summary.TotalBagsCollected);
+        }
+
+        [Fact]
+        public async Task GetPublicMetrics_ReturnsNotFound_WhenEventMissing()
+        {
+            eventManager.Setup(m => m.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Event)null);
+
+            var result = await controller.GetPublicMetrics(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
@@ -1,0 +1,127 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using NetTopologySuite.Geometries;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class EventAttendeeRoutesV2ControllerTests
+    {
+        private static readonly Geometry TestPath = new GeometryFactory()
+            .CreateLineString(new[] { new Coordinate(-122.0, 47.0), new Coordinate(-122.1, 47.1) });
+
+        private readonly Mock<IEventAttendeeRouteManager> routeManager = new();
+        private readonly Mock<ILogger<EventAttendeeRoutesV2Controller>> logger = new();
+        private readonly EventAttendeeRoutesV2Controller controller;
+
+        public EventAttendeeRoutesV2ControllerTests()
+        {
+            controller = new EventAttendeeRoutesV2Controller(routeManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetByEventAndUser_ReturnsOk_WithRoutes()
+        {
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var routes = new List<EventAttendeeRoute>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    EventId = eventId,
+                    CreatedByUserId = userId,
+                    UserId = userId,
+                    TotalDistanceMeters = 1000,
+                    UserPath = TestPath,
+                },
+            };
+
+            routeManager.Setup(m => m.GetByParentIdAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(routes);
+
+            var result = await controller.GetByEventAndUser(eventId, userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<DisplayEventAttendeeRoute>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task GetByEvent_ReturnsOk_FilteringPrivateRoutes()
+        {
+            var eventId = Guid.NewGuid();
+            var routes = new List<EventAttendeeRoute>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    EventId = eventId,
+                    UserId = Guid.NewGuid(),
+                    CreatedByUserId = Guid.NewGuid(),
+                    PrivacyLevel = "Public",
+                    TotalDistanceMeters = 500,
+                    UserPath = TestPath,
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    EventId = eventId,
+                    UserId = Guid.NewGuid(),
+                    CreatedByUserId = Guid.NewGuid(),
+                    PrivacyLevel = "Private",
+                    TotalDistanceMeters = 300,
+                    UserPath = TestPath,
+                },
+            };
+
+            routeManager.Setup(m => m.GetByParentIdAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(routes);
+
+            var result = await controller.GetByEvent(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<DisplayEventAttendeeRoute>>(okResult.Value);
+            Assert.Single(dtos); // Private route filtered out for unauthenticated user
+        }
+
+        [Fact]
+        public async Task Get_ReturnsNotFound_WhenNoRoutes()
+        {
+            routeManager.Setup(m => m.GetAsync(It.IsAny<Expression<Func<EventAttendeeRoute, bool>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventAttendeeRoute>());
+
+            var result = await controller.Get(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent()
+        {
+            var routeId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+
+            var result = await controller.Delete(routeId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            routeManager.Verify(m => m.DeleteAsync(routeId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventLitterReportsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventLitterReportsV2ControllerTests.cs
@@ -1,0 +1,94 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class EventLitterReportsV2ControllerTests
+    {
+        private readonly Mock<IEventLitterReportManager> reportManager = new();
+        private readonly Mock<IUserManager> userManager = new();
+        private readonly Mock<ILogger<EventLitterReportsV2Controller>> logger = new();
+        private readonly EventLitterReportsV2Controller controller;
+
+        public EventLitterReportsV2ControllerTests()
+        {
+            controller = new EventLitterReportsV2Controller(reportManager.Object, userManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetByEvent_ReturnsOk_WithReports()
+        {
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var litterReportId = Guid.NewGuid();
+
+            var reports = new List<EventLitterReport>
+            {
+                new()
+                {
+                    EventId = eventId,
+                    LitterReportId = litterReportId,
+                    LitterReport = new LitterReport
+                    {
+                        Id = litterReportId,
+                        Name = "Test Report",
+                        CreatedByUserId = userId,
+                    },
+                },
+            };
+
+            reportManager.Setup(m => m.GetByParentIdAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(reports);
+            userManager.Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = userId, UserName = "testuser" });
+
+            var result = await controller.GetByEvent(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var fullReports = Assert.IsAssignableFrom<List<FullEventLitterReport>>(okResult.Value);
+            Assert.Single(fullReports);
+            Assert.Equal(eventId, fullReports[0].EventId);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent()
+        {
+            var eventId = Guid.NewGuid();
+            var litterReportId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+
+            var result = await controller.Delete(eventId, litterReportId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            reportManager.Verify(m => m.Delete(eventId, litterReportId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Add_ReturnsCreated()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var report = new EventLitterReport { EventId = Guid.NewGuid(), LitterReportId = Guid.NewGuid() };
+
+            var result = await controller.Add(report, CancellationToken.None);
+
+            Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(201, ((StatusCodeResult)result).StatusCode);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventPartnerLocationServicesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventPartnerLocationServicesV2ControllerTests.cs
@@ -1,0 +1,90 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class EventPartnerLocationServicesV2ControllerTests
+    {
+        private readonly Mock<IEventPartnerLocationServiceManager> serviceManager = new();
+        private readonly Mock<IKeyedManager<Event>> eventManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<EventPartnerLocationServicesV2Controller>> logger = new();
+        private readonly EventPartnerLocationServicesV2Controller controller;
+
+        public EventPartnerLocationServicesV2ControllerTests()
+        {
+            controller = new EventPartnerLocationServicesV2Controller(
+                serviceManager.Object, eventManager.Object, authorizationService.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetByEvent_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            var partners = new List<DisplayEventPartnerLocation>
+            {
+                new() { PartnerLocationId = Guid.NewGuid(), PartnerName = "Test Partner" },
+            };
+
+            serviceManager.Setup(m => m.GetByEventAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partners);
+
+            var result = await controller.GetByEvent(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<DisplayEventPartnerLocation>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task GetHaulingPartnerLocation_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            var partnerLocation = new PartnerLocation { Id = Guid.NewGuid(), Name = "Hauling Partner" };
+
+            serviceManager.Setup(m => m.GetHaulingPartnerLocationForEvent(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partnerLocation);
+
+            var result = await controller.GetHaulingPartnerLocation(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<PartnerLocation>(okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetByEventAndPartnerLocation_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            var partnerLocationId = Guid.NewGuid();
+            var services = new List<DisplayEventPartnerLocationService>
+            {
+                new() { ServiceTypeId = 1 },
+            };
+
+            serviceManager.Setup(m => m.GetByEventAndPartnerLocationAsync(eventId, partnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(services);
+
+            var result = await controller.GetByEventAndPartnerLocation(eventId, partnerLocationId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<DisplayEventPartnerLocationService>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventPhotosV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventPhotosV2ControllerTests.cs
@@ -1,0 +1,128 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class EventPhotosV2ControllerTests
+    {
+        private readonly Mock<IEventPhotoManager> photoManager = new();
+        private readonly Mock<IEventManager> eventManager = new();
+        private readonly Mock<IEventAttendeeManager> attendeeManager = new();
+        private readonly Mock<IImageManager> imageManager = new();
+        private readonly Mock<ILogger<EventPhotosV2Controller>> logger = new();
+        private readonly EventPhotosV2Controller controller;
+
+        public EventPhotosV2ControllerTests()
+        {
+            controller = new EventPhotosV2Controller(
+                photoManager.Object, eventManager.Object, attendeeManager.Object,
+                imageManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetEventPhotos_ReturnsOk_WithPhotos()
+        {
+            var eventId = Guid.NewGuid();
+            var photos = new List<EventPhoto>
+            {
+                new() { Id = Guid.NewGuid(), EventId = eventId, ImageUrl = "url1", ThumbnailUrl = "thumb1", PhotoType = EventPhotoType.During },
+                new() { Id = Guid.NewGuid(), EventId = eventId, ImageUrl = "url2", ThumbnailUrl = "thumb2", PhotoType = EventPhotoType.After },
+            };
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event { Id = eventId });
+            photoManager.Setup(m => m.GetByEventIdAsync(eventId, false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(photos);
+
+            var result = await controller.GetEventPhotos(eventId, null, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<EventPhotoDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+        }
+
+        [Fact]
+        public async Task GetEventPhotos_WithTypeFilter_FiltersPhotos()
+        {
+            var eventId = Guid.NewGuid();
+            var photos = new List<EventPhoto>
+            {
+                new() { Id = Guid.NewGuid(), EventId = eventId, PhotoType = EventPhotoType.Before },
+            };
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event { Id = eventId });
+            photoManager.Setup(m => m.GetByEventIdAndTypeAsync(eventId, EventPhotoType.Before, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(photos);
+
+            var result = await controller.GetEventPhotos(eventId, EventPhotoType.Before, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<EventPhotoDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task GetEventPhotos_ReturnsNotFound_WhenEventMissing()
+        {
+            var eventId = Guid.NewGuid();
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Event)null);
+
+            var result = await controller.GetEventPhotos(eventId, null, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task DeletePhoto_ReturnsNoContent_WhenAuthorized()
+        {
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var photoId = Guid.NewGuid();
+
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            photoManager.Setup(m => m.GetAsync(photoId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventPhoto { Id = photoId, EventId = eventId, UploadedByUserId = userId });
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event { Id = eventId, CreatedByUserId = Guid.NewGuid() });
+            photoManager.Setup(m => m.DeletePhotoAsync(photoId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.DeletePhoto(eventId, photoId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task DeletePhoto_ReturnsNotFound_WhenPhotoMissing()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            photoManager.Setup(m => m.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EventPhoto)null);
+
+            var result = await controller.DeletePhoto(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventRoutesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventRoutesV2ControllerTests.cs
@@ -1,0 +1,93 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class EventRoutesV2ControllerTests
+    {
+        private readonly Mock<IEventAttendeeRouteManager> routeManager = new();
+        private readonly Mock<ILogger<EventRoutesV2Controller>> logger = new();
+        private readonly EventRoutesV2Controller controller;
+
+        public EventRoutesV2ControllerTests()
+        {
+            controller = new EventRoutesV2Controller(routeManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task GetRoutes_ReturnsOk_WithAnonymizedRoutes()
+        {
+            var eventId = Guid.NewGuid();
+            var routes = new List<DisplayAnonymizedRoute>
+            {
+                new() { Id = Guid.NewGuid(), EventId = eventId, TotalDistanceMeters = 1500 },
+            };
+
+            routeManager.Setup(m => m.GetAnonymizedRoutesForEventAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(routes);
+
+            var result = await controller.GetRoutes(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<DisplayAnonymizedRoute>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task GetStats_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            var stats = new DisplayEventRouteStats
+            {
+                EventId = eventId,
+                TotalRoutes = 5,
+                TotalDistanceMeters = 10000,
+            };
+
+            routeManager.Setup(m => m.GetEventRouteStatsAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(stats);
+
+            var result = await controller.GetStats(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<DisplayEventRouteStats>(okResult.Value);
+            Assert.Equal(5, dto.TotalRoutes);
+        }
+
+        [Fact]
+        public async Task GetSummaryPrefill_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+
+            var prefill = new EventSummaryPrefill
+            {
+                NumberOfBags = 10,
+                PickedWeight = 50.5m,
+            };
+
+            routeManager.Setup(m => m.GetEventSummaryPrefillAsync(eventId, 1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(prefill);
+
+            var result = await controller.GetSummaryPrefill(eventId, cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventSummaryPrefill>(okResult.Value);
+            Assert.Equal(10, dto.NumberOfBags);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/NewsletterPreferencesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/NewsletterPreferencesV2ControllerTests.cs
@@ -1,0 +1,46 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using Xunit;
+
+    public class NewsletterPreferencesV2ControllerTests
+    {
+        private readonly Mock<IUserNewsletterPreferenceManager> preferenceManager = new();
+        private readonly Mock<ILookupRepository<NewsletterCategory>> categoryRepository = new();
+        private readonly Mock<ILogger<NewsletterPreferencesV2Controller>> logger = new();
+        private readonly NewsletterPreferencesV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public NewsletterPreferencesV2ControllerTests()
+        {
+            controller = new NewsletterPreferencesV2Controller(
+                preferenceManager.Object, categoryRepository.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+        }
+
+        [Fact]
+        public async Task UnsubscribeAll_ReturnsNoContent()
+        {
+            var result = await controller.UnsubscribeAll(CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            preferenceManager.Verify(m => m.UnsubscribeAllAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PickupLocationsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PickupLocationsV2ControllerTests.cs
@@ -1,0 +1,111 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PickupLocationsV2ControllerTests
+    {
+        private readonly Mock<IPickupLocationManager> pickupLocationManager = new();
+        private readonly Mock<IEventManager> eventManager = new();
+        private readonly Mock<IImageManager> imageManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PickupLocationsV2Controller>> logger = new();
+        private readonly PickupLocationsV2Controller controller;
+
+        public PickupLocationsV2ControllerTests()
+        {
+            controller = new PickupLocationsV2Controller(
+                pickupLocationManager.Object, eventManager.Object, imageManager.Object,
+                authorizationService.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        [Fact]
+        public async Task Get_ReturnsOk_WhenFound()
+        {
+            var id = Guid.NewGuid();
+            var entity = new PickupLocation { Id = id, EventId = Guid.NewGuid(), Name = "Test" };
+
+            pickupLocationManager.Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entity);
+
+            var result = await controller.Get(id, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PickupLocationDto>(okResult.Value);
+            Assert.Equal("Test", dto.Name);
+        }
+
+        [Fact]
+        public async Task Get_ReturnsNotFound_WhenMissing()
+        {
+            pickupLocationManager.Setup(m => m.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PickupLocation)null);
+
+            var result = await controller.Get(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetByEvent_ReturnsOk_WithList()
+        {
+            var eventId = Guid.NewGuid();
+            var entities = new List<PickupLocation>
+            {
+                new() { Id = Guid.NewGuid(), EventId = eventId, Name = "Loc 1" },
+                new() { Id = Guid.NewGuid(), EventId = eventId, Name = "Loc 2" },
+            };
+
+            pickupLocationManager.Setup(m => m.GetByParentIdAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entities);
+
+            var result = await controller.GetByEvent(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<PickupLocationDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+        }
+
+        [Fact]
+        public async Task GetImage_ReturnsOk_WhenUrlExists()
+        {
+            var id = Guid.NewGuid();
+            imageManager.Setup(m => m.GetImageUrlAsync(id, ImageTypeEnum.Pickup, ImageSizeEnum.Raw, It.IsAny<CancellationToken>()))
+                .ReturnsAsync("https://example.com/image.jpg");
+
+            var result = await controller.GetImage(id, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("https://example.com/image.jpg", okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetImage_ReturnsNoContent_WhenNoUrl()
+        {
+            var id = Guid.NewGuid();
+            imageManager.Setup(m => m.GetImageUrlAsync(id, ImageTypeEnum.Pickup, ImageSizeEnum.Raw, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(string.Empty);
+
+            var result = await controller.GetImage(id, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/WaiversV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/WaiversV2ControllerTests.cs
@@ -1,0 +1,173 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class WaiversV2ControllerTests
+    {
+        private readonly Mock<IUserWaiverManager> waiverManager = new();
+        private readonly Mock<IWaiverDocumentManager> documentManager = new();
+        private readonly Mock<IUserManager> userManager = new();
+        private readonly Mock<ILogger<WaiversV2Controller>> logger = new();
+        private readonly WaiversV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public WaiversV2ControllerTests()
+        {
+            controller = new WaiversV2Controller(
+                waiverManager.Object, documentManager.Object, userManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+        }
+
+        [Fact]
+        public async Task GetRequired_ReturnsOk_WithWaiverVersions()
+        {
+            var waivers = new List<WaiverVersion>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Standard Waiver",
+                    Version = "1.0",
+                    WaiverText = "By signing...",
+                    IsActive = true,
+                    Scope = WaiverScope.Global,
+                },
+            };
+
+            waiverManager.Setup(m => m.GetPendingWaiversForUserAsync(userId, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(waivers);
+
+            var result = await controller.GetRequired(cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<WaiverVersionDto>>(okResult.Value);
+            Assert.Single(dtos);
+            Assert.Equal("Standard Waiver", dtos[0].Name);
+        }
+
+        [Fact]
+        public async Task GetMyWaivers_ReturnsOk_WithUserWaivers()
+        {
+            var waivers = new List<UserWaiver>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    WaiverVersionId = Guid.NewGuid(),
+                    AcceptedDate = DateTimeOffset.UtcNow,
+                    TypedLegalName = "Jane Doe",
+                    SigningMethod = "Digital",
+                },
+            };
+
+            waiverManager.Setup(m => m.GetUserWaiversAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(waivers);
+
+            var result = await controller.GetMyWaivers(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<UserWaiverDto>>(okResult.Value);
+            Assert.Single(dtos);
+            Assert.Equal("Jane Doe", dtos[0].TypedLegalName);
+        }
+
+        [Fact]
+        public async Task Accept_ReturnsCreated_OnSuccess()
+        {
+            var waiverVersionId = Guid.NewGuid();
+            var userWaiver = new UserWaiver
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                WaiverVersionId = waiverVersionId,
+                AcceptedDate = DateTimeOffset.UtcNow,
+                TypedLegalName = "Jane Doe",
+                SigningMethod = "Digital",
+            };
+
+            waiverManager.Setup(m => m.AcceptWaiverAsync(It.IsAny<AcceptWaiverRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<UserWaiver>.Success(userWaiver));
+            userManager.Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = userId, UserName = "janedoe" });
+            waiverManager.Setup(m => m.GetUserWaiverWithDetailsAsync(userWaiver.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(userWaiver);
+            documentManager.Setup(m => m.GenerateAndStoreWaiverPdfAsync(It.IsAny<UserWaiver>(), It.IsAny<User>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync("https://example.com/waiver.pdf");
+
+            var request = new AcceptWaiverRequestDto
+            {
+                WaiverVersionId = waiverVersionId,
+                TypedLegalName = "Jane Doe",
+            };
+
+            var result = await controller.Accept(request, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task Accept_ReturnsBadRequest_WhenVersionIdEmpty()
+        {
+            var request = new AcceptWaiverRequestDto
+            {
+                WaiverVersionId = Guid.Empty,
+                TypedLegalName = "Jane Doe",
+            };
+
+            var result = await controller.Accept(request, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Accept_ReturnsBadRequest_WhenNameEmpty()
+        {
+            var request = new AcceptWaiverRequestDto
+            {
+                WaiverVersionId = Guid.NewGuid(),
+                TypedLegalName = "",
+            };
+
+            var result = await controller.Accept(request, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Accept_ReturnsBadRequest_OnFailure()
+        {
+            waiverManager.Setup(m => m.AcceptWaiverAsync(It.IsAny<AcceptWaiverRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<UserWaiver>.Failure("Waiver already signed"));
+
+            var request = new AcceptWaiverRequestDto
+            {
+                WaiverVersionId = Guid.NewGuid(),
+                TypedLegalName = "Jane Doe",
+            };
+
+            var result = await controller.Accept(request, CancellationToken.None);
+
+            var badResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Waiver already signed", badResult.Value);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/DependentMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/DependentMappingsV2Tests.cs
@@ -1,0 +1,100 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using Xunit;
+
+    public class DependentMappingsV2Tests
+    {
+        [Fact]
+        public void Dependent_ToV2Dto_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var parentId = Guid.NewGuid();
+            var dob = new DateOnly(2015, 6, 15);
+
+            var entity = new Dependent
+            {
+                Id = id,
+                ParentUserId = parentId,
+                FirstName = "Jane",
+                LastName = "Doe",
+                DateOfBirth = dob,
+                Relationship = "Child",
+                MedicalNotes = "Allergy to bee stings",
+                EmergencyContactPhone = "555-0100",
+                IsActive = true,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(id, dto.Id);
+            Assert.Equal(parentId, dto.ParentUserId);
+            Assert.Equal("Jane", dto.FirstName);
+            Assert.Equal("Doe", dto.LastName);
+            Assert.Equal(dob, dto.DateOfBirth);
+            Assert.Equal("Child", dto.Relationship);
+            Assert.Equal("Allergy to bee stings", dto.MedicalNotes);
+            Assert.Equal("555-0100", dto.EmergencyContactPhone);
+            Assert.True(dto.IsActive);
+        }
+
+        [Fact]
+        public void DependentDto_ToEntity_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var parentId = Guid.NewGuid();
+            var dob = new DateOnly(2012, 3, 21);
+
+            var dto = new DependentDto
+            {
+                Id = id,
+                ParentUserId = parentId,
+                FirstName = "John",
+                LastName = "Smith",
+                DateOfBirth = dob,
+                Relationship = "Stepchild",
+                MedicalNotes = "None",
+                EmergencyContactPhone = "555-0200",
+                IsActive = false,
+            };
+
+            var entity = dto.ToEntity();
+
+            Assert.Equal(id, entity.Id);
+            Assert.Equal(parentId, entity.ParentUserId);
+            Assert.Equal("John", entity.FirstName);
+            Assert.Equal("Smith", entity.LastName);
+            Assert.Equal(dob, entity.DateOfBirth);
+            Assert.Equal("Stepchild", entity.Relationship);
+            Assert.Equal("None", entity.MedicalNotes);
+            Assert.Equal("555-0200", entity.EmergencyContactPhone);
+            Assert.False(entity.IsActive);
+        }
+
+        [Fact]
+        public void Dependent_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new Dependent
+            {
+                Id = Guid.NewGuid(),
+                ParentUserId = Guid.NewGuid(),
+                FirstName = null,
+                LastName = null,
+                Relationship = null,
+                MedicalNotes = null,
+                EmergencyContactPhone = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.FirstName);
+            Assert.Equal(string.Empty, dto.LastName);
+            Assert.Equal(string.Empty, dto.Relationship);
+            Assert.Equal(string.Empty, dto.MedicalNotes);
+            Assert.Equal(string.Empty, dto.EmergencyContactPhone);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/EventAttendeeMetricsMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventAttendeeMetricsMappingsV2Tests.cs
@@ -1,0 +1,112 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class EventAttendeeMetricsMappingsV2Tests
+    {
+        [Fact]
+        public void EventAttendeeMetrics_ToV2Dto_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var reviewedDate = DateTimeOffset.UtcNow;
+
+            var entity = new EventAttendeeMetrics
+            {
+                Id = id,
+                EventId = eventId,
+                UserId = userId,
+                BagsCollected = 5,
+                PickedWeight = 12.5m,
+                PickedWeightUnitId = 1,
+                DurationMinutes = 120,
+                Notes = "Great event",
+                Status = "Approved",
+                ReviewedDate = reviewedDate,
+                RejectionReason = "",
+                AdjustedBagsCollected = 6,
+                AdjustedPickedWeight = 13.0m,
+                AdjustedPickedWeightUnitId = 1,
+                AdjustedDurationMinutes = 125,
+                AdjustmentReason = "Corrected count",
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(id, dto.Id);
+            Assert.Equal(eventId, dto.EventId);
+            Assert.Equal(userId, dto.UserId);
+            Assert.Equal(5, dto.BagsCollected);
+            Assert.Equal(12.5m, dto.PickedWeight);
+            Assert.Equal(1, dto.PickedWeightUnitId);
+            Assert.Equal(120, dto.DurationMinutes);
+            Assert.Equal("Great event", dto.Notes);
+            Assert.Equal("Approved", dto.Status);
+            Assert.Equal(reviewedDate, dto.ReviewedDate);
+            Assert.Equal("", dto.RejectionReason);
+            Assert.Equal(6, dto.AdjustedBagsCollected);
+            Assert.Equal(13.0m, dto.AdjustedPickedWeight);
+            Assert.Equal(1, dto.AdjustedPickedWeightUnitId);
+            Assert.Equal(125, dto.AdjustedDurationMinutes);
+            Assert.Equal("Corrected count", dto.AdjustmentReason);
+        }
+
+        [Fact]
+        public void EventAttendeeMetrics_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new EventAttendeeMetrics
+            {
+                Id = Guid.NewGuid(),
+                EventId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Notes = null,
+                Status = null,
+                RejectionReason = null,
+                AdjustmentReason = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.Notes);
+            Assert.Equal(string.Empty, dto.Status);
+            Assert.Equal(string.Empty, dto.RejectionReason);
+            Assert.Equal(string.Empty, dto.AdjustmentReason);
+        }
+
+        [Fact]
+        public void EventAttendeeMetrics_ToV2Dto_HandlesNullNumerics()
+        {
+            var entity = new EventAttendeeMetrics
+            {
+                Id = Guid.NewGuid(),
+                EventId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                BagsCollected = null,
+                PickedWeight = null,
+                PickedWeightUnitId = null,
+                DurationMinutes = null,
+                ReviewedDate = null,
+                AdjustedBagsCollected = null,
+                AdjustedPickedWeight = null,
+                AdjustedPickedWeightUnitId = null,
+                AdjustedDurationMinutes = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Null(dto.BagsCollected);
+            Assert.Null(dto.PickedWeight);
+            Assert.Null(dto.PickedWeightUnitId);
+            Assert.Null(dto.DurationMinutes);
+            Assert.Null(dto.ReviewedDate);
+            Assert.Null(dto.AdjustedBagsCollected);
+            Assert.Null(dto.AdjustedPickedWeight);
+            Assert.Null(dto.AdjustedPickedWeightUnitId);
+            Assert.Null(dto.AdjustedDurationMinutes);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/EventPartnerLocationServiceMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventPartnerLocationServiceMappingsV2Tests.cs
@@ -1,0 +1,33 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using Xunit;
+
+    public class EventPartnerLocationServiceMappingsV2Tests
+    {
+        [Fact]
+        public void EventPartnerLocationServiceRequestDto_ToEntity_MapsAllProperties()
+        {
+            var eventId = Guid.NewGuid();
+            var partnerLocationId = Guid.NewGuid();
+
+            var dto = new EventPartnerLocationServiceRequestDto
+            {
+                EventId = eventId,
+                PartnerLocationId = partnerLocationId,
+                ServiceTypeId = 3,
+                EventPartnerLocationServiceStatusId = 1,
+            };
+
+            var entity = dto.ToEntity();
+
+            Assert.Equal(eventId, entity.EventId);
+            Assert.Equal(partnerLocationId, entity.PartnerLocationId);
+            Assert.Equal(3, entity.ServiceTypeId);
+            Assert.Equal(1, entity.EventPartnerLocationServiceStatusId);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/EventPhotoMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventPhotoMappingsV2Tests.cs
@@ -1,0 +1,64 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class EventPhotoMappingsV2Tests
+    {
+        [Fact]
+        public void EventPhoto_ToV2Dto_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var takenAt = DateTimeOffset.UtcNow.AddHours(-1);
+            var uploadedDate = DateTimeOffset.UtcNow;
+
+            var entity = new EventPhoto
+            {
+                Id = id,
+                EventId = eventId,
+                UploadedByUserId = userId,
+                ImageUrl = "https://example.com/photo.jpg",
+                ThumbnailUrl = "https://example.com/thumb.jpg",
+                PhotoType = EventPhotoType.During,
+                Caption = "Test caption",
+                TakenAt = takenAt,
+                UploadedDate = uploadedDate,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(id, dto.Id);
+            Assert.Equal(eventId, dto.EventId);
+            Assert.Equal(userId, dto.UploadedByUserId);
+            Assert.Equal("https://example.com/photo.jpg", dto.ImageUrl);
+            Assert.Equal("https://example.com/thumb.jpg", dto.ThumbnailUrl);
+            Assert.Equal(EventPhotoType.During, dto.PhotoType);
+            Assert.Equal("Test caption", dto.Caption);
+            Assert.Equal(takenAt, dto.TakenAt);
+            Assert.Equal(uploadedDate, dto.UploadedDate);
+        }
+
+        [Fact]
+        public void EventPhoto_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new EventPhoto
+            {
+                Id = Guid.NewGuid(),
+                EventId = Guid.NewGuid(),
+                ImageUrl = null,
+                ThumbnailUrl = null,
+                Caption = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.ImageUrl);
+            Assert.Equal(string.Empty, dto.ThumbnailUrl);
+            Assert.Equal(string.Empty, dto.Caption);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/NewsletterMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/NewsletterMappingsV2Tests.cs
@@ -1,0 +1,46 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class NewsletterMappingsV2Tests
+    {
+        [Fact]
+        public void NewsletterCategory_ToV2Dto_MapsAllProperties()
+        {
+            var entity = new NewsletterCategory
+            {
+                Id = 5,
+                Name = "Monthly Digest",
+                Description = "A monthly summary of activities",
+                IsDefault = true,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(5, dto.Id);
+            Assert.Equal("Monthly Digest", dto.Name);
+            Assert.Equal("A monthly summary of activities", dto.Description);
+            Assert.True(dto.IsDefault);
+        }
+
+        [Fact]
+        public void NewsletterCategory_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new NewsletterCategory
+            {
+                Id = 1,
+                Name = null,
+                Description = null,
+                IsDefault = false,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.Name);
+            Assert.Equal(string.Empty, dto.Description);
+            Assert.False(dto.IsDefault);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/PickupLocationMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/PickupLocationMappingsV2Tests.cs
@@ -1,0 +1,124 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using Xunit;
+
+    public class PickupLocationMappingsV2Tests
+    {
+        [Fact]
+        public void PickupLocation_ToV2Dto_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var entity = new PickupLocation
+            {
+                Id = id,
+                EventId = eventId,
+                Name = "Corner of 1st & Main",
+                StreetAddress = "100 Main St",
+                City = "Seattle",
+                Region = "WA",
+                PostalCode = "98101",
+                Country = "US",
+                County = "King",
+                Latitude = 47.6062,
+                Longitude = -122.3321,
+                HasBeenSubmitted = true,
+                HasBeenPickedUp = false,
+                Notes = "Near the park entrance",
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(id, dto.Id);
+            Assert.Equal(eventId, dto.EventId);
+            Assert.Equal("Corner of 1st & Main", dto.Name);
+            Assert.Equal("100 Main St", dto.StreetAddress);
+            Assert.Equal("Seattle", dto.City);
+            Assert.Equal("WA", dto.Region);
+            Assert.Equal("98101", dto.PostalCode);
+            Assert.Equal("US", dto.Country);
+            Assert.Equal("King", dto.County);
+            Assert.Equal(47.6062, dto.Latitude);
+            Assert.Equal(-122.3321, dto.Longitude);
+            Assert.True(dto.HasBeenSubmitted);
+            Assert.False(dto.HasBeenPickedUp);
+            Assert.Equal("Near the park entrance", dto.Notes);
+        }
+
+        [Fact]
+        public void PickupLocationDto_ToEntity_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var dto = new PickupLocationDto
+            {
+                Id = id,
+                EventId = eventId,
+                Name = "Test Location",
+                StreetAddress = "456 Oak Ave",
+                City = "Portland",
+                Region = "OR",
+                PostalCode = "97201",
+                Country = "US",
+                County = "Multnomah",
+                Latitude = 45.5152,
+                Longitude = -122.6784,
+                HasBeenSubmitted = false,
+                HasBeenPickedUp = true,
+                Notes = "Test notes",
+            };
+
+            var entity = dto.ToEntity();
+
+            Assert.Equal(id, entity.Id);
+            Assert.Equal(eventId, entity.EventId);
+            Assert.Equal("Test Location", entity.Name);
+            Assert.Equal("456 Oak Ave", entity.StreetAddress);
+            Assert.Equal("Portland", entity.City);
+            Assert.Equal("OR", entity.Region);
+            Assert.Equal("97201", entity.PostalCode);
+            Assert.Equal("US", entity.Country);
+            Assert.Equal("Multnomah", entity.County);
+            Assert.Equal(45.5152, entity.Latitude);
+            Assert.Equal(-122.6784, entity.Longitude);
+            Assert.False(entity.HasBeenSubmitted);
+            Assert.True(entity.HasBeenPickedUp);
+            Assert.Equal("Test notes", entity.Notes);
+        }
+
+        [Fact]
+        public void PickupLocation_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new PickupLocation
+            {
+                Id = Guid.NewGuid(),
+                EventId = Guid.NewGuid(),
+                Name = null,
+                StreetAddress = null,
+                City = null,
+                Region = null,
+                PostalCode = null,
+                Country = null,
+                County = null,
+                Notes = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.Name);
+            Assert.Equal(string.Empty, dto.StreetAddress);
+            Assert.Equal(string.Empty, dto.City);
+            Assert.Equal(string.Empty, dto.Region);
+            Assert.Equal(string.Empty, dto.PostalCode);
+            Assert.Equal(string.Empty, dto.Country);
+            Assert.Equal(string.Empty, dto.County);
+            Assert.Equal(string.Empty, dto.Notes);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Extensions/V2/WaiverMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/WaiverMappingsV2Tests.cs
@@ -1,0 +1,122 @@
+namespace TrashMob.Shared.Tests.Extensions.V2
+{
+    using System;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using Xunit;
+
+    public class WaiverMappingsV2Tests
+    {
+        [Fact]
+        public void WaiverVersion_ToV2Dto_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var effectiveDate = DateTimeOffset.UtcNow.AddDays(-30);
+            var expiryDate = DateTimeOffset.UtcNow.AddDays(335);
+
+            var entity = new WaiverVersion
+            {
+                Id = id,
+                Name = "Standard Waiver",
+                Version = "1.0",
+                WaiverText = "By signing...",
+                EffectiveDate = effectiveDate,
+                ExpiryDate = expiryDate,
+                IsActive = true,
+                Scope = WaiverScope.Global,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(id, dto.Id);
+            Assert.Equal("Standard Waiver", dto.Name);
+            Assert.Equal("1.0", dto.Version);
+            Assert.Equal("By signing...", dto.WaiverText);
+            Assert.Equal(effectiveDate, dto.EffectiveDate);
+            Assert.Equal(expiryDate, dto.ExpiryDate);
+            Assert.True(dto.IsActive);
+            Assert.Equal(WaiverScope.Global, dto.Scope);
+        }
+
+        [Fact]
+        public void WaiverVersion_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new WaiverVersion
+            {
+                Id = Guid.NewGuid(),
+                Name = null,
+                Version = null,
+                WaiverText = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.Name);
+            Assert.Equal(string.Empty, dto.Version);
+            Assert.Equal(string.Empty, dto.WaiverText);
+        }
+
+        [Fact]
+        public void UserWaiver_ToV2Dto_MapsAllProperties()
+        {
+            var id = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var waiverVersionId = Guid.NewGuid();
+            var acceptedDate = DateTimeOffset.UtcNow.AddDays(-7);
+            var expiryDate = DateTimeOffset.UtcNow.AddDays(358);
+
+            var entity = new UserWaiver
+            {
+                Id = id,
+                UserId = userId,
+                WaiverVersionId = waiverVersionId,
+                AcceptedDate = acceptedDate,
+                ExpiryDate = expiryDate,
+                TypedLegalName = "Jane Doe",
+                SigningMethod = "Digital",
+                DocumentUrl = "https://example.com/waiver.pdf",
+                IsMinor = true,
+                GuardianName = "John Doe",
+                GuardianRelationship = "Parent",
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(id, dto.Id);
+            Assert.Equal(userId, dto.UserId);
+            Assert.Equal(waiverVersionId, dto.WaiverVersionId);
+            Assert.Equal(acceptedDate, dto.AcceptedDate);
+            Assert.Equal(expiryDate, dto.ExpiryDate);
+            Assert.Equal("Jane Doe", dto.TypedLegalName);
+            Assert.Equal("Digital", dto.SigningMethod);
+            Assert.Equal("https://example.com/waiver.pdf", dto.DocumentUrl);
+            Assert.True(dto.IsMinor);
+            Assert.Equal("John Doe", dto.GuardianName);
+            Assert.Equal("Parent", dto.GuardianRelationship);
+        }
+
+        [Fact]
+        public void UserWaiver_ToV2Dto_HandlesNullStrings()
+        {
+            var entity = new UserWaiver
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                WaiverVersionId = Guid.NewGuid(),
+                TypedLegalName = null,
+                SigningMethod = null,
+                DocumentUrl = null,
+                GuardianName = null,
+                GuardianRelationship = null,
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal(string.Empty, dto.TypedLegalName);
+            Assert.Equal(string.Empty, dto.SigningMethod);
+            Assert.Equal(string.Empty, dto.DocumentUrl);
+            Assert.Equal(string.Empty, dto.GuardianName);
+            Assert.Equal(string.Empty, dto.GuardianRelationship);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/DependentsV2Controller.cs
+++ b/TrashMob/Controllers/V2/DependentsV2Controller.cs
@@ -1,0 +1,167 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing dependents (minors linked to a user's account).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/users/{userId}/dependents")]
+    public class DependentsV2Controller(
+        IDependentManager dependentManager,
+        ILogger<DependentsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all active dependents for a user.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the dependents.</response>
+        /// <response code="403">Not the owner.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<DependentDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetDependents(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetDependents for User={UserId}", userId);
+
+            if (userId != UserId)
+            {
+                return Forbid();
+            }
+
+            var dependents = await dependentManager.GetByParentUserIdAsync(userId, cancellationToken);
+            var dtos = dependents.Select(d => d.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Adds a new dependent to a user's account.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="dto">The dependent data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Dependent created.</response>
+        /// <response code="403">Not the owner.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DependentDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Add(Guid userId, DependentDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddDependent for User={UserId}", userId);
+
+            if (userId != UserId)
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            entity.ParentUserId = userId;
+
+            var result = await dependentManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetDependents), new { userId }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing dependent.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="dto">The updated dependent data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated dependent.</response>
+        /// <response code="403">Not the owner.</response>
+        /// <response code="404">Dependent not found.</response>
+        [HttpPut("{dependentId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DependentDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(
+            Guid userId, Guid dependentId, DependentDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateDependent Id={DependentId} for User={UserId}", dependentId, userId);
+
+            if (userId != UserId)
+            {
+                return Forbid();
+            }
+
+            var existing = await dependentManager.GetAsync(dependentId, cancellationToken);
+            if (existing == null || existing.ParentUserId != userId)
+            {
+                return NotFound();
+            }
+
+            var entity = dto.ToEntity();
+            entity.Id = dependentId;
+            entity.ParentUserId = userId;
+
+            var result = await dependentManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Soft-deletes a dependent.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Dependent deleted.</response>
+        /// <response code="403">Not the owner.</response>
+        /// <response code="404">Dependent not found.</response>
+        [HttpDelete("{dependentId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(Guid userId, Guid dependentId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteDependent Id={DependentId} for User={UserId}", dependentId, userId);
+
+            if (userId != UserId)
+            {
+                return Forbid();
+            }
+
+            var existing = await dependentManager.GetAsync(dependentId, cancellationToken);
+            if (existing == null || existing.ParentUserId != userId)
+            {
+                return NotFound();
+            }
+
+            await dependentManager.SoftDeleteAsync(dependentId, UserId, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventAttendeeMetricsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeeMetricsV2Controller.cs
@@ -1,0 +1,290 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for attendee-submitted event metrics.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/events/{eventId}/attendee-metrics")]
+    public class EventAttendeeMetricsV2Controller(
+        IEventAttendeeMetricsManager metricsManager,
+        IKeyedManager<Event> eventManager,
+        IAuthorizationService authorizationService,
+        ILogger<EventAttendeeMetricsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets the current user's metrics submission for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user's metrics.</response>
+        /// <response code="404">No metrics found.</response>
+        [HttpGet("my-metrics")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(EventAttendeeMetricsDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetMyMetrics(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetMyMetrics for Event={EventId}", eventId);
+
+            var metrics = await metricsManager.GetMyMetricsAsync(eventId, UserId, cancellationToken);
+
+            if (metrics is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(metrics.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Submits or updates metrics for the current user.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="metrics">The metrics to submit.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the submitted metrics.</response>
+        /// <response code="400">Validation error.</response>
+        [HttpPost("my-metrics")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventAttendeeMetricsDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> SubmitMyMetrics(
+            Guid eventId,
+            [FromBody] EventAttendeeMetrics metrics,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SubmitMyMetrics for Event={EventId}", eventId);
+
+            var result = await metricsManager.SubmitMetricsAsync(eventId, UserId, metrics, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Ok(result.Data.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the public metrics summary for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the public metrics summary.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpGet("public")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(EventMetricsPublicSummary), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetPublicMetrics(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPublicMetrics for Event={EventId}", eventId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            var summary = await metricsManager.GetPublicMetricsSummaryAsync(eventId, cancellationToken);
+
+            return Ok(summary);
+        }
+
+        /// <summary>
+        /// Gets pending metrics submissions for an event. Requires event lead.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the pending metrics.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpGet("pending")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<EventAttendeeMetricsDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetPending(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPendingMetrics for Event={EventId}", eventId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var pendingMetrics = await metricsManager.GetPendingByEventIdAsync(eventId, cancellationToken);
+            var dtos = pendingMetrics.Select(m => m.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Approves all pending metrics submissions for an event. Requires event lead.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the count of approved submissions.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpPost("approve-all")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ApproveAll(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ApproveAllPendingMetrics for Event={EventId}", eventId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var result = await metricsManager.ApproveAllPendingAsync(eventId, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Ok(result.Data);
+        }
+
+        /// <summary>
+        /// Approves a metrics submission. Requires event lead.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="metricsId">The metrics ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the approved metrics.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost("{metricsId}/approve")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventAttendeeMetricsDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Approve(Guid eventId, Guid metricsId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ApproveMetrics Metrics={MetricsId} for Event={EventId}", metricsId, eventId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var result = await metricsManager.ApproveAsync(metricsId, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Ok(result.Data.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Rejects a metrics submission. Requires event lead.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="metricsId">The metrics ID.</param>
+        /// <param name="request">The rejection request with reason.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the rejected metrics.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost("{metricsId}/reject")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventAttendeeMetricsDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Reject(
+            Guid eventId,
+            Guid metricsId,
+            [FromBody] RejectMetricsRequestDto request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 RejectMetrics Metrics={MetricsId} for Event={EventId}", metricsId, eventId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var result = await metricsManager.RejectAsync(metricsId, request.RejectionReason, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Ok(result.Data.ToV2Dto());
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
@@ -1,0 +1,153 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing event attendee routes.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/eventattendeeroutes")]
+    public class EventAttendeeRoutesV2Controller(
+        IEventAttendeeRouteManager eventAttendeeRouteManager,
+        ILogger<EventAttendeeRoutesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets event attendee routes for a specific event and user.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the routes for the event and user.</response>
+        [HttpGet("{eventId}/{userId}")]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayEventAttendeeRoute>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByEventAndUser(Guid eventId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventAttendeeRoutes Event={EventId}, User={UserId}", eventId, userId);
+
+            var result = (await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken))
+                .Where(e => e.CreatedByUserId == userId)
+                .Select(x => x.ToDisplayEventAttendeeRoute())
+                .ToList();
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets display event attendee routes by event ID.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the routes for the event.</response>
+        [HttpGet("by-event/{eventId}")]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayEventAttendeeRoute>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByEvent(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventAttendeeRoutesByEvent Event={EventId}", eventId);
+
+            var result = await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken);
+
+            var currentUserId = User.Identity?.IsAuthenticated == true ? UserId : Guid.Empty;
+
+            var displayRoutes = result
+                .Where(r => r.PrivacyLevel != "Private" || r.UserId == currentUserId)
+                .Select(x => x.ToDisplayEventAttendeeRoute())
+                .ToList();
+
+            return Ok(displayRoutes);
+        }
+
+        /// <summary>
+        /// Gets a specific event attendee route by ID.
+        /// </summary>
+        /// <param name="id">The route ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the route.</response>
+        /// <response code="404">Route not found.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayEventAttendeeRoute>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventAttendeeRoute Id={Id}", id);
+
+            var result = await eventAttendeeRouteManager.GetAsync(x => x.Id == id, cancellationToken);
+
+            if (result is null || !result.Any())
+            {
+                return NotFound();
+            }
+
+            var displayRoutes = result.Select(x => x.ToDisplayEventAttendeeRoute()).ToList();
+            return Ok(displayRoutes);
+        }
+
+        /// <summary>
+        /// Adds a new event attendee route.
+        /// </summary>
+        /// <param name="displayEventAttendeeRoute">The route to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Route created.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        public async Task<IActionResult> Add(
+            DisplayEventAttendeeRoute displayEventAttendeeRoute,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddEventAttendeeRoute for Event={EventId}", displayEventAttendeeRoute.EventId);
+
+            var eventAttendeeRoute = displayEventAttendeeRoute.ToEventAttendeeRoute();
+
+            if (displayEventAttendeeRoute.SkipDefaultTrim)
+            {
+                eventAttendeeRoute.TrimStartMeters = -1;
+                eventAttendeeRoute.TrimEndMeters = -1;
+            }
+
+            var result = await eventAttendeeRouteManager.AddAsync(eventAttendeeRoute, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = result.Id }, result);
+        }
+
+        /// <summary>
+        /// Deletes an event attendee route.
+        /// </summary>
+        /// <param name="routeId">The route ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Route deleted.</response>
+        [HttpDelete("{routeId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid routeId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteEventAttendeeRoute Route={RouteId}", routeId);
+
+            await eventAttendeeRouteManager.DeleteAsync(routeId, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventLitterReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventLitterReportsV2Controller.cs
@@ -1,0 +1,140 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing event litter reports.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/eventlitterreports")]
+    public class EventLitterReportsV2Controller(
+        IEventLitterReportManager eventLitterReportManager,
+        IUserManager userManager,
+        ILogger<EventLitterReportsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all event litter reports for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the event litter reports.</response>
+        [HttpGet("by-event/{eventId}")]
+        [ProducesResponseType(typeof(IReadOnlyList<FullEventLitterReport>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByEvent(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventLitterReports for Event={EventId}", eventId);
+
+            var result = await eventLitterReportManager.GetByParentIdAsync(eventId, cancellationToken);
+            var fullReports = await ToFullEventLitterReports(result, cancellationToken);
+
+            return Ok(fullReports);
+        }
+
+        /// <summary>
+        /// Gets the most recent event litter report for a litter report.
+        /// </summary>
+        /// <param name="litterReportId">The litter report ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the event litter report.</response>
+        [HttpGet("by-litter-report/{litterReportId}")]
+        [ProducesResponseType(typeof(FullEventLitterReport), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByLitterReport(Guid litterReportId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventLitterReportByLitterReportId LitterReport={LitterReportId}", litterReportId);
+
+            var result = await eventLitterReportManager.GetAsync(l => l.LitterReportId == litterReportId, cancellationToken);
+            var lastReport = result.OrderByDescending(e => e.CreatedDate).FirstOrDefault();
+            var fullReport = await ToFullEventLitterReport(lastReport, cancellationToken);
+
+            return Ok(fullReport);
+        }
+
+        /// <summary>
+        /// Adds a new event litter report.
+        /// </summary>
+        /// <param name="eventLitterReport">The event litter report to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Event litter report created.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        public async Task<IActionResult> Add(EventLitterReport eventLitterReport, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddEventLitterReport for Event={EventId}", eventLitterReport.EventId);
+
+            await eventLitterReportManager.AddAsync(eventLitterReport, UserId, cancellationToken);
+
+            return StatusCode(StatusCodes.Status201Created);
+        }
+
+        /// <summary>
+        /// Deletes an event litter report.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="litterReportId">The litter report ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Event litter report deleted.</response>
+        [HttpDelete("{eventId}/{litterReportId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid eventId, Guid litterReportId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteEventLitterReport Event={EventId}, LitterReport={LitterReportId}", eventId, litterReportId);
+
+            await eventLitterReportManager.Delete(eventId, litterReportId, cancellationToken);
+
+            return NoContent();
+        }
+
+        private async Task<List<FullEventLitterReport>> ToFullEventLitterReports(
+            IEnumerable<EventLitterReport> eventLitterReports, CancellationToken cancellationToken)
+        {
+            List<FullEventLitterReport> fullReports = [];
+
+            foreach (var eventLitterReport in eventLitterReports)
+            {
+                var fullReport = await ToFullEventLitterReport(eventLitterReport, cancellationToken);
+                fullReports.Add(fullReport);
+            }
+
+            return fullReports;
+        }
+
+        private async Task<FullEventLitterReport> ToFullEventLitterReport(
+            EventLitterReport eventLitterReport, CancellationToken cancellationToken)
+        {
+            var user = await userManager.GetAsync(eventLitterReport.LitterReport.CreatedByUserId, cancellationToken);
+            var fullLitterReport = eventLitterReport.LitterReport.ToFullLitterReport(user.UserName);
+
+            return new FullEventLitterReport
+            {
+                EventId = eventLitterReport.EventId,
+                LitterReportId = eventLitterReport.LitterReportId,
+                LitterReport = fullLitterReport,
+            };
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventPartnerLocationServicesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventPartnerLocationServicesV2Controller.cs
@@ -1,0 +1,210 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing event partner location services.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/eventpartnerlocationservices")]
+    public class EventPartnerLocationServicesV2Controller(
+        IEventPartnerLocationServiceManager eventPartnerLocationServiceManager,
+        IKeyedManager<Event> eventManager,
+        IAuthorizationService authorizationService,
+        ILogger<EventPartnerLocationServicesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all partner locations for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner locations.</response>
+        [HttpGet("{eventId}")]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayEventPartnerLocation>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByEvent(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventPartnerLocationServices for Event={EventId}", eventId);
+
+            var result = await eventPartnerLocationServiceManager.GetByEventAsync(eventId, cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets the hauling partner location for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the hauling partner location.</response>
+        [HttpGet("hauling/{eventId}")]
+        [ProducesResponseType(typeof(PartnerLocation), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetHaulingPartnerLocation(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetHaulingPartnerLocation for Event={EventId}", eventId);
+
+            var result = await eventPartnerLocationServiceManager.GetHaulingPartnerLocationForEvent(eventId, cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets partner location services for a specific event and partner location.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="partnerLocationId">The partner location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner location services.</response>
+        [HttpGet("{eventId}/{partnerLocationId}")]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayEventPartnerLocationService>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByEventAndPartnerLocation(
+            Guid eventId, Guid partnerLocationId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventPartnerLocationServices Event={EventId}, PartnerLocation={PartnerLocationId}",
+                eventId, partnerLocationId);
+
+            var result = await eventPartnerLocationServiceManager.GetByEventAndPartnerLocationAsync(
+                eventId, partnerLocationId, cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Adds a new event partner location service.
+        /// </summary>
+        /// <param name="dto">The service to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Service created.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Add(
+            EventPartnerLocationServiceRequestDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddEventPartnerLocationService for Event={EventId}", dto.EventId);
+
+            var mobEvent = await eventManager.GetAsync(dto.EventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            await eventPartnerLocationServiceManager.AddAsync(entity, UserId, cancellationToken);
+
+            return StatusCode(StatusCodes.Status201Created);
+        }
+
+        /// <summary>
+        /// Updates an event partner location service.
+        /// </summary>
+        /// <param name="dto">The service to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Service updated.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(
+            EventPartnerLocationServiceRequestDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateEventPartnerLocationService for Event={EventId}", dto.EventId);
+
+            var mobEvent = await eventManager.GetAsync(dto.EventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            await eventPartnerLocationServiceManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Deletes an event partner location service.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="partnerLocationId">The partner location ID.</param>
+        /// <param name="serviceTypeId">The service type ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Service deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpDelete("{eventId}/{partnerLocationId}/{serviceTypeId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(
+            Guid eventId, Guid partnerLocationId, int serviceTypeId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteEventPartnerLocationService Event={EventId}, PartnerLocation={PartnerLocationId}, ServiceType={ServiceTypeId}",
+                eventId, partnerLocationId, serviceTypeId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            await eventPartnerLocationServiceManager.DeleteAsync(eventId, partnerLocationId, serviceTypeId, cancellationToken);
+
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventPhotosV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventPhotosV2Controller.cs
@@ -1,0 +1,185 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for managing event photos.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/events/{eventId}/photos")]
+    public class EventPhotosV2Controller(
+        IEventPhotoManager eventPhotoManager,
+        IEventManager eventManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IImageManager imageManager,
+        ILogger<EventPhotosV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all photos for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="photoType">Optional filter by photo type (Before, During, After).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the photo list.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IReadOnlyList<EventPhotoDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetEventPhotos(
+            Guid eventId,
+            [FromQuery] EventPhotoType? photoType,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventPhotos for Event={EventId}, PhotoType={PhotoType}", eventId, photoType);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            IEnumerable<EventPhoto> photos;
+            if (photoType.HasValue)
+            {
+                photos = await eventPhotoManager.GetByEventIdAndTypeAsync(eventId, photoType.Value, cancellationToken);
+            }
+            else
+            {
+                photos = await eventPhotoManager.GetByEventIdAsync(eventId, false, cancellationToken);
+            }
+
+            var dtos = photos.Select(p => p.ToV2Dto()).ToList();
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Uploads a photo for an event. Only event leads and attendees can upload.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="imageUpload">The image upload data.</param>
+        /// <param name="photoType">The type of photo (Before, During, After).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Photo created.</response>
+        /// <response code="403">Not event lead or attendee.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventPhotoDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadPhoto(
+            Guid eventId,
+            [FromForm] ImageUpload imageUpload,
+            [FromQuery] EventPhotoType photoType = EventPhotoType.During,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UploadPhoto for Event={EventId}, Type={PhotoType}", eventId, photoType);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            var isLead = mobEvent.CreatedByUserId == UserId;
+            var attendees = await eventAttendeeManager.GetAsync(ea => ea.EventId == eventId && ea.UserId == UserId, cancellationToken);
+            var isAttendee = attendees.Any();
+
+            if (!isLead && !isAttendee)
+            {
+                return Forbid();
+            }
+
+            var photoId = Guid.NewGuid();
+            var eventPhoto = new EventPhoto
+            {
+                Id = photoId,
+                EventId = eventId,
+                PhotoType = photoType,
+                Caption = string.Empty,
+                UploadedByUserId = UserId,
+                UploadedDate = DateTimeOffset.UtcNow,
+                ModerationStatus = PhotoModerationStatus.Pending,
+            };
+
+            imageUpload.ParentId = photoId;
+            imageUpload.ImageType = ImageTypeEnum.EventPhoto;
+            await imageManager.UploadImageAsync(imageUpload);
+
+            var imageUrl = await imageManager.GetImageUrlAsync(photoId, ImageTypeEnum.EventPhoto, ImageSizeEnum.Reduced, cancellationToken);
+            var thumbnailUrl = await imageManager.GetImageUrlAsync(photoId, ImageTypeEnum.EventPhoto, ImageSizeEnum.Thumb, cancellationToken);
+
+            eventPhoto.ImageUrl = imageUrl;
+            eventPhoto.ThumbnailUrl = thumbnailUrl;
+
+            var createdPhoto = await eventPhotoManager.AddAsync(eventPhoto, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetEventPhotos), new { eventId }, createdPhoto.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a photo. Only the uploader or event lead can delete.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="photoId">The photo ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Photo deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Photo not found.</response>
+        [HttpDelete("{photoId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeletePhoto(
+            Guid eventId,
+            Guid photoId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePhoto Photo={PhotoId} from Event={EventId}", photoId, eventId);
+
+            var photo = await eventPhotoManager.GetAsync(photoId, cancellationToken);
+            if (photo is null || photo.EventId != eventId)
+            {
+                return NotFound();
+            }
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            var isLead = mobEvent?.CreatedByUserId == UserId;
+            var isUploader = photo.UploadedByUserId == UserId;
+
+            if (!isLead && !isUploader)
+            {
+                return Forbid();
+            }
+
+            await eventPhotoManager.DeletePhotoAsync(photoId, UserId, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventRoutesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventRoutesV2Controller.cs
@@ -1,0 +1,87 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for event-level route aggregation.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/events/{eventId}/routes")]
+    public class EventRoutesV2Controller(
+        IEventAttendeeRouteManager eventAttendeeRouteManager,
+        ILogger<EventRoutesV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets anonymized routes for an event (no user identity).
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the anonymized routes.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayAnonymizedRoute>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetRoutes(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventRoutes for Event={EventId}", eventId);
+
+            var routes = await eventAttendeeRouteManager.GetAnonymizedRoutesForEventAsync(eventId, cancellationToken);
+
+            return Ok(routes);
+        }
+
+        /// <summary>
+        /// Gets aggregated route statistics for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the route statistics.</response>
+        [HttpGet("stats")]
+        [ProducesResponseType(typeof(DisplayEventRouteStats), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetStats(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventRouteStats for Event={EventId}", eventId);
+
+            var stats = await eventAttendeeRouteManager.GetEventRouteStatsAsync(eventId, cancellationToken);
+
+            return Ok(stats);
+        }
+
+        /// <summary>
+        /// Gets route aggregate data for pre-filling an event summary.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="weightUnitId">Target weight unit (1=lb, 2=kg). Defaults to 1.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the summary prefill data.</response>
+        [HttpGet("summary-prefill")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(EventSummaryPrefill), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetSummaryPrefill(
+            Guid eventId,
+            [FromQuery] int weightUnitId = 1,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetEventSummaryPrefill for Event={EventId}", eventId);
+
+            var prefill = await eventAttendeeRouteManager.GetEventSummaryPrefillAsync(eventId, weightUnitId, cancellationToken);
+
+            return Ok(prefill);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/NewsletterPreferencesV2Controller.cs
+++ b/TrashMob/Controllers/V2/NewsletterPreferencesV2Controller.cs
@@ -1,0 +1,149 @@
+namespace TrashMob.Controllers.V2
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing newsletter preferences.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/newsletter-preferences")]
+    public class NewsletterPreferencesV2Controller(
+        IUserNewsletterPreferenceManager preferenceManager,
+        ILookupRepository<NewsletterCategory> categoryRepository,
+        ILogger<NewsletterPreferencesV2Controller> logger) : ControllerBase
+    {
+        private System.Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all newsletter categories.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the categories.</response>
+        [HttpGet("categories")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(IReadOnlyList<NewsletterCategoryDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetCategories(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetNewsletterCategories");
+
+            var categories = await categoryRepository.Get(c => c.IsActive == true)
+                .OrderBy(c => c.DisplayOrder)
+                .ToListAsync(cancellationToken);
+
+            var dtos = categories.Select(c => c.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets the current user's newsletter preferences.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user's preferences.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<NewsletterPreferenceDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMyPreferences(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetMyNewsletterPreferences");
+
+            var preferences = await preferenceManager.GetUserPreferencesAsync(UserId, cancellationToken);
+
+            var categories = await categoryRepository.Get(c => c.IsActive == true)
+                .OrderBy(c => c.DisplayOrder)
+                .ToListAsync(cancellationToken);
+
+            var preferenceDict = preferences.ToDictionary(p => p.CategoryId);
+
+            var result = categories.Select(c =>
+            {
+                var hasPreference = preferenceDict.TryGetValue(c.Id, out var pref);
+                return new NewsletterPreferenceDto
+                {
+                    CategoryId = c.Id,
+                    CategoryName = c.Name ?? string.Empty,
+                    CategoryDescription = c.Description ?? string.Empty,
+                    IsSubscribed = hasPreference ? pref.IsSubscribed : c.IsDefault,
+                    SubscribedDate = hasPreference ? pref.SubscribedDate : null,
+                    UnsubscribedDate = hasPreference ? pref.UnsubscribedDate : null,
+                };
+            }).ToList();
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Updates a user's subscription preference for a category.
+        /// </summary>
+        /// <param name="request">The update request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated preference.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(NewsletterPreferenceDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdatePreference(
+            [FromBody] UpdateNewsletterPreferenceDto request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateNewsletterPreference Category={CategoryId}, IsSubscribed={IsSubscribed}",
+                request.CategoryId, request.IsSubscribed);
+
+            var preference = await preferenceManager.UpdatePreferenceAsync(
+                UserId, request.CategoryId, request.IsSubscribed, cancellationToken);
+
+            var category = await categoryRepository.Get(c => c.Id == preference.CategoryId)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            var dto = new NewsletterPreferenceDto
+            {
+                CategoryId = preference.CategoryId,
+                CategoryName = category?.Name ?? string.Empty,
+                CategoryDescription = category?.Description ?? string.Empty,
+                IsSubscribed = preference.IsSubscribed,
+                SubscribedDate = preference.SubscribedDate,
+                UnsubscribedDate = preference.UnsubscribedDate,
+            };
+
+            return Ok(dto);
+        }
+
+        /// <summary>
+        /// Unsubscribes the user from all newsletter categories.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Unsubscribed from all.</response>
+        [HttpPost("unsubscribe-all")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UnsubscribeAll(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UnsubscribeAllNewsletters");
+
+            await preferenceManager.UnsubscribeAllAsync(UserId, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PickupLocationsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PickupLocationsV2Controller.cs
@@ -1,0 +1,299 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for managing pickup locations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/pickuplocations")]
+    public class PickupLocationsV2Controller(
+        IPickupLocationManager pickupLocationManager,
+        IEventManager eventManager,
+        IImageManager imageManager,
+        IAuthorizationService authorizationService,
+        ILogger<PickupLocationsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets a pickup location by ID.
+        /// </summary>
+        /// <param name="id">The pickup location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the pickup location.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(PickupLocationDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPickupLocation Id={Id}", id);
+
+            var entity = await pickupLocationManager.GetAsync(id, cancellationToken);
+            if (entity is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(entity.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets pickup locations by event ID.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the pickup locations for the event.</response>
+        [HttpGet("by-event/{eventId}")]
+        [ProducesResponseType(typeof(IReadOnlyList<PickupLocationDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByEvent(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPickupLocationsByEvent Event={EventId}", eventId);
+
+            var entities = await pickupLocationManager.GetByParentIdAsync(eventId, cancellationToken);
+            var dtos = entities.Select(e => e.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Adds a new pickup location.
+        /// </summary>
+        /// <param name="dto">The pickup location data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Pickup location created.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PickupLocationDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Add(PickupLocationDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPickupLocation for Event={EventId}", dto.EventId);
+
+            var mobEvent = await eventManager.GetAsync(dto.EventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await pickupLocationManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a pickup location.
+        /// </summary>
+        /// <param name="id">The pickup location ID.</param>
+        /// <param name="dto">The updated pickup location data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated pickup location.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPut("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PickupLocationDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(Guid id, PickupLocationDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdatePickupLocation Id={Id}", id);
+
+            var localPickupLocation = await pickupLocationManager.GetAsync(id, cancellationToken);
+            if (localPickupLocation is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(localPickupLocation, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                var mobEvent = await eventManager.GetAsync(localPickupLocation.EventId, cancellationToken);
+                if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+                {
+                    return Forbid();
+                }
+            }
+
+            localPickupLocation.County = dto.County;
+            localPickupLocation.Latitude = dto.Latitude;
+            localPickupLocation.Longitude = dto.Longitude;
+            localPickupLocation.Name = dto.Name;
+            localPickupLocation.Notes = dto.Notes;
+            localPickupLocation.PostalCode = dto.PostalCode;
+            localPickupLocation.Region = dto.Region;
+            localPickupLocation.StreetAddress = dto.StreetAddress;
+            localPickupLocation.Country = dto.Country;
+            localPickupLocation.City = dto.City;
+            localPickupLocation.HasBeenPickedUp = dto.HasBeenPickedUp;
+            localPickupLocation.HasBeenSubmitted = dto.HasBeenSubmitted;
+
+            var result = await pickupLocationManager.UpdateAsync(localPickupLocation, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a pickup location.
+        /// </summary>
+        /// <param name="id">The pickup location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Pickup location deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePickupLocation Id={Id}", id);
+
+            var entity = await pickupLocationManager.GetAsync(id, cancellationToken);
+            if (entity is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(entity, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                var mobEvent = await eventManager.GetAsync(entity.EventId, cancellationToken);
+                if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+                {
+                    return Forbid();
+                }
+            }
+
+            await pickupLocationManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Submits pickup locations for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Pickup locations submitted.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost("submit/{eventId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Submit(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SubmitPickupLocations for Event={EventId}", eventId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+            if (mobEvent is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            await pickupLocationManager.SubmitPickupLocationsAsync(eventId, UserId, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Uploads an image for a pickup location.
+        /// </summary>
+        /// <param name="id">The pickup location ID.</param>
+        /// <param name="imageUpload">The image upload data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Image uploaded.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost("{id}/image")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> UploadImage(Guid id, [FromForm] ImageUpload imageUpload, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadPickupLocationImage Id={Id}", id);
+
+            var entity = await pickupLocationManager.GetAsync(id, cancellationToken);
+            if (entity is null)
+            {
+                return NotFound();
+            }
+
+            var mobEvent = await eventManager.GetAsync(entity.EventId, cancellationToken);
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            await imageManager.UploadImageAsync(imageUpload);
+
+            return StatusCode(StatusCodes.Status201Created);
+        }
+
+        /// <summary>
+        /// Gets the image URL for a pickup location.
+        /// </summary>
+        /// <param name="id">The pickup location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the image URL.</response>
+        /// <response code="204">No image found.</response>
+        [HttpGet("{id}/image")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> GetImage(Guid id, CancellationToken cancellationToken)
+        {
+            var url = await imageManager.GetImageUrlAsync(id, ImageTypeEnum.Pickup, ImageSizeEnum.Raw, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return NoContent();
+            }
+
+            return Ok(url);
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/WaiversV2Controller.cs
+++ b/TrashMob/Controllers/V2/WaiversV2Controller.cs
@@ -1,0 +1,162 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for user waiver operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/waivers")]
+    public class WaiversV2Controller(
+        IUserWaiverManager userWaiverManager,
+        IWaiverDocumentManager waiverDocumentManager,
+        IUserManager userManager,
+        ILogger<WaiversV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets waivers the current user needs to sign.
+        /// </summary>
+        /// <param name="communityId">Optional community ID to include community-specific waivers.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the required waiver versions.</response>
+        [HttpGet("required")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<WaiverVersionDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetRequired(
+            [FromQuery] Guid? communityId = null,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetRequiredWaivers CommunityId={CommunityId}", communityId);
+
+            var result = await userWaiverManager.GetPendingWaiversForUserAsync(UserId, communityId, cancellationToken);
+            var dtos = result.Select(w => w.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all waivers signed by the current user.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user's signed waivers.</response>
+        [HttpGet("my")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<UserWaiverDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMyWaivers(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetMyWaivers");
+
+            var result = await userWaiverManager.GetUserWaiversAsync(UserId, cancellationToken);
+            var dtos = result.Select(w => w.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Accepts a waiver and creates a signed record.
+        /// </summary>
+        /// <param name="request">The waiver acceptance request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Waiver accepted.</response>
+        /// <response code="400">Validation error.</response>
+        [HttpPost("accept")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(UserWaiverDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Accept(
+            [FromBody] AcceptWaiverRequestDto request,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 AcceptWaiver WaiverVersion={WaiverVersionId}", request.WaiverVersionId);
+
+            if (request.WaiverVersionId == Guid.Empty)
+            {
+                return BadRequest("Waiver version ID is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(request.TypedLegalName))
+            {
+                return BadRequest("Typed legal name is required.");
+            }
+
+            var ipAddress = GetClientIpAddress();
+            var userAgent = Request.Headers.UserAgent.ToString();
+
+            var acceptRequest = new AcceptWaiverRequest
+            {
+                WaiverVersionId = request.WaiverVersionId,
+                TypedLegalName = request.TypedLegalName,
+                UserId = UserId,
+                IPAddress = ipAddress,
+                UserAgent = userAgent,
+                IsMinor = request.IsMinor,
+                GuardianUserId = request.GuardianUserId,
+                GuardianName = request.GuardianName,
+                GuardianRelationship = request.GuardianRelationship,
+            };
+
+            var result = await userWaiverManager.AcceptWaiverAsync(acceptRequest, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            var userWaiver = result.Data;
+            var user = await userManager.GetAsync(UserId, cancellationToken);
+
+            try
+            {
+                var waiverWithDetails = await userWaiverManager
+                    .GetUserWaiverWithDetailsAsync(userWaiver.Id, cancellationToken);
+
+                var documentUrl = await waiverDocumentManager
+                    .GenerateAndStoreWaiverPdfAsync(waiverWithDetails, user, cancellationToken);
+
+                userWaiver.DocumentUrl = documentUrl;
+                await userWaiverManager.UpdateAsync(userWaiver, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "PDF generation failed for waiver {WaiverId}", userWaiver.Id);
+            }
+
+            return CreatedAtAction(nameof(GetMyWaivers), userWaiver.ToV2Dto());
+        }
+
+        private string GetClientIpAddress()
+        {
+            var forwardedFor = Request.Headers["X-Forwarded-For"].ToString();
+            if (!string.IsNullOrWhiteSpace(forwardedFor))
+            {
+                return forwardedFor.Split(',')[0].Trim();
+            }
+
+            return HttpContext.Connection.RemoteIpAddress?.ToString() ?? "Unknown";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds all 10 remaining mobile-used v1 controllers as v2 endpoints, completing the API v2 migration
- **10 new v2 controllers**: EventPhotos, PickupLocations, EventLitterReports, EventAttendeeRoutes, EventRoutes, Dependents, EventAttendeeMetrics, EventPartnerLocationServices, NewsletterPreferences, Waivers
- **13 new DTOs** with nullable-enabled types and XML documentation
- **7 mapping extension files** for entity-to-DTO conversion
- **17 test files** (7 mapping tests + 10 controller tests) — 654 tests passing

## Details

### Controllers
| Controller | Route | Endpoints | Key Features |
|-----------|-------|-----------|-------------|
| EventPhotosV2 | `events/{eventId}/photos` | GET, POST, DELETE | Multipart upload, blob storage |
| PickupLocationsV2 | `pickuplocations` | 8 endpoints | CRUD, submit, image upload, event lead auth |
| EventLitterReportsV2 | `eventlitterreports` | 4 endpoints | Composite key, reuses FullEventLitterReport |
| EventAttendeeRoutesV2 | `eventattendeeroutes` | 5 endpoints | Privacy filtering, SkipDefaultTrim |
| EventRoutesV2 | `events/{eventId}/routes` | 3 endpoints | Anonymized routes, stats, summary prefill |
| DependentsV2 | `users/{userId}/dependents` | 4 endpoints | CRUD with soft delete, ownership verification |
| EventAttendeeMetricsV2 | `events/{eventId}/attendee-metrics` | 7 endpoints | ServiceResult pattern, event lead approve/reject |
| EventPartnerLocationServicesV2 | `eventpartnerlocationservices` | 6 endpoints | Composite key delete, reuses display POCOs |
| NewsletterPreferencesV2 | `newsletter-preferences` | 4 endpoints | Named DTOs replacing anonymous objects |
| WaiversV2 | `waivers` | 3 endpoints | PDF generation, IP/UserAgent capture |

### DTOs (13 new)
EventPhotoDto, PickupLocationDto, DependentDto, EventAttendeeMetricsDto, WaiverVersionDto, UserWaiverDto, AcceptWaiverRequestDto, RejectMetricsRequestDto, UpdateNewsletterPreferenceDto, EventPartnerLocationServiceRequestDto, NewsletterCategoryDto, NewsletterPreferenceDto, WaiverCheckResultDto

### Reused POCOs (no wrapper needed)
DisplayEventAttendeeRoute, FullEventLitterReport, DisplayEventPartnerLocation, DisplayEventPartnerLocationService, DisplayAnonymizedRoute, DisplayEventRouteStats, EventSummaryPrefill, EventMetricsPublicSummary

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors, 0 warnings
- [x] `dotnet test TrashMob.Shared.Tests` — 654 passed (2 pre-existing ProspectScoring failures unrelated)
- [ ] CI pipeline passes
- [ ] Manual smoke test of key endpoints via Swagger

🤖 Generated with [Claude Code](https://claude.com/claude-code)