### PR TITLE
Complete Phase 2b: consolidate all lookup endpoints into LookupsV2Controller

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -134,23 +134,23 @@ New v2 controllers alongside existing v1 controllers. V1 remains untouched. All 
 - [x] **Leaderboards v2** - `LeaderboardsV2Controller`: rankings by type (Events, Bags, Weight, Hours); user and team rankings
 - [x] **Achievements v2** - `AchievementsV2Controller`: user achievements and achievement definitions
 - [x] **Maps v2** - `MapsV2Controller`: event and litter report map data
-- [x] **Lookups v2** - `LookupsV2Controller`: event types, event statuses, partner types
+- [x] **Lookups v2** - `LookupsV2Controller`: event types, service types, partner service statuses
 - [x] **PickupLocations v2** - `PickupLocationsV2Controller`: cleanup location management
 - [x] **NewsletterPreferences v2** - `NewsletterPreferencesV2Controller`: category subscriptions
 - [x] **ContactRequest v2** - `ContactRequestV2Controller`: contact form submissions
 - [x] **AppVersion v2** - `AppVersionV2Controller`: mobile app version checking
 
-### Phase 2b - Remaining Lookup Endpoints
+### Phase 2b - Remaining Lookup Endpoints ✅ COMPLETE
 
-The `LookupsV2Controller` currently covers event types, event statuses, and partner types. These additional lookup tables used by v1 still need v2 coverage:
+All lookup types consolidated into `LookupsV2Controller`. The controller now covers all 10 lookup types with cached endpoints (24h ResponseCache):
 
-- [ ] **Weight units** - `WeightUnitsController` → add to `LookupsV2Controller` (needed for event summary metrics on mobile)
-- [ ] **Service types** - `ServiceTypesController` → add to `LookupsV2Controller` (partner service categorization)
-- [ ] **Invitation statuses** - `InvitationStatusesController` → add to `LookupsV2Controller` (partner admin)
-- [ ] **Partner request statuses** - `PartnerRequestStatusesController` → add to `LookupsV2Controller` (partner admin)
-- [ ] **Partner statuses** - `PartnerStatusesController` → add to `LookupsV2Controller` (partner admin)
-- [ ] **Social media account types** - `SocialMediaAccountTypesController` → add to `LookupsV2Controller` (partner profiles)
-- [ ] **Event partner location service statuses** - `EventPartnerLocationServiceStatusesController` → add to `LookupsV2Controller` (partner service workflow)
+- [x] **Event statuses** - `EventStatusesController` → added to `LookupsV2Controller`
+- [x] **Partner types** - `PartnerTypesController` → added to `LookupsV2Controller`
+- [x] **Partner statuses** - `PartnerStatusesController` → added to `LookupsV2Controller`
+- [x] **Partner request statuses** - `PartnerRequestStatusesController` → added to `LookupsV2Controller`
+- [x] **Weight units** - `WeightUnitsController` → added to `LookupsV2Controller`
+- [x] **Invitation statuses** - `InvitationStatusesController` → added to `LookupsV2Controller`
+- [x] **Social media account types** - `SocialMediaAccountTypesController` → added to `LookupsV2Controller`
 
 ### Phase 2c - User & Route Endpoints
 

