### PR TITLE
Fix team member names showing as Unknown

### DIFF
--- a/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
@@ -40,6 +40,13 @@ namespace TrashMob.Models.Extensions.V2
                 UserId = dto.UserId,
                 IsTeamLead = dto.IsTeamLead,
                 JoinedDate = dto.JoinedDate,
+                User = new User
+                {
+                    Id = dto.UserId,
+                    UserName = dto.UserName ?? string.Empty,
+                    GivenName = dto.GivenName ?? string.Empty,
+                    ProfilePhotoUrl = dto.ProfilePhotoUrl ?? string.Empty,
+                },
             };
         }
     }


### PR DESCRIPTION
## Summary
- `TeamMemberDto.ToEntity()` was discarding `UserName`, `GivenName`, and `ProfilePhotoUrl` from the API response
- The mobile `ToTeamMemberViewModel()` extension then fell back to `member.User?.UserName ?? "Unknown"` since `User` was null
- Fix: populate a `User` navigation object in `ToEntity()` with the DTO fields

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 735 tests pass
- [ ] Open Team Details page in mobile app — member names should display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)