### PR TITLE
Complete Phase 2c: v2 controllers for feedback, invites, and images

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -152,15 +152,13 @@ The `LookupsV2Controller` currently covers event types, event statuses, and part
 - [ ] **Social media account types** - `SocialMediaAccountTypesController` → add to `LookupsV2Controller` (partner profiles)
 - [ ] **Event partner location service statuses** - `EventPartnerLocationServiceStatusesController` → add to `LookupsV2Controller` (partner service workflow)
 
-### Phase 2c - User & Route Endpoints
+### Phase 2c - User & Route Endpoints ✅ COMPLETE
 
-Mobile-relevant user endpoints not yet covered by v2:
-
-- [ ] **User routes** - `UserRoutesController` (`/api/users/me/routes`): retrieve user's GPS route history — important for mobile route review
-- [ ] **Route metadata** - `RouteMetadataController` (`/api/routes`): update route privacy, notes, trim settings — mobile route editing
-- [ ] **User feedback** - `UserFeedbackController` (`/api/feedback`): anonymous feedback submission — both web and mobile
-- [ ] **User invites** - `UserInvitesController` (`/api/invites`): refer friends (rate-limited 50/month) — both web and mobile
-- [ ] **Image upload** - `ImageController` (`/api/image`): event lead photo upload — web-centric but could benefit mobile
+- [x] **User routes** - Already covered by `EventAttendeeRoutesV2Controller` (`GET by-user/{userId}`)
+- [x] **Route metadata** - Already covered by `EventAttendeeRoutesV2Controller` (`PUT {routeId}`, `PUT {routeId}/trim-time`, `PUT {routeId}/restore-time`)
+- [x] **User feedback** - `UserFeedbackV2Controller`: submit (anonymous allowed), admin CRUD with status management, DTO-only responses
+- [x] **User invites** - `EmailInvitesV2Controller`: batches, quota, rate-limited send (10/batch, 50/month), DTO-only responses
+- [x] **Image upload** - `ImageV2Controller`: event image upload/delete with event lead authorization
 
 ### Phase 2d - Partner Management (Web Admin)
 

