### PR TITLE
Fix event details not refreshing after editing location

### DIFF
--- a/TrashMobMobile/Pages/ViewEventPage.xaml.cs
+++ b/TrashMobMobile/Pages/ViewEventPage.xaml.cs
@@ -27,11 +27,14 @@ public partial class ViewEventPage : ContentPage
         Switcher.PropertyChanged -= OnSwitcherPropertyChanged;
         Switcher.PropertyChanged += OnSwitcherPropertyChanged;
 
-        // Only re-initialize when loading a different event, not when returning from popups
-        if (loadedEventId != EventId)
+        // Always re-initialize to pick up changes from edit pages.
+        // Popups don't trigger OnNavigatedTo, so this only fires for Shell navigation.
+        var isNewEvent = loadedEventId != EventId;
+        loadedEventId = EventId;
+        await viewModel.Init(new Guid(EventId), RenderRoutesOnDetailsMap);
+
+        if (isNewEvent)
         {
-            loadedEventId = EventId;
-            await viewModel.Init(new Guid(EventId), RenderRoutesOnDetailsMap);
             Switcher.SelectedIndex = 0;
         }
     }


### PR DESCRIPTION
## Summary
- After editing an event's location, the Event Details page showed the old location because `OnNavigatedTo()` skipped re-fetching when the `EventId` was unchanged
- Fix: always call `Init()` on Shell navigation return (popups don't trigger `OnNavigatedTo`, so no duplicate load concern)
- Tab index is only reset when navigating to a *different* event, preserving the user's tab position on return from edit

## Test plan
- [x] `dotnet build` — 0 errors
- [ ] Edit event location, save, verify Event Details page shows updated location
- [ ] Edit event name/date, save, verify details update
- [ ] Verify tab position is preserved when returning from edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)