### PR TITLE
Fix 400 Bad Request on user update: make Email optional

### DIFF
--- a/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
@@ -97,7 +97,7 @@ namespace TrashMob.Models.Extensions.V2
             {
                 Id = dto.Id,
                 UserName = dto.UserName,
-                Email = dto.Email,
+                Email = dto.Email ?? string.Empty,
                 GivenName = dto.GivenName,
                 Surname = dto.Surname,
                 City = dto.City,

--- a/TrashMob.Models/Poco/V2/UserWriteDto.cs
+++ b/TrashMob.Models/Poco/V2/UserWriteDto.cs
@@ -22,8 +22,9 @@ namespace TrashMob.Models.Poco.V2
 
         /// <summary>
         /// Gets or sets the user's email address.
+        /// Optional on update — the server preserves the existing email if not provided.
         /// </summary>
-        public string Email { get; set; } = string.Empty;
+        public string? Email { get; set; }
 
         /// <summary>
         /// Gets or sets the user's given (first) name.

--- a/TrashMob.Shared.Tests/Extensions/V2/UserMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/UserMappingsV2Tests.cs
@@ -179,6 +179,20 @@ namespace TrashMob.Shared.Tests.Extensions.V2
         }
 
         [Fact]
+        public void UserWriteDto_ToEntity_HandlesNullEmail()
+        {
+            var dto = new Models.Poco.V2.UserWriteDto
+            {
+                Id = Guid.NewGuid(),
+                Email = null,
+            };
+
+            var entity = dto.ToEntity();
+
+            Assert.Equal(string.Empty, entity.Email);
+        }
+
+        [Fact]
         public void ToWriteDto_MapsAllProperties()
         {
             var entity = new User

--- a/TrashMobMobile/Services/UserRestService.cs
+++ b/TrashMobMobile/Services/UserRestService.cs
@@ -72,7 +72,15 @@ public class UserRestService(IHttpClientFactory httpClientFactory) : RestService
 
         using (var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken))
         {
-            response.EnsureSuccessStatusCode();
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                System.Diagnostics.Debug.WriteLine($"UpdateUserAsync failed: {response.StatusCode} - {errorBody}");
+                System.Diagnostics.Debug.WriteLine($"Request URL: {response.RequestMessage?.RequestUri}");
+                throw new HttpRequestException(
+                    $"UpdateUser failed ({response.StatusCode}): {errorBody}");
+            }
+
             var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
 
             return JsonConvert.DeserializeObject<UserDto>(responseString)!.ToEntity();


### PR DESCRIPTION
## Summary
- Make `UserWriteDto.Email` nullable (`string?`) so ASP.NET `[ApiController]` model validation doesn't reject requests with missing email
- The mobile app loads users via `UserDto` (PII-safe, no email) then updates via `UserWriteDto` — the email was always empty/null
- Server-side field preservation in the controller (from PR #3062) already handles null email by copying from the existing DB record, but model validation was rejecting the request before the controller action ran
- Added null-coalescing in `UserWriteDto.ToEntity()` mapping and regression test

## Test plan
- [x] `dotnet build TrashMob.sln` — zero errors
- [x] `dotnet test --filter UserMappingsV2Tests` — all 9 pass (including new null email test)
- [ ] After deploy: save location in mobile app without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)