### PR TITLE
Polish Phase 1 middleware infrastructure

### DIFF
--- a/TrashMob.Shared.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/TrashMob.Shared.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -1,6 +1,7 @@
 namespace TrashMob.Shared.Tests.Middleware
 {
     using System;
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
@@ -66,6 +67,21 @@ namespace TrashMob.Shared.Tests.Middleware
             // The correlation ID should be stored in Items for the response callback to use
             Assert.Equal(existingId, capturedCorrelationId);
             Assert.Equal(existingId, context.Items["CorrelationId"]);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_SetsActivityTag_WhenActivityExists()
+        {
+            using var activity = new Activity("TestActivity").Start();
+            var context = new DefaultHttpContext();
+            var correlationId = "activity-correlation-id";
+            context.Request.Headers["X-Correlation-ID"] = correlationId;
+
+            var middleware = new CorrelationIdMiddleware(_ => Task.CompletedTask, logger.Object);
+
+            await middleware.InvokeAsync(context);
+
+            Assert.Equal(correlationId, activity.GetTagItem("correlation.id")?.ToString());
         }
     }
 }

--- a/TrashMob.Shared.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
+++ b/TrashMob.Shared.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
@@ -51,6 +51,7 @@ namespace TrashMob.Shared.Tests.Middleware
             Assert.Equal(400, context.Response.StatusCode);
             var problem = await GetProblemDetailsFromResponse(context);
             Assert.Equal("Bad Request", problem.Title);
+            Assert.Equal("https://httpstatuses.io/400", problem.Type);
         }
 
         [Fact]
@@ -64,6 +65,7 @@ namespace TrashMob.Shared.Tests.Middleware
             Assert.Equal(404, context.Response.StatusCode);
             var problem = await GetProblemDetailsFromResponse(context);
             Assert.Equal("Not Found", problem.Title);
+            Assert.Equal("https://httpstatuses.io/404", problem.Type);
         }
 
         [Fact]
@@ -88,6 +90,7 @@ namespace TrashMob.Shared.Tests.Middleware
             Assert.Equal(500, context.Response.StatusCode);
             var problem = await GetProblemDetailsFromResponse(context);
             Assert.Equal("Internal Server Error", problem.Title);
+            Assert.Equal("https://httpstatuses.io/500", problem.Type);
         }
 
         [Fact]

--- a/TrashMob/Middleware/CorrelationIdMiddleware.cs
+++ b/TrashMob/Middleware/CorrelationIdMiddleware.cs
@@ -2,7 +2,7 @@ namespace TrashMob.Middleware
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
@@ -19,6 +19,8 @@ namespace TrashMob.Middleware
                                 : headerValue;
 
             context.Items["CorrelationId"] = correlationId;
+
+            Activity.Current?.SetTag("correlation.id", correlationId);
 
             context.Response.OnStarting(() =>
             {

--- a/TrashMob/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/TrashMob/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -53,9 +53,12 @@ namespace TrashMob.Middleware
                 ? mapped
                 : (HttpStatusCode.InternalServerError, "Internal Server Error");
 
+            var statusCodeInt = (int)statusCode;
+
             var problemDetails = new ProblemDetails
             {
-                Status = (int)statusCode,
+                Type = $"https://httpstatuses.io/{statusCodeInt}",
+                Status = statusCodeInt,
                 Title = title,
                 Detail = environment.IsDevelopment() ? exception.Message : null,
                 Instance = context.Request.Path,
@@ -68,7 +71,7 @@ namespace TrashMob.Middleware
                 problemDetails.Extensions["correlationId"] = correlationId;
             }
 
-            context.Response.StatusCode = (int)statusCode;
+            context.Response.StatusCode = statusCodeInt;
             context.Response.ContentType = "application/problem+json";
 
             await context.Response.WriteAsync(JsonSerializer.Serialize(problemDetails, JsonOptions));

--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -314,10 +314,45 @@ public class Program
                 name: "database",
                 tags: ["db", "sql", "sqlserver"]);
 
+        builder.Services.AddProblemDetails();
+        builder.Services.Configure<Microsoft.AspNetCore.Mvc.ApiBehaviorOptions>(options =>
+        {
+            options.InvalidModelStateResponseFactory = context =>
+            {
+                var problemDetails = new Microsoft.AspNetCore.Mvc.ValidationProblemDetails(context.ModelState)
+                {
+                    Type = "https://httpstatuses.io/400",
+                    Instance = context.HttpContext.Request.Path,
+                };
+                problemDetails.Extensions["traceId"] = context.HttpContext.TraceIdentifier;
+
+                var correlationId = context.HttpContext.Items["CorrelationId"]?.ToString();
+                if (correlationId is not null)
+                {
+                    problemDetails.Extensions["correlationId"] = correlationId;
+                }
+
+                return new Microsoft.AspNetCore.Mvc.BadRequestObjectResult(problemDetails)
+                {
+                    ContentTypes = { "application/problem+json" },
+                };
+            };
+        });
+
         builder.Services.AddSwaggerGen(options =>
         {
-            options.SwaggerDoc("v1", new OpenApiInfo { Title = "TrashMob API", Version = "v1" });
-            options.SwaggerDoc("v2", new OpenApiInfo { Title = "TrashMob API", Version = "v2" });
+            options.SwaggerDoc("v1", new OpenApiInfo
+            {
+                Title = "TrashMob API",
+                Version = "v1",
+                Description = "Legacy API endpoints. Maintained for backward compatibility while clients migrate to v2.",
+            });
+            options.SwaggerDoc("v2", new OpenApiInfo
+            {
+                Title = "TrashMob API",
+                Version = "v2",
+                Description = "Modern API with server-side pagination, filtering, and lean DTOs. Designed for web and mobile clients.",
+            });
             options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
             {
                 In = ParameterLocation.Header,


### PR DESCRIPTION
## Summary
- Add RFC 9457 `Type` URI (`https://httpstatuses.io/{code}`) to all ProblemDetails exception responses for spec compliance
- Link correlation ID to `Activity.Current` OpenTelemetry tags so it appears in Application Insights traces
- Wrap model validation 400 errors in ProblemDetails format with correlation/trace IDs for consistent error responses
- Add descriptive text to Swagger v1/v2 docs distinguishing legacy vs modern API

## Test plan
- [x] 719 tests pass (718 existing + 1 new Activity tag test)
- [x] Type URI assertions added to 3 existing exception handler tests (400, 404, 500)
- [ ] Verify Swagger UI shows descriptions on v1/v2 docs
- [ ] Verify model validation errors return `application/problem+json` content type

🤖 Generated with [Claude Code](https://claude.com/claude-code)