### PR TITLE
Add full CRUD v2 endpoints for mobile migration

### DIFF
--- a/TrashMob.Shared.Tests/Controllers/V2/DependentInvitationsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/DependentInvitationsV2ControllerTests.cs
@@ -1,0 +1,138 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class DependentInvitationsV2ControllerTests
+    {
+        private readonly Mock<IDependentInvitationManager> invitationManager = new();
+        private readonly Mock<IDependentManager> dependentManager = new();
+        private readonly Mock<ILogger<DependentInvitationsV2Controller>> logger = new();
+        private readonly DependentInvitationsV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public DependentInvitationsV2ControllerTests()
+        {
+            controller = new DependentInvitationsV2Controller(invitationManager.Object, dependentManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+        }
+
+        [Fact]
+        public async Task GetInvitationsForDependent_ReturnsOk()
+        {
+            var dependentId = Guid.NewGuid();
+            var invitations = new List<DependentInvitation>
+            {
+                new() { Id = Guid.NewGuid() },
+            };
+
+            invitationManager.Setup(m => m.GetByDependentIdAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(invitations);
+
+            var result = await controller.GetInvitationsForDependent(userId, dependentId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returned = Assert.IsAssignableFrom<IEnumerable<DependentInvitation>>(okResult.Value);
+            Assert.Single(returned);
+        }
+
+        [Fact]
+        public async Task GetInvitationsForDependent_ReturnsForbid_WhenNotParent()
+        {
+            var otherUserId = Guid.NewGuid();
+            var dependentId = Guid.NewGuid();
+
+            var result = await controller.GetInvitationsForDependent(otherUserId, dependentId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateInvitation_ReturnsCreated()
+        {
+            var dependentId = Guid.NewGuid();
+            var dependent = new Dependent { Id = dependentId, ParentUserId = userId };
+            var request = new CreateDependentInvitationRequest { Email = "minor@example.com" };
+            var invitation = new DependentInvitation { Id = Guid.NewGuid() };
+
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependent);
+            invitationManager.Setup(m => m.CreateInvitationAsync(dependentId, request.Email, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(invitation);
+
+            var result = await controller.CreateInvitation(userId, dependentId, request, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateInvitation_ReturnsForbid_WhenNotParent()
+        {
+            var otherUserId = Guid.NewGuid();
+            var dependentId = Guid.NewGuid();
+            var request = new CreateDependentInvitationRequest { Email = "minor@example.com" };
+
+            var result = await controller.CreateInvitation(otherUserId, dependentId, request, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task CancelInvitation_ReturnsOk()
+        {
+            var invitationId = Guid.NewGuid();
+
+            invitationManager.Setup(m => m.CancelInvitationAsync(invitationId, userId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.CancelInvitation(invitationId, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
+        public async Task CancelInvitation_ReturnsBadRequest_WhenInvalidOperation()
+        {
+            var invitationId = Guid.NewGuid();
+
+            invitationManager.Setup(m => m.CancelInvitationAsync(invitationId, userId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Invitation already cancelled"));
+
+            var result = await controller.CancelInvitation(invitationId, CancellationToken.None);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Invitation already cancelled", badRequest.Value);
+        }
+
+        [Fact]
+        public async Task ResendInvitation_ReturnsOk()
+        {
+            var invitationId = Guid.NewGuid();
+            var updatedInvitation = new DependentInvitation { Id = invitationId };
+
+            invitationManager.Setup(m => m.ResendInvitationAsync(invitationId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(updatedInvitation);
+
+            var result = await controller.ResendInvitation(invitationId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returned = Assert.IsType<DependentInvitation>(okResult.Value);
+            Assert.Equal(invitationId, returned.Id);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/DependentWaiversV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/DependentWaiversV2ControllerTests.cs
@@ -1,0 +1,219 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class DependentWaiversV2ControllerTests
+    {
+        private readonly Mock<IDependentWaiverManager> waiverManager = new();
+        private readonly Mock<IDependentManager> dependentManager = new();
+        private readonly Mock<IWaiverDocumentManager> waiverDocumentManager = new();
+        private readonly Mock<IUserManager> userManager = new();
+        private readonly Mock<ILogger<DependentWaiversV2Controller>> logger = new();
+        private readonly DependentWaiversV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public DependentWaiversV2ControllerTests()
+        {
+            controller = new DependentWaiversV2Controller(
+                waiverManager.Object,
+                dependentManager.Object,
+                waiverDocumentManager.Object,
+                userManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+            httpContext.Request.Headers["User-Agent"] = "TestAgent/1.0";
+            httpContext.Items["UserId"] = userId.ToString();
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task GetCurrentWaiver_ReturnsOk_WhenDependentExistsWithCorrectParentAndWaiverExists()
+        {
+            var dependentId = Guid.NewGuid();
+            var dependent = new Dependent { Id = dependentId, ParentUserId = userId };
+            var waiver = new DependentWaiver
+            {
+                Id = Guid.NewGuid(),
+                DependentId = dependentId,
+                SignedByUserId = userId,
+                AcceptedDate = DateTimeOffset.UtcNow,
+            };
+
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependent);
+            waiverManager.Setup(m => m.GetCurrentWaiverAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(waiver);
+
+            var result = await controller.GetCurrentWaiver(dependentId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedWaiver = Assert.IsType<DependentWaiver>(okResult.Value);
+            Assert.Equal(waiver.Id, returnedWaiver.Id);
+        }
+
+        [Fact]
+        public async Task GetCurrentWaiver_ReturnsForbid_WhenNotParent()
+        {
+            var dependentId = Guid.NewGuid();
+            var otherUserId = Guid.NewGuid();
+            var dependent = new Dependent { Id = dependentId, ParentUserId = otherUserId };
+
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependent);
+
+            var result = await controller.GetCurrentWaiver(dependentId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task GetCurrentWaiver_ReturnsNotFound_WhenNoWaiver()
+        {
+            var dependentId = Guid.NewGuid();
+            var dependent = new Dependent { Id = dependentId, ParentUserId = userId };
+
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependent);
+            waiverManager.Setup(m => m.GetCurrentWaiverAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DependentWaiver)null);
+
+            var result = await controller.GetCurrentWaiver(dependentId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task SignWaiver_ReturnsCreated_WhenSuccess()
+        {
+            var dependentId = Guid.NewGuid();
+            var waiverVersionId = Guid.NewGuid();
+            var dependent = new Dependent { Id = dependentId, ParentUserId = userId };
+            var signedWaiver = new DependentWaiver
+            {
+                Id = Guid.NewGuid(),
+                DependentId = dependentId,
+                WaiverVersionId = waiverVersionId,
+                SignedByUserId = userId,
+                TypedLegalName = "Jane Doe",
+                AcceptedDate = DateTimeOffset.UtcNow,
+            };
+
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependent);
+            waiverManager.Setup(m => m.SignWaiverAsync(
+                    dependentId,
+                    waiverVersionId,
+                    "Jane Doe",
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    userId,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<DependentWaiver>.Success(signedWaiver));
+            userManager.Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = userId, UserName = "janedoe" });
+            waiverDocumentManager.Setup(m => m.GenerateAndStoreDependentWaiverPdfAsync(
+                    It.IsAny<DependentWaiver>(),
+                    It.IsAny<Dependent>(),
+                    It.IsAny<User>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync("https://example.com/waiver.pdf");
+
+            var request = new DependentWaiversV2Controller.SignDependentWaiverRequest
+            {
+                WaiverVersionId = waiverVersionId,
+                TypedLegalName = "Jane Doe",
+            };
+
+            var result = await controller.SignWaiver(dependentId, request, CancellationToken.None);
+
+            var statusResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, statusResult.StatusCode);
+            var returnedWaiver = Assert.IsType<DependentWaiver>(statusResult.Value);
+            Assert.Equal(signedWaiver.Id, returnedWaiver.Id);
+        }
+
+        [Fact]
+        public async Task SignWaiver_ReturnsBadRequest_WhenFailed()
+        {
+            var dependentId = Guid.NewGuid();
+            var waiverVersionId = Guid.NewGuid();
+            var dependent = new Dependent { Id = dependentId, ParentUserId = userId };
+
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependent);
+            waiverManager.Setup(m => m.SignWaiverAsync(
+                    dependentId,
+                    waiverVersionId,
+                    "Jane Doe",
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    userId,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<DependentWaiver>.Failure("Waiver version not found"));
+
+            var request = new DependentWaiversV2Controller.SignDependentWaiverRequest
+            {
+                WaiverVersionId = waiverVersionId,
+                TypedLegalName = "Jane Doe",
+            };
+
+            var result = await controller.SignWaiver(dependentId, request, CancellationToken.None);
+
+            var badResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Waiver version not found", badResult.Value);
+        }
+
+        [Fact]
+        public async Task GetWaiverHistory_ReturnsOk()
+        {
+            var dependentId = Guid.NewGuid();
+            var dependent = new Dependent { Id = dependentId, ParentUserId = userId };
+            var waivers = new List<DependentWaiver>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    DependentId = dependentId,
+                    SignedByUserId = userId,
+                    AcceptedDate = DateTimeOffset.UtcNow.AddMonths(-6),
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    DependentId = dependentId,
+                    SignedByUserId = userId,
+                    AcceptedDate = DateTimeOffset.UtcNow,
+                },
+            };
+
+            dependentManager.Setup(m => m.GetAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependent);
+            waiverManager.Setup(m => m.GetByDependentIdAsync(dependentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(waivers);
+
+            var result = await controller.GetWaiverHistory(dependentId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedWaivers = Assert.IsAssignableFrom<IEnumerable<DependentWaiver>>(okResult.Value);
+            Assert.Equal(2, new List<DependentWaiver>(returnedWaivers).Count);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
@@ -123,5 +123,56 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             Assert.IsType<NoContentResult>(result);
             routeManager.Verify(m => m.DeleteAsync(routeId, It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        [Fact]
+        public async Task GetByUser_ReturnsOk_WithRoutes()
+        {
+            var userId = Guid.NewGuid();
+            var routes = new List<EventAttendeeRoute>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    EventId = Guid.NewGuid(),
+                    CreatedByUserId = userId,
+                    UserId = userId,
+                    TotalDistanceMeters = 2000,
+                    UserPath = TestPath,
+                },
+            };
+
+            routeManager.Setup(m => m.GetByCreatedUserIdAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(routes);
+
+            var result = await controller.GetByUser(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedRoutes = Assert.IsAssignableFrom<IEnumerable<EventAttendeeRoute>>(okResult.Value);
+            Assert.Single(returnedRoutes);
+        }
+
+        [Fact]
+        public async Task Update_ReturnsOk()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var displayRoute = new DisplayEventAttendeeRoute
+            {
+                Id = routeId,
+                EventId = Guid.NewGuid(),
+            };
+            var updatedRoute = new EventAttendeeRoute { Id = routeId };
+
+            routeManager
+                .Setup(m => m.UpdateAsync(It.IsAny<EventAttendeeRoute>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(updatedRoute);
+
+            var result = await controller.Update(displayRoute, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<EventAttendeeRoute>(okResult.Value);
+        }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeesV2ControllerTests.cs
@@ -9,26 +9,32 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Moq;
+    using TrashMob.Controllers;
     using TrashMob.Controllers.V2;
     using TrashMob.Models;
+    using TrashMob.Models.Poco;
     using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
     using TrashMob.Shared.Tests.Fixtures;
     using Xunit;
 
     public class EventAttendeesV2ControllerTests
     {
         private readonly Mock<IEventAttendeeManager> eventAttendeeManager = new();
+        private readonly Mock<IUserWaiverManager> userWaiverManager = new();
         private readonly Mock<ILogger<EventAttendeesV2Controller>> logger = new();
         private readonly EventAttendeesV2Controller controller;
+        private readonly Guid currentUserId = Guid.NewGuid();
 
         public EventAttendeesV2ControllerTests()
         {
-            controller = new EventAttendeesV2Controller(eventAttendeeManager.Object, logger.Object);
+            controller = new EventAttendeesV2Controller(eventAttendeeManager.Object, userWaiverManager.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
             };
+            controller.HttpContext.Items["UserId"] = currentUserId.ToString();
         }
 
         [Fact]
@@ -133,6 +139,172 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var response = Assert.IsType<PagedResponse<EventAttendeeDto>>(okResult.Value);
             Assert.Empty(response.Items);
             Assert.Equal(0, response.Pagination.TotalCount);
+        }
+
+        [Fact]
+        public async Task AddEventAttendee_ReturnsOk_WhenWaiverValid()
+        {
+            var eventId = Guid.NewGuid();
+            var attendee = new EventAttendee { UserId = currentUserId };
+
+            userWaiverManager
+                .Setup(m => m.HasValidWaiverForEventAsync(currentUserId, eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.AddEventAttendee(eventId, attendee, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+            eventAttendeeManager.Verify(
+                m => m.AddAsync(It.Is<EventAttendee>(ea => ea.EventId == eventId), currentUserId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task AddEventAttendee_ReturnsBadRequest_WhenWaiverRequired()
+        {
+            var eventId = Guid.NewGuid();
+            var attendee = new EventAttendee { UserId = currentUserId };
+            var requiredWaivers = new List<WaiverVersion>
+            {
+                new() { Id = Guid.NewGuid() },
+            };
+
+            userWaiverManager
+                .Setup(m => m.HasValidWaiverForEventAsync(currentUserId, eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            userWaiverManager
+                .Setup(m => m.GetRequiredWaiversForEventAsync(currentUserId, eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(requiredWaivers);
+
+            var result = await controller.AddEventAttendee(eventId, attendee, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteEventAttendee_ReturnsNoContent()
+        {
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            var result = await controller.DeleteEventAttendee(eventId, userId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            eventAttendeeManager.Verify(m => m.Delete(eventId, userId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetEventLeads_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            var leads = new List<EventAttendee>
+            {
+                new()
+                {
+                    EventId = eventId,
+                    UserId = Guid.NewGuid(),
+                    IsEventLead = true,
+                    User = new User { UserName = "lead1", City = "Seattle" },
+                },
+            };
+
+            eventAttendeeManager
+                .Setup(m => m.GetEventLeadsAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(leads);
+
+            var result = await controller.GetEventLeads(eventId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var users = Assert.IsAssignableFrom<IEnumerable<DisplayUser>>(okResult.Value);
+            Assert.Single(users);
+        }
+
+        [Fact]
+        public async Task PromoteToLead_ReturnsOk_WhenCurrentUserIsLead()
+        {
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var promoted = new EventAttendee { EventId = eventId, UserId = userId, IsEventLead = true };
+
+            eventAttendeeManager
+                .Setup(m => m.IsEventLeadAsync(eventId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            eventAttendeeManager
+                .Setup(m => m.PromoteToLeadAsync(eventId, userId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(promoted);
+
+            var result = await controller.PromoteToLead(eventId, userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var attendee = Assert.IsType<EventAttendee>(okResult.Value);
+            Assert.True(attendee.IsEventLead);
+        }
+
+        [Fact]
+        public async Task PromoteToLead_ReturnsForbid_WhenNotLead()
+        {
+            var eventId = Guid.NewGuid();
+
+            eventAttendeeManager
+                .Setup(m => m.IsEventLeadAsync(eventId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.PromoteToLead(eventId, Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task DemoteFromLead_ReturnsBadRequest_WhenInvalidOperation()
+        {
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            eventAttendeeManager
+                .Setup(m => m.IsEventLeadAsync(eventId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            eventAttendeeManager
+                .Setup(m => m.DemoteFromLeadAsync(eventId, userId, currentUserId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Cannot demote the last lead"));
+
+            var result = await controller.DemoteFromLead(eventId, userId, CancellationToken.None);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Cannot demote the last lead", badRequest.Value);
+        }
+
+        [Fact]
+        public async Task VerifyWaiverStatus_ReturnsOk_WhenEventLead()
+        {
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            eventAttendeeManager
+                .Setup(m => m.IsEventLeadAsync(eventId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            userWaiverManager
+                .Setup(m => m.HasValidWaiverForEventAsync(userId, eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.VerifyAttendeeWaiverStatus(eventId, userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var waiverResult = Assert.IsType<WaiverCheckResult>(okResult.Value);
+            Assert.True(waiverResult.HasValidWaiver);
+        }
+
+        [Fact]
+        public async Task VerifyWaiverStatus_ReturnsForbid_WhenNotLeadOrAdmin()
+        {
+            var eventId = Guid.NewGuid();
+
+            eventAttendeeManager
+                .Setup(m => m.IsEventLeadAsync(eventId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.VerifyAttendeeWaiverStatus(eventId, Guid.NewGuid(), CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
         }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/EventSummaryV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventSummaryV2ControllerTests.cs
@@ -4,6 +4,8 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -16,12 +18,26 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     public class EventSummaryV2ControllerTests
     {
         private readonly Mock<IEventSummaryManager> eventSummaryManager = new();
+        private readonly Mock<IKeyedManager<Event>> eventManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
         private readonly Mock<ILogger<EventSummaryV2Controller>> logger = new();
         private readonly EventSummaryV2Controller controller;
 
+        private readonly Guid currentUserId = Guid.NewGuid();
+
         public EventSummaryV2ControllerTests()
         {
-            controller = new EventSummaryV2Controller(eventSummaryManager.Object, logger.Object);
+            controller = new EventSummaryV2Controller(eventSummaryManager.Object, eventManager.Object, authorizationService.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new System.Security.Claims.ClaimsPrincipal(
+                        new System.Security.Claims.ClaimsIdentity(
+                            new[] { new System.Security.Claims.Claim("sub", currentUserId.ToString()) }, "test")),
+                },
+            };
+            controller.HttpContext.Items["UserId"] = currentUserId.ToString();
         }
 
         [Fact]
@@ -81,6 +97,59 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             Assert.Equal(0, dto.DurationInMinutes);
             Assert.Equal(0, dto.ActualNumberOfAttendees);
             Assert.Equal(0m, dto.PickedWeight);
+        }
+
+        [Fact]
+        public async Task AddEventSummary_ReturnsCreated_WhenAuthorized()
+        {
+            var eventId = Guid.NewGuid();
+            var summary = new EventSummary { NumberOfBags = 5 };
+            var created = new EventSummary { EventId = eventId, NumberOfBags = 5 };
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            eventSummaryManager
+                .Setup(m => m.AddAsync(It.IsAny<EventSummary>(), currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+
+            var result = await controller.AddEventSummary(eventId, summary, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task AddEventSummary_ReturnsForbid_WhenNotAuthorized()
+        {
+            var eventId = Guid.NewGuid();
+            var summary = new EventSummary { NumberOfBags = 5 };
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.AddEventSummary(eventId, summary, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteEventSummary_ReturnsNoContent_WhenAuthorized()
+        {
+            var eventId = Guid.NewGuid();
+            var mobEvent = new Event { Id = eventId };
+
+            eventManager
+                .Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            var result = await controller.DeleteEventSummary(eventId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            eventSummaryManager.Verify(m => m.DeleteAsync(eventId, It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
@@ -5,6 +5,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
@@ -19,12 +20,14 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     public class EventsV2ControllerTests
     {
         private readonly Mock<IEventManager> eventManager = new();
+        private readonly Mock<IEventAttendeeManager> eventAttendeeManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
         private readonly Mock<ILogger<EventsV2Controller>> logger = new();
         private readonly EventsV2Controller controller;
 
         public EventsV2ControllerTests()
         {
-            controller = new EventsV2Controller(eventManager.Object, logger.Object);
+            controller = new EventsV2Controller(eventManager.Object, eventAttendeeManager.Object, authorizationService.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -169,6 +172,107 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetEvent(eventId, CancellationToken.None);
 
             Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task AddEvent_ReturnsCreated()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+
+            var mobEvent = new Event { Id = Guid.NewGuid(), Name = "New Cleanup" };
+            eventManager.Setup(m => m.AddAsync(mobEvent, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+
+            var result = await controller.AddEvent(mobEvent, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(nameof(EventsV2Controller.GetEvent), createdResult.ActionName);
+        }
+
+        [Fact]
+        public async Task UpdateEvent_ReturnsForbid_WhenNotAuthorized()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+
+            authorizationService.Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(),
+                    It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var mobEvent = new Event { Id = Guid.NewGuid(), Name = "Cleanup" };
+
+            var result = await controller.UpdateEvent(mobEvent, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteEvent_ReturnsNoContent_WhenAuthorized()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            controller.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    new[] { new System.Security.Claims.Claim("sub", Guid.NewGuid().ToString()) }, "test"));
+
+            var eventId = Guid.NewGuid();
+            var mobEvent = new Event { Id = eventId };
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+            authorizationService.Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(),
+                    It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            eventManager.Setup(m => m.DeleteAsync(eventId, It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var request = new TrashMob.Shared.Poco.EventCancellationRequest { EventId = eventId, CancellationReason = "Rain" };
+
+            var result = await controller.DeleteEvent(request, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task GetUserEvents_ReturnsOk()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var userId = Guid.NewGuid();
+
+            eventManager.Setup(m => m.GetUserEventsAsync(userId, true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event>());
+            eventAttendeeManager.Setup(m => m.GetEventsUserIsAttendingAsync(userId, true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event>());
+
+            var result = await controller.GetUserEvents(userId, true, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetEventsUserIsAttending_ReturnsOk()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var userId = Guid.NewGuid();
+
+            eventAttendeeManager.Setup(m => m.GetEventsUserIsAttendingAsync(userId, false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Event>());
+
+            var result = await controller.GetEventsUserIsAttending(userId, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetEventLocationsByTimeRange_ReturnsOk()
+        {
+            var start = DateTimeOffset.UtcNow.AddDays(-30);
+            var end = DateTimeOffset.UtcNow;
+
+            eventManager.Setup(m => m.GetEventLocationsByTimeRangeAsync(start, end, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Models.Poco.Location>());
+
+            var result = await controller.GetEventLocationsByTimeRange(start, end, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
         }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/LitterReportsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/LitterReportsV2ControllerTests.cs
@@ -5,6 +5,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
@@ -13,18 +14,22 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using TrashMob.Models;
     using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
     using TrashMob.Shared.Tests.Fixtures;
     using Xunit;
 
     public class LitterReportsV2ControllerTests
     {
         private readonly Mock<ILitterReportManager> litterReportManager = new();
+        private readonly Mock<ILitterImageManager> litterImageManager = new();
+        private readonly Mock<IImageManager> imageManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
         private readonly Mock<ILogger<LitterReportsV2Controller>> logger = new();
         private readonly LitterReportsV2Controller controller;
 
         public LitterReportsV2ControllerTests()
         {
-            controller = new LitterReportsV2Controller(litterReportManager.Object, logger.Object);
+            controller = new LitterReportsV2Controller(litterReportManager.Object, litterImageManager.Object, imageManager.Object, authorizationService.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -145,6 +150,89 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetLitterReport(reportId, CancellationToken.None);
 
             Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task AddLitterReport_ReturnsOk_WhenSuccess()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var report = new LitterReport { Name = "Test Report" };
+            var created = new LitterReport { Id = Guid.NewGuid(), Name = "Test Report" };
+
+            litterReportManager
+                .Setup(m => m.AddWithResultAsync(report, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<LitterReport>.Success(created));
+
+            var result = await controller.AddLitterReport(report, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedReport = Assert.IsType<LitterReport>(okResult.Value);
+            Assert.Equal("Test Report", returnedReport.Name);
+        }
+
+        [Fact]
+        public async Task AddLitterReport_ReturnsBadRequest_WhenFailure()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var report = new LitterReport { Name = "Bad Report" };
+
+            litterReportManager
+                .Setup(m => m.AddWithResultAsync(report, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<LitterReport>.Failure("Invalid report"));
+
+            var result = await controller.AddLitterReport(report, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetUserLitterReports_ReturnsOk()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var userId = Guid.NewGuid();
+            var reports = new List<LitterReport>
+            {
+                new() { Id = Guid.NewGuid(), Name = "My Report" },
+            };
+
+            litterReportManager
+                .Setup(m => m.GetUserLitterReportsAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(reports);
+
+            var result = await controller.GetUserLitterReports(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedReports = Assert.IsAssignableFrom<IEnumerable<LitterReport>>(okResult.Value);
+            Assert.Single(returnedReports);
+        }
+
+        [Fact]
+        public async Task GetImage_ReturnsOk_WhenUrlExists()
+        {
+            var imageId = Guid.NewGuid();
+
+            imageManager
+                .Setup(m => m.GetImageUrlAsync(imageId, ImageTypeEnum.LitterImage, ImageSizeEnum.Reduced, It.IsAny<CancellationToken>()))
+                .ReturnsAsync("https://blob.example.com/image.jpg");
+
+            var result = await controller.GetImage(imageId, ImageSizeEnum.Reduced, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("https://blob.example.com/image.jpg", okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetImage_ReturnsNoContent_WhenUrlEmpty()
+        {
+            var imageId = Guid.NewGuid();
+
+            imageManager
+                .Setup(m => m.GetImageUrlAsync(imageId, ImageTypeEnum.LitterImage, ImageSizeEnum.Reduced, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(string.Empty);
+
+            var result = await controller.GetImage(imageId, ImageSizeEnum.Reduced, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
         }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamEventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamEventsV2ControllerTests.cs
@@ -1,0 +1,142 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class TeamEventsV2ControllerTests
+    {
+        private readonly Mock<ITeamManager> teamManager = new();
+        private readonly Mock<ITeamMemberManager> teamMemberManager = new();
+        private readonly Mock<IKeyedRepository<TeamEvent>> teamEventRepository = new();
+        private readonly Mock<IKeyedManager<Event>> eventManager = new();
+        private readonly Mock<ILogger<TeamEventsV2Controller>> logger = new();
+        private readonly TeamEventsV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public TeamEventsV2ControllerTests()
+        {
+            controller = new TeamEventsV2Controller(
+                teamManager.Object,
+                teamMemberManager.Object,
+                teamEventRepository.Object,
+                eventManager.Object,
+                logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            // Default setup: repository returns empty queryable
+            var teamEvents = new List<TeamEvent>().AsQueryable();
+            teamEventRepository.Setup(r => r.Get()).Returns(new TestAsyncEnumerable<TeamEvent>(teamEvents));
+        }
+
+        [Fact]
+        public async Task GetUpcomingTeamEvents_ReturnsNotFound_WhenTeamNotFound()
+        {
+            var teamId = Guid.NewGuid();
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team)null);
+
+            var result = await controller.GetUpcomingTeamEvents(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetPastTeamEvents_ReturnsNotFound_WhenTeamNotActive()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team
+            {
+                Id = teamId,
+                Name = "Inactive Team",
+                IsActive = false,
+                IsPublic = true,
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            var result = await controller.GetPastTeamEvents(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task LinkEventToTeam_ReturnsForbid_WhenNotLead()
+        {
+            var teamId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var team = new Team
+            {
+                Id = teamId,
+                Name = "Test Team",
+                IsActive = true,
+                IsPublic = true,
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.LinkEventToTeam(teamId, eventId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task UnlinkEventFromTeam_ReturnsNotFound_WhenLinkDoesNotExist()
+        {
+            var teamId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var team = new Team
+            {
+                Id = teamId,
+                Name = "Test Team",
+                IsActive = true,
+                IsPublic = true,
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            // Repository returns empty list, so no link exists
+            var emptyTeamEvents = new List<TeamEvent>().AsQueryable();
+            teamEventRepository
+                .Setup(r => r.Get())
+                .Returns(new TestAsyncEnumerable<TeamEvent>(emptyTeamEvents));
+
+            var result = await controller.UnlinkEventFromTeam(teamId, eventId, CancellationToken.None);
+
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Equal("Event is not linked to this team.", notFoundResult.Value);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamMembersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamMembersV2ControllerTests.cs
@@ -1,0 +1,254 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class TeamMembersV2ControllerTests
+    {
+        private readonly Mock<ITeamManager> teamManager = new();
+        private readonly Mock<ITeamMemberManager> teamMemberManager = new();
+        private readonly Mock<ILogger<TeamMembersV2Controller>> logger = new();
+        private readonly TeamMembersV2Controller controller;
+
+        public TeamMembersV2ControllerTests()
+        {
+            controller = new TeamMembersV2Controller(teamManager.Object, teamMemberManager.Object, logger.Object);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            };
+        }
+
+        private void SetUserId(Guid userId)
+        {
+            controller.ControllerContext.HttpContext.Items["UserId"] = userId.ToString();
+        }
+
+        [Fact]
+        public async Task GetMembers_ReturnsOk_ForPublicTeam()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Public Team", IsActive = true, IsPublic = true };
+            var members = new List<TeamMember>
+            {
+                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = true },
+                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = false },
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.GetByTeamIdAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(members);
+
+            var result = await controller.GetMembers(teamId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedMembers = Assert.IsAssignableFrom<IEnumerable<TeamMember>>(okResult.Value);
+            Assert.Equal(2, new List<TeamMember>(returnedMembers).Count);
+        }
+
+        [Fact]
+        public async Task GetMembers_ReturnsNotFound_WhenTeamNotFound()
+        {
+            var teamId = Guid.NewGuid();
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team)null);
+
+            var result = await controller.GetMembers(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetLeads_ReturnsOk()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, IsPublic = true };
+            var leads = new List<TeamMember>
+            {
+                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = true },
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.GetTeamLeadsAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(leads);
+
+            var result = await controller.GetLeads(teamId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedLeads = Assert.IsAssignableFrom<IEnumerable<TeamMember>>(okResult.Value);
+            Assert.Single(returnedLeads);
+        }
+
+        [Fact]
+        public async Task JoinTeam_ReturnsCreated_ForPublicTeam()
+        {
+            var teamId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Public Team", IsActive = true, IsPublic = true };
+            var newMember = new TeamMember { TeamId = teamId, UserId = userId, IsTeamLead = false };
+
+            SetUserId(userId);
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.GetByTeamAndUserAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TeamMember)null);
+
+            teamMemberManager
+                .Setup(m => m.AddMemberAsync(teamId, userId, false, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newMember);
+
+            var result = await controller.JoinTeam(teamId, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            var returnedMember = Assert.IsType<TeamMember>(createdResult.Value);
+            Assert.Equal(teamId, returnedMember.TeamId);
+            Assert.Equal(userId, returnedMember.UserId);
+            Assert.False(returnedMember.IsTeamLead);
+        }
+
+        [Fact]
+        public async Task JoinTeam_ReturnsBadRequest_WhenAlreadyMember()
+        {
+            var teamId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Public Team", IsActive = true, IsPublic = true };
+            var existingMember = new TeamMember { TeamId = teamId, UserId = userId, IsTeamLead = false };
+
+            SetUserId(userId);
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.GetByTeamAndUserAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingMember);
+
+            var result = await controller.JoinTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task RemoveMember_ReturnsNoContent()
+        {
+            var teamId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, IsPublic = true };
+            var member = new TeamMember { TeamId = teamId, UserId = userId, IsTeamLead = false };
+
+            SetUserId(userId);
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.GetByTeamAndUserAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(member);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            teamMemberManager
+                .Setup(m => m.RemoveMemberAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.RemoveMember(teamId, userId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task PromoteToLead_ReturnsOk()
+        {
+            var teamId = Guid.NewGuid();
+            var currentUserId = Guid.NewGuid();
+            var targetUserId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, IsPublic = true };
+            var member = new TeamMember { TeamId = teamId, UserId = targetUserId, IsTeamLead = false };
+            var promotedMember = new TeamMember { TeamId = teamId, UserId = targetUserId, IsTeamLead = true };
+
+            SetUserId(currentUserId);
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            teamMemberManager
+                .Setup(m => m.GetByTeamAndUserAsync(teamId, targetUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(member);
+
+            teamMemberManager
+                .Setup(m => m.PromoteToLeadAsync(teamId, targetUserId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(promotedMember);
+
+            var result = await controller.PromoteToLead(teamId, targetUserId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedMember = Assert.IsType<TeamMember>(okResult.Value);
+            Assert.True(returnedMember.IsTeamLead);
+        }
+
+        [Fact]
+        public async Task DemoteFromLead_ReturnsBadRequest_WhenLastLead()
+        {
+            var teamId = Guid.NewGuid();
+            var currentUserId = Guid.NewGuid();
+            var targetUserId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, IsPublic = true };
+            var member = new TeamMember { TeamId = teamId, UserId = targetUserId, IsTeamLead = true };
+
+            SetUserId(currentUserId);
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, currentUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            teamMemberManager
+                .Setup(m => m.GetByTeamAndUserAsync(teamId, targetUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(member);
+
+            teamMemberManager
+                .Setup(m => m.GetTeamLeadCountAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.DemoteFromLead(teamId, targetUserId, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamsV2ControllerTests.cs
@@ -19,12 +19,14 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     public class TeamsV2ControllerTests
     {
         private readonly Mock<ITeamManager> teamManager = new();
+        private readonly Mock<ITeamMemberManager> teamMemberManager = new();
+        private readonly Mock<IKeyedManager<User>> userManager = new();
         private readonly Mock<ILogger<TeamsV2Controller>> logger = new();
         private readonly TeamsV2Controller controller;
 
         public TeamsV2ControllerTests()
         {
-            controller = new TeamsV2Controller(teamManager.Object, logger.Object);
+            controller = new TeamsV2Controller(teamManager.Object, teamMemberManager.Object, userManager.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -154,6 +156,133 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetTeam(teamId, CancellationToken.None);
 
             Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetMyTeams_ReturnsOk()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+            var teams = new List<Team>
+            {
+                new() { Id = Guid.NewGuid(), Name = "My Team", IsActive = true },
+            };
+
+            teamManager
+                .Setup(m => m.GetTeamsByUserAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(teams);
+
+            var result = await controller.GetMyTeams(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedTeams = Assert.IsAssignableFrom<IEnumerable<Team>>(okResult.Value);
+            Assert.Single(returnedTeams);
+        }
+
+        [Fact]
+        public async Task CreateTeam_ReturnsCreated_WhenNameAvailable()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+            var team = new Team { Name = "New Team" };
+            var user = new User { Id = userId, UserName = "creator" };
+
+            teamManager
+                .Setup(m => m.IsTeamNameAvailableAsync("New Team", It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            userManager
+                .Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(user);
+            teamManager
+                .Setup(m => m.AddAsync(It.IsAny<Team>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team t, Guid _, CancellationToken _) => t);
+
+            var result = await controller.CreateTeam(team, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+            teamMemberManager.Verify(
+                m => m.AddMemberAsync(It.IsAny<Guid>(), userId, true, userId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateTeam_ReturnsBadRequest_WhenNameTaken()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+            var team = new Team { Name = "Existing Team" };
+
+            teamManager
+                .Setup(m => m.IsTeamNameAvailableAsync("Existing Team", It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.CreateTeam(team, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task DeactivateTeam_ReturnsNoContent_WhenLead()
+        {
+            var teamId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+            var existingTeam = new Team { Id = teamId, Name = "Team", IsActive = true };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingTeam);
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.DeactivateTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            teamManager.Verify(m => m.UpdateAsync(
+                It.Is<Team>(t => !t.IsActive), userId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeactivateTeam_ReturnsForbid_WhenNotLead()
+        {
+            var teamId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+            var existingTeam = new Team { Id = teamId, Name = "Team", IsActive = true };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingTeam);
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.DeactivateTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task CheckTeamName_ReturnsTrue_WhenAvailable()
+        {
+            teamManager
+                .Setup(m => m.IsTeamNameAvailableAsync("Available", It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.CheckTeamName("Available", null, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(true, okResult.Value);
+        }
+
+        [Fact]
+        public async Task CheckTeamName_ReturnsFalse_WhenBlank()
+        {
+            var result = await controller.CheckTeamName("", null, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(false, okResult.Value);
         }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
@@ -19,12 +19,14 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     public class UsersV2ControllerTests
     {
         private readonly Mock<IUserManager> userManager = new();
+        private readonly Mock<IEventAttendeeMetricsManager> metricsManager = new();
+        private readonly Mock<IImageManager> imageManager = new();
         private readonly Mock<ILogger<UsersV2Controller>> logger = new();
         private readonly UsersV2Controller controller;
 
         public UsersV2ControllerTests()
         {
-            controller = new UsersV2Controller(userManager.Object, logger.Object);
+            controller = new UsersV2Controller(userManager.Object, metricsManager.Object, imageManager.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -157,6 +159,85 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                 .ReturnsAsync((User)null);
 
             var result = await controller.GetUser(userId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task AddUser_ReturnsCreated()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+            var user = new User { UserName = "newuser" };
+            var created = new User { Id = userId, UserName = "newuser" };
+
+            userManager
+                .Setup(m => m.AddAsync(user, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+
+            var result = await controller.AddUser(user, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task GetUserByEmail_ReturnsOk_WhenFound()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var user = new User { Id = Guid.NewGuid(), UserName = "emailuser", Email = "test@example.com" };
+
+            userManager
+                .Setup(m => m.GetUserByEmailAsync("test@example.com", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(user);
+
+            var result = await controller.GetUserByEmail("test@example.com", CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<User>(okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetUserByEmail_ReturnsNotFound_WhenNotFound()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+
+            userManager
+                .Setup(m => m.GetUserByEmailAsync("missing@example.com", It.IsAny<CancellationToken>()))
+                .ReturnsAsync((User)null);
+
+            var result = await controller.GetUserByEmail("missing@example.com", CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetUserByObjectId_ReturnsOk_WhenFound()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var objectId = Guid.NewGuid();
+            var user = new User { Id = Guid.NewGuid(), UserName = "oiduser" };
+
+            userManager
+                .Setup(m => m.GetUserByObjectIdAsync(objectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(user);
+
+            var result = await controller.GetUserByObjectId(objectId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<User>(okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetUserImpact_ReturnsNotFound_WhenUserNotFound()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var userId = Guid.NewGuid();
+
+            userManager
+                .Setup(m => m.GetUserByInternalIdAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((User)null);
+
+            var result = await controller.GetUserImpact(userId, CancellationToken.None);
 
             Assert.IsType<NotFoundResult>(result);
         }

--- a/TrashMob/Controllers/V2/DependentInvitationsV2Controller.cs
+++ b/TrashMob/Controllers/V2/DependentInvitationsV2Controller.cs
@@ -1,0 +1,181 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing dependent invitations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/dependentinvitations")]
+    public class DependentInvitationsV2Controller(
+        IDependentInvitationManager dependentInvitationManager,
+        IDependentManager dependentManager,
+        ILogger<DependentInvitationsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Verifies an invitation token and returns invite details. No authentication required.
+        /// </summary>
+        /// <param name="token">The invitation token.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the invitation details.</response>
+        [HttpGet("verify")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(DependentInvitationInfo), StatusCodes.Status200OK)]
+        public async Task<IActionResult> VerifyToken([FromQuery] string token, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 VerifyInvitationToken");
+
+            var info = await dependentInvitationManager.VerifyTokenAsync(token, cancellationToken);
+            return Ok(info);
+        }
+
+        /// <summary>
+        /// Gets all invitations for a specific dependent.
+        /// </summary>
+        /// <param name="userId">The parent user ID.</param>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the invitations.</response>
+        /// <response code="403">User is not the parent.</response>
+        [HttpGet("users/{userId}/dependents/{dependentId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<DependentInvitation>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetInvitationsForDependent(
+            Guid userId, Guid dependentId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetInvitationsForDependent User={UserId}, Dependent={DependentId}", userId, dependentId);
+
+            if (userId != UserId)
+            {
+                return Forbid();
+            }
+
+            var invitations = await dependentInvitationManager.GetByDependentIdAsync(dependentId, cancellationToken);
+            return Ok(invitations);
+        }
+
+        /// <summary>
+        /// Creates and sends an invitation for a dependent to create their own account.
+        /// </summary>
+        /// <param name="userId">The parent user ID.</param>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="request">The invitation request containing the email.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Invitation created.</response>
+        /// <response code="400">Invalid request.</response>
+        /// <response code="403">User is not the parent.</response>
+        /// <response code="404">Dependent not found.</response>
+        [HttpPost("users/{userId}/dependents/{dependentId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DependentInvitation), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CreateInvitation(
+            Guid userId, Guid dependentId, [FromBody] CreateDependentInvitationRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateInvitation User={UserId}, Dependent={DependentId}", userId, dependentId);
+
+            if (userId != UserId)
+            {
+                return Forbid();
+            }
+
+            var dependent = await dependentManager.GetAsync(dependentId, cancellationToken);
+            if (dependent == null || dependent.ParentUserId != userId)
+            {
+                return NotFound();
+            }
+
+            try
+            {
+                var result = await dependentInvitationManager.CreateInvitationAsync(
+                    dependentId, request.Email, userId, cancellationToken);
+
+                return CreatedAtAction(nameof(GetInvitationsForDependent),
+                    new { userId, dependentId }, result);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Cancels an existing invitation.
+        /// </summary>
+        /// <param name="invitationId">The invitation ID to cancel.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Invitation cancelled.</response>
+        /// <response code="400">Invalid operation.</response>
+        [HttpPost("{invitationId}/cancel")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CancelInvitation(Guid invitationId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CancelInvitation Id={InvitationId}", invitationId);
+
+            try
+            {
+                await dependentInvitationManager.CancelInvitationAsync(invitationId, UserId, cancellationToken);
+                return Ok();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Resends an invitation with a new token.
+        /// </summary>
+        /// <param name="invitationId">The invitation ID to resend.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated invitation.</response>
+        /// <response code="400">Invalid operation.</response>
+        [HttpPost("{invitationId}/resend")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DependentInvitation), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> ResendInvitation(Guid invitationId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ResendInvitation Id={InvitationId}", invitationId);
+
+            try
+            {
+                var result = await dependentInvitationManager.ResendInvitationAsync(invitationId, UserId, cancellationToken);
+                return Ok(result);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/DependentWaiversV2Controller.cs
+++ b/TrashMob/Controllers/V2/DependentWaiversV2Controller.cs
@@ -1,0 +1,169 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing dependent waivers.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/dependents/{dependentId}/waiver")]
+    public class DependentWaiversV2Controller(
+        IDependentWaiverManager dependentWaiverManager,
+        IDependentManager dependentManager,
+        IWaiverDocumentManager waiverDocumentManager,
+        IUserManager userManager,
+        ILogger<DependentWaiversV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets the current valid waiver for a dependent.
+        /// </summary>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the current waiver.</response>
+        /// <response code="403">User is not the parent.</response>
+        /// <response code="404">No valid waiver found.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(DependentWaiver), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetCurrentWaiver(Guid dependentId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetCurrentWaiver Dependent={DependentId}", dependentId);
+
+            var dependent = await dependentManager.GetAsync(dependentId, cancellationToken);
+            if (dependent == null || dependent.ParentUserId != UserId)
+            {
+                return Forbid();
+            }
+
+            var waiver = await dependentWaiverManager.GetCurrentWaiverAsync(dependentId, cancellationToken);
+            if (waiver == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(waiver);
+        }
+
+        /// <summary>
+        /// Signs a waiver on behalf of a dependent.
+        /// </summary>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="request">The waiver signing request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Waiver signed.</response>
+        /// <response code="400">Invalid request.</response>
+        /// <response code="403">User is not the parent.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DependentWaiver), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> SignWaiver(
+            Guid dependentId, SignDependentWaiverRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SignWaiver Dependent={DependentId}", dependentId);
+
+            var dependent = await dependentManager.GetAsync(dependentId, cancellationToken);
+            if (dependent == null || dependent.ParentUserId != UserId)
+            {
+                return Forbid();
+            }
+
+            var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var userAgent = Request.Headers.UserAgent.ToString();
+
+            var result = await dependentWaiverManager.SignWaiverAsync(
+                dependentId,
+                request.WaiverVersionId,
+                request.TypedLegalName,
+                ipAddress,
+                userAgent,
+                UserId,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            try
+            {
+                var user = await userManager.GetAsync(UserId, cancellationToken);
+                var documentUrl = await waiverDocumentManager
+                    .GenerateAndStoreDependentWaiverPdfAsync(result.Data, dependent, user, cancellationToken);
+                result.Data.DocumentUrl = documentUrl;
+                await dependentWaiverManager.UpdateAsync(result.Data, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "PDF generation failed for dependent waiver {WaiverId}", result.Data.Id);
+            }
+
+            return StatusCode(StatusCodes.Status201Created, result.Data);
+        }
+
+        /// <summary>
+        /// Gets the waiver history for a dependent.
+        /// </summary>
+        /// <param name="dependentId">The dependent ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the waiver history.</response>
+        /// <response code="403">User is not the parent.</response>
+        [HttpGet("history")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<DependentWaiver>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetWaiverHistory(Guid dependentId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetWaiverHistory Dependent={DependentId}", dependentId);
+
+            var dependent = await dependentManager.GetAsync(dependentId, cancellationToken);
+            if (dependent == null || dependent.ParentUserId != UserId)
+            {
+                return Forbid();
+            }
+
+            var waivers = await dependentWaiverManager.GetByDependentIdAsync(dependentId, cancellationToken);
+            return Ok(waivers);
+        }
+
+        /// <summary>
+        /// Request model for signing a dependent waiver.
+        /// </summary>
+        public class SignDependentWaiverRequest
+        {
+            /// <summary>
+            /// Gets or sets the waiver version to sign.
+            /// </summary>
+            public Guid WaiverVersionId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the typed legal name of the signer.
+            /// </summary>
+            public string TypedLegalName { get; set; }
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
@@ -132,6 +132,46 @@ namespace TrashMob.Controllers.V2
         }
 
         /// <summary>
+        /// Gets event attendee routes by user ID.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the routes for the user.</response>
+        [HttpGet("by-user/{userId}")]
+        [ProducesResponseType(typeof(IEnumerable<EventAttendeeRoute>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByUser(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventAttendeeRoutesByUser User={UserId}", userId);
+
+            var result = await eventAttendeeRouteManager.GetByCreatedUserIdAsync(userId, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Updates an existing event attendee route.
+        /// </summary>
+        /// <param name="displayEventAttendeeRoute">The route to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated route.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventAttendeeRoute), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update(
+            DisplayEventAttendeeRoute displayEventAttendeeRoute,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateEventAttendeeRoute Id={Id}", displayEventAttendeeRoute.Id);
+
+            var eventAttendeeRoute = displayEventAttendeeRoute.ToEventAttendeeRoute();
+
+            var updatedRoute = await eventAttendeeRouteManager
+                .UpdateAsync(eventAttendeeRoute, UserId, cancellationToken);
+
+            return Ok(updatedRoute);
+        }
+
+        /// <summary>
         /// Deletes an event attendee route.
         /// </summary>
         /// <param name="routeId">The route ID.</param>

--- a/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
@@ -1,6 +1,8 @@
 namespace TrashMob.Controllers.V2
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
@@ -9,11 +11,16 @@ namespace TrashMob.Controllers.V2
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
     using TrashMob.Models.Poco.V2;
     using TrashMob.Security;
+    using TrashMob.Shared;
     using TrashMob.Shared.Extensions;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
 
     /// <summary>
     /// V2 controller for event attendees as a nested resource under events.
@@ -24,8 +31,11 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/events/{eventId}/attendees")]
     public class EventAttendeesV2Controller(
         IEventAttendeeManager eventAttendeeManager,
+        IUserWaiverManager userWaiverManager,
         ILogger<EventAttendeesV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
         /// <summary>
         /// Gets the count of active attendees for an event.
         /// </summary>
@@ -75,6 +85,191 @@ namespace TrashMob.Controllers.V2
             var result = await query.ToPagedAsync(filter, ea => ea.ToV2Dto(), cancellationToken);
 
             return Ok(result);
+        }
+
+        /// <summary>
+        /// Adds a new event attendee. Requires all waivers to be signed.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="eventAttendee">The event attendee to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Attendee registered.</response>
+        /// <response code="400">Waivers required.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(WaiverRequiredResponse), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> AddEventAttendee(
+            Guid eventId,
+            EventAttendee eventAttendee,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddEventAttendee Event={EventId}, User={UserId}", eventId, eventAttendee.UserId);
+
+            eventAttendee.EventId = eventId;
+
+            var hasValidWaiver = await userWaiverManager
+                .HasValidWaiverForEventAsync(eventAttendee.UserId, eventId, cancellationToken);
+
+            if (!hasValidWaiver)
+            {
+                var requiredWaivers = await userWaiverManager
+                    .GetRequiredWaiversForEventAsync(eventAttendee.UserId, eventId, cancellationToken);
+
+                return BadRequest(new WaiverRequiredResponse
+                {
+                    Message = "You must sign all required waivers before registering for this event.",
+                    RequiredWaiverCount = requiredWaivers.Count(),
+                    RequiredWaiverIds = requiredWaivers.Select(w => w.Id).ToList()
+                });
+            }
+
+            await eventAttendeeManager.AddAsync(eventAttendee, UserId, cancellationToken);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Removes an attendee from an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Attendee removed.</response>
+        [HttpDelete("{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> DeleteEventAttendee(Guid eventId, Guid userId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteEventAttendee Event={EventId}, User={UserId}", eventId, userId);
+
+            await eventAttendeeManager.Delete(eventId, userId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Gets all event leads for an event.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the event leads.</response>
+        [HttpGet("leads")]
+        [ProducesResponseType(typeof(IEnumerable<DisplayUser>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEventLeads(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventLeads Event={EventId}", eventId);
+
+            var result =
+                (await eventAttendeeManager.GetEventLeadsAsync(eventId, cancellationToken))
+                .Select(ea => ea.User.ToDisplayUser());
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Promotes an attendee to event lead. Only existing event leads can promote.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="userId">The user ID to promote.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated event attendee.</response>
+        /// <response code="400">Operation not allowed.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpPut("{userId}/promote")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventAttendee), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> PromoteToLead(Guid eventId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 PromoteToLead Event={EventId}, User={UserId}", eventId, userId);
+
+            var isCurrentUserLead = await eventAttendeeManager.IsEventLeadAsync(eventId, UserId, cancellationToken);
+            if (!isCurrentUserLead)
+            {
+                return Forbid();
+            }
+
+            try
+            {
+                var result = await eventAttendeeManager.PromoteToLeadAsync(eventId, userId, UserId, cancellationToken);
+                return Ok(result);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Demotes an event lead to regular attendee. Only existing event leads can demote.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="userId">The user ID to demote.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated event attendee.</response>
+        /// <response code="400">Operation not allowed.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpPut("{userId}/demote")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventAttendee), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DemoteFromLead(Guid eventId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DemoteFromLead Event={EventId}, User={UserId}", eventId, userId);
+
+            var isCurrentUserLead = await eventAttendeeManager.IsEventLeadAsync(eventId, UserId, cancellationToken);
+            if (!isCurrentUserLead)
+            {
+                return Forbid();
+            }
+
+            try
+            {
+                var result = await eventAttendeeManager.DemoteFromLeadAsync(eventId, userId, UserId, cancellationToken);
+                return Ok(result);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Verifies an attendee's waiver status. Only event leads or admins can check.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="userId">The user ID to check.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the waiver status.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpGet("{userId}/waiver-status")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(WaiverCheckResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> VerifyAttendeeWaiverStatus(
+            Guid eventId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 VerifyWaiverStatus Event={EventId}, User={UserId}", eventId, userId);
+
+            var isAdmin = User.IsInRole("Admin");
+            var isEventLead = await eventAttendeeManager
+                .IsEventLeadAsync(eventId, UserId, cancellationToken);
+
+            if (!isAdmin && !isEventLead)
+            {
+                return Forbid();
+            }
+
+            var hasValidWaiver = await userWaiverManager
+                .HasValidWaiverForEventAsync(userId, eventId, cancellationToken);
+
+            return Ok(new WaiverCheckResult { HasValidWaiver = hasValidWaiver });
         }
     }
 }

--- a/TrashMob/Controllers/V2/EventSummaryV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventSummaryV2Controller.cs
@@ -5,13 +5,17 @@ namespace TrashMob.Controllers.V2
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Cors;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
     using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
     using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
 
     /// <summary>
@@ -23,8 +27,12 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/events/{eventId}/summary")]
     public class EventSummaryV2Controller(
         IEventSummaryManager eventSummaryManager,
+        IKeyedManager<Event> eventManager,
+        IAuthorizationService authorizationService,
         ILogger<EventSummaryV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
         /// <summary>
         /// Gets the post-completion summary for an event.
         /// Returns an empty summary with just the EventId if none exists yet.
@@ -49,6 +57,103 @@ namespace TrashMob.Controllers.V2
             }
 
             return Ok(eventSummary.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a new event summary. Only event leads can add.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="eventSummary">The event summary to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Event summary created.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventSummary), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> AddEventSummary(Guid eventId, EventSummary eventSummary,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddEventSummary Event={EventId}", eventId);
+
+            eventSummary.EventId = eventId;
+
+            if (!await IsAuthorizedAsync(eventSummary, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var result = await eventSummaryManager.AddAsync(eventSummary, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetEventSummary), new { eventId }, result);
+        }
+
+        /// <summary>
+        /// Updates an existing event summary. Only event leads can update.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="eventSummary">The event summary to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated event summary.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventSummary), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> UpdateEventSummary(Guid eventId, EventSummary eventSummary,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateEventSummary Event={EventId}", eventId);
+
+            eventSummary.EventId = eventId;
+
+            if (!await IsAuthorizedAsync(eventSummary, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            var updatedEvent = await eventSummaryManager.UpdateAsync(eventSummary, UserId, cancellationToken);
+            return Ok(updatedEvent);
+        }
+
+        /// <summary>
+        /// Deletes an event summary. Only event leads can delete.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Event summary deleted.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpDelete]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DeleteEventSummary(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteEventSummary Event={EventId}", eventId);
+
+            var mobEvent = await eventManager.GetAsync(eventId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            await eventSummaryManager.DeleteAsync(eventId, cancellationToken);
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
         }
     }
 }

--- a/TrashMob/Controllers/V2/EventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventsV2Controller.cs
@@ -1,17 +1,27 @@
 namespace TrashMob.Controllers.V2
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Cors;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
     using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
     using TrashMob.Shared.Extensions;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
 
     /// <summary>
     /// V2 controller for events with server-side pagination and filtering.
@@ -22,8 +32,12 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/events")]
     public class EventsV2Controller(
         IEventManager eventManager,
+        IEventAttendeeManager eventAttendeeManager,
+        IAuthorizationService authorizationService,
         ILogger<EventsV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
         /// <summary>
         /// Gets a paginated list of events with optional filtering.
         /// </summary>
@@ -42,9 +56,7 @@ namespace TrashMob.Controllers.V2
             logger.LogInformation("V2 GetEvents requested with Page={Page}, PageSize={PageSize}",
                 filter.Page, filter.PageSize);
 
-            Guid? userId = User.Identity?.IsAuthenticated == true
-                ? new Guid(HttpContext.Items["UserId"]?.ToString() ?? string.Empty)
-                : null;
+            Guid? userId = User.Identity?.IsAuthenticated == true ? UserId : (Guid?)null;
 
             var query = await eventManager.GetFilteredEventsQueryableAsync(filter, userId, cancellationToken);
             var result = await query.ToPagedAsync(filter, e => e.ToV2Dto(), cancellationToken);
@@ -76,6 +88,234 @@ namespace TrashMob.Controllers.V2
             }
 
             return Ok(mobEvent.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets events for a specific user (created + attending).
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="futureEventsOnly">When true, only return future events.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user's events.</response>
+        [HttpGet("userevents/{userId}/{futureEventsOnly}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetUserEvents(Guid userId, bool futureEventsOnly,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUserEvents User={UserId}, FutureOnly={FutureOnly}", userId, futureEventsOnly);
+
+            var result1 = await eventManager.GetUserEventsAsync(userId, futureEventsOnly, cancellationToken);
+            var result2 = await eventAttendeeManager
+                .GetEventsUserIsAttendingAsync(userId, futureEventsOnly, cancellationToken);
+
+            var allResults = result1.Union(result2, new EventComparer());
+            return Ok(allResults);
+        }
+
+        /// <summary>
+        /// Gets events a specific user is attending.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns events the user is attending.</response>
+        [HttpGet("eventsuserisattending/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEventsUserIsAttending(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventsUserIsAttending User={UserId}", userId);
+
+            var result = await eventAttendeeManager
+                .GetEventsUserIsAttendingAsync(userId, cancellationToken: cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets event locations within a specific time range.
+        /// </summary>
+        /// <param name="startTime">The start time (ISO 8601).</param>
+        /// <param name="endTime">The end time (ISO 8601).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns event locations in the time range.</response>
+        [HttpGet("locationsbytimerange")]
+        [ProducesResponseType(typeof(IEnumerable<Location>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEventLocationsByTimeRange(
+            [FromQuery] DateTimeOffset? startTime,
+            [FromQuery] DateTimeOffset? endTime,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEventLocationsByTimeRange Start={Start}, End={End}", startTime, endTime);
+
+            var result = await eventManager.GetEventLocationsByTimeRangeAsync(startTime, endTime, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a paginated list of filtered events.
+        /// </summary>
+        /// <param name="filter">The event filter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns a paginated list of filtered events.</response>
+        [HttpPost("pagedfilteredevents")]
+        [ProducesResponseType(typeof(PaginatedList<Event>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetPagedFilteredEvents(
+            [FromBody] EventFilter filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPagedFilteredEvents");
+
+            Guid? userId = User.Identity?.IsAuthenticated == true ? UserId : (Guid?)null;
+            var result = await eventManager.GetFilteredEventsAsync(filter, userId, cancellationToken);
+
+            if (filter.PageSize is not null)
+            {
+                var pagedResults = PaginatedList<Event>.Create(
+                    result.OrderByDescending(e => e.EventDate).AsQueryable(),
+                    filter.PageIndex.GetValueOrDefault(0),
+                    filter.PageSize.GetValueOrDefault(10));
+                return Ok(pagedResults);
+            }
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a paginated list of events for a user (created + attending).
+        /// </summary>
+        /// <param name="filter">The event filter.</param>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns a paginated list of user events.</response>
+        [HttpPost("pageduserevents/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(PaginatedList<Event>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetPagedUserEvents(
+            [FromBody] EventFilter filter,
+            Guid userId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPagedUserEvents User={UserId}", userId);
+
+            var result1 = await eventManager.GetUserEventsAsync(filter, userId, cancellationToken);
+            var result2 = await eventAttendeeManager
+                .GetEventsUserIsAttendingAsync(filter, userId, cancellationToken);
+
+            var allResults = result1.Union(result2, new EventComparer());
+
+            if (filter.PageSize is not null)
+            {
+                var pagedResults = PaginatedList<Event>.Create(
+                    allResults.OrderByDescending(e => e.EventDate).AsQueryable(),
+                    filter.PageIndex.GetValueOrDefault(0),
+                    filter.PageSize.GetValueOrDefault(10));
+                return Ok(pagedResults);
+            }
+
+            return Ok(allResults);
+        }
+
+        /// <summary>
+        /// Adds a new event.
+        /// </summary>
+        /// <param name="mobEvent">The event to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Event created.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(Event), StatusCodes.Status201Created)]
+        public async Task<IActionResult> AddEvent(Event mobEvent, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddEvent Name={Name}", mobEvent.Name);
+
+            var newEvent = await eventManager.AddAsync(mobEvent, UserId, cancellationToken);
+            return CreatedAtAction(nameof(GetEvent), new { id = newEvent.Id }, newEvent);
+        }
+
+        /// <summary>
+        /// Updates an existing event. Only event leads can update.
+        /// </summary>
+        /// <param name="mobEvent">The event to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated event.</response>
+        /// <response code="403">User is not an event lead.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(Event), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateEvent(Event mobEvent, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateEvent Event={EventId}", mobEvent.Id);
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            try
+            {
+                var updatedEvent = await eventManager.UpdateAsync(mobEvent, UserId, cancellationToken);
+                return Ok(updatedEvent);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                var existing = await eventManager.GetAsync(mobEvent.Id, cancellationToken);
+                if (existing is null)
+                {
+                    return NotFound();
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Deletes (cancels) an event. Only event leads or admins can delete.
+        /// </summary>
+        /// <param name="eventCancellationRequest">The cancellation request with event ID and reason.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Event deleted.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpDelete]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DeleteEvent(
+            EventCancellationRequest eventCancellationRequest,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteEvent Event={EventId}", eventCancellationRequest.EventId);
+
+            var mobEvent = await eventManager.GetAsync(eventCancellationRequest.EventId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLeadOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await eventManager.DeleteAsync(eventCancellationRequest.EventId,
+                eventCancellationRequest.CancellationReason, UserId, cancellationToken);
+
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
         }
     }
 }

--- a/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
@@ -1,17 +1,26 @@
 namespace TrashMob.Controllers.V2
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Cors;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
     using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
     using TrashMob.Shared.Extensions;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
 
     /// <summary>
     /// V2 controller for litter reports with server-side pagination and filtering.
@@ -22,8 +31,13 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/litterreports")]
     public class LitterReportsV2Controller(
         ILitterReportManager litterReportManager,
+        ILitterImageManager litterImageManager,
+        IImageManager imageManager,
+        IAuthorizationService authorizationService,
         ILogger<LitterReportsV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
         /// <summary>
         /// Gets a paginated list of litter reports with optional filtering.
         /// </summary>
@@ -72,6 +86,248 @@ namespace TrashMob.Controllers.V2
             }
 
             return Ok(litterReport.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a new litter report.
+        /// </summary>
+        /// <param name="litterReport">The litter report to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the created litter report.</response>
+        /// <response code="400">Invalid litter report data.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(LitterReport), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> AddLitterReport(LitterReport litterReport, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddLitterReport Name={Name}", litterReport.Name);
+
+            var result = await litterReportManager.AddWithResultAsync(litterReport, UserId, cancellationToken);
+
+            if (result.IsSuccess)
+            {
+                return Ok(result.Data);
+            }
+
+            return BadRequest(result.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Updates an existing litter report. Only the owner or admin can update.
+        /// </summary>
+        /// <param name="litterReport">The litter report to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated litter report.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(LitterReport), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> UpdateLitterReport(LitterReport litterReport,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateLitterReport Id={Id}", litterReport.Id);
+
+            if (!await IsAuthorizedAsync(litterReport, AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var updatedLitterReport = await litterReportManager.UpdateAsync(litterReport, UserId, cancellationToken);
+
+            if (updatedLitterReport is not null)
+            {
+                return Ok(updatedLitterReport);
+            }
+
+            return BadRequest("Failed to update litter report");
+        }
+
+        /// <summary>
+        /// Deletes a litter report. Only the owner or admin can delete.
+        /// </summary>
+        /// <param name="id">The litter report ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Litter report deleted.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> DeleteLitterReport(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteLitterReport Id={Id}", id);
+
+            var litterReport = await litterReportManager.GetAsync(id, cancellationToken);
+
+            if (!await IsAuthorizedAsync(litterReport, AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var result = await litterReportManager.DeleteAsync(id, UserId, cancellationToken);
+
+            if (result != -1)
+            {
+                return NoContent();
+            }
+
+            return BadRequest("Could not find the litter report, delete failed");
+        }
+
+        /// <summary>
+        /// Gets all litter reports for a specific user.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user's litter reports.</response>
+        [HttpGet("userlitterreports/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<LitterReport>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetUserLitterReports(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUserLitterReports User={UserId}", userId);
+
+            var result = await litterReportManager.GetUserLitterReportsAsync(userId, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets a paginated list of filtered litter reports.
+        /// </summary>
+        /// <param name="filter">The litter report filter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns a paginated list of filtered litter reports.</response>
+        [HttpPost("pagedfilteredlitterreports")]
+        [ProducesResponseType(typeof(PaginatedList<LitterReport>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetPagedFilteredLitterReports(
+            [FromBody] LitterReportFilter filter,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPagedFilteredLitterReports");
+
+            var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken);
+
+            if (filter.PageSize is not null)
+            {
+                var pagedResults = PaginatedList<LitterReport>.Create(
+                    result.OrderByDescending(e => e.CreatedDate).AsQueryable(),
+                    filter.PageIndex.GetValueOrDefault(0),
+                    filter.PageSize.GetValueOrDefault(10));
+                return Ok(pagedResults);
+            }
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets litter locations within a specific time range.
+        /// </summary>
+        /// <param name="startTime">The start time.</param>
+        /// <param name="endTime">The end time.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns litter locations in the time range.</response>
+        [HttpGet("locationsbytimerange")]
+        [ProducesResponseType(typeof(IEnumerable<Location>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetLitterLocationsByTimeRange(
+            [FromQuery] DateTimeOffset? startTime,
+            [FromQuery] DateTimeOffset? endTime,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLitterLocationsByTimeRange Start={Start}, End={End}", startTime, endTime);
+
+            var result = await litterReportManager
+                .GeLitterLocationsByTimeRangeAsync(startTime, endTime, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Uploads an image for a litter report.
+        /// </summary>
+        /// <param name="imageUpload">The image upload data.</param>
+        /// <param name="litterImageId">The litter image ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Image uploaded.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpPost("image/{litterImageId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> UploadImage(
+            [FromForm] ImageUpload imageUpload,
+            Guid litterImageId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadLitterImage LitterImageId={LitterImageId}", litterImageId);
+
+            var litterImage = await litterImageManager.GetAsync(litterImageId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(litterImage, AuthorizationPolicyConstants.UserOwnsEntity))
+            {
+                return Forbid();
+            }
+
+            await imageManager.UploadImageAsync(imageUpload);
+
+            var imageUrl = await imageManager.GetImageUrlAsync(litterImageId, ImageTypeEnum.LitterImage,
+                ImageSizeEnum.Reduced, cancellationToken);
+            litterImage.AzureBlobURL = imageUrl;
+            await litterImageManager.UpdateAsync(litterImage, UserId, cancellationToken);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Gets the image URL for a litter image.
+        /// </summary>
+        /// <param name="litterImageId">The litter image ID.</param>
+        /// <param name="imageSize">The image size.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the image URL.</response>
+        /// <response code="204">Image not found.</response>
+        [HttpGet("image/{litterImageId}/{imageSize}")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> GetImage(Guid litterImageId, ImageSizeEnum imageSize,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLitterImage LitterImageId={LitterImageId}", litterImageId);
+
+            try
+            {
+                var url = await imageManager.GetImageUrlAsync(litterImageId, ImageTypeEnum.LitterImage,
+                    imageSize, cancellationToken);
+
+                if (string.IsNullOrWhiteSpace(url))
+                {
+                    return NoContent();
+                }
+
+                return Ok(url);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to get image URL for litter image {LitterImageId}", litterImageId);
+                return NoContent();
+            }
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
         }
     }
 }

--- a/TrashMob/Controllers/V2/TeamEventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamEventsV2Controller.cs
@@ -1,0 +1,235 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// V2 controller for team event associations as a nested resource under teams.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/teams/{teamId}/events")]
+    public class TeamEventsV2Controller(
+        ITeamManager teamManager,
+        ITeamMemberManager teamMemberManager,
+        IKeyedRepository<TeamEvent> teamEventRepository,
+        IKeyedManager<Event> eventManager,
+        ILogger<TeamEventsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets upcoming events for a team.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns upcoming team events.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpGet("upcoming")]
+        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetUpcomingTeamEvents(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUpcomingTeamEvents Team={TeamId}", teamId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            if (!team.IsPublic)
+            {
+                if (User.Identity?.IsAuthenticated != true)
+                {
+                    return NotFound();
+                }
+
+                var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+                if (!isMember)
+                {
+                    return NotFound();
+                }
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var teamEvents = await teamEventRepository.Get()
+                .Where(te => te.TeamId == teamId)
+                .Include(te => te.Event)
+                .Where(te => te.Event.EventDate >= now && te.Event.EventStatusId != (int)EventStatusEnum.Canceled)
+                .Select(te => te.Event)
+                .OrderBy(e => e.EventDate)
+                .ToListAsync(cancellationToken);
+
+            return Ok(teamEvents);
+        }
+
+        /// <summary>
+        /// Gets past events for a team.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns past team events.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpGet("past")]
+        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetPastTeamEvents(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPastTeamEvents Team={TeamId}", teamId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            if (!team.IsPublic)
+            {
+                if (User.Identity?.IsAuthenticated != true)
+                {
+                    return NotFound();
+                }
+
+                var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+                if (!isMember)
+                {
+                    return NotFound();
+                }
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var teamEvents = await teamEventRepository.Get()
+                .Where(te => te.TeamId == teamId)
+                .Include(te => te.Event)
+                .Where(te => te.Event.EventDate < now)
+                .Select(te => te.Event)
+                .OrderByDescending(e => e.EventDate)
+                .ToListAsync(cancellationToken);
+
+            return Ok(teamEvents);
+        }
+
+        /// <summary>
+        /// Links an event to a team. Only team leads can link events.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="eventId">The event ID to link.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Event linked to team.</response>
+        /// <response code="400">Event already linked.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team or event not found.</response>
+        [HttpPost("{eventId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamEvent), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> LinkEventToTeam(Guid teamId, Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 LinkEventToTeam Team={TeamId}, Event={EventId}", teamId, eventId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound("Team not found.");
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var eventEntity = await eventManager.GetAsync(eventId, cancellationToken);
+            if (eventEntity is null)
+            {
+                return NotFound("Event not found.");
+            }
+
+            var existingLink = await teamEventRepository.Get()
+                .FirstOrDefaultAsync(te => te.TeamId == teamId && te.EventId == eventId, cancellationToken);
+
+            if (existingLink is not null)
+            {
+                return BadRequest("Event is already linked to this team.");
+            }
+
+            var teamEvent = new TeamEvent
+            {
+                Id = Guid.NewGuid(),
+                TeamId = teamId,
+                EventId = eventId,
+                CreatedByUserId = UserId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = UserId,
+                LastUpdatedDate = DateTimeOffset.UtcNow,
+            };
+
+            var created = await teamEventRepository.AddAsync(teamEvent);
+            return CreatedAtAction(nameof(GetUpcomingTeamEvents), new { teamId }, created);
+        }
+
+        /// <summary>
+        /// Unlinks an event from a team. Only team leads can unlink events.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="eventId">The event ID to unlink.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Event unlinked.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team or link not found.</response>
+        [HttpDelete("{eventId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UnlinkEventFromTeam(Guid teamId, Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UnlinkEventFromTeam Team={TeamId}, Event={EventId}", teamId, eventId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound("Team not found.");
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var teamEvent = await teamEventRepository.Get()
+                .FirstOrDefaultAsync(te => te.TeamId == teamId && te.EventId == eventId, cancellationToken);
+
+            if (teamEvent is null)
+            {
+                return NotFound("Event is not linked to this team.");
+            }
+
+            await teamEventRepository.DeleteAsync(teamEvent.Id);
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/TeamMembersV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamMembersV2Controller.cs
@@ -1,0 +1,288 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for team membership operations as a nested resource under teams.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/teams/{teamId}/members")]
+    public class TeamMembersV2Controller(
+        ITeamManager teamManager,
+        ITeamMemberManager teamMemberManager,
+        ILogger<TeamMembersV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all members of a team.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the team members.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<TeamMember>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetMembers(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetMembers Team={TeamId}", teamId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            if (!team.IsPublic)
+            {
+                if (User.Identity?.IsAuthenticated != true)
+                {
+                    return NotFound();
+                }
+
+                var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+                if (!isMember)
+                {
+                    return NotFound();
+                }
+            }
+
+            var members = await teamMemberManager.GetByTeamIdAsync(teamId, cancellationToken);
+            return Ok(members);
+        }
+
+        /// <summary>
+        /// Gets all team leads of a team.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the team leads.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpGet("leads")]
+        [ProducesResponseType(typeof(IEnumerable<TeamMember>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetLeads(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLeads Team={TeamId}", teamId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            var leads = await teamMemberManager.GetTeamLeadsAsync(teamId, cancellationToken);
+            return Ok(leads);
+        }
+
+        /// <summary>
+        /// Joins a public team. Private teams cannot be joined directly.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Joined the team.</response>
+        /// <response code="400">Already a member or team is private.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpPost("join")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamMember), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> JoinTeam(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 JoinTeam Team={TeamId}, User={UserId}", teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            var existingMember = await teamMemberManager.GetByTeamAndUserAsync(teamId, UserId, cancellationToken);
+            if (existingMember is not null)
+            {
+                return BadRequest("You are already a member of this team.");
+            }
+
+            if (!team.IsPublic)
+            {
+                return BadRequest("This is a private team. You must be invited by a team lead.");
+            }
+
+            var member = await teamMemberManager.AddMemberAsync(teamId, UserId, isTeamLead: false, UserId, cancellationToken);
+            return CreatedAtAction(nameof(GetMembers), new { teamId }, member);
+        }
+
+        /// <summary>
+        /// Removes a member from a team. Team leads can remove any member, or a member can leave.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="userId">The user ID to remove.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Member removed.</response>
+        /// <response code="400">Cannot remove the last team lead.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Team or member not found.</response>
+        [HttpDelete("{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> RemoveMember(Guid teamId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 RemoveMember Team={TeamId}, User={UserId}", teamId, userId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            var member = await teamMemberManager.GetByTeamAndUserAsync(teamId, userId, cancellationToken);
+            if (member is null)
+            {
+                return NotFound();
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (userId != UserId && !isLead)
+            {
+                return Forbid();
+            }
+
+            if (member.IsTeamLead)
+            {
+                var leadCount = await teamMemberManager.GetTeamLeadCountAsync(teamId, cancellationToken);
+                if (leadCount <= 1)
+                {
+                    return BadRequest("Cannot remove the last team lead. Promote another member to lead first or deactivate the team.");
+                }
+            }
+
+            await teamMemberManager.RemoveMemberAsync(teamId, userId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Promotes a member to team lead. Only existing team leads can promote.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="userId">The user ID to promote.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated team member.</response>
+        /// <response code="400">User is already a team lead.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team or member not found.</response>
+        [HttpPut("{userId}/promote")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamMember), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> PromoteToLead(Guid teamId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 PromoteToLead Team={TeamId}, User={UserId}", teamId, userId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var member = await teamMemberManager.GetByTeamAndUserAsync(teamId, userId, cancellationToken);
+            if (member is null)
+            {
+                return NotFound("User is not a member of this team.");
+            }
+
+            if (member.IsTeamLead)
+            {
+                return BadRequest("User is already a team lead.");
+            }
+
+            var updatedMember = await teamMemberManager.PromoteToLeadAsync(teamId, userId, UserId, cancellationToken);
+            return Ok(updatedMember);
+        }
+
+        /// <summary>
+        /// Demotes a team lead to regular member. Only existing team leads can demote.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="userId">The user ID to demote.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated team member.</response>
+        /// <response code="400">Cannot demote the last team lead.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team or member not found.</response>
+        [HttpPut("{userId}/demote")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamMember), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DemoteFromLead(Guid teamId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DemoteFromLead Team={TeamId}, User={UserId}", teamId, userId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null || !team.IsActive)
+            {
+                return NotFound();
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var member = await teamMemberManager.GetByTeamAndUserAsync(teamId, userId, cancellationToken);
+            if (member is null)
+            {
+                return NotFound("User is not a member of this team.");
+            }
+
+            if (!member.IsTeamLead)
+            {
+                return BadRequest("User is not a team lead.");
+            }
+
+            var leadCount = await teamMemberManager.GetTeamLeadCountAsync(teamId, cancellationToken);
+            if (leadCount <= 1)
+            {
+                return BadRequest("Cannot demote the last team lead. Promote another member to lead first.");
+            }
+
+            var updatedMember = await teamMemberManager.DemoteFromLeadAsync(teamId, userId, UserId, cancellationToken);
+            return Ok(updatedMember);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/TeamsV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamsV2Controller.cs
@@ -1,15 +1,21 @@
 namespace TrashMob.Controllers.V2
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Cors;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
     using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
     using TrashMob.Shared.Extensions;
     using TrashMob.Shared.Managers.Interfaces;
 
@@ -22,8 +28,12 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/teams")]
     public class TeamsV2Controller(
         ITeamManager teamManager,
+        ITeamMemberManager teamMemberManager,
+        IKeyedManager<User> userManager,
         ILogger<TeamsV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
         /// <summary>
         /// Gets a paginated list of public, active teams with optional filtering.
         /// </summary>
@@ -72,6 +82,192 @@ namespace TrashMob.Controllers.V2
             }
 
             return Ok(team.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets all teams that the current user is a member of.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user's teams.</response>
+        [HttpGet("my")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<Team>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMyTeams(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetMyTeams User={UserId}", UserId);
+
+            var teams = await teamManager.GetTeamsByUserAsync(UserId, cancellationToken);
+            return Ok(teams);
+        }
+
+        /// <summary>
+        /// Creates a new team. The creator becomes the first team lead.
+        /// </summary>
+        /// <param name="team">The team to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Team created.</response>
+        /// <response code="400">Team name not available or invalid data.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(Team), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CreateTeam([FromBody] Team team, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateTeam Name={Name}", team.Name);
+
+            var isAvailable = await teamManager.IsTeamNameAvailableAsync(team.Name, cancellationToken: cancellationToken);
+            if (!isAvailable)
+            {
+                return BadRequest("A team with this name already exists.");
+            }
+
+            var user = await userManager.GetAsync(UserId, cancellationToken);
+            if (user is null)
+            {
+                return BadRequest("User not found.");
+            }
+
+            team.Id = Guid.NewGuid();
+            team.IsActive = true;
+            team.CreatedByUserId = UserId;
+            team.CreatedDate = DateTimeOffset.UtcNow;
+            team.LastUpdatedByUserId = UserId;
+            team.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var createdTeam = await teamManager.AddAsync(team, UserId, cancellationToken);
+
+            await teamMemberManager.AddMemberAsync(createdTeam.Id, UserId, isTeamLead: true, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetTeam), new { id = createdTeam.Id }, createdTeam);
+        }
+
+        /// <summary>
+        /// Updates a team. Only team leads can update.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="team">The updated team data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated team.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpPut("{teamId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(Team), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateTeam(Guid teamId, [FromBody] Team team, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateTeam Team={TeamId}", teamId);
+
+            if (teamId != team.Id)
+            {
+                return BadRequest("Team ID mismatch.");
+            }
+
+            var existingTeam = await teamManager.GetAsync(teamId, cancellationToken);
+            if (existingTeam is null)
+            {
+                return NotFound();
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            if (!string.Equals(existingTeam.Name, team.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                var isAvailable = await teamManager.IsTeamNameAvailableAsync(team.Name, teamId, cancellationToken);
+                if (!isAvailable)
+                {
+                    return BadRequest("A team with this name already exists.");
+                }
+            }
+
+            existingTeam.Name = team.Name;
+            existingTeam.Description = team.Description;
+            existingTeam.LogoUrl = team.LogoUrl;
+            existingTeam.IsPublic = team.IsPublic;
+            existingTeam.RequiresApproval = team.RequiresApproval;
+            existingTeam.Latitude = team.Latitude;
+            existingTeam.Longitude = team.Longitude;
+            existingTeam.City = team.City;
+            existingTeam.Region = team.Region;
+            existingTeam.Country = team.Country;
+            existingTeam.PostalCode = team.PostalCode;
+            existingTeam.LastUpdatedByUserId = UserId;
+            existingTeam.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var updatedTeam = await teamManager.UpdateAsync(existingTeam, UserId, cancellationToken);
+            return Ok(updatedTeam);
+        }
+
+        /// <summary>
+        /// Deactivates a team (soft delete). Only team leads can deactivate.
+        /// </summary>
+        /// <param name="teamId">The team ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Team deactivated.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpDelete("{teamId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeactivateTeam(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeactivateTeam Team={TeamId}", teamId);
+
+            var existingTeam = await teamManager.GetAsync(teamId, cancellationToken);
+            if (existingTeam is null)
+            {
+                return NotFound();
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            existingTeam.IsActive = false;
+            existingTeam.LastUpdatedByUserId = UserId;
+            existingTeam.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            await teamManager.UpdateAsync(existingTeam, UserId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Checks if a team name is available.
+        /// </summary>
+        /// <param name="name">The team name to check.</param>
+        /// <param name="excludeTeamId">Optional team ID to exclude (for updates).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns true if available, false otherwise.</response>
+        [HttpGet("check-name")]
+        [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+        public async Task<IActionResult> CheckTeamName(
+            [FromQuery] string name,
+            [FromQuery] Guid? excludeTeamId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CheckTeamName Name={Name}", name);
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return Ok(false);
+            }
+
+            var isAvailable = await teamManager.IsTeamNameAvailableAsync(name, excludeTeamId, cancellationToken);
+            return Ok(isAvailable);
         }
     }
 }

--- a/TrashMob/Controllers/V2/UsersV2Controller.cs
+++ b/TrashMob/Controllers/V2/UsersV2Controller.cs
@@ -4,14 +4,21 @@ namespace TrashMob.Controllers.V2
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Cors;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
     using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
     using TrashMob.Shared.Extensions;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
 
     /// <summary>
     /// V2 controller for users with server-side pagination and filtering.
@@ -23,8 +30,12 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/users")]
     public class UsersV2Controller(
         IUserManager userManager,
+        IEventAttendeeMetricsManager metricsManager,
+        IImageManager imageManager,
         ILogger<UsersV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
         /// <summary>
         /// Gets a paginated list of users with optional filtering.
         /// </summary>
@@ -73,6 +84,187 @@ namespace TrashMob.Controllers.V2
             }
 
             return Ok(user.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a new user.
+        /// </summary>
+        /// <param name="user">The user to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">User created.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(User), StatusCodes.Status201Created)]
+        public async Task<IActionResult> AddUser(User user, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddUser UserName={UserName}", user.UserName);
+
+            var result = await userManager.AddAsync(user, UserId, cancellationToken);
+            return CreatedAtAction(nameof(GetUser), new { id = result.Id }, result);
+        }
+
+        /// <summary>
+        /// Updates a user. Users can only update themselves unless they are a site admin.
+        /// </summary>
+        /// <param name="user">The user to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated user.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">User not found.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateUser(User user, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateUser User={UserId}", user.Id);
+
+            var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
+
+            if (currentUser is null)
+            {
+                return NotFound();
+            }
+
+            if (user.Id != UserId && !currentUser.IsSiteAdmin)
+            {
+                return Forbid();
+            }
+
+            try
+            {
+                var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
+                return Ok(updatedUser);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!await userManager.UserExistsAsync(user.Id, cancellationToken))
+                {
+                    return NotFound();
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Gets a user by email address.
+        /// </summary>
+        /// <param name="email">The email address.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user.</response>
+        /// <response code="404">User not found.</response>
+        [HttpGet("getuserbyemail/{email}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetUserByEmail(string email, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUserByEmail");
+
+            var user = await userManager.GetUserByEmailAsync(email, cancellationToken);
+
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(user);
+        }
+
+        /// <summary>
+        /// Gets a user by identity provider object ID.
+        /// </summary>
+        /// <param name="objectId">The object ID from the identity provider.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the user.</response>
+        /// <response code="404">User not found.</response>
+        [HttpGet("getbyobjectid/{objectId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetUserByObjectId(Guid objectId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUserByObjectId ObjectId={ObjectId}", objectId);
+
+            var user = await userManager.GetUserByObjectIdAsync(objectId, cancellationToken);
+
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(user);
+        }
+
+        /// <summary>
+        /// Gets a user's personal impact statistics across all events.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns impact statistics.</response>
+        /// <response code="404">User not found.</response>
+        [HttpGet("{userId}/impact")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetUserImpact(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetUserImpact User={UserId}", userId);
+
+            var user = await userManager.GetUserByInternalIdAsync(userId, cancellationToken);
+
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            var impactStats = await metricsManager.GetUserImpactStatsAsync(userId, cancellationToken);
+            return Ok(impactStats);
+        }
+
+        /// <summary>
+        /// Uploads a profile photo for the current user.
+        /// </summary>
+        /// <param name="imageUpload">The image upload data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns updated user with new profile photo URL.</response>
+        /// <response code="404">User not found.</response>
+        [HttpPost("photo")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadProfilePhoto(
+            [FromForm] ImageUpload imageUpload,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadProfilePhoto");
+
+            var user = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
+            if (user is null)
+            {
+                return NotFound();
+            }
+
+            if (!string.IsNullOrWhiteSpace(user.ProfilePhotoUrl))
+            {
+                await imageManager.DeleteImageAsync(UserId, ImageTypeEnum.UserProfilePhoto);
+            }
+
+            imageUpload.ParentId = UserId;
+            imageUpload.ImageType = ImageTypeEnum.UserProfilePhoto;
+            await imageManager.UploadImageAsync(imageUpload);
+
+            var imageUrl = await imageManager.GetImageUrlAsync(UserId, ImageTypeEnum.UserProfilePhoto,
+                ImageSizeEnum.Reduced, cancellationToken);
+            user.ProfilePhotoUrl = imageUrl;
+
+            var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
+            return Ok(updatedUser);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds ~40 missing v2 API endpoints across 11 controllers (7 modified + 4 new) completing Phase 3 of API v2 modernization
- Enables the mobile app to fully migrate from v1 to v2 API endpoints
- All write endpoints follow existing v2 patterns: primary constructors, auth attributes, XML docs, CancellationToken, structured logging

### Modified Controllers (7)
- **EventsV2**: add/update/delete events, user events, filtered/paged events, event locations
- **UsersV2**: add/update users, lookup by email/objectid, impact stats, profile photo upload
- **LitterReportsV2**: full CRUD, filtered reports, image upload/retrieval, location queries
- **TeamsV2**: create/update/deactivate teams, my teams, team name availability
- **EventAttendeesV2**: register/remove attendees, event leads, promote/demote, waiver status
- **EventSummaryV2**: add/update/delete event summaries with event lead authorization
- **EventAttendeeRoutesV2**: get routes by user, update routes

### New Controllers (4)
- **TeamMembersV2**: member listing, join/leave teams, promote/demote team leads
- **TeamEventsV2**: link/unlink events to teams, upcoming/past event queries
- **DependentInvitationsV2**: create/cancel/resend dependent invitations
- **DependentWaiversV2**: sign dependent waivers, view waiver history

## Test plan
- [x] `dotnet build TrashMob.sln` — zero errors
- [x] `dotnet test TrashMob.Shared.Tests` — 716 passing (62 new tests), 2 pre-existing failures (ProspectScoringManager)
- [ ] Verify Swagger shows new v2 endpoints
- [ ] Smoke test key endpoints in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)