### PR TITLE
Fix 2 failing ProspectScoringManager tests

### DIFF
--- a/TrashMob.Shared.Tests/Managers/Prospects/ProspectScoringManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/ProspectScoringManagerTests.cs
@@ -171,6 +171,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
 
             _eventRepo.SetupGet(events);
             _partnerRepo.SetupGet(partners);
+            _prospectRepo.SetupGet(new List<CommunityProspect>());
 
             var gaps = (await _sut.GetGeographicGapsAsync()).ToList();
 
@@ -192,6 +193,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
 
             _eventRepo.SetupGet(events);
             _partnerRepo.SetupGet(new List<Partner>());
+            _prospectRepo.SetupGet(new List<CommunityProspect>());
 
             var gaps = (await _sut.GetGeographicGapsAsync()).ToList();
 


### PR DESCRIPTION
## Summary

- Fixed 2 `ProspectScoringManagerTests` that were failing with `IAsyncEnumerable` errors
- Root cause: `GetGeographicGaps_ExcludesCitiesWithActivePartners` and `GetGeographicGaps_ExcludesCancelledEvents` didn't mock `prospectRepository.Get()`, which is called internally by `GetGeographicGapsAsync`
- Fix: Added `_prospectRepo.SetupGet(new List<CommunityProspect>())` to both tests

## Test plan
- [x] All 19 ProspectScoringManager tests pass
- [x] Full test suite: 718 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)