### PR TITLE
Migrate MAUI mobile REST services to v2 API endpoints

### DIFF
--- a/TrashMob.Models/Extensions/V2/AddressMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/AddressMappingsV2.cs
@@ -22,5 +22,21 @@ namespace TrashMob.Models.Extensions.V2
                 County = entity.County ?? string.Empty,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 <see cref="AddressDto"/> back to an <see cref="Address"/>.
+        /// </summary>
+        public static Address ToEntity(this AddressDto dto)
+        {
+            return new Address
+            {
+                StreetAddress = dto.StreetAddress,
+                City = dto.City,
+                Region = dto.Region,
+                PostalCode = dto.PostalCode,
+                Country = dto.Country,
+                County = dto.County,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/ContactRequestMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/ContactRequestMappingsV2.cs
@@ -8,6 +8,19 @@ namespace TrashMob.Models.Extensions.V2
     public static class ContactRequestMappingsV2
     {
         /// <summary>
+        /// Maps a <see cref="ContactRequest"/> entity to a <see cref="ContactRequestDto"/>.
+        /// </summary>
+        public static ContactRequestDto ToV2Dto(this ContactRequest entity)
+        {
+            return new ContactRequestDto
+            {
+                Name = entity.Name,
+                Email = entity.Email,
+                Message = entity.Message,
+            };
+        }
+
+        /// <summary>
         /// Maps a <see cref="ContactRequestDto"/> to a <see cref="ContactRequest"/> entity.
         /// </summary>
         public static ContactRequest ToEntity(this ContactRequestDto dto)

--- a/TrashMob.Models/Extensions/V2/DependentInvitationMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/DependentInvitationMappingsV2.cs
@@ -28,5 +28,24 @@ namespace TrashMob.Models.Extensions.V2
                 AcceptedByUserId = entity.AcceptedByUserId,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 DependentInvitationDto back to a DependentInvitation entity.
+        /// </summary>
+        public static DependentInvitation ToEntity(this DependentInvitationDto dto)
+        {
+            return new DependentInvitation
+            {
+                Id = dto.Id,
+                DependentId = dto.DependentId,
+                ParentUserId = dto.ParentUserId,
+                Email = dto.Email,
+                InvitationStatusId = dto.InvitationStatusId,
+                DateInvited = dto.DateInvited,
+                ExpiresDate = dto.ExpiresDate,
+                DateAccepted = dto.DateAccepted,
+                AcceptedByUserId = dto.AcceptedByUserId,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/DependentWaiverMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/DependentWaiverMappingsV2.cs
@@ -27,5 +27,23 @@ namespace TrashMob.Models.Extensions.V2
                 DocumentUrl = entity.DocumentUrl ?? string.Empty,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 DependentWaiverDto back to a DependentWaiver entity.
+        /// </summary>
+        public static DependentWaiver ToEntity(this DependentWaiverDto dto)
+        {
+            return new DependentWaiver
+            {
+                Id = dto.Id,
+                DependentId = dto.DependentId,
+                WaiverVersionId = dto.WaiverVersionId,
+                SignedByUserId = dto.SignedByUserId,
+                TypedLegalName = dto.TypedLegalName,
+                AcceptedDate = dto.AcceptedDate,
+                ExpiryDate = dto.ExpiryDate,
+                DocumentUrl = dto.DocumentUrl,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/EventAttendeeMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventAttendeeMappingsV2.cs
@@ -25,5 +25,19 @@ namespace TrashMob.Models.Extensions.V2
                 IsEventLead = entity.IsEventLead,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 <see cref="EventAttendeeDto"/> back to an <see cref="EventAttendee"/> entity.
+        /// Note: EventId is not present in the DTO and must be set separately.
+        /// </summary>
+        public static EventAttendee ToEntity(this EventAttendeeDto dto)
+        {
+            return new EventAttendee
+            {
+                UserId = dto.UserId,
+                SignUpDate = dto.SignUpDate,
+                IsEventLead = dto.IsEventLead,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/EventPhotoMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventPhotoMappingsV2.cs
@@ -25,5 +25,24 @@ namespace TrashMob.Models.Extensions.V2
                 UploadedDate = entity.UploadedDate,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 <see cref="EventPhotoDto"/> back to an <see cref="EventPhoto"/> entity.
+        /// </summary>
+        public static EventPhoto ToEntity(this EventPhotoDto dto)
+        {
+            return new EventPhoto
+            {
+                Id = dto.Id,
+                EventId = dto.EventId,
+                UploadedByUserId = dto.UploadedByUserId,
+                ImageUrl = dto.ImageUrl,
+                ThumbnailUrl = dto.ThumbnailUrl,
+                PhotoType = dto.PhotoType,
+                Caption = dto.Caption,
+                TakenAt = dto.TakenAt,
+                UploadedDate = dto.UploadedDate,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/LookupMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/LookupMappingsV2.cs
@@ -20,5 +20,53 @@ namespace TrashMob.Models.Extensions.V2
                 DisplayOrder = entity.DisplayOrder ?? 0,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 <see cref="LookupItemDto"/> to an <see cref="EventType"/> entity.
+        /// Sets IsActive to true by default.
+        /// </summary>
+        public static EventType ToEventType(this LookupItemDto dto)
+        {
+            return new EventType
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Description = dto.Description,
+                DisplayOrder = dto.DisplayOrder,
+                IsActive = true,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 <see cref="LookupItemDto"/> to a <see cref="ServiceType"/> entity.
+        /// Sets IsActive to true by default.
+        /// </summary>
+        public static ServiceType ToServiceType(this LookupItemDto dto)
+        {
+            return new ServiceType
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Description = dto.Description,
+                DisplayOrder = dto.DisplayOrder,
+                IsActive = true,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 <see cref="LookupItemDto"/> to an <see cref="EventPartnerLocationServiceStatus"/> entity.
+        /// Sets IsActive to true by default.
+        /// </summary>
+        public static EventPartnerLocationServiceStatus ToEventPartnerLocationServiceStatus(this LookupItemDto dto)
+        {
+            return new EventPartnerLocationServiceStatus
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Description = dto.Description,
+                DisplayOrder = dto.DisplayOrder,
+                IsActive = true,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/PartnerMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/PartnerMappingsV2.cs
@@ -48,5 +48,43 @@ namespace TrashMob.Models.Extensions.V2
                 LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
             };
         }
+
+        /// <summary>
+        /// Maps a V2 <see cref="PartnerDto"/> back to a <see cref="Partner"/> entity.
+        /// </summary>
+        public static Partner ToEntity(this PartnerDto dto)
+        {
+            return new Partner
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Website = dto.Website,
+                PublicNotes = dto.PublicNotes,
+                LogoUrl = dto.LogoUrl,
+                PartnerStatusId = dto.PartnerStatusId,
+                PartnerTypeId = dto.PartnerTypeId,
+                Slug = dto.Slug,
+                HomePageEnabled = dto.HomePageEnabled,
+                IsFeatured = dto.IsFeatured,
+                BrandingPrimaryColor = dto.BrandingPrimaryColor,
+                BrandingSecondaryColor = dto.BrandingSecondaryColor,
+                BannerImageUrl = dto.BannerImageUrl,
+                Tagline = dto.Tagline,
+                Latitude = dto.Latitude,
+                Longitude = dto.Longitude,
+                City = dto.City,
+                Region = dto.Region,
+                Country = dto.Country,
+                PhysicalAddress = dto.PhysicalAddress,
+                BoundsNorth = dto.BoundsNorth,
+                BoundsSouth = dto.BoundsSouth,
+                BoundsEast = dto.BoundsEast,
+                BoundsWest = dto.BoundsWest,
+                BoundaryGeoJson = dto.BoundaryGeoJson,
+                RegionType = dto.RegionType,
+                CountyName = dto.CountyName,
+                CreatedByUserId = dto.CreatedByUserId,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/StatsMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/StatsMappingsV2.cs
@@ -27,5 +27,23 @@ namespace TrashMob.Models.Extensions.V2
                 TotalLitterReportsClosed = stats.TotalLitterReportsClosed,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 StatsDto back to a Stats object.
+        /// </summary>
+        public static Stats ToEntity(this StatsDto dto)
+        {
+            return new Stats
+            {
+                TotalBags = dto.TotalBags,
+                TotalHours = dto.TotalHours,
+                TotalEvents = dto.TotalEvents,
+                TotalWeightInPounds = dto.TotalWeightInPounds,
+                TotalWeightInKilograms = dto.TotalWeightInKilograms,
+                TotalParticipants = dto.TotalParticipants,
+                TotalLitterReportsSubmitted = dto.TotalLitterReportsSubmitted,
+                TotalLitterReportsClosed = dto.TotalLitterReportsClosed,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
@@ -27,5 +27,20 @@ namespace TrashMob.Models.Extensions.V2
                 JoinedDate = entity.JoinedDate,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 <see cref="TeamMemberDto"/> back to a <see cref="TeamMember"/> entity.
+        /// </summary>
+        public static TeamMember ToEntity(this TeamMemberDto dto)
+        {
+            return new TeamMember
+            {
+                Id = dto.Id,
+                TeamId = dto.TeamId,
+                UserId = dto.UserId,
+                IsTeamLead = dto.IsTeamLead,
+                JoinedDate = dto.JoinedDate,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
@@ -34,6 +34,59 @@ namespace TrashMob.Models.Extensions.V2
         }
 
         /// <summary>
+        /// Maps a V2 <see cref="UserDto"/> back to a <see cref="User"/> entity.
+        /// PII fields (Email, DateOfBirth, TravelLimitForLocalEvents) are not available
+        /// in UserDto and will not be populated on the returned entity.
+        /// </summary>
+        public static User ToEntity(this UserDto dto)
+        {
+            return new User
+            {
+                Id = dto.Id,
+                UserName = dto.UserName,
+                City = dto.City,
+                Region = dto.Region,
+                Country = dto.Country,
+                PostalCode = dto.PostalCode,
+                Latitude = dto.Latitude,
+                Longitude = dto.Longitude,
+                PrefersMetric = dto.PrefersMetric,
+                GivenName = dto.GivenName,
+                Surname = dto.Surname,
+                ProfilePhotoUrl = dto.ProfilePhotoUrl,
+                MemberSince = dto.MemberSince,
+                IsMinor = dto.IsMinor,
+            };
+        }
+
+        /// <summary>
+        /// Maps a User entity to a V2 UserWriteDto for create/update operations.
+        /// Includes PII fields needed for write endpoints.
+        /// </summary>
+        public static Poco.V2.UserWriteDto ToWriteDto(this User entity)
+        {
+            return new Poco.V2.UserWriteDto
+            {
+                Id = entity.Id,
+                UserName = entity.UserName,
+                Email = entity.Email,
+                GivenName = entity.GivenName,
+                Surname = entity.Surname,
+                City = entity.City,
+                Region = entity.Region,
+                Country = entity.Country,
+                PostalCode = entity.PostalCode,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+                PrefersMetric = entity.PrefersMetric,
+                DateOfBirth = entity.DateOfBirth,
+                IsMinor = entity.IsMinor,
+                TravelLimitForLocalEvents = entity.TravelLimitForLocalEvents,
+                ProfilePhotoUrl = entity.ProfilePhotoUrl,
+            };
+        }
+
+        /// <summary>
         /// Maps a V2 UserWriteDto to a User entity for create/update operations.
         /// </summary>
         public static User ToEntity(this Poco.V2.UserWriteDto dto)

--- a/TrashMob.Models/Extensions/V2/WaiverMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/WaiverMappingsV2.cs
@@ -45,5 +45,44 @@ namespace TrashMob.Models.Extensions.V2
                 GuardianRelationship = entity.GuardianRelationship ?? string.Empty,
             };
         }
+
+        /// <summary>
+        /// Maps a V2 <see cref="WaiverVersionDto"/> back to a <see cref="WaiverVersion"/> entity.
+        /// </summary>
+        public static WaiverVersion ToEntity(this WaiverVersionDto dto)
+        {
+            return new WaiverVersion
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Version = dto.Version,
+                WaiverText = dto.WaiverText,
+                EffectiveDate = dto.EffectiveDate,
+                ExpiryDate = dto.ExpiryDate,
+                IsActive = dto.IsActive,
+                Scope = dto.Scope,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 <see cref="UserWaiverDto"/> back to a <see cref="UserWaiver"/> entity.
+        /// </summary>
+        public static UserWaiver ToEntity(this UserWaiverDto dto)
+        {
+            return new UserWaiver
+            {
+                Id = dto.Id,
+                UserId = dto.UserId,
+                WaiverVersionId = dto.WaiverVersionId,
+                AcceptedDate = dto.AcceptedDate,
+                ExpiryDate = dto.ExpiryDate,
+                TypedLegalName = dto.TypedLegalName,
+                SigningMethod = dto.SigningMethod,
+                DocumentUrl = dto.DocumentUrl,
+                IsMinor = dto.IsMinor,
+                GuardianName = dto.GuardianName,
+                GuardianRelationship = dto.GuardianRelationship,
+            };
+        }
     }
 }

--- a/TrashMobMobile/Config/Settings.cs
+++ b/TrashMobMobile/Config/Settings.cs
@@ -3,11 +3,11 @@
 public static class Settings
 {
 #if USETEST
-    public const string ApiBaseUrl = "https://dev.trashmob.eco/api/";
+    public const string ApiBaseUrl = "https://dev.trashmob.eco/api/v2.0/";
 
     public const string SiteBaseUrl = "https://dev.trashmob.eco";
 #else
-    public const string ApiBaseUrl = "https://www.trashmob.eco/api/";
+    public const string ApiBaseUrl = "https://www.trashmob.eco/api/v2.0/";
 
     public const string SiteBaseUrl = "https://www.trashmob.eco";
 #endif

--- a/TrashMobMobile/Services/CommunityRestService.cs
+++ b/TrashMobMobile/Services/CommunityRestService.cs
@@ -3,7 +3,9 @@ namespace TrashMobMobile.Services;
 using System.Globalization;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
 using TrashMob.Models.Poco;
+using TrashMob.Models.Poco.V2;
 
 public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), ICommunityRestService
 {
@@ -37,7 +39,8 @@ public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestSe
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<Partner>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<PartnerDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task<Partner> GetCommunityBySlugAsync(string slug, CancellationToken cancellationToken = default)
@@ -46,7 +49,8 @@ public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestSe
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<Partner>(content)!;
+        var dto = JsonConvert.DeserializeObject<PartnerDto>(content)!;
+        return dto.ToEntity();
     }
 
     public async Task<IEnumerable<Event>> GetCommunityEventsAsync(string slug, bool upcomingOnly = true, CancellationToken cancellationToken = default)
@@ -55,7 +59,8 @@ public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestSe
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<Event>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<EventDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task<IEnumerable<Team>> GetCommunityTeamsAsync(string slug, double radiusMiles = 50, CancellationToken cancellationToken = default)
@@ -64,7 +69,8 @@ public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestSe
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<Team>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<TeamDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task<Stats> GetCommunityStatsAsync(string slug, CancellationToken cancellationToken = default)
@@ -73,6 +79,7 @@ public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestSe
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<Stats>(content) ?? new Stats();
+        var dto = JsonConvert.DeserializeObject<StatsDto>(content)!;
+        return dto.ToEntity();
     }
 }

--- a/TrashMobMobile/Services/ContactRequestRestService.cs
+++ b/TrashMobMobile/Services/ContactRequestRestService.cs
@@ -3,6 +3,8 @@
 using System.Diagnostics;
 using System.Net.Http.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class ContactRequestRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IContactRequestRestService
 {
@@ -10,8 +12,8 @@ public class ContactRequestRestService(IHttpClientFactory httpClientFactory) : R
 
     public async Task AddContactRequest(ContactRequest contactRequest, CancellationToken cancellationToken = default)
     {
-        contactRequest.Id = Guid.NewGuid();
-        var content = JsonContent.Create(contactRequest, typeof(ContactRequest), null, SerializerOptions);
+        var dto = contactRequest.ToV2Dto();
+        var content = JsonContent.Create(dto, typeof(ContactRequestDto), null, SerializerOptions);
 
         using (var response = await AnonymousHttpClient.PostAsync(Controller, content, cancellationToken))
         {

--- a/TrashMobMobile/Services/DependentRestService.cs
+++ b/TrashMobMobile/Services/DependentRestService.cs
@@ -1,9 +1,12 @@
 namespace TrashMobMobile.Services
 {
+    using System.Linq;
     using System.Net;
     using System.Net.Http.Json;
     using Newtonsoft.Json;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
 
     public class DependentRestService(IHttpClientFactory httpClientFactory)
         : RestServiceBase(httpClientFactory), IDependentRestService
@@ -19,29 +22,34 @@ namespace TrashMobMobile.Services
             using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<List<Dependent>>(content) ?? [];
+            var dtos = JsonConvert.DeserializeObject<List<DependentDto>>(content) ?? [];
+            return dtos.Select(d => d.ToEntity()).ToList();
         }
 
         public async Task<Dependent> AddDependentAsync(Guid userId, Dependent dependent, CancellationToken cancellationToken = default)
         {
             var requestUri = userId + "/dependents";
-            var body = JsonContent.Create(dependent, typeof(Dependent), null, SerializerOptions);
+            var dto = dependent.ToV2Dto();
+            var body = JsonContent.Create(dto, typeof(DependentDto), null, SerializerOptions);
 
             using var response = await AuthorizedHttpClient.PostAsync(requestUri, body, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<Dependent>(content)!;
+            var resultDto = JsonConvert.DeserializeObject<DependentDto>(content)!;
+            return resultDto.ToEntity();
         }
 
         public async Task<Dependent> UpdateDependentAsync(Guid userId, Dependent dependent, CancellationToken cancellationToken = default)
         {
             var requestUri = userId + "/dependents/" + dependent.Id;
-            var body = JsonContent.Create(dependent, typeof(Dependent), null, SerializerOptions);
+            var dto = dependent.ToV2Dto();
+            var body = JsonContent.Create(dto, typeof(DependentDto), null, SerializerOptions);
 
             using var response = await AuthorizedHttpClient.PutAsync(requestUri, body, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<Dependent>(content)!;
+            var resultDto = JsonConvert.DeserializeObject<DependentDto>(content)!;
+            return resultDto.ToEntity();
         }
 
         public async Task DeleteDependentAsync(Guid userId, Guid dependentId, CancellationToken cancellationToken = default)
@@ -63,7 +71,8 @@ namespace TrashMobMobile.Services
             using var response = await client.GetAsync(requestUri, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<List<DependentInvitation>>(content) ?? [];
+            var dtos = JsonConvert.DeserializeObject<List<DependentInvitationDto>>(content) ?? [];
+            return dtos.Select(d => d.ToEntity()).ToList();
         }
 
         public async Task<DependentInvitation> CreateDependentInvitationAsync(
@@ -76,7 +85,8 @@ namespace TrashMobMobile.Services
             using var response = await client.PostAsync(requestUri, body, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<DependentInvitation>(content)!;
+            var dto = JsonConvert.DeserializeObject<DependentInvitationDto>(content)!;
+            return dto.ToEntity();
         }
 
         public async Task CancelDependentInvitationAsync(Guid invitationId, CancellationToken cancellationToken = default)
@@ -96,7 +106,8 @@ namespace TrashMobMobile.Services
             using var response = await client.PostAsync(requestUri, null, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<DependentInvitation>(content)!;
+            var dto = JsonConvert.DeserializeObject<DependentInvitationDto>(content)!;
+            return dto.ToEntity();
         }
 
         // Dependent Waivers
@@ -113,7 +124,8 @@ namespace TrashMobMobile.Services
             using var response = await client.PostAsync(requestUri, body, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<DependentWaiver>(content)!;
+            var dto = JsonConvert.DeserializeObject<DependentWaiverDto>(content)!;
+            return dto.ToEntity();
         }
 
         public async Task<DependentWaiver?> GetCurrentWaiverAsync(Guid dependentId, CancellationToken cancellationToken = default)
@@ -130,7 +142,8 @@ namespace TrashMobMobile.Services
 
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<DependentWaiver>(content);
+            var dto = JsonConvert.DeserializeObject<DependentWaiverDto>(content);
+            return dto?.ToEntity();
         }
 
         // Event Dependents

--- a/TrashMobMobile/Services/EventAttendeeMetricsRestService.cs
+++ b/TrashMobMobile/Services/EventAttendeeMetricsRestService.cs
@@ -4,7 +4,9 @@ namespace TrashMobMobile.Services
     using System.Net.Http.Json;
     using Newtonsoft.Json;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
 
     public class EventAttendeeMetricsRestService(IHttpClientFactory httpClientFactory)
         : RestServiceBase(httpClientFactory), IEventAttendeeMetricsRestService
@@ -24,18 +26,19 @@ namespace TrashMobMobile.Services
 
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content);
+            return JsonConvert.DeserializeObject<EventAttendeeMetricsDto>(content)?.ToEntity();
         }
 
         public async Task<EventAttendeeMetrics> SubmitMyMetricsAsync(Guid eventId, EventAttendeeMetrics metrics, CancellationToken cancellationToken = default)
         {
             var requestUri = eventId + "/attendee-metrics/my-metrics";
-            var body = JsonContent.Create(metrics, typeof(EventAttendeeMetrics), null, SerializerOptions);
+            var dto = metrics.ToV2Dto();
+            var body = JsonContent.Create(dto, typeof(EventAttendeeMetricsDto), null, SerializerOptions);
 
             using var response = await AuthorizedHttpClient.PostAsync(requestUri, body, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content)!;
+            return JsonConvert.DeserializeObject<EventAttendeeMetricsDto>(content)!.ToEntity();
         }
 
         public async Task<EventMetricsPublicSummary> GetPublicMetricsAsync(Guid eventId, CancellationToken cancellationToken = default)
@@ -55,7 +58,8 @@ namespace TrashMobMobile.Services
             using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<List<EventAttendeeMetrics>>(content) ?? [];
+            var dtos = JsonConvert.DeserializeObject<List<EventAttendeeMetricsDto>>(content) ?? [];
+            return dtos.Select(d => d.ToEntity()).ToList();
         }
 
         public async Task<int> ApproveAllPendingAsync(Guid eventId, CancellationToken cancellationToken = default)
@@ -75,24 +79,23 @@ namespace TrashMobMobile.Services
             using var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content)!;
+            return JsonConvert.DeserializeObject<EventAttendeeMetricsDto>(content)!.ToEntity();
         }
 
         public async Task<EventAttendeeMetrics> RejectMetricsAsync(Guid eventId, Guid metricsId, string reason, CancellationToken cancellationToken = default)
         {
             var requestUri = eventId + "/attendee-metrics/" + metricsId + "/reject";
-            var body = JsonContent.Create(new { RejectionReason = reason }, null, SerializerOptions);
+            var body = JsonContent.Create(new RejectMetricsRequestDto { RejectionReason = reason }, typeof(RejectMetricsRequestDto), null, SerializerOptions);
 
             using var response = await AuthorizedHttpClient.PostAsync(requestUri, body, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<EventAttendeeMetrics>(content)!;
+            return JsonConvert.DeserializeObject<EventAttendeeMetricsDto>(content)!.ToEntity();
         }
 
         public async Task<UserImpactStats> GetUserImpactAsync(Guid userId, CancellationToken cancellationToken = default)
         {
-            // This endpoint is on the users controller: api/users/{userId}/impact
-            // Need to use a different base path
+            // This endpoint is on the users controller: api/v2.0/users/{userId}/impact
             using var httpClient = CreateHttpClient("users/");
 
             var requestUri = userId + "/impact";

--- a/TrashMobMobile/Services/EventAttendeeRestService.cs
+++ b/TrashMobMobile/Services/EventAttendeeRestService.cs
@@ -1,33 +1,45 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
 using System.Net.Http.Json;
+using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
 using TrashMob.Models.Poco;
+using TrashMob.Models.Poco.V2;
 
 public class EventAttendeeRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IEventAttendeeRestService
 {
-    protected override string Controller => "eventattendees";
+    protected override string Controller => "events";
 
     public async Task<IEnumerable<DisplayUser>> GetEventAttendeesAsync(Guid eventId,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = string.Concat(Controller, $"/{eventId}");
-        var eventAttendees =
-            await AuthorizedHttpClient.GetFromJsonAsync<IEnumerable<DisplayUser>>(requestUri, SerializerOptions,
-                cancellationToken);
-        return eventAttendees ?? [];
+        var requestUri = Controller + $"/{eventId}/attendees";
+        var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var pagedResponse = JsonConvert.DeserializeObject<PagedResponse<EventAttendeeDto>>(content);
+        var dtos = pagedResponse?.Items ?? [];
+        return dtos.Select(d => new DisplayUser
+        {
+            Id = d.UserId,
+            UserName = d.UserName,
+            ProfilePhotoUrl = d.ProfilePhotoUrl,
+        });
     }
 
     public async Task AddAttendeeAsync(EventAttendee eventAttendee, CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(eventAttendee, typeof(EventAttendee), null, SerializerOptions);
-        var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken);
+        var dto = new EventAttendeeDto { UserId = eventAttendee.UserId };
+        var content = JsonContent.Create(dto, typeof(EventAttendeeDto), null, SerializerOptions);
+        var requestUri = Controller + $"/{eventAttendee.EventId}/attendees";
+        var response = await AuthorizedHttpClient.PostAsync(requestUri, content, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task RemoveAttendeeAsync(EventAttendee eventAttendee, CancellationToken cancellationToken = default)
     {
-        var requestUri = string.Concat(Controller, $"/{eventAttendee.EventId}/{eventAttendee.UserId}");
+        var requestUri = Controller + $"/{eventAttendee.EventId}/attendees/{eventAttendee.UserId}";
 
         using (var response = await AuthorizedHttpClient.DeleteAsync(requestUri, cancellationToken))
         {
@@ -37,26 +49,32 @@ public class EventAttendeeRestService(IHttpClientFactory httpClientFactory) : Re
 
     public async Task<IEnumerable<DisplayUser>> GetEventLeadsAsync(Guid eventId, CancellationToken cancellationToken = default)
     {
-        var requestUri = string.Concat(Controller, $"/{eventId}/leads");
+        var requestUri = Controller + $"/{eventId}/attendees/leads";
         var eventLeads = await AuthorizedHttpClient.GetFromJsonAsync<IEnumerable<DisplayUser>>(requestUri, SerializerOptions, cancellationToken);
         return eventLeads ?? [];
     }
 
     public async Task<EventAttendee> PromoteToLeadAsync(Guid eventId, Guid userId, CancellationToken cancellationToken = default)
     {
-        var requestUri = string.Concat(Controller, $"/{eventId}/{userId}/promote");
+        var requestUri = Controller + $"/{eventId}/attendees/{userId}/promote";
         var response = await AuthorizedHttpClient.PutAsync(requestUri, null, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<EventAttendee>(SerializerOptions, cancellationToken);
-        return result!;
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var dto = JsonConvert.DeserializeObject<EventAttendeeDto>(content)!;
+        var entity = dto.ToEntity();
+        entity.EventId = eventId;
+        return entity;
     }
 
     public async Task<EventAttendee> DemoteFromLeadAsync(Guid eventId, Guid userId, CancellationToken cancellationToken = default)
     {
-        var requestUri = string.Concat(Controller, $"/{eventId}/{userId}/demote");
+        var requestUri = Controller + $"/{eventId}/attendees/{userId}/demote";
         var response = await AuthorizedHttpClient.PutAsync(requestUri, null, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadFromJsonAsync<EventAttendee>(SerializerOptions, cancellationToken);
-        return result!;
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var dto = JsonConvert.DeserializeObject<EventAttendeeDto>(content)!;
+        var entity = dto.ToEntity();
+        entity.EventId = eventId;
+        return entity;
     }
 }

--- a/TrashMobMobile/Services/EventAttendeeRouteRestService.cs
+++ b/TrashMobMobile/Services/EventAttendeeRouteRestService.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMobMobile.Services
+namespace TrashMobMobile.Services
 {
     using System.Diagnostics;
     using System.Net.Http.Json;
@@ -26,7 +26,7 @@
         public async Task<IEnumerable<DisplayEventAttendeeRoute>> GetEventAttendeeRoutesForEventAsync(Guid eventId,
                 CancellationToken cancellationToken = default)
         {
-            var requestUri = Controller + "/byeventid/" + eventId;
+            var requestUri = Controller + "/by-event/" + eventId;
 
             using (var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken))
             {
@@ -39,7 +39,7 @@
         public async Task<IEnumerable<DisplayEventAttendeeRoute>> GetEventAttendeeRoutesForUserAsync(Guid userId,
         CancellationToken cancellationToken = default)
         {
-            var requestUri = Controller + "/byuserid/" + userId;
+            var requestUri = Controller + "/by-user/" + userId;
 
             using (var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken))
             {
@@ -87,9 +87,10 @@
 
         public async Task<DisplayEventAttendeeRoute> SimulateRouteAsync(Guid eventId, CancellationToken cancellationToken = default)
         {
-            var requestUri = "routes/simulate/" + eventId;
+            using var client = CreateHttpClient("events/");
+            var requestUri = eventId + "/routes/simulate";
 
-            using (var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken))
+            using (var response = await client.PostAsync(requestUri, null, cancellationToken))
             {
                 response.EnsureSuccessStatusCode();
                 var content = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -99,7 +100,7 @@
 
         public async Task<DisplayEventAttendeeRoute> UpdateRouteMetadataAsync(Guid routeId, UpdateRouteMetadataRequest request, CancellationToken cancellationToken = default)
         {
-            var requestUri = "routes/" + routeId;
+            var requestUri = Controller + "/" + routeId;
             var content = JsonContent.Create(request, typeof(UpdateRouteMetadataRequest), null, SerializerOptions);
 
             using (var response = await AuthorizedHttpClient.PutAsync(requestUri, content, cancellationToken))
@@ -112,9 +113,10 @@
 
         public async Task<EventSummaryPrefill> GetEventSummaryPrefillAsync(Guid eventId, int weightUnitId = 1, CancellationToken cancellationToken = default)
         {
-            var requestUri = $"events/{eventId}/routes/summary-prefill?weightUnitId={weightUnitId}";
+            using var client = CreateHttpClient("events/");
+            var requestUri = $"{eventId}/routes/summary-prefill?weightUnitId={weightUnitId}";
 
-            using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
+            using (var response = await client.GetAsync(requestUri, cancellationToken))
             {
                 response.EnsureSuccessStatusCode();
                 var content = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -124,7 +126,7 @@
 
         public async Task<DisplayEventAttendeeRoute> TrimRouteTimeAsync(Guid routeId, TrimRouteTimeRequest request, CancellationToken cancellationToken = default)
         {
-            var requestUri = "routes/" + routeId + "/trim-time";
+            var requestUri = Controller + "/" + routeId + "/trim-time";
             var content = JsonContent.Create(request, typeof(TrimRouteTimeRequest), null, SerializerOptions);
 
             using (var response = await AuthorizedHttpClient.PutAsync(requestUri, content, cancellationToken))
@@ -137,7 +139,7 @@
 
         public async Task<DisplayEventAttendeeRoute> RestoreRouteTimeAsync(Guid routeId, CancellationToken cancellationToken = default)
         {
-            var requestUri = "routes/" + routeId + "/restore-time";
+            var requestUri = Controller + "/" + routeId + "/restore-time";
 
             using (var response = await AuthorizedHttpClient.PutAsync(requestUri, null, cancellationToken))
             {

--- a/TrashMobMobile/Services/EventLitterReportRestService.cs
+++ b/TrashMobMobile/Services/EventLitterReportRestService.cs
@@ -1,4 +1,4 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
 using System.Net.Http.Json;
 using TrashMob.Models;
@@ -11,7 +11,7 @@ public class EventLitterReportRestService(IHttpClientFactory httpClientFactory) 
     public async Task<IEnumerable<FullEventLitterReport>> GetEventLitterReportsAsync(Guid eventId,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = string.Concat(Controller, $"/{eventId}");
+        var requestUri = string.Concat(Controller, $"/by-event/{eventId}");
         var eventLitterReports =
             await AuthorizedHttpClient.GetFromJsonAsync<IEnumerable<FullEventLitterReport>>(requestUri, SerializerOptions,
                 cancellationToken);
@@ -21,7 +21,7 @@ public class EventLitterReportRestService(IHttpClientFactory httpClientFactory) 
     public async Task<FullEventLitterReport> GetEventLitterReportByLitterReportIdAsync(Guid litterReportId,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = string.Concat(Controller, $"/GetByLitterReportId/{litterReportId}");
+        var requestUri = string.Concat(Controller, $"/by-litter-report/{litterReportId}");
         var eventLitterReport =
             await AuthorizedHttpClient.GetFromJsonAsync<FullEventLitterReport>(requestUri, SerializerOptions,
                 cancellationToken);

--- a/TrashMobMobile/Services/EventPartnerLocationServiceRestService.cs
+++ b/TrashMobMobile/Services/EventPartnerLocationServiceRestService.cs
@@ -1,10 +1,12 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
 using System.Diagnostics;
 using System.Net.Http.Json;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
 using TrashMob.Models.Poco;
+using TrashMob.Models.Poco.V2;
 
 public class EventPartnerLocationServiceRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IEventPartnerLocationServiceRestService
 {
@@ -13,7 +15,7 @@ public class EventPartnerLocationServiceRestService(IHttpClientFactory httpClien
     public async Task<PartnerLocation> GetHaulingPartnerLocationAsync(Guid eventId,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + "/gethaulingpartnerlocation/" + eventId;
+        var requestUri = Controller + "/hauling/" + eventId;
 
         using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
         {
@@ -55,23 +57,39 @@ public class EventPartnerLocationServiceRestService(IHttpClientFactory httpClien
     public async Task<EventPartnerLocationService> UpdateEventPartnerLocationService(
         EventPartnerLocationService eventPartnerLocationService, CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(eventPartnerLocationService, typeof(EventPartnerLocationService), null,
+        var dto = new EventPartnerLocationServiceRequestDto
+        {
+            EventId = eventPartnerLocationService.EventId,
+            PartnerLocationId = eventPartnerLocationService.PartnerLocationId,
+            ServiceTypeId = eventPartnerLocationService.ServiceTypeId,
+            EventPartnerLocationServiceStatusId = eventPartnerLocationService.EventPartnerLocationServiceStatusId,
+        };
+        var content = JsonContent.Create(dto, typeof(EventPartnerLocationServiceRequestDto), null,
             SerializerOptions);
         var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<EventPartnerLocationService>(returnContent)!;
+
+        // V2 PUT returns 200 with no body; return the original entity with updated values
+        return eventPartnerLocationService;
     }
 
     public async Task<EventPartnerLocationService> AddEventPartnerLocationService(
         EventPartnerLocationService eventPartnerLocationService, CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(eventPartnerLocationService, typeof(EventPartnerLocationService), null,
+        var dto = new EventPartnerLocationServiceRequestDto
+        {
+            EventId = eventPartnerLocationService.EventId,
+            PartnerLocationId = eventPartnerLocationService.PartnerLocationId,
+            ServiceTypeId = eventPartnerLocationService.ServiceTypeId,
+            EventPartnerLocationServiceStatusId = eventPartnerLocationService.EventPartnerLocationServiceStatusId,
+        };
+        var content = JsonContent.Create(dto, typeof(EventPartnerLocationServiceRequestDto), null,
             SerializerOptions);
         var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<EventPartnerLocationService>(returnContent)!;
+
+        // V2 POST returns 201 with no body; return the original entity
+        return eventPartnerLocationService;
     }
 
     public async Task DeleteEventPartnerLocationServiceAsync(EventPartnerLocationService eventPartnerLocationService,

--- a/TrashMobMobile/Services/EventPartnerLocationServiceStatusRestService.cs
+++ b/TrashMobMobile/Services/EventPartnerLocationServiceStatusRestService.cs
@@ -1,23 +1,25 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
-using System.Diagnostics;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class EventPartnerLocationServiceStatusRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory),
     IEventPartnerLocationServiceStatusRestService
 {
-    protected override string Controller => "eventpartnerlocationservicestatuses";
+    protected override string Controller => "lookups";
 
     public async Task<IEnumerable<EventPartnerLocationServiceStatus>> GetEventPartnerLocationServiceStatusesAsync(
         CancellationToken cancellationToken = default)
     {
-        using (var response = await AnonymousHttpClient.GetAsync(Controller, cancellationToken))
+        using (var response = await AnonymousHttpClient.GetAsync("lookups/partner-service-statuses", cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<List<EventPartnerLocationServiceStatus>>(responseString) ?? [];
+            var dtos = JsonConvert.DeserializeObject<List<LookupItemDto>>(responseString) ?? [];
+            return dtos.Select(d => d.ToEventPartnerLocationServiceStatus()).ToList();
         }
     }
 }

--- a/TrashMobMobile/Services/EventPhotoRestService.cs
+++ b/TrashMobMobile/Services/EventPhotoRestService.cs
@@ -1,8 +1,11 @@
 namespace TrashMobMobile.Services;
 
+using System.Linq;
 using System.Net.Http.Json;
 using System.Text.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class EventPhotoRestService(IHttpClientFactory httpClientFactory)
     : RestServiceBase(httpClientFactory), IEventPhotoRestService
@@ -23,7 +26,8 @@ public class EventPhotoRestService(IHttpClientFactory httpClientFactory)
             return [];
         }
 
-        return JsonSerializer.Deserialize<IEnumerable<EventPhoto>>(content, SerializerOptions) ?? [];
+        var dtos = JsonSerializer.Deserialize<IEnumerable<EventPhotoDto>>(content, SerializerOptions) ?? [];
+        return dtos.Select(d => d.ToEntity());
     }
 
     public async Task<EventPhoto> UploadPhotoAsync(Guid eventId, string localFilePath,
@@ -51,8 +55,9 @@ public class EventPhotoRestService(IHttpClientFactory httpClientFactory)
         response.EnsureSuccessStatusCode();
         var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        return JsonSerializer.Deserialize<EventPhoto>(responseContent, SerializerOptions)
+        var dto = JsonSerializer.Deserialize<EventPhotoDto>(responseContent, SerializerOptions)
                ?? throw new InvalidOperationException("Failed to deserialize uploaded photo response.");
+        return dto.ToEntity();
     }
 
     public async Task DeletePhotoAsync(Guid eventId, Guid photoId,

--- a/TrashMobMobile/Services/EventSummaryRestService.cs
+++ b/TrashMobMobile/Services/EventSummaryRestService.cs
@@ -1,18 +1,19 @@
-﻿namespace TrashMobMobile.Services
+namespace TrashMobMobile.Services
 {
-    using System.Diagnostics;
     using System.Net.Http.Json;
     using Newtonsoft.Json;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
 
     public class EventSummaryRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IEventSummaryRestService
     {
-        protected override string Controller => "eventsummaries";
+        protected override string Controller => "events";
 
         public async Task<EventSummary> GetEventSummaryAsync(Guid eventId,
             CancellationToken cancellationToken = default)
         {
-            var requestUri = Controller + "/v2/" + eventId;
+            var requestUri = Controller + "/" + eventId + "/summary";
 
             HttpResponseMessage? response = null;
             try
@@ -21,7 +22,7 @@
 
                 response.EnsureSuccessStatusCode();
                 var content = await response.Content.ReadAsStringAsync(cancellationToken);
-                return JsonConvert.DeserializeObject<EventSummary>(content)!;
+                return JsonConvert.DeserializeObject<EventSummaryDto>(content)!.ToEntity();
             }
             catch (HttpRequestException)
             {
@@ -46,9 +47,11 @@
         public async Task<EventSummary> UpdateEventSummaryAsync(EventSummary eventSummary,
             CancellationToken cancellationToken = default)
         {
-            var content = JsonContent.Create(eventSummary, typeof(EventSummary), null, SerializerOptions);
+            var dto = eventSummary.ToV2Dto();
+            var content = JsonContent.Create(dto, typeof(EventSummaryDto), null, SerializerOptions);
+            var requestUri = Controller + "/" + eventSummary.EventId + "/summary";
 
-            using (var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken))
+            using (var response = await AuthorizedHttpClient.PutAsync(requestUri, content, cancellationToken))
             {
                 response.EnsureSuccessStatusCode();
             }
@@ -59,9 +62,11 @@
         public async Task<EventSummary> AddEventSummaryAsync(EventSummary eventSummary,
             CancellationToken cancellationToken = default)
         {
-            var content = JsonContent.Create(eventSummary, typeof(EventSummary), null, SerializerOptions);
+            var dto = eventSummary.ToV2Dto();
+            var content = JsonContent.Create(dto, typeof(EventSummaryDto), null, SerializerOptions);
+            var requestUri = Controller + "/" + eventSummary.EventId + "/summary";
 
-            using (var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken))
+            using (var response = await AuthorizedHttpClient.PostAsync(requestUri, content, cancellationToken))
             {
                 response.EnsureSuccessStatusCode();
             }

--- a/TrashMobMobile/Services/EventTypeRestService.cs
+++ b/TrashMobMobile/Services/EventTypeRestService.cs
@@ -1,21 +1,23 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
-using System.Diagnostics;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class EventTypeRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IEventTypeRestService
 {
-    protected override string Controller => "eventtypes";
+    protected override string Controller => "lookups";
 
     public async Task<IEnumerable<EventType>> GetEventTypesAsync(CancellationToken cancellationToken = default)
     {
-        using (var response = await AnonymousHttpClient.GetAsync(Controller, cancellationToken))
+        using (var response = await AnonymousHttpClient.GetAsync("lookups/event-types", cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<List<EventType>>(responseString) ?? [];
+            var dtos = JsonConvert.DeserializeObject<List<LookupItemDto>>(responseString) ?? [];
+            return dtos.Select(d => d.ToEventType()).ToList();
         }
     }
 }

--- a/TrashMobMobile/Services/LitterReportRestService.cs
+++ b/TrashMobMobile/Services/LitterReportRestService.cs
@@ -1,15 +1,17 @@
-﻿namespace TrashMobMobile.Services
+namespace TrashMobMobile.Services
 {
     using System.Globalization;
     using System.Net.Http.Json;
     using Newtonsoft.Json;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
     using TrashMobMobile.Models;
 
     public class LitterReportRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), ILitterReportRestService
     {
-        protected override string Controller => "litterreport";
+        protected override string Controller => "litterreports";
 
         public async Task<LitterReport> GetLitterReportAsync(Guid litterReportId,
             CancellationToken cancellationToken = default)
@@ -20,7 +22,8 @@
             {
                 response.EnsureSuccessStatusCode();
                 var content = await response.Content.ReadAsStringAsync(cancellationToken);
-                return JsonConvert.DeserializeObject<LitterReport>(content)!;
+                var dto = JsonConvert.DeserializeObject<LitterReportDto>(content)!;
+                return dto.ToEntity();
             }
         }
 
@@ -50,7 +53,8 @@
         public async Task<LitterReport> UpdateLitterReportAsync(LitterReport litterReport,
             CancellationToken cancellationToken = default)
         {
-            var content = JsonContent.Create(litterReport, typeof(LitterReport), null, SerializerOptions);
+            var dto = litterReport.ToV2Dto();
+            var content = JsonContent.Create(dto, typeof(LitterReportDto), null, SerializerOptions);
 
             using (var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken))
             {
@@ -62,7 +66,7 @@
                 }
 
                 var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-                var result = JsonConvert.DeserializeObject<LitterReport>(responseContent);
+                var result = JsonConvert.DeserializeObject<LitterReportDto>(responseContent);
 
                 if (result != null)
                 {
@@ -81,7 +85,8 @@
         public async Task<LitterReport> AddLitterReportAsync(LitterReport litterReport,
             CancellationToken cancellationToken = default)
         {
-            var content = JsonContent.Create(litterReport, typeof(LitterReport), null, SerializerOptions);
+            var dto = litterReport.ToV2Dto();
+            var content = JsonContent.Create(dto, typeof(LitterReportDto), null, SerializerOptions);
 
             using (var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken))
             {
@@ -93,7 +98,7 @@
                 }
 
                 var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-                var result = JsonConvert.DeserializeObject<LitterReport>(responseContent);
+                var result = JsonConvert.DeserializeObject<LitterReportDto>(responseContent);
 
                 if (result != null)
                 {
@@ -117,7 +122,12 @@
                 response.EnsureSuccessStatusCode();
                 var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
-                return JsonConvert.DeserializeObject<PaginatedList<LitterReport>>(returnContent)!;
+                var dtoPaged = JsonConvert.DeserializeObject<PaginatedList<LitterReportDto>>(returnContent)!;
+                var entityItems = dtoPaged.Select(d => d.ToEntity()).ToList();
+                // Reconstruct PaginatedList preserving pagination metadata from the DTO list
+                var pageSize = filter.PageSize.GetValueOrDefault(10);
+                var totalCount = dtoPaged.TotalPages * pageSize;
+                return new PaginatedList<LitterReport>(entityItems, totalCount, dtoPaged.PageIndex, pageSize);
             }
         }
 
@@ -136,7 +146,8 @@
                     return [];
                 }
 
-                return JsonConvert.DeserializeObject<IEnumerable<LitterReport>>(content) ?? [];
+                var dtos = JsonConvert.DeserializeObject<IEnumerable<LitterReportDto>>(content) ?? [];
+                return dtos.Select(d => d.ToEntity());
             }
         }
 

--- a/TrashMobMobile/Services/MapRestService.cs
+++ b/TrashMobMobile/Services/MapRestService.cs
@@ -3,6 +3,8 @@
 using System.Diagnostics;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class MapRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IMapRestService
 {
@@ -11,14 +13,14 @@ public class MapRestService(IHttpClientFactory httpClientFactory) : RestServiceB
     public async Task<Address> GetAddressAsync(double latitude, double longitude,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + $"/GetAddress?latitude={latitude}&longitude={longitude}";
+        var requestUri = Controller + $"/address?latitude={latitude}&longitude={longitude}";
 
         using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<Address>(responseString)!;
+            return JsonConvert.DeserializeObject<AddressDto>(responseString)!.ToEntity();
         }
     }
 }

--- a/TrashMobMobile/Services/MobEventRestService.cs
+++ b/TrashMobMobile/Services/MobEventRestService.cs
@@ -1,10 +1,12 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
 using System.Globalization;
 using System.Net.Http.Json;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
 using TrashMob.Models.Poco;
+using TrashMob.Models.Poco.V2;
 using TrashMobMobile.Models;
 
 public class MobEventRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IMobEventRestService
@@ -18,17 +20,23 @@ public class MobEventRestService(IHttpClientFactory httpClientFactory) : RestSer
         var response = await AnonymousHttpClient.PostAsync(requestUri, content, cancellationToken);
         response.EnsureSuccessStatusCode();
         var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<PaginatedList<Event>>(returnContent) ?? new();
+        var dtoResult = JsonConvert.DeserializeObject<PaginatedList<EventDto>>(returnContent) ?? new();
+        var result = new PaginatedList<Event>();
+        result.AddRange(dtoResult.Select(d => d.ToEntity()));
+        return result;
     }
 
     public async Task<PaginatedList<Event>> GetUserEventsAsync(EventFilter filter, Guid userId, CancellationToken cancellationToken = default)
     {
         var content = JsonContent.Create(filter, typeof(EventFilter), null, SerializerOptions);
         var requestUri = $"{Controller}/pageduserevents/{userId}";
-        var response = await AnonymousHttpClient.PostAsync(requestUri, content, cancellationToken);
+        var response = await AuthorizedHttpClient.PostAsync(requestUri, content, cancellationToken);
         response.EnsureSuccessStatusCode();
         var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<PaginatedList<Event>>(returnContent) ?? new();
+        var dtoResult = JsonConvert.DeserializeObject<PaginatedList<EventDto>>(returnContent) ?? new();
+        var result = new PaginatedList<Event>();
+        result.AddRange(dtoResult.Select(d => d.ToEntity()));
+        return result;
     }
 
     public async Task<IEnumerable<Event>> GetUserEventsAsync(Guid userId, bool showFutureEventsOnly,
@@ -38,9 +46,9 @@ public class MobEventRestService(IHttpClientFactory httpClientFactory) : RestSer
         var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        var mobEvents = JsonConvert.DeserializeObject<List<Event>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<EventDto>>(content) ?? [];
 
-        return mobEvents;
+        return dtos.Select(d => d.ToEntity());
     }
 
     public async Task<Event> GetEventAsync(Guid eventId, CancellationToken cancellationToken = default)
@@ -49,25 +57,27 @@ public class MobEventRestService(IHttpClientFactory httpClientFactory) : RestSer
         var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<Event>(content)!;
+        return JsonConvert.DeserializeObject<EventDto>(content)!.ToEntity();
     }
 
     public async Task<Event> UpdateEventAsync(Event mobEvent, CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(mobEvent, typeof(Event), null, SerializerOptions);
+        var dto = mobEvent.ToV2Dto();
+        var content = JsonContent.Create(dto, typeof(EventDto), null, SerializerOptions);
         var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken);
         response.EnsureSuccessStatusCode();
         var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<Event>(returnContent)!;
+        return JsonConvert.DeserializeObject<EventDto>(returnContent)!.ToEntity();
     }
 
     public async Task<Event> AddEventAsync(Event mobEvent, CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(mobEvent, typeof(Event), null, SerializerOptions);
+        var dto = mobEvent.ToV2Dto();
+        var content = JsonContent.Create(dto, typeof(EventDto), null, SerializerOptions);
         var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken);
         response.EnsureSuccessStatusCode();
         var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<Event>(returnContent)!;
+        return JsonConvert.DeserializeObject<EventDto>(returnContent)!.ToEntity();
     }
 
     public async Task DeleteEventAsync(EventCancellationRequest cancelEvent,
@@ -92,9 +102,9 @@ public class MobEventRestService(IHttpClientFactory httpClientFactory) : RestSer
         var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        var mobEvents = JsonConvert.DeserializeObject<List<Event>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<EventDto>>(content) ?? [];
 
-        return mobEvents;
+        return dtos.Select(d => d.ToEntity());
     }
 
     public async Task<IEnumerable<Location>> GetLocationsByTimeRangeAsync(DateTimeOffset startDate,

--- a/TrashMobMobile/Services/PickupLocationRestService.cs
+++ b/TrashMobMobile/Services/PickupLocationRestService.cs
@@ -1,8 +1,10 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
 using System.Net.Http.Json;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 using TrashMobMobile.Models;
 
 public class PickupLocationRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IPickupLocationRestService
@@ -18,35 +20,39 @@ public class PickupLocationRestService(IHttpClientFactory httpClientFactory) : R
         {
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            return JsonConvert.DeserializeObject<PickupLocation>(content)!;
+            var dto = JsonConvert.DeserializeObject<PickupLocationDto>(content)!;
+            return dto.ToEntity();
         }
     }
 
     public async Task<PickupLocation> UpdatePickupLocationAsync(PickupLocation pickupLocation,
         CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(pickupLocation, typeof(PickupLocation), null, SerializerOptions);
+        var dto = pickupLocation.ToV2Dto();
+        var content = JsonContent.Create(dto, typeof(PickupLocationDto), null, SerializerOptions);
+        var requestUri = Controller + "/" + pickupLocation.Id;
 
-        using (var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken))
+        using (var response = await AuthorizedHttpClient.PutAsync(requestUri, content, cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            var result = JsonConvert.DeserializeObject<PickupLocation>(responseContent)!;
-            return result;
+            var resultDto = JsonConvert.DeserializeObject<PickupLocationDto>(responseContent)!;
+            return resultDto.ToEntity();
         }
     }
 
     public async Task<PickupLocation> AddPickupLocationAsync(PickupLocation pickupLocation,
         CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(pickupLocation, typeof(PickupLocation), null, SerializerOptions);
+        var dto = pickupLocation.ToV2Dto();
+        var content = JsonContent.Create(dto, typeof(PickupLocationDto), null, SerializerOptions);
 
         using (var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            var result = JsonConvert.DeserializeObject<PickupLocation>(responseContent)!;
-            return result;
+            var resultDto = JsonConvert.DeserializeObject<PickupLocationDto>(responseContent)!;
+            return resultDto.ToEntity();
         }
     }
 
@@ -66,14 +72,14 @@ public class PickupLocationRestService(IHttpClientFactory httpClientFactory) : R
     public async Task<IEnumerable<PickupLocation>> GetPickupLocationsAsync(Guid eventId,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + "/getbyevent/" + eventId;
+        var requestUri = Controller + "/by-event/" + eventId;
 
         using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            var result = JsonConvert.DeserializeObject<List<PickupLocation>>(content) ?? [];
-            return result;
+            var dtos = JsonConvert.DeserializeObject<List<PickupLocationDto>>(content) ?? [];
+            return dtos.Select(d => d.ToEntity()).ToList();
         }
     }
 
@@ -90,7 +96,7 @@ public class PickupLocationRestService(IHttpClientFactory httpClientFactory) : R
     public async Task<string> GetPickupLocationImageAsync(Guid pickupLocationId, ImageSizeEnum imageSize,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + "/image/" + pickupLocationId + "/" + imageSize;
+        var requestUri = Controller + "/" + pickupLocationId + "/image";
 
         using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
         {
@@ -103,7 +109,7 @@ public class PickupLocationRestService(IHttpClientFactory httpClientFactory) : R
     public async Task AddPickupLocationImageAsync(Guid eventId, Guid pickupLocationId, string localFileName,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + "/image/" + eventId;
+        var requestUri = Controller + "/" + pickupLocationId + "/image";
 
         using (var stream = File.OpenRead(localFileName))
         {

--- a/TrashMobMobile/Services/ServiceTypeRestService.cs
+++ b/TrashMobMobile/Services/ServiceTypeRestService.cs
@@ -1,21 +1,23 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class ServiceTypeRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IServiceTypeRestService
 {
-    protected override string Controller => "servicetypes";
+    protected override string Controller => "lookups";
 
     public async Task<IEnumerable<ServiceType>> GetServiceTypesAsync(CancellationToken cancellationToken = default)
     {
-
-        using (var response = await AnonymousHttpClient.GetAsync(Controller, cancellationToken))
+        using (var response = await AnonymousHttpClient.GetAsync("lookups/service-types", cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<List<ServiceType>>(responseString) ?? [];
+            var dtos = JsonConvert.DeserializeObject<List<LookupItemDto>>(responseString) ?? [];
+            return dtos.Select(d => d.ToServiceType()).ToList();
         }
     }
 }

--- a/TrashMobMobile/Services/StatsRestService.cs
+++ b/TrashMobMobile/Services/StatsRestService.cs
@@ -2,7 +2,9 @@
 
 using System.Diagnostics;
 using Newtonsoft.Json;
+using TrashMob.Models.Extensions.V2;
 using TrashMob.Models.Poco;
+using TrashMob.Models.Poco.V2;
 
 public class StatsRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IStatsRestService
 {
@@ -15,7 +17,7 @@ public class StatsRestService(IHttpClientFactory httpClientFactory) : RestServic
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<Stats>(responseString)!;
+            return JsonConvert.DeserializeObject<StatsDto>(responseString)!.ToEntity();
         }
     }
 
@@ -28,7 +30,7 @@ public class StatsRestService(IHttpClientFactory httpClientFactory) : RestServic
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<Stats>(responseString)!;
+            return JsonConvert.DeserializeObject<StatsDto>(responseString)!.ToEntity();
         }
     }
 }

--- a/TrashMobMobile/Services/TeamRestService.cs
+++ b/TrashMobMobile/Services/TeamRestService.cs
@@ -3,6 +3,8 @@ namespace TrashMobMobile.Services;
 using System.Globalization;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class TeamRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), ITeamRestService
 {
@@ -36,7 +38,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<Team>>(content) ?? [];
+        var pagedResponse = JsonConvert.DeserializeObject<PagedResponse<TeamDto>>(content);
+        return pagedResponse?.Items.Select(d => d.ToEntity()).ToList() ?? [];
     }
 
     public async Task<Team> GetTeamAsync(Guid teamId, CancellationToken cancellationToken = default)
@@ -45,7 +48,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<Team>(content)!;
+        var dto = JsonConvert.DeserializeObject<TeamDto>(content)!;
+        return dto.ToEntity();
     }
 
     public async Task<IEnumerable<Team>> GetMyTeamsAsync(CancellationToken cancellationToken = default)
@@ -54,7 +58,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<Team>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<TeamDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task<IEnumerable<TeamMember>> GetTeamMembersAsync(Guid teamId, CancellationToken cancellationToken = default)
@@ -63,7 +68,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<TeamMember>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<TeamMemberDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task<IEnumerable<TeamMember>> GetTeamLeadsAsync(Guid teamId, CancellationToken cancellationToken = default)
@@ -72,7 +78,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<TeamMember>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<TeamMemberDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task<TeamMember> JoinTeamAsync(Guid teamId, CancellationToken cancellationToken = default)
@@ -81,7 +88,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<TeamMember>(content)!;
+        var dto = JsonConvert.DeserializeObject<TeamMemberDto>(content)!;
+        return dto.ToEntity();
     }
 
     public async Task<IEnumerable<Event>> GetUpcomingTeamEventsAsync(Guid teamId, CancellationToken cancellationToken = default)
@@ -90,7 +98,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<Event>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<EventDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task<IEnumerable<Event>> GetPastTeamEventsAsync(Guid teamId, CancellationToken cancellationToken = default)
@@ -99,7 +108,8 @@ public class TeamRestService(IHttpClientFactory httpClientFactory) : RestService
         using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<List<Event>>(content) ?? [];
+        var dtos = JsonConvert.DeserializeObject<List<EventDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity()).ToList();
     }
 
     public async Task LinkEventAsync(Guid teamId, Guid eventId, CancellationToken cancellationToken = default)

--- a/TrashMobMobile/Services/UserRestService.cs
+++ b/TrashMobMobile/Services/UserRestService.cs
@@ -1,8 +1,10 @@
-﻿namespace TrashMobMobile.Services;
+namespace TrashMobMobile.Services;
 
 using System.Net.Http.Json;
 using Newtonsoft.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 
 public class UserRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IUserRestService
 {
@@ -17,7 +19,7 @@ public class UserRestService(IHttpClientFactory httpClientFactory) : RestService
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<User>(responseString)!;
+            return JsonConvert.DeserializeObject<UserDto>(responseString)!.ToEntity();
         }
     }
 
@@ -31,7 +33,7 @@ public class UserRestService(IHttpClientFactory httpClientFactory) : RestService
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<User>(responseString)!;
+            return JsonConvert.DeserializeObject<UserDto>(responseString)!.ToEntity();
         }
     }
 
@@ -45,32 +47,35 @@ public class UserRestService(IHttpClientFactory httpClientFactory) : RestService
         if (!response.IsSuccessStatusCode) return null;
 
         var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<User>(responseString);
+        var dto = JsonConvert.DeserializeObject<UserDto>(responseString);
+        return dto?.ToEntity();
     }
 
     public async Task<User> AddUserAsync(User user, CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(user, typeof(User), null, SerializerOptions);
+        var writeDto = user.ToWriteDto();
+        var content = JsonContent.Create(writeDto, typeof(UserWriteDto), null, SerializerOptions);
 
         using (var response = await AuthorizedHttpClient.PostAsync(Controller, content, cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<User>(responseString)!;
+            return JsonConvert.DeserializeObject<UserDto>(responseString)!.ToEntity();
         }
     }
 
     public async Task<User> UpdateUserAsync(User user, CancellationToken cancellationToken = default)
     {
-        var content = JsonContent.Create(user, typeof(User), null, SerializerOptions);
+        var writeDto = user.ToWriteDto();
+        var content = JsonContent.Create(writeDto, typeof(UserWriteDto), null, SerializerOptions);
 
         using (var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken))
         {
             response.EnsureSuccessStatusCode();
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            return JsonConvert.DeserializeObject<User>(responseString)!;
+            return JsonConvert.DeserializeObject<UserDto>(responseString)!.ToEntity();
         }
     }
 }

--- a/TrashMobMobile/Services/WaiverRestService.cs
+++ b/TrashMobMobile/Services/WaiverRestService.cs
@@ -1,7 +1,10 @@
 namespace TrashMobMobile.Services;
 
+using System.Linq;
 using System.Net.Http.Json;
 using TrashMob.Models;
+using TrashMob.Models.Extensions.V2;
+using TrashMob.Models.Poco.V2;
 using TrashMobMobile.Models;
 
 public class WaiverRestService(IHttpClientFactory httpClientFactory) : RestServiceBase(httpClientFactory), IWaiverRestService
@@ -14,26 +17,35 @@ public class WaiverRestService(IHttpClientFactory httpClientFactory) : RestServi
             ? $"{Controller}/required?communityId={communityId.Value}"
             : $"{Controller}/required";
 
-        var result = await AuthorizedHttpClient.GetFromJsonAsync<List<WaiverVersion>>(requestUri, SerializerOptions, cancellationToken);
-        return result ?? [];
+        var dtos = await AuthorizedHttpClient.GetFromJsonAsync<List<WaiverVersionDto>>(requestUri, SerializerOptions, cancellationToken);
+        return dtos?.Select(d => d.ToEntity()).ToList() ?? [];
     }
 
     public async Task<List<UserWaiver>> GetMyWaiversAsync(CancellationToken cancellationToken = default)
     {
         var requestUri = $"{Controller}/my";
-        var result = await AuthorizedHttpClient.GetFromJsonAsync<List<UserWaiver>>(requestUri, SerializerOptions, cancellationToken);
-        return result ?? [];
+        var dtos = await AuthorizedHttpClient.GetFromJsonAsync<List<UserWaiverDto>>(requestUri, SerializerOptions, cancellationToken);
+        return dtos?.Select(d => d.ToEntity()).ToList() ?? [];
     }
 
     public async Task<UserWaiver> AcceptWaiverAsync(AcceptWaiverApiRequest request, CancellationToken cancellationToken = default)
     {
         var requestUri = $"{Controller}/accept";
-        var content = JsonContent.Create(request, typeof(AcceptWaiverApiRequest), null, SerializerOptions);
+        var dto = new AcceptWaiverRequestDto
+        {
+            WaiverVersionId = request.WaiverVersionId,
+            TypedLegalName = request.TypedLegalName,
+            IsMinor = request.IsMinor,
+            GuardianUserId = request.GuardianUserId,
+            GuardianName = request.GuardianName ?? string.Empty,
+            GuardianRelationship = request.GuardianRelationship ?? string.Empty,
+        };
+        var content = JsonContent.Create(dto, typeof(AcceptWaiverRequestDto), null, SerializerOptions);
 
         using var response = await AuthorizedHttpClient.PostAsync(requestUri, content, cancellationToken);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<UserWaiver>(SerializerOptions, cancellationToken);
-        return result!;
+        var resultDto = await response.Content.ReadFromJsonAsync<UserWaiverDto>(SerializerOptions, cancellationToken);
+        return resultDto!.ToEntity();
     }
 }


### PR DESCRIPTION
## Summary
- Migrated all 25 MAUI mobile REST services from v1 (`/api/`) to v2 (`/api/v2.0/`) API endpoints
- Added 14 new `ToEntity()` reverse mapping methods + `ToWriteDto()`/`ToV2Dto()` for bidirectional DTO↔entity conversion
- All service interfaces remain unchanged — zero ViewModel/UI changes needed

## Key Changes

**Infrastructure:**
- `Settings.ApiBaseUrl` changed from `/api/` to `/api/v2.0/`

**Mapping layer** (12 files in `TrashMob.Models/Extensions/V2/`):
- Added reverse `ToEntity()` methods for: Stats, Address, WaiverVersion, UserWaiver, EventPhoto, Partner, EventAttendee, TeamMember, DependentInvitation, DependentWaiver, UserDto
- Added `ToEventType()`, `ToServiceType()`, `ToEventPartnerLocationServiceStatus()` for lookup conversions
- Added `User.ToWriteDto()` and `ContactRequest.ToV2Dto()` for write endpoints

**Service pattern** (21 mobile service files updated):
- Read endpoints: deserialize as DTO → `.ToEntity()` → return entity
- Write endpoints: entity → `.ToV2Dto()` → serialize as DTO
- Nested route handling: EventSummary (`events/{id}/summary`), EventAttendees (`events/{id}/attendees`), EventAttendeeMetrics (`events/{id}/attendee-metrics`)
- Lookup consolidation: EventType/ServiceType/EPLSS → `lookups/` controller

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 errors
- [x] `dotnet build TrashMobMobile -f net10.0-android` — 0 errors
- [x] `dotnet test TrashMob.Shared.Tests` — 719 passed, 0 failed
- [ ] Smoke test on Android emulator against dev server
- [ ] Verify auth flow (login → user lookup → profile display)
- [ ] Verify event CRUD (create, edit, delete, list)
- [ ] Verify team operations (join, leave, list members)

🤖 Generated with [Claude Code](https://claude.com/claude-code)