### PR TITLE
Add v2 simulate route endpoint and fix spinner stuck bug

### DIFF
--- a/TrashMob.Shared.Tests/Controllers/V2/EventRoutesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventRoutesV2ControllerTests.cs
@@ -9,19 +9,22 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using Microsoft.Extensions.Logging;
     using Moq;
     using TrashMob.Controllers.V2;
+    using TrashMob.Models;
     using TrashMob.Models.Poco;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
     using Xunit;
 
     public class EventRoutesV2ControllerTests
     {
         private readonly Mock<IEventAttendeeRouteManager> routeManager = new();
+        private readonly Mock<IKeyedRepository<Event>> eventRepository = new();
         private readonly Mock<ILogger<EventRoutesV2Controller>> logger = new();
         private readonly EventRoutesV2Controller controller;
 
         public EventRoutesV2ControllerTests()
         {
-            controller = new EventRoutesV2Controller(routeManager.Object, logger.Object);
+            controller = new EventRoutesV2Controller(routeManager.Object, eventRepository.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),

--- a/TrashMob/Controllers/V2/EventRoutesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventRoutesV2Controller.cs
@@ -11,10 +11,14 @@ namespace TrashMob.Controllers.V2
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
+    using NetTopologySuite.Geometries;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions;
     using TrashMob.Models.Poco;
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
 
     /// <summary>
     /// V2 controller for event-level route aggregation.
@@ -25,8 +29,18 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/events/{eventId}/routes")]
     public class EventRoutesV2Controller(
         IEventAttendeeRouteManager eventAttendeeRouteManager,
+        IKeyedRepository<Event> eventRepository,
         ILogger<EventRoutesV2Controller> logger) : ControllerBase
     {
+        private static readonly HashSet<string> ProductionHosts = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "www.trashmob.eco",
+            "trashmob.eco",
+        };
+        private const double EarthRadiusMeters = 6_371_000;
+        private static readonly Random Rng = new();
+
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
         /// <summary>
         /// Gets anonymized routes for an event (no user identity).
         /// </summary>
@@ -82,6 +96,149 @@ namespace TrashMob.Controllers.V2
             var prefill = await eventAttendeeRouteManager.GetEventSummaryPrefillAsync(eventId, weightUnitId, cancellationToken);
 
             return Ok(prefill);
+        }
+
+        /// <summary>
+        /// Generates a simulated GPS route around an event's location.
+        /// Only available in non-production environments.
+        /// </summary>
+        /// <param name="eventId">The event to simulate a route for.</param>
+        /// <param name="distanceMeters">Target total distance in meters.</param>
+        /// <param name="durationMinutes">Target duration in minutes.</param>
+        /// <param name="pointCount">Number of GPS waypoints to generate.</param>
+        /// <param name="gpsJitterMeters">GPS noise standard deviation in meters.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the simulated route.</response>
+        /// <response code="404">Event not found or production environment.</response>
+        [HttpPost("simulate")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DisplayEventAttendeeRoute), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SimulateRoute(
+            Guid eventId,
+            [FromQuery] int distanceMeters = 1000,
+            [FromQuery] int durationMinutes = 30,
+            [FromQuery] int pointCount = 50,
+            [FromQuery] int gpsJitterMeters = 3,
+            CancellationToken cancellationToken = default)
+        {
+            if (ProductionHosts.Contains(Request.Host.Host))
+            {
+                return NotFound();
+            }
+
+            var eventData = await eventRepository.GetAsync(eventId, cancellationToken);
+            if (eventData is null)
+            {
+                return NotFound($"Event {eventId} not found");
+            }
+
+            logger.LogInformation("V2 SimulateRoute for Event={EventId}", eventId);
+
+            var centerLat = eventData.Latitude ?? 47.6062;
+            var centerLon = eventData.Longitude ?? -122.3321;
+
+            var coordinates = GenerateWalkingLoop(centerLat, centerLon, distanceMeters, pointCount, gpsJitterMeters);
+
+            var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+            var userPath = factory.CreateLineString(coordinates.ToArray());
+
+            var startTime = DateTimeOffset.UtcNow.AddMinutes(-durationMinutes);
+            var endTime = DateTimeOffset.UtcNow;
+
+            var route = new EventAttendeeRoute
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                UserId = UserId,
+                UserPath = userPath,
+                StartTime = startTime,
+                EndTime = endTime,
+                PrivacyLevel = "EventOnly",
+                Notes = "Simulated route for testing",
+                BagsCollected = Rng.Next(1, 6),
+                WeightCollected = Math.Round((decimal)(Rng.NextDouble() * 10 + 1), 1),
+            };
+
+            var created = await eventAttendeeRouteManager.AddAsync(route, UserId, cancellationToken);
+
+            return Ok(created.ToDisplayEventAttendeeRoute());
+        }
+
+        private static List<Coordinate> GenerateWalkingLoop(
+            double centerLat, double centerLon,
+            int totalDistanceMeters, int pointCount, int jitterMeters)
+        {
+            var stepDistance = (double)totalDistanceMeters / pointCount;
+            var bearing = Rng.NextDouble() * 360;
+            List<Coordinate> coordinates = [];
+
+            var currentLat = centerLat;
+            var currentLon = centerLon;
+            coordinates.Add(new Coordinate(currentLon, currentLat));
+
+            for (var i = 1; i < pointCount; i++)
+            {
+                var progress = (double)i / pointCount;
+
+                if (progress > 0.8)
+                {
+                    var targetBearing = BearingTo(currentLat, currentLon, centerLat, centerLon);
+                    bearing = bearing + (targetBearing - bearing) * 0.3;
+                }
+                else
+                {
+                    bearing += (Rng.NextDouble() - 0.5) * 30;
+                }
+
+                var (newLat, newLon) = OffsetLatLon(currentLat, currentLon, bearing, stepDistance);
+
+                if (jitterMeters > 0)
+                {
+                    var jitterLat = (Rng.NextDouble() - 0.5) * 2 * jitterMeters / EarthRadiusMeters * (180 / Math.PI);
+                    var jitterLon = jitterLat / Math.Cos(newLat * Math.PI / 180);
+                    newLat += jitterLat;
+                    newLon += jitterLon;
+                }
+
+                coordinates.Add(new Coordinate(newLon, newLat));
+                currentLat = newLat;
+                currentLon = newLon;
+            }
+
+            return coordinates;
+        }
+
+        private static (double Lat, double Lon) OffsetLatLon(double lat, double lon, double bearingDeg, double distanceMeters)
+        {
+            var latRad = lat * Math.PI / 180;
+            var lonRad = lon * Math.PI / 180;
+            var bearingRad = bearingDeg * Math.PI / 180;
+            var angularDistance = distanceMeters / EarthRadiusMeters;
+
+            var newLatRad = Math.Asin(
+                Math.Sin(latRad) * Math.Cos(angularDistance) +
+                Math.Cos(latRad) * Math.Sin(angularDistance) * Math.Cos(bearingRad));
+
+            var newLonRad = lonRad + Math.Atan2(
+                Math.Sin(bearingRad) * Math.Sin(angularDistance) * Math.Cos(latRad),
+                Math.Cos(angularDistance) - Math.Sin(latRad) * Math.Sin(newLatRad));
+
+            return (newLatRad * 180 / Math.PI, newLonRad * 180 / Math.PI);
+        }
+
+        private static double BearingTo(double lat1, double lon1, double lat2, double lon2)
+        {
+            var lat1Rad = lat1 * Math.PI / 180;
+            var lat2Rad = lat2 * Math.PI / 180;
+            var dLonRad = (lon2 - lon1) * Math.PI / 180;
+
+            var y = Math.Sin(dLonRad) * Math.Cos(lat2Rad);
+            var x = Math.Cos(lat1Rad) * Math.Sin(lat2Rad) -
+                    Math.Sin(lat1Rad) * Math.Cos(lat2Rad) * Math.Cos(dLonRad);
+
+            return Math.Atan2(y, x) * 180 / Math.PI;
         }
     }
 }