--- a/TrashMob.Models/Extensions/V2/EmailInviteBatchMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EmailInviteBatchMappingsV2.cs
@@ -1,0 +1,31 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for EmailInviteBatch.
+    /// </summary>
+    public static class EmailInviteBatchMappingsV2
+    {
+        /// <summary>
+        /// Maps an EmailInviteBatch entity to an EmailInviteBatchDto.
+        /// </summary>
+        public static EmailInviteBatchDto ToV2Dto(this EmailInviteBatch entity)
+        {
+            return new EmailInviteBatchDto
+            {
+                Id = entity.Id,
+                SenderUserId = entity.SenderUserId,
+                BatchType = entity.BatchType,
+                TotalCount = entity.TotalCount,
+                SentCount = entity.SentCount,
+                DeliveredCount = entity.DeliveredCount,
+                BouncedCount = entity.BouncedCount,
+                FailedCount = entity.FailedCount,
+                Status = entity.Status,
+                CompletedDate = entity.CompletedDate,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/UserFeedbackMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/UserFeedbackMappingsV2.cs
@@ -1,0 +1,51 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for UserFeedback.
+    /// </summary>
+    public static class UserFeedbackMappingsV2
+    {
+        /// <summary>
+        /// Maps a UserFeedback entity to a UserFeedbackDto.
+        /// </summary>
+        public static UserFeedbackDto ToV2Dto(this UserFeedback entity)
+        {
+            return new UserFeedbackDto
+            {
+                Id = entity.Id,
+                UserId = entity.UserId,
+                Category = entity.Category,
+                Description = entity.Description,
+                Email = entity.Email,
+                ScreenshotUrl = entity.ScreenshotUrl,
+                PageUrl = entity.PageUrl,
+                UserAgent = entity.UserAgent,
+                Status = entity.Status,
+                InternalNotes = entity.InternalNotes,
+                ReviewedByUserId = entity.ReviewedByUserId,
+                ReviewedDate = entity.ReviewedDate,
+                GitHubIssueUrl = entity.GitHubIssueUrl,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a UserFeedbackWriteDto to a UserFeedback entity.
+        /// </summary>
+        public static UserFeedback ToEntity(this UserFeedbackWriteDto dto)
+        {
+            return new UserFeedback
+            {
+                Category = dto.Category,
+                Description = dto.Description,
+                Email = dto.Email,
+                ScreenshotUrl = dto.ScreenshotUrl,
+                PageUrl = dto.PageUrl,
+                UserAgent = dto.UserAgent,
+                Status = "New",
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/CreateEmailInviteBatchDto.cs
+++ b/TrashMob.Models/Poco/V2/CreateEmailInviteBatchDto.cs
@@ -1,0 +1,13 @@
+namespace TrashMob.Models.Poco.V2
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Write DTO for creating a new email invite batch.
+    /// </summary>
+    public class CreateEmailInviteBatchDto
+    {
+        /// <summary>Gets or sets the list of email addresses to invite.</summary>
+        public IEnumerable<string> Emails { get; set; } = [];
+    }
+}

--- a/TrashMob.Models/Poco/V2/EmailInviteBatchDto.cs
+++ b/TrashMob.Models/Poco/V2/EmailInviteBatchDto.cs
@@ -1,0 +1,41 @@
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// Read DTO for email invite batches.
+    /// </summary>
+    public class EmailInviteBatchDto
+    {
+        /// <summary>Gets or sets the batch ID.</summary>
+        public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the sender's user ID.</summary>
+        public Guid SenderUserId { get; set; }
+
+        /// <summary>Gets or sets the batch type (Admin, Community, Team, User).</summary>
+        public string BatchType { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the total invite count.</summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>Gets or sets the sent count.</summary>
+        public int SentCount { get; set; }
+
+        /// <summary>Gets or sets the delivered count.</summary>
+        public int DeliveredCount { get; set; }
+
+        /// <summary>Gets or sets the bounced count.</summary>
+        public int BouncedCount { get; set; }
+
+        /// <summary>Gets or sets the failed count.</summary>
+        public int FailedCount { get; set; }
+
+        /// <summary>Gets or sets the batch status.</summary>
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the completion date.</summary>
+        public DateTimeOffset? CompletedDate { get; set; }
+
+        /// <summary>Gets or sets the creation date.</summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/EmailInviteQuotaDto.cs
+++ b/TrashMob.Models/Poco/V2/EmailInviteQuotaDto.cs
@@ -1,0 +1,20 @@
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// DTO for user's email invite quota information.
+    /// </summary>
+    public class EmailInviteQuotaDto
+    {
+        /// <summary>Gets or sets the maximum emails per batch.</summary>
+        public int MaxPerBatch { get; set; }
+
+        /// <summary>Gets or sets the maximum invites per month.</summary>
+        public int MaxPerMonth { get; set; }
+
+        /// <summary>Gets or sets the number used this month.</summary>
+        public int UsedThisMonth { get; set; }
+
+        /// <summary>Gets or sets the remaining invites this month.</summary>
+        public int RemainingThisMonth { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UpdateFeedbackStatusDto.cs
+++ b/TrashMob.Models/Poco/V2/UpdateFeedbackStatusDto.cs
@@ -1,0 +1,14 @@
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// DTO for admin updating feedback status.
+    /// </summary>
+    public class UpdateFeedbackStatusDto
+    {
+        /// <summary>Gets or sets the new status (New, Reviewed, Resolved, Deferred).</summary>
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets internal admin notes.</summary>
+        public string? InternalNotes { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserFeedbackDto.cs
+++ b/TrashMob.Models/Poco/V2/UserFeedbackDto.cs
@@ -1,0 +1,50 @@
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// Read DTO for user feedback (admin view).
+    /// </summary>
+    public class UserFeedbackDto
+    {
+        /// <summary>Gets or sets the feedback ID.</summary>
+        public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the submitter's user ID (null if anonymous).</summary>
+        public Guid? UserId { get; set; }
+
+        /// <summary>Gets or sets the feedback category (Bug, FeatureRequest, General, Praise).</summary>
+        public string Category { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the feedback description.</summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the optional email for anonymous follow-up.</summary>
+        public string? Email { get; set; }
+
+        /// <summary>Gets or sets the screenshot URL.</summary>
+        public string? ScreenshotUrl { get; set; }
+
+        /// <summary>Gets or sets the page URL where feedback was submitted.</summary>
+        public string? PageUrl { get; set; }
+
+        /// <summary>Gets or sets the user agent string.</summary>
+        public string? UserAgent { get; set; }
+
+        /// <summary>Gets or sets the feedback status (New, Reviewed, Resolved, Deferred).</summary>
+        public string Status { get; set; } = "New";
+
+        /// <summary>Gets or sets internal admin notes.</summary>
+        public string? InternalNotes { get; set; }
+
+        /// <summary>Gets or sets the reviewer's user ID.</summary>
+        public Guid? ReviewedByUserId { get; set; }
+
+        /// <summary>Gets or sets the review date.</summary>
+        public DateTimeOffset? ReviewedDate { get; set; }
+
+        /// <summary>Gets or sets the linked GitHub issue URL.</summary>
+        public string? GitHubIssueUrl { get; set; }
+
+        /// <summary>Gets or sets the creation date.</summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/UserFeedbackWriteDto.cs
+++ b/TrashMob.Models/Poco/V2/UserFeedbackWriteDto.cs
@@ -1,0 +1,26 @@
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// Write DTO for submitting user feedback.
+    /// </summary>
+    public class UserFeedbackWriteDto
+    {
+        /// <summary>Gets or sets the feedback category (Bug, FeatureRequest, General, Praise).</summary>
+        public string Category { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the feedback description.</summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the optional email for anonymous follow-up.</summary>
+        public string? Email { get; set; }
+
+        /// <summary>Gets or sets the screenshot URL.</summary>
+        public string? ScreenshotUrl { get; set; }
+
+        /// <summary>Gets or sets the page URL where feedback was submitted.</summary>
+        public string? PageUrl { get; set; }
+
+        /// <summary>Gets or sets the user agent string.</summary>
+        public string? UserAgent { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EmailInvitesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EmailInvitesV2ControllerTests.cs
@@ -1,0 +1,205 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class EmailInvitesV2ControllerTests
+    {
+        private readonly Mock<IEmailInviteManager> emailInviteManager = new();
+        private readonly Mock<ILogger<EmailInvitesV2Controller>> logger = new();
+        private readonly EmailInvitesV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public EmailInvitesV2ControllerTests()
+        {
+            controller = new EmailInvitesV2Controller(emailInviteManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task GetBatches_ReturnsOkWithList()
+        {
+            var batches = new List<EmailInviteBatch>
+            {
+                new() { Id = Guid.NewGuid(), SenderUserId = testUserId, BatchType = "User", TotalCount = 5, Status = "Complete" },
+                new() { Id = Guid.NewGuid(), SenderUserId = testUserId, BatchType = "User", TotalCount = 3, Status = "Pending" },
+            };
+
+            emailInviteManager.Setup(m => m.GetUserBatchesAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(batches);
+
+            var result = await controller.GetBatches();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<EmailInviteBatchDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("User", dtos[0].BatchType);
+        }
+
+        [Fact]
+        public async Task GetBatch_OwnBatch_ReturnsOk()
+        {
+            var batchId = Guid.NewGuid();
+            emailInviteManager.Setup(m => m.GetBatchDetailsAsync(batchId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EmailInviteBatch
+                {
+                    Id = batchId,
+                    SenderUserId = testUserId,
+                    BatchType = "User",
+                    TotalCount = 5,
+                    Status = "Complete",
+                });
+
+            var result = await controller.GetBatch(batchId);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EmailInviteBatchDto>(okResult.Value);
+            Assert.Equal(batchId, dto.Id);
+        }
+
+        [Fact]
+        public async Task GetBatch_OtherUserBatch_ReturnsForbid()
+        {
+            var batchId = Guid.NewGuid();
+            emailInviteManager.Setup(m => m.GetBatchDetailsAsync(batchId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EmailInviteBatch
+                {
+                    Id = batchId,
+                    SenderUserId = Guid.NewGuid(), // Different user
+                    BatchType = "User",
+                });
+
+            var result = await controller.GetBatch(batchId);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task GetBatch_NotFound_Returns404()
+        {
+            emailInviteManager.Setup(m => m.GetBatchDetailsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EmailInviteBatch)null);
+
+            var result = await controller.GetBatch(Guid.NewGuid());
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetQuota_ReturnsOkWithQuota()
+        {
+            emailInviteManager.Setup(m => m.GetUserMonthlyInviteCountAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(15);
+
+            var result = await controller.GetQuota();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var quota = Assert.IsType<EmailInviteQuotaDto>(okResult.Value);
+            Assert.Equal(10, quota.MaxPerBatch);
+            Assert.Equal(50, quota.MaxPerMonth);
+            Assert.Equal(15, quota.UsedThisMonth);
+            Assert.Equal(35, quota.RemainingThisMonth);
+        }
+
+        [Fact]
+        public async Task CreateBatch_ValidInput_Returns201()
+        {
+            var batchId = Guid.NewGuid();
+            var dto = new CreateEmailInviteBatchDto
+            {
+                Emails = new[] { "a@b.com", "c@d.com" },
+            };
+
+            emailInviteManager.Setup(m => m.GetUserMonthlyInviteCountAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(10);
+
+            emailInviteManager.Setup(m => m.CreateBatchAsync(
+                    It.IsAny<IEnumerable<string>>(), testUserId, "User", null, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EmailInviteBatch { Id = batchId, SenderUserId = testUserId });
+
+            emailInviteManager.Setup(m => m.ProcessBatchAsync(batchId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EmailInviteBatch
+                {
+                    Id = batchId,
+                    SenderUserId = testUserId,
+                    BatchType = "User",
+                    TotalCount = 2,
+                    SentCount = 2,
+                    Status = "Complete",
+                });
+
+            var result = await controller.CreateBatch(dto);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(201, objectResult.StatusCode);
+            var resultDto = Assert.IsType<EmailInviteBatchDto>(objectResult.Value);
+            Assert.Equal(2, resultDto.TotalCount);
+        }
+
+        [Fact]
+        public async Task CreateBatch_EmptyEmails_ReturnsBadRequest()
+        {
+            var dto = new CreateEmailInviteBatchDto { Emails = Enumerable.Empty<string>() };
+
+            var result = await controller.CreateBatch(dto);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(400, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateBatch_QuotaExceeded_Returns429()
+        {
+            var dto = new CreateEmailInviteBatchDto
+            {
+                Emails = new[] { "a@b.com" },
+            };
+
+            emailInviteManager.Setup(m => m.GetUserMonthlyInviteCountAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(50); // At limit
+
+            var result = await controller.CreateBatch(dto);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(429, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateBatch_TooManyEmails_ReturnsBadRequest()
+        {
+            var dto = new CreateEmailInviteBatchDto
+            {
+                Emails = Enumerable.Range(1, 11).Select(i => $"user{i}@example.com"),
+            };
+
+            var result = await controller.CreateBatch(dto);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(400, objectResult.StatusCode);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ImageV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ImageV2ControllerTests.cs
@@ -1,0 +1,130 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class ImageV2ControllerTests
+    {
+        private readonly Mock<IImageManager> imageManager = new();
+        private readonly Mock<IEventManager> eventManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<ImageV2Controller>> logger = new();
+        private readonly ImageV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public ImageV2ControllerTests()
+        {
+            controller = new ImageV2Controller(
+                imageManager.Object,
+                eventManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task UploadImage_Authorized_ReturnsOk()
+        {
+            var eventId = Guid.NewGuid();
+            var mobEvent = new Event { Id = eventId, CreatedByUserId = testUserId };
+            var imageUpload = new ImageUpload { ParentId = eventId };
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), mobEvent, It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            var result = await controller.UploadImage(imageUpload);
+
+            Assert.IsType<OkResult>(result);
+            imageManager.Verify(m => m.UploadImageAsync(imageUpload), Times.Once);
+        }
+
+        [Fact]
+        public async Task UploadImage_NotAuthorized_ReturnsForbid()
+        {
+            var eventId = Guid.NewGuid();
+            var mobEvent = new Event { Id = eventId, CreatedByUserId = Guid.NewGuid() };
+            var imageUpload = new ImageUpload { ParentId = eventId };
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), mobEvent, It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.UploadImage(imageUpload);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteImage_Authorized_ReturnsNoContent()
+        {
+            var eventId = Guid.NewGuid();
+            var mobEvent = new Event { Id = eventId, CreatedByUserId = testUserId };
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), mobEvent, It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            imageManager.Setup(m => m.DeleteImageAsync(eventId, ImageTypeEnum.Before))
+                .ReturnsAsync(true);
+
+            var result = await controller.DeleteImage(eventId, ImageTypeEnum.Before);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteImage_DeleteFails_ReturnsBadRequest()
+        {
+            var eventId = Guid.NewGuid();
+            var mobEvent = new Event { Id = eventId, CreatedByUserId = testUserId };
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mobEvent);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), mobEvent, It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            imageManager.Setup(m => m.DeleteImageAsync(eventId, ImageTypeEnum.Before))
+                .ReturnsAsync(false);
+
+            var result = await controller.DeleteImage(eventId, ImageTypeEnum.Before);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(400, objectResult.StatusCode);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/UserFeedbackV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/UserFeedbackV2ControllerTests.cs
@@ -1,0 +1,214 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class UserFeedbackV2ControllerTests
+    {
+        private readonly Mock<IUserFeedbackManager> feedbackManager = new();
+        private readonly Mock<ILogger<UserFeedbackV2Controller>> logger = new();
+        private readonly UserFeedbackV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public UserFeedbackV2ControllerTests()
+        {
+            controller = new UserFeedbackV2Controller(feedbackManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task SubmitFeedback_ValidInput_Returns201()
+        {
+            var writeDto = new UserFeedbackWriteDto
+            {
+                Category = "Bug",
+                Description = "Something is broken",
+                Email = "test@example.com",
+            };
+
+            feedbackManager.Setup(m => m.AddAsync(It.IsAny<UserFeedback>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UserFeedback
+                {
+                    Id = Guid.NewGuid(),
+                    Category = "Bug",
+                    Description = "Something is broken",
+                    Email = "test@example.com",
+                    Status = "New",
+                });
+
+            var result = await controller.SubmitFeedback(writeDto);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(201, objectResult.StatusCode);
+            var dto = Assert.IsType<UserFeedbackDto>(objectResult.Value);
+            Assert.Equal("Bug", dto.Category);
+            Assert.Equal("Something is broken", dto.Description);
+        }
+
+        [Fact]
+        public async Task SubmitFeedback_MissingCategory_ReturnsBadRequest()
+        {
+            var writeDto = new UserFeedbackWriteDto
+            {
+                Category = "",
+                Description = "Something is broken",
+            };
+
+            var result = await controller.SubmitFeedback(writeDto);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(400, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task SubmitFeedback_InvalidCategory_ReturnsBadRequest()
+        {
+            var writeDto = new UserFeedbackWriteDto
+            {
+                Category = "InvalidCat",
+                Description = "Something is broken",
+            };
+
+            var result = await controller.SubmitFeedback(writeDto);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(400, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetFeedback_Found_ReturnsOk()
+        {
+            var feedbackId = Guid.NewGuid();
+            feedbackManager.Setup(m => m.GetAsync(feedbackId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UserFeedback
+                {
+                    Id = feedbackId,
+                    Category = "General",
+                    Description = "Nice app",
+                    Status = "New",
+                });
+
+            var result = await controller.GetFeedback(feedbackId);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserFeedbackDto>(okResult.Value);
+            Assert.Equal(feedbackId, dto.Id);
+        }
+
+        [Fact]
+        public async Task GetFeedback_NotFound_Returns404()
+        {
+            feedbackManager.Setup(m => m.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((UserFeedback)null);
+
+            var result = await controller.GetFeedback(Guid.NewGuid());
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetAllFeedback_ReturnsOkWithList()
+        {
+            var items = new List<UserFeedback>
+            {
+                new() { Id = Guid.NewGuid(), Category = "Bug", Description = "Bug 1", Status = "New" },
+                new() { Id = Guid.NewGuid(), Category = "General", Description = "General 1", Status = "Reviewed" },
+            };
+
+            feedbackManager.Setup(m => m.GetByStatusAsync(null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(items);
+
+            var result = await controller.GetAllFeedback();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<UserFeedbackDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+        }
+
+        [Fact]
+        public async Task UpdateFeedback_ValidInput_ReturnsOk()
+        {
+            var feedbackId = Guid.NewGuid();
+            var updateDto = new UpdateFeedbackStatusDto
+            {
+                Status = "Reviewed",
+                InternalNotes = "Looks good",
+            };
+
+            feedbackManager.Setup(m => m.UpdateStatusAsync(feedbackId, "Reviewed", "Looks good", testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UserFeedback
+                {
+                    Id = feedbackId,
+                    Category = "Bug",
+                    Description = "Bug report",
+                    Status = "Reviewed",
+                    InternalNotes = "Looks good",
+                });
+
+            var result = await controller.UpdateFeedback(feedbackId, updateDto);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserFeedbackDto>(okResult.Value);
+            Assert.Equal("Reviewed", dto.Status);
+        }
+
+        [Fact]
+        public async Task UpdateFeedback_NotFound_Returns404()
+        {
+            var updateDto = new UpdateFeedbackStatusDto { Status = "Reviewed" };
+            feedbackManager.Setup(m => m.UpdateStatusAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((UserFeedback)null);
+
+            var result = await controller.UpdateFeedback(Guid.NewGuid(), updateDto);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteFeedback_Found_ReturnsNoContent()
+        {
+            var feedbackId = Guid.NewGuid();
+            feedbackManager.Setup(m => m.GetAsync(feedbackId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UserFeedback { Id = feedbackId });
+
+            var result = await controller.DeleteFeedback(feedbackId);
+
+            Assert.IsType<NoContentResult>(result);
+            feedbackManager.Verify(m => m.DeleteAsync(feedbackId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteFeedback_NotFound_Returns404()
+        {
+            feedbackManager.Setup(m => m.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((UserFeedback)null);
+
+            var result = await controller.DeleteFeedback(Guid.NewGuid());
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EmailInvitesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EmailInvitesV2Controller.cs
@@ -1,0 +1,169 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for user-initiated email invitations with rate limiting.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/invites")]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+    public class EmailInvitesV2Controller(
+        IEmailInviteManager emailInviteManager,
+        ILogger<EmailInvitesV2Controller> logger) : ControllerBase
+    {
+        private const int MaxEmailsPerBatch = 10;
+        private const int MaxInvitesPerMonth = 50;
+
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets the current user's invite batches.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of batches sent by the user.</returns>
+        /// <response code="200">Returns the batch list.</response>
+        [HttpGet("batches")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(System.Collections.Generic.IReadOnlyList<EmailInviteBatchDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetBatches(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetBatches for user {UserId}", UserId);
+
+            var batches = await emailInviteManager.GetUserBatchesAsync(UserId, cancellationToken);
+            var dtos = batches.Select(b => b.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a batch with its details. Users can only view their own batches.
+        /// </summary>
+        /// <param name="id">Batch ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The batch or 404.</returns>
+        /// <response code="200">Returns the batch.</response>
+        /// <response code="403">User does not own this batch.</response>
+        /// <response code="404">Batch not found.</response>
+        [HttpGet("batches/{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(EmailInviteBatchDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetBatch(Guid id, CancellationToken cancellationToken = default)
+        {
+            var batch = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
+
+            if (batch is null)
+            {
+                return NotFound();
+            }
+
+            if (batch.SenderUserId != UserId)
+            {
+                return Forbid();
+            }
+
+            return Ok(batch.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the user's remaining invite quota for the month.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Quota information.</returns>
+        /// <response code="200">Returns quota info.</response>
+        [HttpGet("quota")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(EmailInviteQuotaDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetQuota(CancellationToken cancellationToken = default)
+        {
+            var monthlyCount = await emailInviteManager.GetUserMonthlyInviteCountAsync(UserId, cancellationToken);
+            var remaining = MaxInvitesPerMonth - monthlyCount;
+
+            var quota = new EmailInviteQuotaDto
+            {
+                MaxPerBatch = MaxEmailsPerBatch,
+                MaxPerMonth = MaxInvitesPerMonth,
+                UsedThisMonth = monthlyCount,
+                RemainingThisMonth = remaining > 0 ? remaining : 0,
+            };
+
+            return Ok(quota);
+        }
+
+        /// <summary>
+        /// Creates and sends a new batch of email invites.
+        /// Limited to 10 emails per batch and 50 per month.
+        /// </summary>
+        /// <param name="dto">The batch creation request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created batch.</returns>
+        /// <response code="201">Batch created and sent.</response>
+        /// <response code="400">Invalid request data.</response>
+        /// <response code="429">Rate limit exceeded.</response>
+        [HttpPost("batch")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EmailInviteBatchDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        public async Task<IActionResult> CreateBatch([FromBody] CreateEmailInviteBatchDto dto, CancellationToken cancellationToken = default)
+        {
+            if (dto is null || dto.Emails is null || !dto.Emails.Any())
+            {
+                return Problem("Email list is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var emailCount = dto.Emails.Count();
+
+            if (emailCount > MaxEmailsPerBatch)
+            {
+                return Problem($"Maximum {MaxEmailsPerBatch} emails per batch allowed.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var monthlyCount = await emailInviteManager.GetUserMonthlyInviteCountAsync(UserId, cancellationToken);
+            var remaining = MaxInvitesPerMonth - monthlyCount;
+
+            if (remaining <= 0)
+            {
+                return Problem("Monthly invite limit reached. Please try again next month.", statusCode: StatusCodes.Status429TooManyRequests);
+            }
+
+            if (emailCount > remaining)
+            {
+                return Problem($"You can only send {remaining} more invite(s) this month.", statusCode: StatusCodes.Status429TooManyRequests);
+            }
+
+            logger.LogInformation("V2 CreateBatch: {Count} emails for user {UserId}", emailCount, UserId);
+
+            var batch = await emailInviteManager.CreateBatchAsync(
+                dto.Emails,
+                UserId,
+                "User",
+                null,
+                null,
+                cancellationToken);
+
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken);
+
+            return StatusCode(StatusCodes.Status201Created, result.ToV2Dto());
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ImageV2Controller.cs
+++ b/TrashMob/Controllers/V2/ImageV2Controller.cs
@@ -1,0 +1,110 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for event image upload and deletion.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/image")]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+    public class ImageV2Controller(
+        IImageManager imageManager,
+        IEventManager eventManager,
+        IAuthorizationService authorizationService,
+        ILogger<ImageV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Uploads an image for an event. Requires event lead authorization.
+        /// </summary>
+        /// <param name="imageUpload">The image upload data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>OK on success.</returns>
+        /// <response code="200">Image uploaded successfully.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> UploadImage([FromForm] ImageUpload imageUpload, CancellationToken cancellationToken = default)
+        {
+            var mobEvent = await eventManager.GetAsync(imageUpload.ParentId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            logger.LogInformation("V2 UploadImage for event {EventId}", imageUpload.ParentId);
+
+            await imageManager.UploadImageAsync(imageUpload);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Deletes an image for an event. Requires event lead authorization.
+        /// </summary>
+        /// <param name="parentId">The parent entity ID.</param>
+        /// <param name="imageType">The image type.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Image deleted successfully.</response>
+        /// <response code="400">Image could not be deleted.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpDelete]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DeleteImage(Guid parentId, ImageTypeEnum imageType, CancellationToken cancellationToken = default)
+        {
+            var mobEvent = await eventManager.GetAsync(parentId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                return Forbid();
+            }
+
+            logger.LogInformation("V2 DeleteImage for event {EventId}", parentId);
+
+            var deleted = await imageManager.DeleteImageAsync(parentId, imageType);
+
+            if (deleted)
+            {
+                return NoContent();
+            }
+
+            return Problem("The image could not be deleted.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policyName)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var result = await authorizationService.AuthorizeAsync(User, resource, policyName);
+            return result.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/UserFeedbackV2Controller.cs
+++ b/TrashMob/Controllers/V2/UserFeedbackV2Controller.cs
@@ -1,0 +1,208 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for user feedback submissions and admin management.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/feedback")]
+    public class UserFeedbackV2Controller(
+        IUserFeedbackManager feedbackManager,
+        ILogger<UserFeedbackV2Controller> logger) : ControllerBase
+    {
+        private static readonly string[] ValidCategories = ["Bug", "FeatureRequest", "General", "Praise"];
+        private static readonly string[] ValidStatuses = ["New", "Reviewed", "Resolved", "Deferred"];
+
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Submits new user feedback. Can be called by authenticated or anonymous users.
+        /// </summary>
+        /// <param name="dto">The feedback to submit.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created feedback.</returns>
+        /// <response code="201">Feedback created successfully.</response>
+        /// <response code="400">Invalid request data.</response>
+        [HttpPost]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(UserFeedbackDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> SubmitFeedback([FromBody] UserFeedbackWriteDto dto, CancellationToken cancellationToken = default)
+        {
+            if (dto is null)
+            {
+                return Problem("Feedback cannot be null.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (string.IsNullOrWhiteSpace(dto.Category))
+            {
+                return Problem("Category is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (string.IsNullOrWhiteSpace(dto.Description))
+            {
+                return Problem("Description is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (!Array.Exists(ValidCategories, c => c.Equals(dto.Category, StringComparison.OrdinalIgnoreCase)))
+            {
+                return Problem("Invalid category. Must be one of: Bug, FeatureRequest, General, Praise", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var feedback = dto.ToEntity();
+
+            // Try to get UserId if authenticated
+            try
+            {
+                if (HttpContext.Items.ContainsKey("UserId") && HttpContext.Items["UserId"] is not null)
+                {
+                    feedback.UserId = new Guid(HttpContext.Items["UserId"].ToString()!);
+                }
+            }
+            catch
+            {
+                // Anonymous user - UserId remains null
+            }
+
+            logger.LogInformation("V2 SubmitFeedback: category={Category}", dto.Category);
+
+            var result = await feedbackManager.AddAsync(feedback, cancellationToken);
+
+            return StatusCode(StatusCodes.Status201Created, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets a specific feedback item by ID. Admin only.
+        /// </summary>
+        /// <param name="id">The feedback ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The feedback item.</returns>
+        /// <response code="200">Returns the feedback item.</response>
+        /// <response code="404">Feedback not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(UserFeedbackDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetFeedback(Guid id, CancellationToken cancellationToken = default)
+        {
+            var feedback = await feedbackManager.GetAsync(id, cancellationToken);
+
+            if (feedback is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(feedback.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets all feedback, optionally filtered by status. Admin only.
+        /// </summary>
+        /// <param name="status">Optional status filter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of feedback items.</returns>
+        /// <response code="200">Returns the feedback list.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<UserFeedbackDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAllFeedback([FromQuery] string status = null, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetAllFeedback: status={Status}", status);
+
+            var feedback = await feedbackManager.GetByStatusAsync(status, cancellationToken);
+            var dtos = feedback.Select(f => f.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Updates the status of a feedback item. Admin only.
+        /// </summary>
+        /// <param name="id">The feedback ID.</param>
+        /// <param name="dto">The update request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated feedback item.</returns>
+        /// <response code="200">Feedback updated successfully.</response>
+        /// <response code="400">Invalid request data.</response>
+        /// <response code="404">Feedback not found.</response>
+        [HttpPut("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(UserFeedbackDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateFeedback(Guid id, [FromBody] UpdateFeedbackStatusDto dto, CancellationToken cancellationToken = default)
+        {
+            if (dto is null)
+            {
+                return Problem("Request body is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (!string.IsNullOrWhiteSpace(dto.Status) && !Array.Exists(ValidStatuses, s => s.Equals(dto.Status, StringComparison.OrdinalIgnoreCase)))
+            {
+                return Problem("Invalid status. Must be one of: New, Reviewed, Resolved, Deferred", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            logger.LogInformation("V2 UpdateFeedback: id={Id}, status={Status}", id, dto.Status);
+
+            var feedback = await feedbackManager.UpdateStatusAsync(id, dto.Status, dto.InternalNotes, UserId, cancellationToken);
+
+            if (feedback is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(feedback.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a feedback item. Admin only.
+        /// </summary>
+        /// <param name="id">The feedback ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Feedback deleted successfully.</response>
+        /// <response code="404">Feedback not found.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteFeedback(Guid id, CancellationToken cancellationToken = default)
+        {
+            var existing = await feedbackManager.GetAsync(id, cancellationToken);
+            if (existing is null)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 DeleteFeedback: id={Id}", id);
+
+            await feedbackManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `UserFeedbackV2Controller`: anonymous feedback submission, admin CRUD with status management (New/Reviewed/Resolved/Deferred)
- Add `EmailInvitesV2Controller`: batch listing, quota endpoint, rate-limited invite sending (10/batch, 50/month)
- Add `ImageV2Controller`: event image upload/delete with event lead authorization
- User routes and route metadata already covered by `EventAttendeeRoutesV2Controller` — marked complete in plan
- 6 new DTOs + 2 mapping extension classes
- 23 new unit tests across 3 test classes

## Test plan
- [x] All 23 new controller tests pass
- [x] Solution builds with no errors or warnings
- [ ] Verify feedback submission works on dev after merge
- [ ] Verify invite quota/batch endpoints on dev after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)