### PR TITLE
Fix litter report Images not deserializing on server

### DIFF
--- a/TrashMob.Models/Extensions/V2/LitterReportMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/LitterReportMappingsV2.cs
@@ -29,7 +29,7 @@ namespace TrashMob.Models.Extensions.V2
                     .Where(li => !li.IsCancelled)
                     .Select(li => li.ToV2Dto())
                     .ToList()
-                    ?? (IReadOnlyList<LitterImageDto>)[],
+                    ?? [],
             };
         }
 

--- a/TrashMob.Models/Poco/V2/LitterReportDto.cs
+++ b/TrashMob.Models/Poco/V2/LitterReportDto.cs
@@ -48,6 +48,6 @@ namespace TrashMob.Models.Poco.V2
         /// <summary>
         /// Gets or sets the associated images for this litter report.
         /// </summary>
-        public IReadOnlyList<LitterImageDto> Images { get; set; } = [];
+        public List<LitterImageDto> Images { get; set; } = [];
     }
 }


### PR DESCRIPTION
## Summary
- Diagnostic from PR #3073 confirmed: **0 images arrive at the server** when updating a litter report
- Root cause: `IReadOnlyList<LitterImageDto>` on `LitterReportDto.Images` was not being populated by ASP.NET Core's System.Text.Json model binding
- Fix: change property type from `IReadOnlyList<LitterImageDto>` to `List<LitterImageDto>`

## Test plan
- [ ] Mark as Cleaned on a litter report with images — should succeed
- [ ] Edit and save a litter report — should succeed
- [ ] All 735 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)