### PR TITLE
Fix useIsInViewport race condition causing news section to not render

### DIFF
--- a/TrashMob/client-app/src/hooks/useIsInViewport.ts
+++ b/TrashMob/client-app/src/hooks/useIsInViewport.ts
@@ -1,16 +1,22 @@
-import { RefObject, useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 export function useIsInViewport<T extends HTMLElement = HTMLDivElement>() {
-    const ref = useRef<T>(null);
     const [isIntersecting, setIntersecting] = useState(false);
+    const observerRef = useRef<IntersectionObserver | null>(null);
 
-    const observer = useMemo(() => new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting)), []);
+    const ref = useCallback((node: T | null) => {
+        if (observerRef.current) {
+            observerRef.current.disconnect();
+        }
+
+        if (node) {
+            observerRef.current = new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
+            observerRef.current.observe(node);
+        }
+    }, []);
 
     useEffect(() => {
-        if (ref.current) {
-            observer.observe(ref.current);
-        }
-        return () => observer.disconnect();
+        return () => observerRef.current?.disconnect();
     }, []);
 
     return { ref, isInViewPort: isIntersecting };


### PR DESCRIPTION
## Summary
- Fixed a race condition in the `useIsInViewport` hook where components that conditionally render (returning `null` until async data loads) were never observed by the `IntersectionObserver`
- The old implementation used `useRef` + `useEffect([])` which only ran once on mount — before the DOM element existed
- Switched to a **callback ref** pattern so the observer attaches when the element actually mounts into the DOM
- This fixes the Latest News section not appearing on the home page despite the API returning data correctly

## Test plan
- [ ] Verify the Latest News section appears on the home page when news posts exist
- [ ] Verify viewport animation (fade-in on scroll) still works for all home page sections: Hero, What Is TrashMob, Stats, Featured Communities, Latest News, Events, Getting Started
- [ ] Verify community maps and other components using `useIsInViewport` still animate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)