--- a/TrashMob.Shared.Tests/Controllers/V2/LookupsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/LookupsV2ControllerTests.cs
@@ -14,8 +14,15 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     public class LookupsV2ControllerTests
     {
         private readonly Mock<ILookupManager<EventType>> eventTypeManager = new();
+        private readonly Mock<ILookupManager<EventStatus>> eventStatusManager = new();
         private readonly Mock<ILookupManager<ServiceType>> serviceTypeManager = new();
         private readonly Mock<ILookupManager<EventPartnerLocationServiceStatus>> partnerServiceStatusManager = new();
+        private readonly Mock<ILookupManager<PartnerType>> partnerTypeManager = new();
+        private readonly Mock<ILookupManager<PartnerStatus>> partnerStatusManager = new();
+        private readonly Mock<ILookupManager<PartnerRequestStatus>> partnerRequestStatusManager = new();
+        private readonly Mock<ILookupManager<WeightUnit>> weightUnitManager = new();
+        private readonly Mock<ILookupManager<InvitationStatus>> invitationStatusManager = new();
+        private readonly Mock<ILookupManager<SocialMediaAccountType>> socialMediaAccountTypeManager = new();
         private readonly Mock<ILogger<LookupsV2Controller>> logger = new();
         private readonly LookupsV2Controller controller;
 
@@ -23,8 +30,15 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         {
             controller = new LookupsV2Controller(
                 eventTypeManager.Object,
+                eventStatusManager.Object,
                 serviceTypeManager.Object,
                 partnerServiceStatusManager.Object,
+                partnerTypeManager.Object,
+                partnerStatusManager.Object,
+                partnerRequestStatusManager.Object,
+                weightUnitManager.Object,
+                invitationStatusManager.Object,
+                socialMediaAccountTypeManager.Object,
                 logger.Object);
         }
 
@@ -84,6 +98,146 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             Assert.Equal(2, dtos.Count);
             Assert.Equal("Requested", dtos[0].Name);
             Assert.Equal("Accepted", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetEventStatuses_ReturnsOkWithList()
+        {
+            var statuses = new List<EventStatus>
+            {
+                new() { Id = 1, Name = "Active", Description = "Event is active", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Cancelled", Description = "Event is cancelled", DisplayOrder = 2 },
+            };
+
+            eventStatusManager.Setup(m => m.GetAsync()).ReturnsAsync(statuses);
+
+            var result = await controller.GetEventStatuses();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Active", dtos[0].Name);
+            Assert.Equal("Cancelled", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetPartnerTypes_ReturnsOkWithList()
+        {
+            var types = new List<PartnerType>
+            {
+                new() { Id = 1, Name = "Government", Description = "Government entity", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Business", Description = "Business partner", DisplayOrder = 2 },
+            };
+
+            partnerTypeManager.Setup(m => m.GetAsync()).ReturnsAsync(types);
+
+            var result = await controller.GetPartnerTypes();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Government", dtos[0].Name);
+            Assert.Equal("Business", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetPartnerStatuses_ReturnsOkWithList()
+        {
+            var statuses = new List<PartnerStatus>
+            {
+                new() { Id = 1, Name = "Active", Description = "Active partner", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Inactive", Description = "Inactive partner", DisplayOrder = 2 },
+            };
+
+            partnerStatusManager.Setup(m => m.GetAsync()).ReturnsAsync(statuses);
+
+            var result = await controller.GetPartnerStatuses();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Active", dtos[0].Name);
+            Assert.Equal("Inactive", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetPartnerRequestStatuses_ReturnsOkWithList()
+        {
+            var statuses = new List<PartnerRequestStatus>
+            {
+                new() { Id = 1, Name = "Pending", Description = "Request pending", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Approved", Description = "Request approved", DisplayOrder = 2 },
+            };
+
+            partnerRequestStatusManager.Setup(m => m.GetAsync()).ReturnsAsync(statuses);
+
+            var result = await controller.GetPartnerRequestStatuses();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Pending", dtos[0].Name);
+            Assert.Equal("Approved", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetWeightUnits_ReturnsOkWithList()
+        {
+            var units = new List<WeightUnit>
+            {
+                new() { Id = 1, Name = "Pounds", Description = "Weight in pounds", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Kilograms", Description = "Weight in kilograms", DisplayOrder = 2 },
+            };
+
+            weightUnitManager.Setup(m => m.GetAsync()).ReturnsAsync(units);
+
+            var result = await controller.GetWeightUnits();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Pounds", dtos[0].Name);
+            Assert.Equal("Kilograms", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetInvitationStatuses_ReturnsOkWithList()
+        {
+            var statuses = new List<InvitationStatus>
+            {
+                new() { Id = 1, Name = "Pending", Description = "Invitation pending", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Accepted", Description = "Invitation accepted", DisplayOrder = 2 },
+            };
+
+            invitationStatusManager.Setup(m => m.GetAsync()).ReturnsAsync(statuses);
+
+            var result = await controller.GetInvitationStatuses();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Pending", dtos[0].Name);
+            Assert.Equal("Accepted", dtos[1].Name);
+        }
+
+        [Fact]
+        public async Task GetSocialMediaAccountTypes_ReturnsOkWithList()
+        {
+            var types = new List<SocialMediaAccountType>
+            {
+                new() { Id = 1, Name = "Facebook", Description = "Facebook account", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Instagram", Description = "Instagram account", DisplayOrder = 2 },
+            };
+
+            socialMediaAccountTypeManager.Setup(m => m.GetAsync()).ReturnsAsync(types);
+
+            var result = await controller.GetSocialMediaAccountTypes();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<LookupItemDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("Facebook", dtos[0].Name);
+            Assert.Equal("Instagram", dtos[1].Name);
         }
     }
 }

--- a/TrashMob/Controllers/V2/LookupsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LookupsV2Controller.cs
@@ -23,8 +23,15 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/lookups")]
     public class LookupsV2Controller(
         ILookupManager<EventType> eventTypeManager,
+        ILookupManager<EventStatus> eventStatusManager,
         ILookupManager<ServiceType> serviceTypeManager,
         ILookupManager<EventPartnerLocationServiceStatus> partnerServiceStatusManager,
+        ILookupManager<PartnerType> partnerTypeManager,
+        ILookupManager<PartnerStatus> partnerStatusManager,
+        ILookupManager<PartnerRequestStatus> partnerRequestStatusManager,
+        ILookupManager<WeightUnit> weightUnitManager,
+        ILookupManager<InvitationStatus> invitationStatusManager,
+        ILookupManager<SocialMediaAccountType> socialMediaAccountTypeManager,
         ILogger<LookupsV2Controller> logger) : ControllerBase
     {
         /// <summary>
@@ -41,6 +48,24 @@ namespace TrashMob.Controllers.V2
 
             var types = await eventTypeManager.GetAsync();
             var dtos = types.Select(t => t.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all event statuses.
+        /// </summary>
+        /// <returns>A list of event statuses.</returns>
+        /// <response code="200">Returns the event status list.</response>
+        [HttpGet("event-statuses")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEventStatuses(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetEventStatuses requested");
+
+            var statuses = await eventStatusManager.GetAsync();
+            var dtos = statuses.Select(s => s.ToV2Dto()).ToList();
 
             return Ok(dtos);
         }
@@ -77,6 +102,114 @@ namespace TrashMob.Controllers.V2
 
             var statuses = await partnerServiceStatusManager.GetAsync();
             var dtos = statuses.Select(s => s.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all partner types.
+        /// </summary>
+        /// <returns>A list of partner types.</returns>
+        /// <response code="200">Returns the partner type list.</response>
+        [HttpGet("partner-types")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetPartnerTypes(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetPartnerTypes requested");
+
+            var types = await partnerTypeManager.GetAsync();
+            var dtos = types.Select(t => t.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all partner statuses.
+        /// </summary>
+        /// <returns>A list of partner statuses.</returns>
+        /// <response code="200">Returns the partner status list.</response>
+        [HttpGet("partner-statuses")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetPartnerStatuses(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetPartnerStatuses requested");
+
+            var statuses = await partnerStatusManager.GetAsync();
+            var dtos = statuses.Select(s => s.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all partner request statuses.
+        /// </summary>
+        /// <returns>A list of partner request statuses.</returns>
+        /// <response code="200">Returns the partner request status list.</response>
+        [HttpGet("partner-request-statuses")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetPartnerRequestStatuses(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetPartnerRequestStatuses requested");
+
+            var statuses = await partnerRequestStatusManager.GetAsync();
+            var dtos = statuses.Select(s => s.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all weight units.
+        /// </summary>
+        /// <returns>A list of weight units.</returns>
+        /// <response code="200">Returns the weight unit list.</response>
+        [HttpGet("weight-units")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetWeightUnits(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetWeightUnits requested");
+
+            var units = await weightUnitManager.GetAsync();
+            var dtos = units.Select(u => u.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all invitation statuses.
+        /// </summary>
+        /// <returns>A list of invitation statuses.</returns>
+        /// <response code="200">Returns the invitation status list.</response>
+        [HttpGet("invitation-statuses")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetInvitationStatuses(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetInvitationStatuses requested");
+
+            var statuses = await invitationStatusManager.GetAsync();
+            var dtos = statuses.Select(s => s.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets all social media account types.
+        /// </summary>
+        /// <returns>A list of social media account types.</returns>
+        /// <response code="200">Returns the social media account type list.</response>
+        [HttpGet("social-media-account-types")]
+        [ResponseCache(Duration = 86400, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(IReadOnlyList<LookupItemDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetSocialMediaAccountTypes(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetSocialMediaAccountTypes requested");
+
+            var types = await socialMediaAccountTypeManager.GetAsync();
+            var dtos = types.Select(t => t.ToV2Dto()).ToList();
 
             return Ok(dtos);
         }


### PR DESCRIPTION
## Summary
- Add 7 new lookup endpoints to `LookupsV2Controller`: event-statuses, partner-types, partner-statuses, partner-request-statuses, weight-units, invitation-statuses, social-media-account-types
- All 10 lookup types now served from a single consolidated v2 controller with 24h response caching
- Add 7 new unit tests (10 total, up from 3)
- Update Project 24 plan: mark Phase 2b complete, fix Phase 2a description accuracy

## Test plan
- [x] All 10 `LookupsV2ControllerTests` pass
- [x] Solution builds with no errors or warnings
- [ ] Verify endpoints return correct data on dev after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)