### PR TITLE
Fix event details refresh and invisible button icons

### DIFF
--- a/TrashMobMobile/Pages/ProfilePage.xaml
+++ b/TrashMobMobile/Pages/ProfilePage.xaml
@@ -241,27 +241,27 @@
                             Command="{Binding MyDependentsCommand}"
                             Style="{StaticResource SecondaryLargeButton}"
                             ContentLayout="Left, 12"
-                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconHumanChild}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconHumanChild}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                     <Button Text="Privacy Policy"
                             Command="{Binding OpenPrivacyPolicyCommand}"
                             Style="{StaticResource SecondaryLargeButton}"
                             ContentLayout="Left, 12"
-                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconBinoculars}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconBinoculars}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                     <Button Text="Terms of Service"
                             Command="{Binding OpenTermsOfServiceCommand}"
                             Style="{StaticResource SecondaryLargeButton}"
                             ContentLayout="Left, 12"
-                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconFileDocument}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconFileDocument}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                     <Button Text="Contact Us"
                             Command="{Binding ContactUsCommand}"
                             Style="{StaticResource SecondaryLargeButton}"
                             ContentLayout="Left, 12"
-                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmail}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmail}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                     <Button Text="Newsletter Preferences"
                             Command="{Binding ManageNewsletterPreferencesCommand}"
                             Style="{StaticResource SecondaryLargeButton}"
                             ContentLayout="Left, 12"
-                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmailNewsletter}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDarkText}}}" />
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEmailNewsletter}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                 </VerticalStackLayout>
             </Border>
 

--- a/TrashMobMobile/Pages/ViewLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/ViewLitterReportPage.xaml
@@ -81,7 +81,7 @@
                                 Style="{StaticResource SecondaryLargeButton}"
                                 Text="Mark as Cleaned"
                                 ContentLayout="Left, 12"
-                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconCheck}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconCheck}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                         <Button Command="{Binding DeleteLitterReportCommand}"
                                 IsEnabled="{Binding CanDeleteLitterReport}"
                                 IsVisible="{Binding CanDeleteLitterReport}"
@@ -95,14 +95,14 @@
                                 Style="{StaticResource SecondaryLargeButton}"
                                 Text="View Event"
                                 ContentLayout="Left, 12"
-                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEye}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconEye}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                         <Button Command="{Binding CreateEventCommand}"
                                 IsEnabled="{Binding IsNotAssignedToEvent}"
                                 IsVisible="{Binding IsNotAssignedToEvent}"
                                 Style="{StaticResource SecondaryLargeButton}"
                                 Text="Create Event"
                                 ContentLayout="Left, 12"
-                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconCalendarPlus}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
+                                ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconCalendarPlus}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
                     </VerticalStackLayout>
                 </Border>
             </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- **Event details not refreshing after edit**: `ViewEventPage.OnNavigatedTo()` skipped re-fetching when returning from EditEventPage because EventId was unchanged. Now always calls `Init()` on Shell navigation (popups don't trigger `OnNavigatedTo`). Tab position preserved on return from edit.
- **Invisible button icons**: Icon colors were `Primary` (dark green) on buttons with `Primary` background, making icons invisible. Changed to `PrimaryReverseText` (white) on:
  - ViewLitterReportPage: Mark as Cleaned, View Event, Create Event
  - ProfilePage: My Dependents, Privacy Policy, Terms of Service, Contact Us, Newsletter Preferences

## Test plan
- [x] `dotnet build` — 0 errors
- [ ] Edit event location, save — details page shows updated location
- [ ] View Litter Report page — Create Event button shows calendar+ icon
- [ ] Profile page — all Settings buttons show their icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)