### PR TITLE
Fix litter report 0-images deserialization with JsonPropertyName

### DIFF
--- a/TrashMob.Models/Poco/V2/LitterImageDto.cs
+++ b/TrashMob.Models/Poco/V2/LitterImageDto.cs
@@ -3,6 +3,7 @@
 namespace TrashMob.Models.Poco.V2
 {
     using System;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// V2 API representation of a litter image. Excludes moderation internals.
@@ -12,46 +13,55 @@ namespace TrashMob.Models.Poco.V2
         /// <summary>
         /// Gets or sets the unique identifier for the image.
         /// </summary>
+        [JsonPropertyName("id")]
         public Guid Id { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the image.
         /// </summary>
+        [JsonPropertyName("imageUrl")]
         public string ImageUrl { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the street address where the litter was photographed.
         /// </summary>
+        [JsonPropertyName("streetAddress")]
         public string StreetAddress { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the city.
         /// </summary>
+        [JsonPropertyName("city")]
         public string City { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the region (state/province).
         /// </summary>
+        [JsonPropertyName("region")]
         public string Region { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the country.
         /// </summary>
+        [JsonPropertyName("country")]
         public string Country { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the postal code.
         /// </summary>
+        [JsonPropertyName("postalCode")]
         public string PostalCode { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the latitude.
         /// </summary>
+        [JsonPropertyName("latitude")]
         public double? Latitude { get; set; }
 
         /// <summary>
         /// Gets or sets the longitude.
         /// </summary>
+        [JsonPropertyName("longitude")]
         public double? Longitude { get; set; }
     }
 }

--- a/TrashMob.Models/Poco/V2/LitterReportDto.cs
+++ b/TrashMob.Models/Poco/V2/LitterReportDto.cs
@@ -4,6 +4,7 @@ namespace TrashMob.Models.Poco.V2
 {
     using System;
     using System.Collections.Generic;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// V2 API representation of a litter report with associated images.
@@ -13,41 +14,49 @@ namespace TrashMob.Models.Poco.V2
         /// <summary>
         /// Gets or sets the unique identifier for the litter report.
         /// </summary>
+        [JsonPropertyName("id")]
         public Guid Id { get; set; }
 
         /// <summary>
         /// Gets or sets the name or title of the litter report.
         /// </summary>
+        [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the description of the litter report.
         /// </summary>
+        [JsonPropertyName("description")]
         public string Description { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the status identifier (New=1, Assigned=2, Cleaned=3, Cancelled=4).
         /// </summary>
+        [JsonPropertyName("litterReportStatusId")]
         public int LitterReportStatusId { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the user who created the report.
         /// </summary>
+        [JsonPropertyName("createdByUserId")]
         public Guid CreatedByUserId { get; set; }
 
         /// <summary>
         /// Gets or sets when the report was created.
         /// </summary>
+        [JsonPropertyName("createdDate")]
         public DateTimeOffset CreatedDate { get; set; }
 
         /// <summary>
         /// Gets or sets when the report was last updated.
         /// </summary>
+        [JsonPropertyName("lastUpdatedDate")]
         public DateTimeOffset LastUpdatedDate { get; set; }
 
         /// <summary>
         /// Gets or sets the associated images for this litter report.
         /// </summary>
+        [JsonPropertyName("images")]
         public List<LitterImageDto> Images { get; set; } = [];
     }
 }

--- a/TrashMob.Shared.Tests/LitterReportDtoSerializationTests.cs
+++ b/TrashMob.Shared.Tests/LitterReportDtoSerializationTests.cs
@@ -156,10 +156,11 @@ namespace TrashMob.Shared.Tests
         }
 
         [Fact]
-        public void ServerOptions_WithoutCaseInsensitive_FailsToDeserializeCamelCase()
+        public void ServerOptions_WithoutCaseInsensitive_StillWorksWithJsonPropertyName()
         {
-            // This test proves the bug: if PropertyNameCaseInsensitive is not set,
-            // camelCase JSON won't map to PascalCase C# properties
+            // With [JsonPropertyName] attributes on DTO properties, deserialization
+            // succeeds even without PropertyNameCaseInsensitive because the attribute
+            // explicitly defines the JSON property name.
             var dto = new LitterReportDto
             {
                 Id = Guid.NewGuid(),
@@ -174,10 +175,11 @@ namespace TrashMob.Shared.Tests
 
             var deserialized = JsonSerializer.Deserialize<LitterReportDto>(json, StrictServerOptions);
 
-            // With strict case matching, camelCase "images" won't match "Images"
+            // With [JsonPropertyName] attributes, deserialization works regardless of case sensitivity settings
             Assert.NotNull(deserialized);
-            Assert.Empty(deserialized.Images); // Images will be empty!
-            Assert.Equal(Guid.Empty, deserialized.Id); // Even Id won't match "id"!
+            Assert.Single(deserialized.Images);
+            Assert.Equal(dto.Id, deserialized.Id);
+            Assert.Equal(dto.Images[0].ImageUrl, deserialized.Images[0].ImageUrl);
         }
     }
 }

--- a/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
@@ -131,13 +131,19 @@ namespace TrashMob.Controllers.V2
             CancellationToken cancellationToken)
         {
             var imageCount = litterReport.Images?.Count ?? 0;
-            logger.LogInformation("V2 UpdateLitterReport Id={Id}, ImageCount={ImageCount}",
-                litterReport.Id, imageCount);
+            logger.LogInformation("V2 UpdateLitterReport Id={Id}, ImageCount={ImageCount}, Name={Name}",
+                litterReport.Id, imageCount, litterReport.Name);
 
             if (imageCount == 0)
             {
+                // Log raw body for diagnostics
+                HttpContext.Request.Body.Position = 0;
+                using var reader = new System.IO.StreamReader(HttpContext.Request.Body);
+                var rawBody = await reader.ReadToEndAsync(cancellationToken);
+                logger.LogWarning("V2 UpdateLitterReport 0 images. RawBody={RawBody}", rawBody);
+
                 return Problem(
-                    detail: "Litter report must have at least one image.",
+                    detail: $"Litter report must have at least one image. Received 0 images for report {litterReport.Id}.",
                     statusCode: StatusCodes.Status400BadRequest,
                     title: "Validation failed");
             }

--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -7,6 +7,7 @@ using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
@@ -389,6 +390,13 @@ public class Program
 
         var enableSwagger = builder.Environment.IsDevelopment() ||
                             builder.Configuration.GetValue<bool>("EnableSwagger");
+
+        // Enable request body buffering so controllers can re-read the body for diagnostics
+        app.Use(async (context, next) =>
+        {
+            context.Request.EnableBuffering();
+            await next();
+        });
 
         app.UseMiddleware<CorrelationIdMiddleware>();
         app.UseMiddleware<GlobalExceptionHandlerMiddleware>();


### PR DESCRIPTION
## Summary
- Add `[JsonPropertyName]` attributes to `LitterReportDto` and `LitterImageDto` properties to guarantee correct JSON property matching regardless of server configuration
- Add raw request body logging when 0 images are received, for diagnostics if the issue persists
- Enable request body buffering middleware so the body can be re-read after model binding

## Root cause
Previous fixes (PropertyNameCaseInsensitive, CamelCase naming policy) were correct in theory but insufficient in practice — likely due to `GeoJsonConverterFactory` or other pipeline interference. Explicit `[JsonPropertyName]` attributes override all naming policies and work with any converter configuration.

## Test plan
- [x] All 739 tests pass
- [x] Serialization tests verify DTOs deserialize correctly with and without PropertyNameCaseInsensitive
- [ ] Deploy server and verify litter report update/Mark as Cleaned works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)