--- a/TrashMobMobile/Pages/HomeFeedPage.xaml
+++ b/TrashMobMobile/Pages/HomeFeedPage.xaml
@@ -11,7 +11,7 @@
         <converters:StringToBoolConverter x:Key="StringToBoolConverter" />
     </ContentPage.Resources>
 
-    <RefreshView Command="{Binding RefreshCommand}" IsRefreshing="{Binding IsBusy}">
+    <RefreshView Command="{Binding RefreshCommand}" IsRefreshing="{Binding IsBusy, Mode=OneWay}">
         <ScrollView>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
 


### PR DESCRIPTION
## Summary
- **v2 simulate endpoint**: Mobile emulator stop-route was 404ing because `RouteSimulationController` is unversioned at `api/routes/simulate/{eventId}`, but mobile calls `api/v2.0/events/{eventId}/routes/simulate`. Added `POST simulate` to `EventRoutesV2Controller`.
- **Spinner fix**: `HomeFeedPage` `RefreshView` had `IsRefreshing="{Binding IsBusy}"` (two-way default). Pull-to-refresh set `IsBusy=true` before `RefreshCommand` ran, causing `Init()` guard `if (IsBusy) return` to skip, leaving spinner stuck. Changed to `Mode=OneWay`.

## Test plan
- [ ] Deploy to dev, start emulator, navigate to event → start route → stop route → route simulated successfully
- [ ] Pull down on home feed → spinner shows, loads, spinner clears
- [ ] Verify Swagger shows `POST events/{eventId}/routes/simulate` under v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)