### PR TITLE
Fix 405 on Log Pickup, Trim, Restore route actions in mobile app

### DIFF
--- a/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventAttendeeRoutesV2ControllerTests.cs
@@ -15,6 +15,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using TrashMob.Models.Poco;
     using NetTopologySuite.Geometries;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
     using Xunit;
 
     public class EventAttendeeRoutesV2ControllerTests
@@ -173,6 +174,139 @@ namespace TrashMob.Shared.Tests.Controllers.V2
 
             var okResult = Assert.IsType<OkObjectResult>(result);
             Assert.IsType<DisplayEventAttendeeRoute>(okResult.Value);
+        }
+
+        [Fact]
+        public async Task UpdateRouteMetadata_ReturnsOk_WhenSuccessful()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var request = new UpdateRouteMetadataRequest { Notes = "Picked up 3 bags" };
+            var route = new EventAttendeeRoute { Id = routeId, UserPath = TestPath };
+
+            routeManager
+                .Setup(m => m.UpdateRouteMetadataAsync(routeId, userId, request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeRoute>.Success(route));
+
+            var result = await controller.UpdateRouteMetadata(routeId, request, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<DisplayEventAttendeeRoute>(okResult.Value);
+        }
+
+        [Fact]
+        public async Task UpdateRouteMetadata_ReturnsNotFound_WhenRouteNotFound()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var request = new UpdateRouteMetadataRequest();
+
+            routeManager
+                .Setup(m => m.UpdateRouteMetadataAsync(routeId, userId, request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeRoute>.Failure("Route not found."));
+
+            var result = await controller.UpdateRouteMetadata(routeId, request, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateRouteMetadata_ReturnsBadRequest_WhenValidationFails()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var request = new UpdateRouteMetadataRequest();
+
+            routeManager
+                .Setup(m => m.UpdateRouteMetadataAsync(routeId, userId, request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeRoute>.Failure("You do not own this route."));
+
+            var result = await controller.UpdateRouteMetadata(routeId, request, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task TrimRouteTime_ReturnsOk_WhenSuccessful()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var request = new TrimRouteTimeRequest { NewEndTime = DateTimeOffset.UtcNow };
+            var route = new EventAttendeeRoute { Id = routeId, UserPath = TestPath };
+
+            routeManager
+                .Setup(m => m.TrimRouteTimeAsync(routeId, userId, request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeRoute>.Success(route));
+
+            var result = await controller.TrimRouteTime(routeId, request, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<DisplayEventAttendeeRoute>(okResult.Value);
+        }
+
+        [Fact]
+        public async Task TrimRouteTime_ReturnsNotFound_WhenRouteNotFound()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var request = new TrimRouteTimeRequest { NewEndTime = DateTimeOffset.UtcNow };
+
+            routeManager
+                .Setup(m => m.TrimRouteTimeAsync(routeId, userId, request, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeRoute>.Failure("Route not found."));
+
+            var result = await controller.TrimRouteTime(routeId, request, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task RestoreRouteTime_ReturnsOk_WhenSuccessful()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var route = new EventAttendeeRoute { Id = routeId, UserPath = TestPath };
+
+            routeManager
+                .Setup(m => m.RestoreRouteTimeAsync(routeId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeRoute>.Success(route));
+
+            var result = await controller.RestoreRouteTime(routeId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.IsType<DisplayEventAttendeeRoute>(okResult.Value);
+        }
+
+        [Fact]
+        public async Task RestoreRouteTime_ReturnsNotFound_WhenRouteNotFound()
+        {
+            var routeId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            routeManager
+                .Setup(m => m.RestoreRouteTimeAsync(routeId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<EventAttendeeRoute>.Failure("Route not found."));
+
+            var result = await controller.RestoreRouteTime(routeId, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
         }
     }
 }

--- a/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
@@ -189,5 +189,111 @@ namespace TrashMob.Controllers.V2
 
             return NoContent();
         }
+
+        /// <summary>
+        /// Updates route metadata (privacy, trim, notes, pickup data). Owner only.
+        /// </summary>
+        /// <param name="routeId">The route ID.</param>
+        /// <param name="request">The metadata update request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated route.</response>
+        /// <response code="400">Validation error.</response>
+        /// <response code="404">Route not found.</response>
+        [HttpPut("{routeId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DisplayEventAttendeeRoute), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateRouteMetadata(Guid routeId, UpdateRouteMetadataRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateRouteMetadata Route={RouteId}", routeId);
+
+            var result = await eventAttendeeRouteManager
+                .UpdateRouteMetadataAsync(routeId, UserId, request, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                if (result.ErrorMessage.Contains("not found"))
+                {
+                    return Problem(detail: result.ErrorMessage, statusCode: StatusCodes.Status404NotFound, title: "Not found");
+                }
+
+                return Problem(detail: result.ErrorMessage, statusCode: StatusCodes.Status400BadRequest, title: "Validation failed");
+            }
+
+            return Ok(result.Data.ToDisplayEventAttendeeRoute());
+        }
+
+        /// <summary>
+        /// Trims a route's end time, rebuilding the path from GPS points up to the new end time.
+        /// </summary>
+        /// <param name="routeId">The route ID.</param>
+        /// <param name="request">The trim request containing the new end time.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the trimmed route.</response>
+        /// <response code="400">Validation error.</response>
+        /// <response code="404">Route not found.</response>
+        [HttpPut("{routeId}/trim-time")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DisplayEventAttendeeRoute), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> TrimRouteTime(Guid routeId, TrimRouteTimeRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 TrimRouteTime Route={RouteId}", routeId);
+
+            var result = await eventAttendeeRouteManager
+                .TrimRouteTimeAsync(routeId, UserId, request, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                if (result.ErrorMessage.Contains("not found"))
+                {
+                    return Problem(detail: result.ErrorMessage, statusCode: StatusCodes.Status404NotFound, title: "Not found");
+                }
+
+                return Problem(detail: result.ErrorMessage, statusCode: StatusCodes.Status400BadRequest, title: "Validation failed");
+            }
+
+            return Ok(result.Data.ToDisplayEventAttendeeRoute());
+        }
+
+        /// <summary>
+        /// Restores a time-trimmed route to its original values.
+        /// </summary>
+        /// <param name="routeId">The route ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the restored route.</response>
+        /// <response code="400">Validation error.</response>
+        /// <response code="404">Route not found.</response>
+        [HttpPut("{routeId}/restore-time")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DisplayEventAttendeeRoute), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> RestoreRouteTime(Guid routeId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 RestoreRouteTime Route={RouteId}", routeId);
+
+            var result = await eventAttendeeRouteManager
+                .RestoreRouteTimeAsync(routeId, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                if (result.ErrorMessage.Contains("not found"))
+                {
+                    return Problem(detail: result.ErrorMessage, statusCode: StatusCodes.Status404NotFound, title: "Not found");
+                }
+
+                return Problem(detail: result.ErrorMessage, statusCode: StatusCodes.Status400BadRequest, title: "Validation failed");
+            }
+
+            return Ok(result.Data.ToDisplayEventAttendeeRoute());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add 3 missing endpoints to `EventAttendeeRoutesV2Controller` that the mobile app calls but only existed on the v1 `RouteMetadataController` (`/api/routes/`):
  - `PUT {routeId}` — UpdateRouteMetadata (Log Pickup button)
  - `PUT {routeId}/trim-time` — TrimRouteTime (Trim End button)
  - `PUT {routeId}/restore-time` — RestoreRouteTime (Restore button)
- The mobile app sends requests to `/api/v2.0/eventattendeeroutes/{routeId}` but the v2 controller only had `[HttpPut]` (no route param), causing 405 Method Not Allowed
- Added 7 unit tests covering success, not-found, and validation-failure cases

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 735 tests pass (7 new)
- [ ] Deploy to dev, open mobile app, tap Log Pickup on a route card — should succeed
- [ ] Tap Trim End on a route card — should succeed
- [ ] Tap Restore on a trimmed route card — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)