### PR TITLE
Fix 400 error when updating litter report via v2 API

### DIFF
--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -61,9 +61,11 @@ namespace TrashMob.Shared.Managers.LitterReport
                 existingInstance.Description = litterReport.Description;
                 existingInstance.LitterReportStatusId = litterReport.LitterReportStatusId;
 
+                var existingImageIds = existingInstance.LitterImages.Select(x => x.Id).ToHashSet();
+
                 foreach (var litterImage in litterReport.LitterImages)
                 {
-                    if (litterImage.CreatedByUserId == Guid.Empty)
+                    if (!existingImageIds.Contains(litterImage.Id))
                     {
                         litterImage.LitterReportId = litterReport.Id;
                         litterImage.CreatedByUserId = userId;


### PR DESCRIPTION
## Summary
- Fixed 400 BadRequest when saving an edited litter report from the mobile app
- Root cause: `LitterReportManager.UpdateAsync` used `CreatedByUserId == Guid.Empty` to detect new images, but the v2 DTO round-trip strips `CreatedByUserId` (not included in `LitterImageDto`), so ALL existing images were treated as new and re-added to the EF-tracked collection, causing a duplicate tracking exception (silently caught → null → 400)
- Fix: detect new images by checking whether the image ID already exists in the DB record's `LitterImages` collection

## Test plan
- [x] All 735 existing tests pass
- [ ] Edit an existing litter report on mobile and verify save succeeds
- [ ] Verify adding new images to an existing report still works
- [ ] Verify removing images from an existing report still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)