### PR TITLE
Enforce DTO consistency across all v2 API controllers

### DIFF
--- a/TrashMob.Models/Extensions/V2/DependentInvitationMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/DependentInvitationMappingsV2.cs
@@ -1,0 +1,32 @@
+#nullable enable
+
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping DependentInvitation entities to V2 DTOs.
+    /// </summary>
+    public static class DependentInvitationMappingsV2
+    {
+        /// <summary>
+        /// Maps a DependentInvitation entity to a V2 DependentInvitationDto.
+        /// Excludes security-sensitive fields (token hash).
+        /// </summary>
+        public static DependentInvitationDto ToV2Dto(this DependentInvitation entity)
+        {
+            return new DependentInvitationDto
+            {
+                Id = entity.Id,
+                DependentId = entity.DependentId,
+                ParentUserId = entity.ParentUserId,
+                Email = entity.Email ?? string.Empty,
+                InvitationStatusId = entity.InvitationStatusId,
+                DateInvited = entity.DateInvited,
+                ExpiresDate = entity.ExpiresDate,
+                DateAccepted = entity.DateAccepted,
+                AcceptedByUserId = entity.AcceptedByUserId,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/DependentWaiverMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/DependentWaiverMappingsV2.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping DependentWaiver entities to V2 DTOs.
+    /// </summary>
+    public static class DependentWaiverMappingsV2
+    {
+        /// <summary>
+        /// Maps a DependentWaiver entity to a V2 DependentWaiverDto.
+        /// Excludes internal tracking fields (IP address, user agent).
+        /// </summary>
+        public static DependentWaiverDto ToV2Dto(this DependentWaiver entity)
+        {
+            return new DependentWaiverDto
+            {
+                Id = entity.Id,
+                DependentId = entity.DependentId,
+                WaiverVersionId = entity.WaiverVersionId,
+                SignedByUserId = entity.SignedByUserId,
+                TypedLegalName = entity.TypedLegalName ?? string.Empty,
+                AcceptedDate = entity.AcceptedDate,
+                ExpiryDate = entity.ExpiryDate,
+                DocumentUrl = entity.DocumentUrl ?? string.Empty,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/EventAttendeeMetricsMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventAttendeeMetricsMappingsV2.cs
@@ -32,5 +32,23 @@ namespace TrashMob.Models.Extensions.V2
                 AdjustmentReason = entity.AdjustmentReason ?? string.Empty,
             };
         }
+        /// <summary>
+        /// Maps a V2 EventAttendeeMetricsDto to an EventAttendeeMetrics entity.
+        /// </summary>
+        public static EventAttendeeMetrics ToEntity(this EventAttendeeMetricsDto dto)
+        {
+            return new EventAttendeeMetrics
+            {
+                Id = dto.Id,
+                EventId = dto.EventId,
+                UserId = dto.UserId,
+                BagsCollected = dto.BagsCollected,
+                PickedWeight = dto.PickedWeight,
+                PickedWeightUnitId = dto.PickedWeightUnitId,
+                DurationMinutes = dto.DurationMinutes,
+                Notes = dto.Notes,
+                Status = dto.Status,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/EventMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventMappingsV2.cs
@@ -2,6 +2,9 @@
 
 namespace TrashMob.Models.Extensions.V2
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using TrashMob.Models.Poco;
     using TrashMob.Models.Poco.V2;
 
     /// <summary>
@@ -38,5 +41,33 @@ namespace TrashMob.Models.Extensions.V2
                 LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
             };
         }
+        /// <summary>
+        /// Maps a V2 EventDto to an Event entity.
+        /// </summary>
+        public static Event ToEntity(this EventDto dto)
+        {
+            return new Event
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Description = dto.Description,
+                EventDate = dto.EventDate,
+                DurationHours = dto.DurationHours,
+                DurationMinutes = dto.DurationMinutes,
+                EventTypeId = dto.EventTypeId,
+                EventStatusId = dto.EventStatusId,
+                StreetAddress = dto.StreetAddress,
+                City = dto.City,
+                Region = dto.Region,
+                Country = dto.Country,
+                PostalCode = dto.PostalCode,
+                Latitude = dto.Latitude,
+                Longitude = dto.Longitude,
+                MaxNumberOfParticipants = dto.MaxNumberOfParticipants,
+                EventVisibilityId = dto.IsEventPublic ? (int)EventVisibilityEnum.Public : (int)EventVisibilityEnum.Private,
+                CreatedByUserId = dto.CreatedByUserId,
+            };
+        }
+
     }
 }

--- a/TrashMob.Models/Extensions/V2/EventSummaryMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventSummaryMappingsV2.cs
@@ -29,5 +29,23 @@ namespace TrashMob.Models.Extensions.V2
                 LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
             };
         }
