### PR TITLE
Fix litter report update: make images optional for metadata-only changes

### DIFF
--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -36,13 +36,8 @@ namespace TrashMob.Shared.Managers.LitterReport
         {
             try
             {
-                if (litterReport.LitterImages is null || litterReport.LitterImages.Count == 0)
-                {
-                    logger.LogWarning("UpdateAsync returning null: LitterImages is null or empty for report {Id}", litterReport.Id);
-                    return null;
-                }
-
-                logger.LogInformation("Updating litter report {Id} with {ImageCount} images", litterReport.Id, litterReport.LitterImages.Count);
+                logger.LogInformation("Updating litter report {Id} with {ImageCount} images",
+                    litterReport.Id, litterReport.LitterImages?.Count ?? 0);
 
                 var existingInstance = Repo.Get(l => l.Id == litterReport.Id, withNoTracking: false)
                     .Include(l => l.LitterImages)
@@ -63,32 +58,37 @@ namespace TrashMob.Shared.Managers.LitterReport
                 existingInstance.Description = litterReport.Description;
                 existingInstance.LitterReportStatusId = litterReport.LitterReportStatusId;
 
-                var existingImageIds = existingInstance.LitterImages.Select(x => x.Id).ToHashSet();
-
-                foreach (var litterImage in litterReport.LitterImages)
+                // Only process image changes if images were provided in the request.
+                // If no images sent, keep existing images unchanged (metadata-only update).
+                if (litterReport.LitterImages is not null && litterReport.LitterImages.Count > 0)
                 {
-                    if (!existingImageIds.Contains(litterImage.Id))
+                    var existingImageIds = existingInstance.LitterImages.Select(x => x.Id).ToHashSet();
+
+                    foreach (var litterImage in litterReport.LitterImages)
                     {
-                        litterImage.LitterReportId = litterReport.Id;
-                        litterImage.CreatedByUserId = userId;
-                        litterImage.CreatedDate = DateTime.UtcNow;
-                        existingInstance.LitterImages.Add(litterImage);
+                        if (!existingImageIds.Contains(litterImage.Id))
+                        {
+                            litterImage.LitterReportId = litterReport.Id;
+                            litterImage.CreatedByUserId = userId;
+                            litterImage.CreatedDate = DateTime.UtcNow;
+                            existingInstance.LitterImages.Add(litterImage);
+                        }
                     }
-                }
 
-                List<Guid> deletedIds = [];
-                foreach (var litterImage in existingInstance.LitterImages)
-                {
-                    if (!litterReport.LitterImages.Select(x => x.Id).Contains(litterImage.Id))
+                    List<Guid> deletedIds = [];
+                    foreach (var litterImage in existingInstance.LitterImages)
                     {
-                        deletedIds.Add(litterImage.Id);
+                        if (!litterReport.LitterImages.Select(x => x.Id).Contains(litterImage.Id))
+                        {
+                            deletedIds.Add(litterImage.Id);
+                        }
                     }
-                }
 
-                foreach (var deletedId in deletedIds)
-                {
-                    await litterImageManager.DeleteAsync(deletedId, userId, cancellationToken);
-                    existingInstance.LitterImages.Remove(existingInstance.LitterImages.First(x => x.Id == deletedId));
+                    foreach (var deletedId in deletedIds)
+                    {
+                        await litterImageManager.DeleteAsync(deletedId, userId, cancellationToken);
+                        existingInstance.LitterImages.Remove(existingInstance.LitterImages.First(x => x.Id == deletedId));
+                    }
                 }
 
                 var resultLitterReport = await base.UpdateAsync(existingInstance, userId, cancellationToken);

--- a/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
@@ -36,11 +36,6 @@ namespace TrashMob.Controllers.V2
         IAuthorizationService authorizationService,
         ILogger<LitterReportsV2Controller> logger) : ControllerBase
     {
-        private static readonly System.Text.Json.JsonSerializerOptions ManualDeserializeOptions = new()
-        {
-            PropertyNameCaseInsensitive = true,
-        };
-
         private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
 
         /// <summary>
@@ -121,8 +116,9 @@ namespace TrashMob.Controllers.V2
 
         /// <summary>
         /// Updates an existing litter report. Only the owner or admin can update.
-        /// Reads and deserializes the request body manually to bypass model binding.
+        /// Images are optional — if omitted, existing images are preserved.
         /// </summary>
+        /// <param name="litterReport">The litter report to update.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns the updated litter report.</response>
         /// <response code="403">User is not authorized.</response>
@@ -132,37 +128,11 @@ namespace TrashMob.Controllers.V2
         [ProducesResponseType(typeof(LitterReportDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> UpdateLitterReport(CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateLitterReport(LitterReportDto litterReport,
+            CancellationToken cancellationToken)
         {
-            // Bypass ASP.NET Core model binding: read and deserialize body manually
-            HttpContext.Request.Body.Position = 0;
-            using var reader = new System.IO.StreamReader(HttpContext.Request.Body);
-            var rawBody = await reader.ReadToEndAsync(cancellationToken);
-
-            logger.LogInformation("V2 UpdateLitterReport RawBodyLength={Length}, RawBody={RawBody}",
-                rawBody.Length, rawBody);
-
-            var litterReport = System.Text.Json.JsonSerializer.Deserialize<LitterReportDto>(rawBody, ManualDeserializeOptions);
-
-            if (litterReport is null)
-            {
-                return Problem(
-                    detail: "Failed to deserialize litter report from request body.",
-                    statusCode: StatusCodes.Status400BadRequest,
-                    title: "Deserialization failed");
-            }
-
-            var imageCount = litterReport.Images?.Count ?? 0;
             logger.LogInformation("V2 UpdateLitterReport Id={Id}, ImageCount={ImageCount}, Name={Name}",
-                litterReport.Id, imageCount, litterReport.Name);
-
-            if (imageCount == 0)
-            {
-                return Problem(
-                    detail: $"Litter report must have at least one image. Received 0 images for report {litterReport.Id}. RawBody length: {rawBody.Length}",
-                    statusCode: StatusCodes.Status400BadRequest,
-                    title: "Validation failed");
-            }
+                litterReport.Id, litterReport.Images?.Count ?? 0, litterReport.Name);
 
             var entity = litterReport.ToEntity();
 

--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -391,13 +391,6 @@ public class Program
         var enableSwagger = builder.Environment.IsDevelopment() ||
                             builder.Configuration.GetValue<bool>("EnableSwagger");
 
-        // Enable request body buffering so controllers can re-read the body for diagnostics
-        app.Use(async (context, next) =>
-        {
-            context.Request.EnableBuffering();
-            await next();
-        });
-
         app.UseMiddleware<CorrelationIdMiddleware>();
         app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
 

--- a/TrashMobMobile/Services/LitterReportRestService.cs
+++ b/TrashMobMobile/Services/LitterReportRestService.cs
@@ -23,7 +23,16 @@ namespace TrashMobMobile.Services
                 response.EnsureSuccessStatusCode();
                 var content = await response.Content.ReadAsStringAsync(cancellationToken);
                 var dto = JsonConvert.DeserializeObject<LitterReportDto>(content)!;
-                return dto.ToEntity();
+
+                System.Diagnostics.Debug.WriteLine(
+                    $"[LitterReport] GetLitterReportAsync Id={litterReportId}, DtoImages={dto.Images?.Count ?? 0}, ResponseLength={content.Length}");
+
+                var entity = dto.ToEntity();
+
+                System.Diagnostics.Debug.WriteLine(
+                    $"[LitterReport] GetLitterReportAsync after ToEntity, EntityImages={entity.LitterImages?.Count ?? 0}");
+
+                return entity;
             }
         }
 
@@ -53,7 +62,19 @@ namespace TrashMobMobile.Services
         public async Task<LitterReport> UpdateLitterReportAsync(LitterReport litterReport,
             CancellationToken cancellationToken = default)
         {
+            var entityImageCount = litterReport.LitterImages?.Count ?? 0;
             var dto = litterReport.ToV2Dto();
+            var dtoImageCount = dto.Images?.Count ?? 0;
+
+            System.Diagnostics.Debug.WriteLine(
+                $"[LitterReport] UpdateLitterReportAsync Id={litterReport.Id}, EntityImages={entityImageCount}, DtoImages={dtoImageCount}");
+
+            if (dtoImageCount == 0 && entityImageCount > 0)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[LitterReport] WARNING: Images lost during ToV2Dto()! Entity had {entityImageCount} images but DTO has 0");
+            }
+
             var content = JsonContent.Create(dto, typeof(LitterReportDto), null, SerializerOptions);
 
             using (var response = await AuthorizedHttpClient.PutAsync(Controller, content, cancellationToken))


### PR DESCRIPTION
## Summary
- Make images optional in litter report update — if no images sent, existing images are preserved
- This matches the create pattern where images are uploaded separately via dedicated endpoints
- Fixes "Mark as Cleaned" and edit flows that were failing with "0 images" because images weren't surviving the mobile→server round-trip

## Root cause
The update endpoint required images in the request body, but the mobile's serialization round-trip (server GET → Newtonsoft.Json deserialize → ToEntity → ToV2Dto → System.Text.Json serialize → server PUT) was losing images during deserialization. Instead of fighting the serialization mismatch, this makes images optional — matching how create already works (report metadata first, images uploaded separately).

## Changes
- **LitterReportManager.UpdateAsync**: Skip image add/remove logic when no images provided; only process image changes when images are explicitly sent
- **LitterReportsV2Controller.UpdateLitterReport**: Remove image count validation, restore standard model binding
- **Program.cs**: Remove EnableBuffering middleware (no longer needed)
- **Mobile LitterReportRestService**: Add diagnostic logging for image counts

## Test plan
- [x] All 739 tests pass
- [ ] Deploy server and test "Mark as Cleaned" on mobile
- [ ] Deploy server and test edit litter report on mobile
- [ ] Verify creating a new litter report still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)