+        /// <summary>
+        /// Maps a V2 EventSummaryDto to an EventSummary entity.
+        /// </summary>
+        public static EventSummary ToEntity(this EventSummaryDto dto)
+        {
+            return new EventSummary
+            {
+                EventId = dto.EventId,
+                NumberOfBuckets = dto.NumberOfBuckets,
+                NumberOfBags = dto.NumberOfBags,
+                DurationInMinutes = dto.DurationInMinutes,
+                ActualNumberOfAttendees = dto.ActualNumberOfAttendees,
+                PickedWeight = dto.PickedWeight,
+                PickedWeightUnitId = dto.PickedWeightUnitId,
+                IsFromRouteData = dto.IsFromRouteData,
+                Notes = dto.Notes,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/LitterReportMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/LitterReportMappingsV2.cs
@@ -53,5 +53,21 @@ namespace TrashMob.Models.Extensions.V2
                 Longitude = entity.Longitude,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 LitterReportDto to a LitterReport entity.
+        /// Note: LitterImages are not reverse-mapped; they are handled separately via image upload.
+        /// </summary>
+        public static LitterReport ToEntity(this LitterReportDto dto)
+        {
+            return new LitterReport
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Description = dto.Description,
+                LitterReportStatusId = dto.LitterReportStatusId,
+                CreatedByUserId = dto.CreatedByUserId,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/TeamMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamMappingsV2.cs
@@ -34,5 +34,28 @@ namespace TrashMob.Models.Extensions.V2
                 LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
             };
         }
+        /// <summary>
+        /// Maps a V2 TeamDto to a Team entity.
+        /// </summary>
+        public static Team ToEntity(this TeamDto dto)
+        {
+            return new Team
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Description = dto.Description,
+                LogoUrl = dto.LogoUrl,
+                IsPublic = dto.IsPublic,
+                RequiresApproval = dto.RequiresApproval,
+                Latitude = dto.Latitude,
+                Longitude = dto.Longitude,
+                City = dto.City,
+                Region = dto.Region,
+                Country = dto.Country,
+                PostalCode = dto.PostalCode,
+                IsActive = dto.IsActive,
+                CreatedByUserId = dto.CreatedByUserId,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping TeamMember entities to V2 DTOs.
+    /// </summary>
+    public static class TeamMemberMappingsV2
+    {
+        /// <summary>
+        /// Maps a TeamMember entity to a V2 TeamMemberDto.
+        /// Requires the User navigation property to be loaded.
+        /// </summary>
+        public static TeamMemberDto ToV2Dto(this TeamMember entity)
+        {
+            return new TeamMemberDto
+            {
+                Id = entity.Id,
+                TeamId = entity.TeamId,
+                UserId = entity.UserId,
+                UserName = entity.User?.UserName ?? string.Empty,
+                GivenName = entity.User?.GivenName ?? string.Empty,
+                ProfilePhotoUrl = entity.User?.ProfilePhotoUrl ?? string.Empty,
+                IsTeamLead = entity.IsTeamLead,
+                JoinedDate = entity.JoinedDate,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
@@ -32,5 +32,31 @@ namespace TrashMob.Models.Extensions.V2
                 IsMinor = entity.IsMinor,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 UserWriteDto to a User entity for create/update operations.
+        /// </summary>
+        public static User ToEntity(this Poco.V2.UserWriteDto dto)
+        {
+            return new User
+            {
+                Id = dto.Id,
+                UserName = dto.UserName,
+                Email = dto.Email,
+                GivenName = dto.GivenName,
+                Surname = dto.Surname,
+                City = dto.City,
+                Region = dto.Region,
+                Country = dto.Country,
+                PostalCode = dto.PostalCode,
+                Latitude = dto.Latitude,
+                Longitude = dto.Longitude,
+                PrefersMetric = dto.PrefersMetric,
+                DateOfBirth = dto.DateOfBirth,
+                IsMinor = dto.IsMinor,
+                TravelLimitForLocalEvents = dto.TravelLimitForLocalEvents,
+                ProfilePhotoUrl = dto.ProfilePhotoUrl,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Poco/V2/DependentInvitationDto.cs
+++ b/TrashMob.Models/Poco/V2/DependentInvitationDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a dependent invitation. Excludes security-sensitive fields (token hash).
+    /// </summary>
+    public class DependentInvitationDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the invitation.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dependent identifier.
+        /// </summary>
+        public Guid DependentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent user identifier.
+        /// </summary>
+        public Guid ParentUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the email address the invitation was sent to.
+        /// </summary>
+        public string Email { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the invitation status identifier.
+        /// </summary>
+        public int InvitationStatusId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date the invitation was sent.
+        /// </summary>
+        public DateTimeOffset DateInvited { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date the invitation expires.
+        /// </summary>
+        public DateTimeOffset ExpiresDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date the invitation was accepted, if applicable.
+        /// </summary>
+        public DateTimeOffset? DateAccepted { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user identifier of who accepted the invitation, if applicable.
+        /// </summary>
+        public Guid? AcceptedByUserId { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/DependentWaiverDto.cs
+++ b/TrashMob.Models/Poco/V2/DependentWaiverDto.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a dependent waiver. Excludes internal tracking fields (IP, UserAgent).
+    /// </summary>
+    public class DependentWaiverDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the waiver.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dependent identifier.
+        /// </summary>
+        public Guid DependentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the waiver version identifier.
+        /// </summary>
+        public Guid WaiverVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user identifier of who signed the waiver.
+        /// </summary>
+        public Guid SignedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the typed legal name used when signing.
+        /// </summary>
+        public string TypedLegalName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the date the waiver was accepted.
+        /// </summary>
+        public DateTimeOffset AcceptedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date the waiver expires.
+        /// </summary>
+        public DateTimeOffset ExpiryDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the signed waiver document.
+        /// </summary>
+        public string DocumentUrl { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Models/Poco/V2/TeamMemberDto.cs
+++ b/TrashMob.Models/Poco/V2/TeamMemberDto.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a team member. Flat DTO with no navigation properties.
+    /// </summary>
+    public class TeamMemberDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the team membership.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the team identifier.
+        /// </summary>
+        public Guid TeamId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user identifier.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the member's display username.
+        /// </summary>
+        public string UserName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the member's given name.
+        /// </summary>
+        public string GivenName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the member's profile photo URL.
+        /// </summary>
+        public string ProfilePhotoUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets whether the member is a team lead.
+        /// </summary>
+        public bool IsTeamLead { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date the member joined the team.
+        /// </summary>
+        public DateTimeOffset JoinedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserWriteDto.cs
+++ b/TrashMob.Models/Poco/V2/UserWriteDto.cs
@@ -1,0 +1,93 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API request DTO for creating or updating a user profile. Includes writable PII fields
+    /// that are excluded from the read-only <see cref="UserDto"/>.
+    /// </summary>
+    public class UserWriteDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the user.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display username.
+        /// </summary>
+        public string UserName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's email address.
+        /// </summary>
+        public string Email { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's given (first) name.
+        /// </summary>
+        public string GivenName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's surname (last name).
+        /// </summary>
+        public string Surname { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's city.
+        /// </summary>
+        public string City { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's region (state/province).
+        /// </summary>
+        public string Region { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's country.
+        /// </summary>
+        public string Country { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's postal code.
+        /// </summary>
+        public string PostalCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the latitude of the user's location.
+        /// </summary>
+        public double? Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude of the user's location.
+        /// </summary>
+        public double? Longitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the user prefers metric units.
+        /// </summary>
+        public bool PrefersMetric { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's date of birth (used for age verification).
+        /// </summary>
+        public DateTimeOffset? DateOfBirth { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the user is a minor (13-17).
+        /// </summary>
+        public bool IsMinor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum travel distance for local event notifications.
+        /// </summary>
+        public int TravelLimitForLocalEvents { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the user's profile photo.
+        /// </summary>
+        public string ProfilePhotoUrl { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/DependentInvitationsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/DependentInvitationsV2ControllerTests.cs
@@ -11,6 +11,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using TrashMob.Controllers.V2;
     using TrashMob.Models;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Managers.Interfaces;
     using Xunit;
 
@@ -38,7 +39,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var dependentId = Guid.NewGuid();
             var invitations = new List<DependentInvitation>
             {
-                new() { Id = Guid.NewGuid() },
+                new() { Id = Guid.NewGuid(), DependentId = dependentId, ParentUserId = userId, Email = "test@example.com" },
             };
 
             invitationManager.Setup(m => m.GetByDependentIdAsync(dependentId, It.IsAny<CancellationToken>()))
@@ -47,7 +48,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetInvitationsForDependent(userId, dependentId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returned = Assert.IsAssignableFrom<IEnumerable<DependentInvitation>>(okResult.Value);
+            var returned = Assert.IsAssignableFrom<IEnumerable<DependentInvitationDto>>(okResult.Value);
             Assert.Single(returned);
         }
 
@@ -123,7 +124,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task ResendInvitation_ReturnsOk()
         {
             var invitationId = Guid.NewGuid();
-            var updatedInvitation = new DependentInvitation { Id = invitationId };
+            var updatedInvitation = new DependentInvitation { Id = invitationId, DependentId = Guid.NewGuid(), ParentUserId = userId, Email = "test@example.com" };
 
             invitationManager.Setup(m => m.ResendInvitationAsync(invitationId, userId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(updatedInvitation);
@@ -131,7 +132,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.ResendInvitation(invitationId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returned = Assert.IsType<DependentInvitation>(okResult.Value);
+            var returned = Assert.IsType<DependentInvitationDto>(okResult.Value);
             Assert.Equal(invitationId, returned.Id);
         }
     }

--- a/TrashMob.Shared.Tests/Controllers/V2/DependentWaiversV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/DependentWaiversV2ControllerTests.cs
@@ -10,6 +10,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using Moq;
     using TrashMob.Controllers.V2;
     using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Poco;
     using Xunit;
@@ -65,7 +66,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetCurrentWaiver(dependentId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedWaiver = Assert.IsType<DependentWaiver>(okResult.Value);
+            var returnedWaiver = Assert.IsType<DependentWaiverDto>(okResult.Value);
             Assert.Equal(waiver.Id, returnedWaiver.Id);
         }
 
@@ -146,7 +147,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
 
             var statusResult = Assert.IsType<ObjectResult>(result);
             Assert.Equal(StatusCodes.Status201Created, statusResult.StatusCode);
-            var returnedWaiver = Assert.IsType<DependentWaiver>(statusResult.Value);
+            var returnedWaiver = Assert.IsType<DependentWaiverDto>(statusResult.Value);
             Assert.Equal(signedWaiver.Id, returnedWaiver.Id);
         }
 
@@ -212,8 +213,8 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetWaiverHistory(dependentId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedWaivers = Assert.IsAssignableFrom<IEnumerable<DependentWaiver>>(okResult.Value);
-            Assert.Equal(2, new List<DependentWaiver>(returnedWaivers).Count);
+            var returnedWaivers = Assert.IsAssignableFrom<IEnumerable<DependentWaiverDto>>(okResult.Value);
+            Assert.Equal(2, new List<DependentWaiverDto>(returnedWaivers).Count);
         }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeMetricsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeMetricsV2ControllerTests.cs
@@ -76,7 +76,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task SubmitMyMetrics_ReturnsOk_OnSuccess()
         {
             var eventId = Guid.NewGuid();
-            var metrics = new EventAttendeeMetrics { BagsCollected = 5 };
+            var metricsDto = new EventAttendeeMetricsDto { BagsCollected = 5 };
             var resultMetrics = new EventAttendeeMetrics
             {
                 Id = Guid.NewGuid(),
@@ -86,10 +86,10 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                 Status = "Pending",
             };
 
-            metricsManager.Setup(m => m.SubmitMetricsAsync(eventId, userId, metrics, It.IsAny<CancellationToken>()))
+            metricsManager.Setup(m => m.SubmitMetricsAsync(eventId, userId, It.IsAny<EventAttendeeMetrics>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ServiceResult<EventAttendeeMetrics>.Success(resultMetrics));
 
-            var result = await controller.SubmitMyMetrics(eventId, metrics, CancellationToken.None);
+            var result = await controller.SubmitMyMetrics(eventId, metricsDto, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
             var dto = Assert.IsType<EventAttendeeMetricsDto>(okResult.Value);
@@ -103,7 +103,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             metricsManager.Setup(m => m.SubmitMetricsAsync(eventId, userId, It.IsAny<EventAttendeeMetrics>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ServiceResult<EventAttendeeMetrics>.Failure("Event not found"));
 
-            var result = await controller.SubmitMyMetrics(eventId, new EventAttendeeMetrics(), CancellationToken.None);
+            var result = await controller.SubmitMyMetrics(eventId, new EventAttendeeMetricsDto(), CancellationToken.None);
 
             var badResult = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal("Event not found", badResult.Value);

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
@@ -147,7 +147,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetByUser(userId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedRoutes = Assert.IsAssignableFrom<IEnumerable<EventAttendeeRoute>>(okResult.Value);
+            var returnedRoutes = Assert.IsAssignableFrom<IEnumerable<DisplayEventAttendeeRoute>>(okResult.Value);
             Assert.Single(returnedRoutes);
         }
 
@@ -163,7 +163,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                 Id = routeId,
                 EventId = Guid.NewGuid(),
             };
-            var updatedRoute = new EventAttendeeRoute { Id = routeId };
+            var updatedRoute = new EventAttendeeRoute { Id = routeId, UserPath = TestPath };
 
             routeManager
                 .Setup(m => m.UpdateAsync(It.IsAny<EventAttendeeRoute>(), userId, It.IsAny<CancellationToken>()))
@@ -172,7 +172,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.Update(displayRoute, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            Assert.IsType<EventAttendeeRoute>(okResult.Value);
+            Assert.IsType<DisplayEventAttendeeRoute>(okResult.Value);
         }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeesV2ControllerTests.cs
@@ -145,13 +145,13 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task AddEventAttendee_ReturnsOk_WhenWaiverValid()
         {
             var eventId = Guid.NewGuid();
-            var attendee = new EventAttendee { UserId = currentUserId };
+            var attendeeDto = new EventAttendeeDto { UserId = currentUserId };
 
             userWaiverManager
                 .Setup(m => m.HasValidWaiverForEventAsync(currentUserId, eventId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
-            var result = await controller.AddEventAttendee(eventId, attendee, CancellationToken.None);
+            var result = await controller.AddEventAttendee(eventId, attendeeDto, CancellationToken.None);
 
             Assert.IsType<OkResult>(result);
             eventAttendeeManager.Verify(
@@ -163,7 +163,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task AddEventAttendee_ReturnsBadRequest_WhenWaiverRequired()
         {
             var eventId = Guid.NewGuid();
-            var attendee = new EventAttendee { UserId = currentUserId };
+            var attendeeDto = new EventAttendeeDto { UserId = currentUserId };
             var requiredWaivers = new List<WaiverVersion>
             {
                 new() { Id = Guid.NewGuid() },
@@ -176,7 +176,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                 .Setup(m => m.GetRequiredWaiversForEventAsync(currentUserId, eventId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requiredWaivers);
 
-            var result = await controller.AddEventAttendee(eventId, attendee, CancellationToken.None);
+            var result = await controller.AddEventAttendee(eventId, attendeeDto, CancellationToken.None);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -224,7 +224,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         {
             var eventId = Guid.NewGuid();
             var userId = Guid.NewGuid();
-            var promoted = new EventAttendee { EventId = eventId, UserId = userId, IsEventLead = true };
+            var promoted = new EventAttendee { EventId = eventId, UserId = userId, IsEventLead = true, User = new User { UserName = "promoted" } };
 
             eventAttendeeManager
                 .Setup(m => m.IsEventLeadAsync(eventId, currentUserId, It.IsAny<CancellationToken>()))
@@ -236,7 +236,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.PromoteToLead(eventId, userId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var attendee = Assert.IsType<EventAttendee>(okResult.Value);
+            var attendee = Assert.IsType<EventAttendeeDto>(okResult.Value);
             Assert.True(attendee.IsEventLead);
         }
 

--- a/TrashMob.Shared.Tests/Controllers/V2/EventSummaryV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventSummaryV2ControllerTests.cs
@@ -103,7 +103,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task AddEventSummary_ReturnsCreated_WhenAuthorized()
         {
             var eventId = Guid.NewGuid();
-            var summary = new EventSummary { NumberOfBags = 5 };
+            var summaryDto = new EventSummaryDto { NumberOfBags = 5 };
             var created = new EventSummary { EventId = eventId, NumberOfBags = 5 };
 
             authorizationService
@@ -113,7 +113,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                 .Setup(m => m.AddAsync(It.IsAny<EventSummary>(), currentUserId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(created);
 
-            var result = await controller.AddEventSummary(eventId, summary, CancellationToken.None);
+            var result = await controller.AddEventSummary(eventId, summaryDto, CancellationToken.None);
 
             Assert.IsType<CreatedAtActionResult>(result);
         }
@@ -122,13 +122,13 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task AddEventSummary_ReturnsForbid_WhenNotAuthorized()
         {
             var eventId = Guid.NewGuid();
-            var summary = new EventSummary { NumberOfBags = 5 };
+            var summaryDto = new EventSummaryDto { NumberOfBags = 5 };
 
             authorizationService
                 .Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
                 .ReturnsAsync(AuthorizationResult.Failed());
 
-            var result = await controller.AddEventSummary(eventId, summary, CancellationToken.None);
+            var result = await controller.AddEventSummary(eventId, summaryDto, CancellationToken.None);
 
             Assert.IsType<ForbidResult>(result);
         }

--- a/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
@@ -179,11 +179,11 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         {
             controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
 
-            var mobEvent = new Event { Id = Guid.NewGuid(), Name = "New Cleanup" };
-            eventManager.Setup(m => m.AddAsync(mobEvent, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(mobEvent);
+            var eventDto = new EventDto { Id = Guid.NewGuid(), Name = "New Cleanup" };
+            eventManager.Setup(m => m.AddAsync(It.IsAny<Event>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event { Id = eventDto.Id, Name = eventDto.Name });
 
-            var result = await controller.AddEvent(mobEvent, CancellationToken.None);
+            var result = await controller.AddEvent(eventDto, CancellationToken.None);
 
             var createdResult = Assert.IsType<CreatedAtActionResult>(result);
             Assert.Equal(nameof(EventsV2Controller.GetEvent), createdResult.ActionName);
@@ -198,9 +198,9 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                     It.IsAny<object>(), It.IsAny<string>()))
                 .ReturnsAsync(AuthorizationResult.Failed());
 
-            var mobEvent = new Event { Id = Guid.NewGuid(), Name = "Cleanup" };
+            var eventDto = new EventDto { Id = Guid.NewGuid(), Name = "Cleanup" };
 
-            var result = await controller.UpdateEvent(mobEvent, CancellationToken.None);
+            var result = await controller.UpdateEvent(eventDto, CancellationToken.None);
 
             Assert.IsType<ForbidResult>(result);
         }

--- a/TrashMob.Shared.Tests/Controllers/V2/LitterReportsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/LitterReportsV2ControllerTests.cs
@@ -156,17 +156,17 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task AddLitterReport_ReturnsOk_WhenSuccess()
         {
             controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
-            var report = new LitterReport { Name = "Test Report" };
+            var reportDto = new LitterReportDto { Name = "Test Report" };
             var created = new LitterReport { Id = Guid.NewGuid(), Name = "Test Report" };
 
             litterReportManager
-                .Setup(m => m.AddWithResultAsync(report, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.AddWithResultAsync(It.IsAny<LitterReport>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ServiceResult<LitterReport>.Success(created));
 
-            var result = await controller.AddLitterReport(report, CancellationToken.None);
+            var result = await controller.AddLitterReport(reportDto, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedReport = Assert.IsType<LitterReport>(okResult.Value);
+            var returnedReport = Assert.IsType<LitterReportDto>(okResult.Value);
             Assert.Equal("Test Report", returnedReport.Name);
         }
 
@@ -174,13 +174,13 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public async Task AddLitterReport_ReturnsBadRequest_WhenFailure()
         {
             controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
-            var report = new LitterReport { Name = "Bad Report" };
+            var reportDto = new LitterReportDto { Name = "Bad Report" };
 
             litterReportManager
-                .Setup(m => m.AddWithResultAsync(report, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.AddWithResultAsync(It.IsAny<LitterReport>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ServiceResult<LitterReport>.Failure("Invalid report"));
 
-            var result = await controller.AddLitterReport(report, CancellationToken.None);
+            var result = await controller.AddLitterReport(reportDto, CancellationToken.None);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -202,7 +202,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetUserLitterReports(userId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedReports = Assert.IsAssignableFrom<IEnumerable<LitterReport>>(okResult.Value);
+            var returnedReports = Assert.IsAssignableFrom<IEnumerable<LitterReportDto>>(okResult.Value);
             Assert.Single(returnedReports);
         }
 

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamMembersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamMembersV2ControllerTests.cs
@@ -10,6 +10,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using Moq;
     using TrashMob.Controllers.V2;
     using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Managers.Interfaces;
     using Xunit;
 
@@ -41,8 +42,8 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var team = new Team { Id = teamId, Name = "Public Team", IsActive = true, IsPublic = true };
             var members = new List<TeamMember>
             {
-                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = true },
-                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = false },
+                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = true, User = new User { UserName = "lead" } },
+                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = false, User = new User { UserName = "member" } },
             };
 
             teamManager
@@ -56,8 +57,8 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetMembers(teamId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedMembers = Assert.IsAssignableFrom<IEnumerable<TeamMember>>(okResult.Value);
-            Assert.Equal(2, new List<TeamMember>(returnedMembers).Count);
+            var returnedMembers = Assert.IsAssignableFrom<IEnumerable<TeamMemberDto>>(okResult.Value);
+            Assert.Equal(2, new List<TeamMemberDto>(returnedMembers).Count);
         }
 
         [Fact]
@@ -81,7 +82,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, IsPublic = true };
             var leads = new List<TeamMember>
             {
-                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = true },
+                new() { TeamId = teamId, UserId = Guid.NewGuid(), IsTeamLead = true, User = new User { UserName = "lead" } },
             };
 
             teamManager
@@ -95,7 +96,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetLeads(teamId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedLeads = Assert.IsAssignableFrom<IEnumerable<TeamMember>>(okResult.Value);
+            var returnedLeads = Assert.IsAssignableFrom<IEnumerable<TeamMemberDto>>(okResult.Value);
             Assert.Single(returnedLeads);
         }
 
@@ -105,7 +106,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var teamId = Guid.NewGuid();
             var userId = Guid.NewGuid();
             var team = new Team { Id = teamId, Name = "Public Team", IsActive = true, IsPublic = true };
-            var newMember = new TeamMember { TeamId = teamId, UserId = userId, IsTeamLead = false };
+            var newMember = new TeamMember { TeamId = teamId, UserId = userId, IsTeamLead = false, User = new User { UserName = "newmember" } };
 
             SetUserId(userId);
 
@@ -124,7 +125,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.JoinTeam(teamId, CancellationToken.None);
 
             var createdResult = Assert.IsType<CreatedAtActionResult>(result);
-            var returnedMember = Assert.IsType<TeamMember>(createdResult.Value);
+            var returnedMember = Assert.IsType<TeamMemberDto>(createdResult.Value);
             Assert.Equal(teamId, returnedMember.TeamId);
             Assert.Equal(userId, returnedMember.UserId);
             Assert.False(returnedMember.IsTeamLead);
@@ -192,7 +193,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var targetUserId = Guid.NewGuid();
             var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, IsPublic = true };
             var member = new TeamMember { TeamId = teamId, UserId = targetUserId, IsTeamLead = false };
-            var promotedMember = new TeamMember { TeamId = teamId, UserId = targetUserId, IsTeamLead = true };
+            var promotedMember = new TeamMember { TeamId = teamId, UserId = targetUserId, IsTeamLead = true, User = new User { UserName = "promoted" } };
 
             SetUserId(currentUserId);
 
@@ -215,7 +216,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.PromoteToLead(teamId, targetUserId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedMember = Assert.IsType<TeamMember>(okResult.Value);
+            var returnedMember = Assert.IsType<TeamMemberDto>(okResult.Value);
             Assert.True(returnedMember.IsTeamLead);
         }
 

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamsV2ControllerTests.cs
@@ -175,7 +175,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetMyTeams(CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var returnedTeams = Assert.IsAssignableFrom<IEnumerable<Team>>(okResult.Value);
+            var returnedTeams = Assert.IsAssignableFrom<IEnumerable<TeamDto>>(okResult.Value);
             Assert.Single(returnedTeams);
         }
 
@@ -184,7 +184,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         {
             var userId = Guid.NewGuid();
             controller.HttpContext.Items["UserId"] = userId.ToString();
-            var team = new Team { Name = "New Team" };
+            var teamDto = new TeamDto { Name = "New Team" };
             var user = new User { Id = userId, UserName = "creator" };
 
             teamManager
@@ -197,7 +197,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                 .Setup(m => m.AddAsync(It.IsAny<Team>(), userId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Team t, Guid _, CancellationToken _) => t);
 
-            var result = await controller.CreateTeam(team, CancellationToken.None);
+            var result = await controller.CreateTeam(teamDto, CancellationToken.None);
 
             Assert.IsType<CreatedAtActionResult>(result);
             teamMemberManager.Verify(
@@ -210,13 +210,13 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         {
             var userId = Guid.NewGuid();
             controller.HttpContext.Items["UserId"] = userId.ToString();
-            var team = new Team { Name = "Existing Team" };
+            var teamDto = new TeamDto { Name = "Existing Team" };
 
             teamManager
                 .Setup(m => m.IsTeamNameAvailableAsync("Existing Team", It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(false);
 
-            var result = await controller.CreateTeam(team, CancellationToken.None);
+            var result = await controller.CreateTeam(teamDto, CancellationToken.None);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }

--- a/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
@@ -168,14 +168,14 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         {
             var userId = Guid.NewGuid();
             controller.HttpContext.Items["UserId"] = userId.ToString();
-            var user = new User { UserName = "newuser" };
+            var userDto = new UserWriteDto { UserName = "newuser" };
             var created = new User { Id = userId, UserName = "newuser" };
 
             userManager
-                .Setup(m => m.AddAsync(user, userId, It.IsAny<CancellationToken>()))
+                .Setup(m => m.AddAsync(It.IsAny<User>(), userId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(created);
 
-            var result = await controller.AddUser(user, CancellationToken.None);
+            var result = await controller.AddUser(userDto, CancellationToken.None);
 
             Assert.IsType<CreatedAtActionResult>(result);
         }
@@ -193,7 +193,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetUserByEmail("test@example.com", CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            Assert.IsType<User>(okResult.Value);
+            Assert.IsType<UserDto>(okResult.Value);
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetUserByObjectId(objectId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            Assert.IsType<User>(okResult.Value);
+            Assert.IsType<UserDto>(okResult.Value);
         }
 
         [Fact]

--- a/TrashMob/Controllers/V2/DependentInvitationsV2Controller.cs
+++ b/TrashMob/Controllers/V2/DependentInvitationsV2Controller.cs
@@ -2,6 +2,7 @@ namespace TrashMob.Controllers.V2
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
@@ -12,7 +13,9 @@ namespace TrashMob.Controllers.V2
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
@@ -59,7 +62,7 @@ namespace TrashMob.Controllers.V2
         [HttpGet("users/{userId}/dependents/{dependentId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(IEnumerable<DependentInvitation>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<DependentInvitationDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetInvitationsForDependent(
             Guid userId, Guid dependentId, CancellationToken cancellationToken)
@@ -72,7 +75,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var invitations = await dependentInvitationManager.GetByDependentIdAsync(dependentId, cancellationToken);
-            return Ok(invitations);
+            return Ok(invitations.Select(i => i.ToV2Dto()));
         }
 
         /// <summary>
@@ -89,7 +92,7 @@ namespace TrashMob.Controllers.V2
         [HttpPost("users/{userId}/dependents/{dependentId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(DependentInvitation), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(DependentInvitationDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -116,7 +119,7 @@ namespace TrashMob.Controllers.V2
                     dependentId, request.Email, userId, cancellationToken);
 
                 return CreatedAtAction(nameof(GetInvitationsForDependent),
-                    new { userId, dependentId }, result);
+                    new { userId, dependentId }, result.ToV2Dto());
             }
             catch (InvalidOperationException ex)
             {
@@ -161,7 +164,7 @@ namespace TrashMob.Controllers.V2
         [HttpPost("{invitationId}/resend")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(DependentInvitation), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(DependentInvitationDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> ResendInvitation(Guid invitationId, CancellationToken cancellationToken)
         {
@@ -170,7 +173,7 @@ namespace TrashMob.Controllers.V2
             try
             {
                 var result = await dependentInvitationManager.ResendInvitationAsync(invitationId, UserId, cancellationToken);
-                return Ok(result);
+                return Ok(result.ToV2Dto());
             }
             catch (InvalidOperationException ex)
             {

--- a/TrashMob/Controllers/V2/DependentWaiversV2Controller.cs
+++ b/TrashMob/Controllers/V2/DependentWaiversV2Controller.cs
@@ -11,7 +11,10 @@ namespace TrashMob.Controllers.V2
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
+    using System.Linq;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
@@ -43,7 +46,7 @@ namespace TrashMob.Controllers.V2
         [HttpGet]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(DependentWaiver), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(DependentWaiverDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetCurrentWaiver(Guid dependentId, CancellationToken cancellationToken)
@@ -62,7 +65,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            return Ok(waiver);
+            return Ok(waiver.ToV2Dto());
         }
 
         /// <summary>
@@ -77,7 +80,7 @@ namespace TrashMob.Controllers.V2
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(DependentWaiver), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(DependentWaiverDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> SignWaiver(
@@ -121,7 +124,7 @@ namespace TrashMob.Controllers.V2
                 logger.LogWarning(ex, "PDF generation failed for dependent waiver {WaiverId}", result.Data.Id);
             }
 
-            return StatusCode(StatusCodes.Status201Created, result.Data);
+            return StatusCode(StatusCodes.Status201Created, result.Data.ToV2Dto());
         }
 
         /// <summary>
@@ -134,7 +137,7 @@ namespace TrashMob.Controllers.V2
         [HttpGet("history")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(IEnumerable<DependentWaiver>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<DependentWaiverDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> GetWaiverHistory(Guid dependentId, CancellationToken cancellationToken)
         {
@@ -147,7 +150,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var waivers = await dependentWaiverManager.GetByDependentIdAsync(dependentId, cancellationToken);
-            return Ok(waivers);
+            return Ok(waivers.Select(w => w.ToV2Dto()));
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/EventAttendeeMetricsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeeMetricsV2Controller.cs
@@ -65,7 +65,7 @@ namespace TrashMob.Controllers.V2
         /// Submits or updates metrics for the current user.
         /// </summary>
         /// <param name="eventId">The event ID.</param>
-        /// <param name="metrics">The metrics to submit.</param>
+        /// <param name="dto">The metrics DTO to submit.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns the submitted metrics.</response>
         /// <response code="400">Validation error.</response>
@@ -76,10 +76,13 @@ namespace TrashMob.Controllers.V2
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> SubmitMyMetrics(
             Guid eventId,
-            [FromBody] EventAttendeeMetrics metrics,
+            [FromBody] EventAttendeeMetricsDto dto,
             CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 SubmitMyMetrics for Event={EventId}", eventId);
+
+            var metrics = dto.ToEntity();
+            metrics.EventId = eventId;
 
             var result = await metricsManager.SubmitMetricsAsync(eventId, UserId, metrics, cancellationToken);
 

--- a/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
@@ -138,13 +138,13 @@ namespace TrashMob.Controllers.V2
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns the routes for the user.</response>
         [HttpGet("by-user/{userId}")]
-        [ProducesResponseType(typeof(IEnumerable<EventAttendeeRoute>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<DisplayEventAttendeeRoute>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetByUser(Guid userId, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 GetEventAttendeeRoutesByUser User={UserId}", userId);
 
             var result = await eventAttendeeRouteManager.GetByCreatedUserIdAsync(userId, cancellationToken);
-            return Ok(result);
+            return Ok(result.Select(x => x.ToDisplayEventAttendeeRoute()));
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace TrashMob.Controllers.V2
         [HttpPut]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(EventAttendeeRoute), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(DisplayEventAttendeeRoute), StatusCodes.Status200OK)]
         public async Task<IActionResult> Update(
             DisplayEventAttendeeRoute displayEventAttendeeRoute,
             CancellationToken cancellationToken)
@@ -168,7 +168,7 @@ namespace TrashMob.Controllers.V2
             var updatedRoute = await eventAttendeeRouteManager
                 .UpdateAsync(eventAttendeeRoute, UserId, cancellationToken);
 
-            return Ok(updatedRoute);
+            return Ok(updatedRoute.ToDisplayEventAttendeeRoute());
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
@@ -91,7 +91,7 @@ namespace TrashMob.Controllers.V2
         /// Adds a new event attendee. Requires all waivers to be signed.
         /// </summary>
         /// <param name="eventId">The event identifier.</param>
-        /// <param name="eventAttendee">The event attendee to add.</param>
+        /// <param name="dto">The event attendee DTO containing the UserId.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Attendee registered.</response>
         /// <response code="400">Waivers required.</response>
@@ -102,12 +102,12 @@ namespace TrashMob.Controllers.V2
         [ProducesResponseType(typeof(WaiverRequiredResponse), StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> AddEventAttendee(
             Guid eventId,
-            EventAttendee eventAttendee,
+            EventAttendeeDto dto,
             CancellationToken cancellationToken)
         {
-            logger.LogInformation("V2 AddEventAttendee Event={EventId}, User={UserId}", eventId, eventAttendee.UserId);
+            logger.LogInformation("V2 AddEventAttendee Event={EventId}, User={UserId}", eventId, dto.UserId);
 
-            eventAttendee.EventId = eventId;
+            var eventAttendee = new EventAttendee { EventId = eventId, UserId = dto.UserId };
 
             var hasValidWaiver = await userWaiverManager
                 .HasValidWaiverForEventAsync(eventAttendee.UserId, eventId, cancellationToken);
@@ -179,7 +179,7 @@ namespace TrashMob.Controllers.V2
         [HttpPut("{userId}/promote")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(EventAttendee), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(EventAttendeeDto), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> PromoteToLead(Guid eventId, Guid userId, CancellationToken cancellationToken)
@@ -195,7 +195,7 @@ namespace TrashMob.Controllers.V2
             try
             {
                 var result = await eventAttendeeManager.PromoteToLeadAsync(eventId, userId, UserId, cancellationToken);
-                return Ok(result);
+                return Ok(result.ToV2Dto());
             }
             catch (InvalidOperationException ex)
             {
@@ -215,7 +215,7 @@ namespace TrashMob.Controllers.V2
         [HttpPut("{userId}/demote")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(EventAttendee), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(EventAttendeeDto), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> DemoteFromLead(Guid eventId, Guid userId, CancellationToken cancellationToken)
@@ -231,7 +231,7 @@ namespace TrashMob.Controllers.V2
             try
             {
                 var result = await eventAttendeeManager.DemoteFromLeadAsync(eventId, userId, UserId, cancellationToken);
-                return Ok(result);
+                return Ok(result.ToV2Dto());
             }
             catch (InvalidOperationException ex)
             {

--- a/TrashMob/Controllers/V2/EventSummaryV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventSummaryV2Controller.cs
@@ -63,20 +63,21 @@ namespace TrashMob.Controllers.V2
         /// Adds a new event summary. Only event leads can add.
         /// </summary>
         /// <param name="eventId">The event identifier.</param>
-        /// <param name="eventSummary">The event summary to add.</param>
+        /// <param name="dto">The event summary DTO to add.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="201">Event summary created.</response>
         /// <response code="403">User is not an event lead.</response>
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(EventSummary), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(EventSummaryDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IActionResult> AddEventSummary(Guid eventId, EventSummary eventSummary,
+        public async Task<IActionResult> AddEventSummary(Guid eventId, EventSummaryDto dto,
             CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 AddEventSummary Event={EventId}", eventId);
 
+            var eventSummary = dto.ToEntity();
             eventSummary.EventId = eventId;
 
             if (!await IsAuthorizedAsync(eventSummary, AuthorizationPolicyConstants.UserIsEventLead))
@@ -86,27 +87,28 @@ namespace TrashMob.Controllers.V2
 
             var result = await eventSummaryManager.AddAsync(eventSummary, UserId, cancellationToken);
 
-            return CreatedAtAction(nameof(GetEventSummary), new { eventId }, result);
+            return CreatedAtAction(nameof(GetEventSummary), new { eventId }, result.ToV2Dto());
         }
 
         /// <summary>
         /// Updates an existing event summary. Only event leads can update.
         /// </summary>
         /// <param name="eventId">The event identifier.</param>
-        /// <param name="eventSummary">The event summary to update.</param>
+        /// <param name="dto">The event summary DTO to update.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns the updated event summary.</response>
         /// <response code="403">User is not an event lead.</response>
         [HttpPut]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(EventSummary), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(EventSummaryDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IActionResult> UpdateEventSummary(Guid eventId, EventSummary eventSummary,
+        public async Task<IActionResult> UpdateEventSummary(Guid eventId, EventSummaryDto dto,
             CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 UpdateEventSummary Event={EventId}", eventId);
 
+            var eventSummary = dto.ToEntity();
             eventSummary.EventId = eventId;
 
             if (!await IsAuthorizedAsync(eventSummary, AuthorizationPolicyConstants.UserIsEventLead))
@@ -115,7 +117,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var updatedEvent = await eventSummaryManager.UpdateAsync(eventSummary, UserId, cancellationToken);
-            return Ok(updatedEvent);
+            return Ok(updatedEvent.ToV2Dto());
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/EventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventsV2Controller.cs
@@ -100,7 +100,7 @@ namespace TrashMob.Controllers.V2
         [HttpGet("userevents/{userId}/{futureEventsOnly}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetUserEvents(Guid userId, bool futureEventsOnly,
             CancellationToken cancellationToken)
         {
@@ -110,7 +110,7 @@ namespace TrashMob.Controllers.V2
             var result2 = await eventAttendeeManager
                 .GetEventsUserIsAttendingAsync(userId, futureEventsOnly, cancellationToken);
 
-            var allResults = result1.Union(result2, new EventComparer());
+            var allResults = result1.Union(result2, new EventComparer()).Select(e => e.ToV2Dto());
             return Ok(allResults);
         }
 
@@ -123,14 +123,14 @@ namespace TrashMob.Controllers.V2
         [HttpGet("eventsuserisattending/{userId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetEventsUserIsAttending(Guid userId, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 GetEventsUserIsAttending User={UserId}", userId);
 
             var result = await eventAttendeeManager
                 .GetEventsUserIsAttendingAsync(userId, cancellationToken: cancellationToken);
-            return Ok(result);
+            return Ok(result.Select(e => e.ToV2Dto()));
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace TrashMob.Controllers.V2
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns a paginated list of filtered events.</response>
         [HttpPost("pagedfilteredevents")]
-        [ProducesResponseType(typeof(PaginatedList<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(PaginatedList<EventDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPagedFilteredEvents(
             [FromBody] EventFilter filter,
             CancellationToken cancellationToken)
@@ -170,16 +170,17 @@ namespace TrashMob.Controllers.V2
             Guid? userId = User.Identity?.IsAuthenticated == true ? UserId : (Guid?)null;
             var result = await eventManager.GetFilteredEventsAsync(filter, userId, cancellationToken);
 
+            var ordered = result.OrderByDescending(e => e.EventDate).ToList();
+
             if (filter.PageSize is not null)
             {
-                var pagedResults = PaginatedList<Event>.Create(
-                    result.OrderByDescending(e => e.EventDate).AsQueryable(),
-                    filter.PageIndex.GetValueOrDefault(0),
-                    filter.PageSize.GetValueOrDefault(10));
-                return Ok(pagedResults);
+                var pageIndex = filter.PageIndex.GetValueOrDefault(0);
+                var pageSize = filter.PageSize.GetValueOrDefault(10);
+                var items = ordered.Skip((pageIndex - 1) * pageSize).Take(pageSize).Select(e => e.ToV2Dto()).ToList();
+                return Ok(new PaginatedList<EventDto>(items, ordered.Count, pageIndex, pageSize));
             }
 
-            return Ok(result);
+            return Ok(ordered.Select(e => e.ToV2Dto()));
         }
 
         /// <summary>
@@ -192,7 +193,7 @@ namespace TrashMob.Controllers.V2
         [HttpPost("pageduserevents/{userId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(PaginatedList<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(PaginatedList<EventDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPagedUserEvents(
             [FromBody] EventFilter filter,
             Guid userId,
@@ -204,42 +205,43 @@ namespace TrashMob.Controllers.V2
             var result2 = await eventAttendeeManager
                 .GetEventsUserIsAttendingAsync(filter, userId, cancellationToken);
 
-            var allResults = result1.Union(result2, new EventComparer());
+            var ordered = result1.Union(result2, new EventComparer())
+                .OrderByDescending(e => e.EventDate).ToList();
 
             if (filter.PageSize is not null)
             {
-                var pagedResults = PaginatedList<Event>.Create(
-                    allResults.OrderByDescending(e => e.EventDate).AsQueryable(),
-                    filter.PageIndex.GetValueOrDefault(0),
-                    filter.PageSize.GetValueOrDefault(10));
-                return Ok(pagedResults);
+                var pageIndex = filter.PageIndex.GetValueOrDefault(0);
+                var pageSize = filter.PageSize.GetValueOrDefault(10);
+                var items = ordered.Skip((pageIndex - 1) * pageSize).Take(pageSize).Select(e => e.ToV2Dto()).ToList();
+                return Ok(new PaginatedList<EventDto>(items, ordered.Count, pageIndex, pageSize));
             }
 
-            return Ok(allResults);
+            return Ok(ordered.Select(e => e.ToV2Dto()));
         }
 
         /// <summary>
         /// Adds a new event.
         /// </summary>
-        /// <param name="mobEvent">The event to add.</param>
+        /// <param name="eventDto">The event to add.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="201">Event created.</response>
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(Event), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddEvent(Event mobEvent, CancellationToken cancellationToken)
+        [ProducesResponseType(typeof(EventDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> AddEvent(EventDto eventDto, CancellationToken cancellationToken)
         {
-            logger.LogInformation("V2 AddEvent Name={Name}", mobEvent.Name);
+            logger.LogInformation("V2 AddEvent Name={Name}", eventDto.Name);
 
+            var mobEvent = eventDto.ToEntity();
             var newEvent = await eventManager.AddAsync(mobEvent, UserId, cancellationToken);
-            return CreatedAtAction(nameof(GetEvent), new { id = newEvent.Id }, newEvent);
+            return CreatedAtAction(nameof(GetEvent), new { id = newEvent.Id }, newEvent.ToV2Dto());
         }
 
         /// <summary>
         /// Updates an existing event. Only event leads can update.
         /// </summary>
-        /// <param name="mobEvent">The event to update.</param>
+        /// <param name="eventDto">The event to update.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns the updated event.</response>
         /// <response code="403">User is not an event lead.</response>
@@ -247,12 +249,14 @@ namespace TrashMob.Controllers.V2
         [HttpPut]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(Event), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(EventDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> UpdateEvent(Event mobEvent, CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateEvent(EventDto eventDto, CancellationToken cancellationToken)
         {
-            logger.LogInformation("V2 UpdateEvent Event={EventId}", mobEvent.Id);
+            logger.LogInformation("V2 UpdateEvent Event={EventId}", eventDto.Id);
+
+            var mobEvent = eventDto.ToEntity();
 
             if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
             {
@@ -262,7 +266,7 @@ namespace TrashMob.Controllers.V2
             try
             {
                 var updatedEvent = await eventManager.UpdateAsync(mobEvent, UserId, cancellationToken);
-                return Ok(updatedEvent);
+                return Ok(updatedEvent.ToV2Dto());
             }
             catch (DbUpdateConcurrencyException)
             {

--- a/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
@@ -98,17 +98,17 @@ namespace TrashMob.Controllers.V2
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(LitterReport), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(LitterReportDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> AddLitterReport(LitterReport litterReport, CancellationToken cancellationToken)
+        public async Task<IActionResult> AddLitterReport(LitterReportDto litterReport, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 AddLitterReport Name={Name}", litterReport.Name);
 
-            var result = await litterReportManager.AddWithResultAsync(litterReport, UserId, cancellationToken);
+            var result = await litterReportManager.AddWithResultAsync(litterReport.ToEntity(), UserId, cancellationToken);
 
             if (result.IsSuccess)
             {
-                return Ok(result.Data);
+                return Ok(result.Data.ToV2Dto());
             }
 
             return BadRequest(result.ErrorMessage);
@@ -124,24 +124,26 @@ namespace TrashMob.Controllers.V2
         [HttpPut]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(LitterReport), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(LitterReportDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> UpdateLitterReport(LitterReport litterReport,
+        public async Task<IActionResult> UpdateLitterReport(LitterReportDto litterReport,
             CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 UpdateLitterReport Id={Id}", litterReport.Id);
 
-            if (!await IsAuthorizedAsync(litterReport, AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin))
+            var entity = litterReport.ToEntity();
+
+            if (!await IsAuthorizedAsync(entity, AuthorizationPolicyConstants.UserOwnsEntityOrIsAdmin))
             {
                 return Forbid();
             }
 
-            var updatedLitterReport = await litterReportManager.UpdateAsync(litterReport, UserId, cancellationToken);
+            var updatedLitterReport = await litterReportManager.UpdateAsync(entity, UserId, cancellationToken);
 
             if (updatedLitterReport is not null)
             {
-                return Ok(updatedLitterReport);
+                return Ok(updatedLitterReport.ToV2Dto());
             }
 
             return BadRequest("Failed to update litter report");
@@ -190,13 +192,13 @@ namespace TrashMob.Controllers.V2
         [HttpGet("userlitterreports/{userId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(IEnumerable<LitterReport>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<LitterReportDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetUserLitterReports(Guid userId, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 GetUserLitterReports User={UserId}", userId);
 
             var result = await litterReportManager.GetUserLitterReportsAsync(userId, cancellationToken);
-            return Ok(result);
+            return Ok(result.Select(r => r.ToV2Dto()));
         }
 
         /// <summary>
@@ -206,7 +208,7 @@ namespace TrashMob.Controllers.V2
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns a paginated list of filtered litter reports.</response>
         [HttpPost("pagedfilteredlitterreports")]
-        [ProducesResponseType(typeof(PaginatedList<LitterReport>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(PaginatedList<LitterReportDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetPagedFilteredLitterReports(
             [FromBody] LitterReportFilter filter,
             CancellationToken cancellationToken)
@@ -215,16 +217,16 @@ namespace TrashMob.Controllers.V2
 
             var result = await litterReportManager.GetFilteredLitterReportsAsync(filter, cancellationToken);
 
+            var ordered = result.OrderByDescending(r => r.CreatedDate).ToList();
             if (filter.PageSize is not null)
             {
-                var pagedResults = PaginatedList<LitterReport>.Create(
-                    result.OrderByDescending(e => e.CreatedDate).AsQueryable(),
-                    filter.PageIndex.GetValueOrDefault(0),
-                    filter.PageSize.GetValueOrDefault(10));
-                return Ok(pagedResults);
+                var pageIndex = filter.PageIndex.GetValueOrDefault(0);
+                var pageSize = filter.PageSize.GetValueOrDefault(10);
+                var items = ordered.Skip((pageIndex - 1) * pageSize).Take(pageSize).Select(r => r.ToV2Dto()).ToList();
+                return Ok(new PaginatedList<LitterReportDto>(items, ordered.Count, pageIndex, pageSize));
             }
 
-            return Ok(result);
+            return Ok(ordered.Select(r => r.ToV2Dto()));
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/TeamEventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamEventsV2Controller.cs
@@ -14,6 +14,8 @@ namespace TrashMob.Controllers.V2
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
@@ -43,7 +45,7 @@ namespace TrashMob.Controllers.V2
         /// <response code="200">Returns upcoming team events.</response>
         /// <response code="404">Team not found.</response>
         [HttpGet("upcoming")]
-        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetUpcomingTeamEvents(Guid teamId, CancellationToken cancellationToken)
         {
@@ -78,7 +80,7 @@ namespace TrashMob.Controllers.V2
                 .OrderBy(e => e.EventDate)
                 .ToListAsync(cancellationToken);
 
-            return Ok(teamEvents);
+            return Ok(teamEvents.Select(e => e.ToV2Dto()));
         }
 
         /// <summary>
@@ -89,7 +91,7 @@ namespace TrashMob.Controllers.V2
         /// <response code="200">Returns past team events.</response>
         /// <response code="404">Team not found.</response>
         [HttpGet("past")]
-        [ProducesResponseType(typeof(IEnumerable<Event>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetPastTeamEvents(Guid teamId, CancellationToken cancellationToken)
         {
@@ -124,7 +126,7 @@ namespace TrashMob.Controllers.V2
                 .OrderByDescending(e => e.EventDate)
                 .ToListAsync(cancellationToken);
 
-            return Ok(teamEvents);
+            return Ok(teamEvents.Select(e => e.ToV2Dto()));
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/TeamMembersV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamMembersV2Controller.cs
@@ -2,6 +2,7 @@ namespace TrashMob.Controllers.V2
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
@@ -12,6 +13,8 @@ namespace TrashMob.Controllers.V2
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
@@ -38,7 +41,7 @@ namespace TrashMob.Controllers.V2
         /// <response code="200">Returns the team members.</response>
         /// <response code="404">Team not found.</response>
         [HttpGet]
-        [ProducesResponseType(typeof(IEnumerable<TeamMember>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<TeamMemberDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetMembers(Guid teamId, CancellationToken cancellationToken)
         {
@@ -65,7 +68,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var members = await teamMemberManager.GetByTeamIdAsync(teamId, cancellationToken);
-            return Ok(members);
+            return Ok(members.Select(m => m.ToV2Dto()));
         }
 
         /// <summary>
@@ -76,7 +79,7 @@ namespace TrashMob.Controllers.V2
         /// <response code="200">Returns the team leads.</response>
         /// <response code="404">Team not found.</response>
         [HttpGet("leads")]
-        [ProducesResponseType(typeof(IEnumerable<TeamMember>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<TeamMemberDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetLeads(Guid teamId, CancellationToken cancellationToken)
         {
@@ -89,7 +92,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var leads = await teamMemberManager.GetTeamLeadsAsync(teamId, cancellationToken);
-            return Ok(leads);
+            return Ok(leads.Select(m => m.ToV2Dto()));
         }
 
         /// <summary>
@@ -103,7 +106,7 @@ namespace TrashMob.Controllers.V2
         [HttpPost("join")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(TeamMember), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(TeamMemberDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> JoinTeam(Guid teamId, CancellationToken cancellationToken)
@@ -128,7 +131,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var member = await teamMemberManager.AddMemberAsync(teamId, UserId, isTeamLead: false, UserId, cancellationToken);
-            return CreatedAtAction(nameof(GetMembers), new { teamId }, member);
+            return CreatedAtAction(nameof(GetMembers), new { teamId }, member.ToV2Dto());
         }
 
         /// <summary>
@@ -196,7 +199,7 @@ namespace TrashMob.Controllers.V2
         [HttpPut("{userId}/promote")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(TeamMember), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(TeamMemberDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -228,7 +231,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var updatedMember = await teamMemberManager.PromoteToLeadAsync(teamId, userId, UserId, cancellationToken);
-            return Ok(updatedMember);
+            return Ok(updatedMember.ToV2Dto());
         }
 
         /// <summary>
@@ -244,7 +247,7 @@ namespace TrashMob.Controllers.V2
         [HttpPut("{userId}/demote")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(TeamMember), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(TeamMemberDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -282,7 +285,7 @@ namespace TrashMob.Controllers.V2
             }
 
             var updatedMember = await teamMemberManager.DemoteFromLeadAsync(teamId, userId, UserId, cancellationToken);
-            return Ok(updatedMember);
+            return Ok(updatedMember.ToV2Dto());
         }
     }
 }

--- a/TrashMob/Controllers/V2/TeamsV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamsV2Controller.cs
@@ -2,6 +2,7 @@ namespace TrashMob.Controllers.V2
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
@@ -92,13 +93,13 @@ namespace TrashMob.Controllers.V2
         [HttpGet("my")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(IEnumerable<Team>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<TeamDto>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetMyTeams(CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 GetMyTeams User={UserId}", UserId);
 
             var teams = await teamManager.GetTeamsByUserAsync(UserId, cancellationToken);
-            return Ok(teams);
+            return Ok(teams.Select(t => t.ToV2Dto()));
         }
 
         /// <summary>
@@ -111,9 +112,9 @@ namespace TrashMob.Controllers.V2
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(Team), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(TeamDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> CreateTeam([FromBody] Team team, CancellationToken cancellationToken)
+        public async Task<IActionResult> CreateTeam([FromBody] TeamDto team, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 CreateTeam Name={Name}", team.Name);
 
@@ -129,18 +130,19 @@ namespace TrashMob.Controllers.V2
                 return BadRequest("User not found.");
             }
 
-            team.Id = Guid.NewGuid();
-            team.IsActive = true;
-            team.CreatedByUserId = UserId;
-            team.CreatedDate = DateTimeOffset.UtcNow;
-            team.LastUpdatedByUserId = UserId;
-            team.LastUpdatedDate = DateTimeOffset.UtcNow;
+            var entity = team.ToEntity();
+            entity.Id = Guid.NewGuid();
+            entity.IsActive = true;
+            entity.CreatedByUserId = UserId;
+            entity.CreatedDate = DateTimeOffset.UtcNow;
+            entity.LastUpdatedByUserId = UserId;
+            entity.LastUpdatedDate = DateTimeOffset.UtcNow;
 
-            var createdTeam = await teamManager.AddAsync(team, UserId, cancellationToken);
+            var createdTeam = await teamManager.AddAsync(entity, UserId, cancellationToken);
 
             await teamMemberManager.AddMemberAsync(createdTeam.Id, UserId, isTeamLead: true, UserId, cancellationToken);
 
-            return CreatedAtAction(nameof(GetTeam), new { id = createdTeam.Id }, createdTeam);
+            return CreatedAtAction(nameof(GetTeam), new { id = createdTeam.Id }, createdTeam.ToV2Dto());
         }
 
         /// <summary>
@@ -155,11 +157,11 @@ namespace TrashMob.Controllers.V2
         [HttpPut("{teamId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(Team), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(TeamDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> UpdateTeam(Guid teamId, [FromBody] Team team, CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateTeam(Guid teamId, [FromBody] TeamDto team, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 UpdateTeam Team={TeamId}", teamId);
 
@@ -204,7 +206,7 @@ namespace TrashMob.Controllers.V2
             existingTeam.LastUpdatedDate = DateTimeOffset.UtcNow;
 
             var updatedTeam = await teamManager.UpdateAsync(existingTeam, UserId, cancellationToken);
-            return Ok(updatedTeam);
+            return Ok(updatedTeam.ToV2Dto());
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/UsersV2Controller.cs
+++ b/TrashMob/Controllers/V2/UsersV2Controller.cs
@@ -89,37 +89,38 @@ namespace TrashMob.Controllers.V2
         /// <summary>
         /// Adds a new user.
         /// </summary>
-        /// <param name="user">The user to add.</param>
+        /// <param name="userDto">The user to add.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="201">User created.</response>
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(User), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddUser(User user, CancellationToken cancellationToken)
+        [ProducesResponseType(typeof(UserDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> AddUser(UserWriteDto userDto, CancellationToken cancellationToken)
         {
-            logger.LogInformation("V2 AddUser UserName={UserName}", user.UserName);
+            logger.LogInformation("V2 AddUser UserName={UserName}", userDto.UserName);
 
+            var user = userDto.ToEntity();
             var result = await userManager.AddAsync(user, UserId, cancellationToken);
-            return CreatedAtAction(nameof(GetUser), new { id = result.Id }, result);
+            return CreatedAtAction(nameof(GetUser), new { id = result.Id }, result.ToV2Dto());
         }
 
         /// <summary>
         /// Updates a user. Users can only update themselves unless they are a site admin.
         /// </summary>
-        /// <param name="user">The user to update.</param>
+        /// <param name="userDto">The user to update.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns the updated user.</response>
         /// <response code="403">User is not authorized.</response>
         /// <response code="404">User not found.</response>
         [HttpPut]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
-        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> UpdateUser(User user, CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateUser(UserWriteDto userDto, CancellationToken cancellationToken)
         {
-            logger.LogInformation("V2 UpdateUser User={UserId}", user.Id);
+            logger.LogInformation("V2 UpdateUser User={UserId}", userDto.Id);
 
             var currentUser = await userManager.GetUserByInternalIdAsync(UserId, cancellationToken);
 
@@ -128,19 +129,20 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            if (user.Id != UserId && !currentUser.IsSiteAdmin)
+            if (userDto.Id != UserId && !currentUser.IsSiteAdmin)
             {
                 return Forbid();
             }
 
             try
             {
+                var user = userDto.ToEntity();
                 var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
-                return Ok(updatedUser);
+                return Ok(updatedUser.ToV2Dto());
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!await userManager.UserExistsAsync(user.Id, cancellationToken))
+                if (!await userManager.UserExistsAsync(userDto.Id, cancellationToken))
                 {
                     return NotFound();
                 }
@@ -158,7 +160,7 @@ namespace TrashMob.Controllers.V2
         /// <response code="404">User not found.</response>
         [HttpGet("getuserbyemail/{email}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
-        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetUserByEmail(string email, CancellationToken cancellationToken)
         {
@@ -171,7 +173,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            return Ok(user);
+            return Ok(user.ToV2Dto());
         }
 
         /// <summary>
@@ -183,7 +185,7 @@ namespace TrashMob.Controllers.V2
         /// <response code="404">User not found.</response>
         [HttpGet("getbyobjectid/{objectId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
-        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetUserByObjectId(Guid objectId, CancellationToken cancellationToken)
         {
@@ -196,7 +198,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            return Ok(user);
+            return Ok(user.ToV2Dto());
         }
 
         /// <summary>
@@ -236,7 +238,7 @@ namespace TrashMob.Controllers.V2
         [HttpPost("photo")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> UploadProfilePhoto(
             [FromForm] ImageUpload imageUpload,
@@ -264,7 +266,7 @@ namespace TrashMob.Controllers.V2
             user.ProfilePhotoUrl = imageUrl;
 
             var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
-            return Ok(updatedUser);
+            return Ok(updatedUser.ToV2Dto());
         }
     }
 }


### PR DESCRIPTION
## Summary
- All 14 non-compliant v2 controllers now accept and return DTOs (not raw EF entities) at the API boundary
- Created 4 new DTOs: `TeamMemberDto`, `DependentInvitationDto`, `DependentWaiverDto`, `UserWriteDto`
- Created 3 new mapping files and added `ToEntity()` reverse mappings to 6 existing mapping files
- Updated 11 controller test files to match new DTO-based signatures
- 719 tests pass, 0 errors

## Details

**New DTOs** (`TrashMob.Models/Poco/V2/`):
| DTO | Purpose |
|-----|---------|
| `UserWriteDto` | Extends UserDto with writable PII fields (email, DOB) for POST/PUT |
| `TeamMemberDto` | PII-safe member info (no email, includes role) |
| `DependentInvitationDto` | Excludes TokenHash (security) |
| `DependentWaiverDto` | Excludes IPAddress/UserAgent (internal tracking) |

**Controllers updated** (14 total):
Events, Users, LitterReports, Teams, EventAttendees, EventSummary, EventAttendeeMetrics, EventAttendeeRoutes, TeamMembers, TeamEvents, DependentInvitations, DependentWaivers

**Pattern**: Write endpoints accept DTOs → `ToEntity()` → manager → `ToV2Dto()` → response

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors
- [x] `dotnet test TrashMob.Shared.Tests` — 719 passed, 0 failed
- [ ] Verify Swagger shows correct DTO schemas for all v2 endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)