### PR TITLE
Complete Phase 2d: migrate all partner management endpoints to v2

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -160,21 +160,20 @@ All lookup types consolidated into `LookupsV2Controller`. The controller now cov
 - [x] **User invites** - `EmailInvitesV2Controller`: batches, quota, rate-limited send (10/batch, 50/month), DTO-only responses
 - [x] **Image upload** - `ImageV2Controller`: event image upload/delete with event lead authorization
 
-### Phase 2d - Partner Management (Web Admin)
+### Phase 2d - Partner Management (Web Admin) ✅ COMPLETE
 
-Partner organization management — 11 v1 controllers, all web-only admin/portal features. Lower priority since these are not mobile-facing.
+All partner management endpoints migrated to v2 with DTO-only responses. 9 new controllers, 9 DTOs, consolidated mapping file.
 
-- [ ] **Partner locations** - `PartnerLocationsController`: CRUD partner office/service locations
-- [ ] **Partner location contacts** - `PartnerLocationContactsController`: contacts at specific locations
-- [ ] **Partner location services** - `PartnerLocationServicesController`: services offered at partner locations
-- [ ] **Partner location event services** - `PartnerLocationEventServicesController`: services provided at events
-- [ ] **Partner contacts** - `PartnerContactsController`: organizational contacts
-- [ ] **Partner admins** - `PartnerAdminsController`: assign/view partner admin users
-- [ ] **Partner admin invitations** - `PartnerAdminInvitationsController`: invite partner admins
-- [ ] **Partner requests** - `PartnerRequestsController`: public partner suggestion + admin approval
-- [ ] **Partner documents** - `PartnerDocumentsController`: file upload/download (25MB max)
-- [ ] **Partner document admin** - `PartnerDocumentAdminController`: site admin cross-partner doc view
-- [ ] **Partner social media** - `PartnerSocialMediaAccountsController`: partner social media accounts
+- [x] **Partner locations** - `PartnerLocationsV2Controller`: CRUD + nearby search with PartnerLocationDto
+- [x] **Partner location contacts** - `PartnerLocationContactsV2Controller`: CRUD with PartnerLocationContactDto
+- [x] **Partner location services** - `PartnerLocationServicesV2Controller`: CRUD (composite key) with PartnerLocationServiceDto
+- [x] **Partner location event services** - Already covered by `EventPartnerLocationServicesV2Controller` (Phase 2a)
+- [x] **Partner contacts** - `PartnerContactsV2Controller`: CRUD with PartnerContactDto
+- [x] **Partner admins** - `PartnerAdminsV2Controller`: admin listing, my partners, add admin with PartnerAdminDto
+- [x] **Partner admin invitations** - `PartnerAdminInvitationsV2Controller`: invite/accept/decline/resend with PartnerAdminInvitationDto
+- [x] **Partner requests** - `PartnerRequestsV2Controller`: submit/approve/deny with PartnerRequestDto
+- [x] **Partner documents** - `PartnerDocumentsV2Controller`: CRUD + upload/download + admin view with PartnerDocumentDto (combines PartnerDocumentAdminController)
+- [x] **Partner social media** - `PartnerSocialMediaAccountsV2Controller`: CRUD with PartnerSocialMediaAccountDto
 
 ### Phase 2e - Community & Adoption Management (Web Admin)
 

--- a/TrashMob.Models/Extensions/V2/PartnerManagementMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/PartnerManagementMappingsV2.cs
@@ -1,0 +1,216 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    public static class PartnerManagementMappingsV2
+    {
+        public static PartnerLocationDto ToV2Dto(this PartnerLocation entity) => new()
+        {
+            Id = entity.Id,
+            PartnerId = entity.PartnerId,
+            Name = entity.Name,
+            StreetAddress = entity.StreetAddress,
+            City = entity.City,
+            Region = entity.Region,
+            Country = entity.Country,
+            PostalCode = entity.PostalCode,
+            Latitude = entity.Latitude,
+            Longitude = entity.Longitude,
+            PublicNotes = entity.PublicNotes,
+            PrivateNotes = entity.PrivateNotes,
+            IsActive = entity.IsActive,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerLocation ToEntity(this PartnerLocationDto dto) => new()
+        {
+            Id = dto.Id,
+            PartnerId = dto.PartnerId,
+            Name = dto.Name,
+            StreetAddress = dto.StreetAddress,
+            City = dto.City,
+            Region = dto.Region,
+            Country = dto.Country,
+            PostalCode = dto.PostalCode,
+            Latitude = dto.Latitude,
+            Longitude = dto.Longitude,
+            PublicNotes = dto.PublicNotes,
+            PrivateNotes = dto.PrivateNotes,
+            IsActive = dto.IsActive,
+        };
+
+        public static PartnerContactDto ToV2Dto(this PartnerContact entity) => new()
+        {
+            Id = entity.Id,
+            PartnerId = entity.PartnerId,
+            Name = entity.Name,
+            Email = entity.Email,
+            Phone = entity.Phone,
+            Notes = entity.Notes,
+            IsActive = entity.IsActive,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerContact ToEntity(this PartnerContactDto dto) => new()
+        {
+            Id = dto.Id,
+            PartnerId = dto.PartnerId,
+            Name = dto.Name,
+            Email = dto.Email,
+            Phone = dto.Phone,
+            Notes = dto.Notes,
+            IsActive = dto.IsActive,
+        };
+
+        public static PartnerLocationContactDto ToV2Dto(this PartnerLocationContact entity) => new()
+        {
+            Id = entity.Id,
+            PartnerLocationId = entity.PartnerLocationId,
+            Name = entity.Name,
+            Email = entity.Email,
+            Phone = entity.Phone,
+            Notes = entity.Notes,
+            IsActive = entity.IsActive,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerLocationContact ToEntity(this PartnerLocationContactDto dto) => new()
+        {
+            Id = dto.Id,
+            PartnerLocationId = dto.PartnerLocationId,
+            Name = dto.Name,
+            Email = dto.Email,
+            Phone = dto.Phone,
+            Notes = dto.Notes,
+            IsActive = dto.IsActive,
+        };
+
+        public static PartnerLocationServiceDto ToV2Dto(this PartnerLocationService entity) => new()
+        {
+            PartnerLocationId = entity.PartnerLocationId,
+            ServiceTypeId = entity.ServiceTypeId,
+            IsAutoApproved = entity.IsAutoApproved,
+            IsAdvanceNoticeRequired = entity.IsAdvanceNoticeRequired,
+            Notes = entity.Notes,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerLocationService ToEntity(this PartnerLocationServiceDto dto) => new()
+        {
+            PartnerLocationId = dto.PartnerLocationId,
+            ServiceTypeId = dto.ServiceTypeId,
+            IsAutoApproved = dto.IsAutoApproved,
+            IsAdvanceNoticeRequired = dto.IsAdvanceNoticeRequired,
+            Notes = dto.Notes,
+        };
+
+        public static PartnerAdminDto ToV2Dto(this PartnerAdmin entity) => new()
+        {
+            PartnerId = entity.PartnerId,
+            UserId = entity.UserId,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerAdminInvitationDto ToV2Dto(this PartnerAdminInvitation entity) => new()
+        {
+            Id = entity.Id,
+            PartnerId = entity.PartnerId,
+            Email = entity.Email,
+            InvitationStatusId = entity.InvitationStatusId,
+            DateInvited = entity.DateInvited,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerAdminInvitation ToEntity(this PartnerAdminInvitationDto dto) => new()
+        {
+            Id = dto.Id,
+            PartnerId = dto.PartnerId,
+            Email = dto.Email,
+            InvitationStatusId = dto.InvitationStatusId,
+            DateInvited = dto.DateInvited,
+        };
+
+        public static PartnerRequestDto ToV2Dto(this PartnerRequest entity) => new()
+        {
+            Id = entity.Id,
+            Name = entity.Name,
+            Email = entity.Email,
+            Website = entity.Website,
+            Phone = entity.Phone,
+            City = entity.City,
+            Region = entity.Region,
+            Country = entity.Country,
+            PostalCode = entity.PostalCode,
+            Latitude = entity.Latitude,
+            Longitude = entity.Longitude,
+            Notes = entity.Notes,
+            PartnerRequestStatusId = entity.PartnerRequestStatusId,
+            PartnerTypeId = entity.PartnerTypeId,
+            IsBecomeAPartnerRequest = entity.isBecomeAPartnerRequest,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerRequest ToEntity(this PartnerRequestDto dto) => new()
+        {
+            Id = dto.Id,
+            Name = dto.Name,
+            Email = dto.Email,
+            Website = dto.Website,
+            Phone = dto.Phone,
+            City = dto.City,
+            Region = dto.Region,
+            Country = dto.Country,
+            PostalCode = dto.PostalCode,
+            Latitude = dto.Latitude,
+            Longitude = dto.Longitude,
+            Notes = dto.Notes,
+            PartnerRequestStatusId = dto.PartnerRequestStatusId,
+            PartnerTypeId = dto.PartnerTypeId,
+            isBecomeAPartnerRequest = dto.IsBecomeAPartnerRequest,
+        };
+
+        public static PartnerDocumentDto ToV2Dto(this PartnerDocument entity) => new()
+        {
+            Id = entity.Id,
+            PartnerId = entity.PartnerId,
+            Name = entity.Name,
+            Url = entity.Url,
+            ContentType = entity.ContentType,
+            FileSizeBytes = entity.FileSizeBytes,
+            DocumentTypeId = entity.DocumentTypeId,
+            ExpirationDate = entity.ExpirationDate,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerDocument ToEntity(this PartnerDocumentDto dto) => new()
+        {
+            Id = dto.Id,
+            PartnerId = dto.PartnerId,
+            Name = dto.Name,
+            Url = dto.Url,
+            ContentType = dto.ContentType,
+            FileSizeBytes = dto.FileSizeBytes,
+            DocumentTypeId = dto.DocumentTypeId,
+            ExpirationDate = dto.ExpirationDate,
+        };
+
+        public static PartnerSocialMediaAccountDto ToV2Dto(this PartnerSocialMediaAccount entity) => new()
+        {
+            Id = entity.Id,
+            PartnerId = entity.PartnerId,
+            AccountIdentifier = entity.AccountIdentifier,
+            IsActive = entity.IsActive,
+            SocialMediaAccountTypeId = entity.SocialMediaAccountTypeId,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        public static PartnerSocialMediaAccount ToEntity(this PartnerSocialMediaAccountDto dto) => new()
+        {
+            Id = dto.Id,
+            PartnerId = dto.PartnerId,
+            AccountIdentifier = dto.AccountIdentifier,
+            IsActive = dto.IsActive,
+            SocialMediaAccountTypeId = dto.SocialMediaAccountTypeId,
+        };
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerAdminDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerAdminDto.cs
@@ -1,0 +1,9 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerAdminDto
+    {
+        public Guid PartnerId { get; set; }
+        public Guid UserId { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerAdminInvitationDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerAdminInvitationDto.cs
@@ -1,0 +1,12 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerAdminInvitationDto
+    {
+        public Guid Id { get; set; }
+        public Guid PartnerId { get; set; }
+        public string Email { get; set; } = string.Empty;
+        public int InvitationStatusId { get; set; }
+        public DateTimeOffset DateInvited { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerContactDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerContactDto.cs
@@ -1,0 +1,14 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerContactDto
+    {
+        public Guid Id { get; set; }
+        public Guid PartnerId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? Notes { get; set; }
+        public bool? IsActive { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerDocumentDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerDocumentDto.cs
@@ -1,0 +1,15 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerDocumentDto
+    {
+        public Guid Id { get; set; }
+        public Guid PartnerId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Url { get; set; }
+        public string? ContentType { get; set; }
+        public long? FileSizeBytes { get; set; }
+        public int DocumentTypeId { get; set; }
+        public DateTimeOffset? ExpirationDate { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerLocationContactDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerLocationContactDto.cs
@@ -1,0 +1,14 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerLocationContactDto
+    {
+        public Guid Id { get; set; }
+        public Guid PartnerLocationId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? Notes { get; set; }
+        public bool? IsActive { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerLocationDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerLocationDto.cs
@@ -1,0 +1,20 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerLocationDto
+    {
+        public Guid Id { get; set; }
+        public Guid PartnerId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? StreetAddress { get; set; }
+        public string? City { get; set; }
+        public string? Region { get; set; }
+        public string? Country { get; set; }
+        public string? PostalCode { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public string? PublicNotes { get; set; }
+        public string? PrivateNotes { get; set; }
+        public bool IsActive { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerLocationServiceDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerLocationServiceDto.cs
@@ -1,0 +1,12 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerLocationServiceDto
+    {
+        public Guid PartnerLocationId { get; set; }
+        public int ServiceTypeId { get; set; }
+        public bool IsAutoApproved { get; set; }
+        public bool IsAdvanceNoticeRequired { get; set; }
+        public string? Notes { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerRequestDto.cs
@@ -1,0 +1,22 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerRequestDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public string? Website { get; set; }
+        public string? Phone { get; set; }
+        public string? City { get; set; }
+        public string? Region { get; set; }
+        public string? Country { get; set; }
+        public string? PostalCode { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public string? Notes { get; set; }
+        public int PartnerRequestStatusId { get; set; }
+        public int PartnerTypeId { get; set; }
+        public bool IsBecomeAPartnerRequest { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PartnerSocialMediaAccountDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerSocialMediaAccountDto.cs
@@ -1,0 +1,12 @@
+namespace TrashMob.Models.Poco.V2
+{
+    public class PartnerSocialMediaAccountDto
+    {
+        public Guid Id { get; set; }
+        public Guid PartnerId { get; set; }
+        public string AccountIdentifier { get; set; } = string.Empty;
+        public bool? IsActive { get; set; }
+        public int SocialMediaAccountTypeId { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerAdminInvitationsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerAdminInvitationsV2ControllerTests.cs
@@ -1,0 +1,227 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerAdminInvitationsV2ControllerTests
+    {
+        private readonly Mock<IKeyedManager<User>> userManager = new();
+        private readonly Mock<IPartnerAdminInvitationManager> partnerAdminInvitationManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerAdminInvitationsV2Controller>> logger = new();
+        private readonly PartnerAdminInvitationsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerAdminInvitationsV2ControllerTests()
+        {
+            controller = new PartnerAdminInvitationsV2Controller(
+                userManager.Object,
+                partnerAdminInvitationManager.Object,
+                partnerManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetByPartner_Authorized_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var invitations = new List<PartnerAdminInvitation>
+            {
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Email = "user1@test.com", InvitationStatusId = 1 },
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Email = "user2@test.com", InvitationStatusId = 1 },
+            };
+
+            partnerManager.Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            SetupAuthSuccess();
+            partnerAdminInvitationManager.Setup(m => m.GetByParentIdAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(invitations);
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerAdminInvitationDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetByPartner_Unauthorized_ReturnsForbid()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+
+            partnerManager.Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_Authorized_ReturnsCreated()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var dto = new PartnerAdminInvitationDto
+            {
+                PartnerId = partnerId,
+                Email = "newadmin@test.com",
+                InvitationStatusId = 1,
+            };
+            var user = new User { Id = Guid.NewGuid(), Email = "newadmin@test.com" };
+            var created = new PartnerAdminInvitation
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Email = "newadmin@test.com",
+                InvitationStatusId = 1,
+            };
+
+            partnerManager.Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            SetupAuthSuccess();
+            userManager.Setup(m => m.GetAsync(It.IsAny<System.Linq.Expressions.Expression<Func<User, bool>>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IEnumerable<User>)new List<User> { user });
+            partnerAdminInvitationManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerAdminInvitation>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<PartnerAdminInvitationDto>(createdResult.Value);
+            Assert.Equal("newadmin@test.com", resultDto.Email);
+        }
+
+        [Fact]
+        public async Task Accept_ReturnsOk()
+        {
+            var invitationId = Guid.NewGuid();
+
+            partnerAdminInvitationManager
+                .Setup(m => m.AcceptInvitationAsync(invitationId, testUserId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.Accept(invitationId, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+            partnerAdminInvitationManager.Verify(
+                m => m.AcceptInvitationAsync(invitationId, testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Decline_ReturnsOk()
+        {
+            var invitationId = Guid.NewGuid();
+
+            partnerAdminInvitationManager
+                .Setup(m => m.DeclineInvitationAsync(invitationId, testUserId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.Decline(invitationId, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+            partnerAdminInvitationManager.Verify(
+                m => m.DeclineInvitationAsync(invitationId, testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete_Authorized_ReturnsNoContent()
+        {
+            var invitationId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+
+            partnerAdminInvitationManager
+                .Setup(m => m.GetPartnerForInvitation(invitationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            SetupAuthSuccess();
+            partnerAdminInvitationManager
+                .Setup(m => m.DeleteAsync(invitationId, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(0));
+
+            var result = await controller.Delete(invitationId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            partnerAdminInvitationManager.Verify(
+                m => m.DeleteAsync(invitationId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete_Unauthorized_ReturnsForbid()
+        {
+            var invitationId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+
+            partnerAdminInvitationManager
+                .Setup(m => m.GetPartnerForInvitation(invitationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.Delete(invitationId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task GetByUser_ReturnsOkWithList()
+        {
+            var userId = Guid.NewGuid();
+            var invitations = new List<DisplayPartnerAdminInvitation>
+            {
+                new() { Id = Guid.NewGuid(), PartnerName = "Partner A" },
+            };
+
+            partnerAdminInvitationManager
+                .Setup(m => m.GetInvitationsForUser(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(invitations);
+
+            var result = await controller.GetByUser(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var results = Assert.IsAssignableFrom<IEnumerable<DisplayPartnerAdminInvitation>>(okResult.Value);
+            Assert.Single(results);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerAdminsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerAdminsV2ControllerTests.cs
@@ -1,0 +1,210 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerAdminsV2ControllerTests
+    {
+        private readonly Mock<IPartnerAdminManager> partnerAdminManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerAdminsV2Controller>> logger = new();
+        private readonly PartnerAdminsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerAdminsV2ControllerTests()
+        {
+            controller = new PartnerAdminsV2Controller(
+                partnerAdminManager.Object, partnerManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetAdmins_Authorized_ReturnsOkWithUserList()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var admins = new List<User>
+            {
+                new() { Id = Guid.NewGuid(), UserName = "admin1" },
+                new() { Id = Guid.NewGuid(), UserName = "admin2" },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            partnerAdminManager
+                .Setup(m => m.GetAdminsForPartnerAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(admins);
+
+            var result = await controller.GetAdmins(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<UserDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetAdmins_PartnerNotFound_Returns404()
+        {
+            var partnerId = Guid.NewGuid();
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.GetAdmins(partnerId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetMyPartners_ReturnsOkWithPartnerList()
+        {
+            var partners = new List<Partner>
+            {
+                new() { Id = Guid.NewGuid(), Name = "Partner A" },
+                new() { Id = Guid.NewGuid(), Name = "Partner B" },
+            };
+
+            partnerAdminManager
+                .Setup(m => m.GetPartnersByUserIdAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partners);
+
+            var result = await controller.GetMyPartners(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetPartnerUser_Found_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var admins = new List<PartnerAdmin>
+            {
+                new() { PartnerId = partnerId, UserId = userId },
+                new() { PartnerId = partnerId, UserId = Guid.NewGuid() },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            partnerAdminManager
+                .Setup(m => m.GetByParentIdAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(admins);
+
+            var result = await controller.GetPartnerUser(partnerId, userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerAdminDto>(okResult.Value);
+            Assert.Equal(partnerId, dto.PartnerId);
+            Assert.Equal(userId, dto.UserId);
+        }
+
+        [Fact]
+        public async Task GetPartnerUser_NotFound_Returns404()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var admins = new List<PartnerAdmin>
+            {
+                new() { PartnerId = partnerId, UserId = Guid.NewGuid() },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            partnerAdminManager
+                .Setup(m => m.GetByParentIdAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(admins);
+
+            var result = await controller.GetPartnerUser(partnerId, userId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task AddPartnerUser_Authorized_Returns201()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            partnerAdminManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerAdmin>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PartnerAdmin { PartnerId = partnerId, UserId = userId });
+
+            var result = await controller.AddPartnerUser(partnerId, userId, CancellationToken.None);
+
+            var statusResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, statusResult.StatusCode);
+            var dto = Assert.IsType<PartnerAdminDto>(statusResult.Value);
+            Assert.Equal(partnerId, dto.PartnerId);
+            Assert.Equal(userId, dto.UserId);
+        }
+
+        [Fact]
+        public async Task AddPartnerUser_PartnerNotFound_Returns404()
+        {
+            var partnerId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.AddPartnerUser(partnerId, userId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerContactsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerContactsV2ControllerTests.cs
@@ -1,0 +1,199 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerContactsV2ControllerTests
+    {
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IPartnerContactManager> partnerContactManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerContactsV2Controller>> logger = new();
+        private readonly PartnerContactsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerContactsV2ControllerTests()
+        {
+            controller = new PartnerContactsV2Controller(
+                partnerManager.Object, partnerContactManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetByPartner_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var contacts = new List<PartnerContact>
+            {
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Name = "Alice", Email = "alice@test.com" },
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Name = "Bob", Email = "bob@test.com" },
+            };
+
+            partnerContactManager
+                .Setup(m => m.GetByParentIdAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contacts);
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerContactDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task Get_Found_ReturnsOk()
+        {
+            var contactId = Guid.NewGuid();
+            var contact = new PartnerContact
+            {
+                Id = contactId,
+                PartnerId = Guid.NewGuid(),
+                Name = "Alice",
+                Email = "alice@test.com",
+                Phone = "555-1234",
+            };
+
+            partnerContactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contact);
+
+            var result = await controller.Get(contactId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerContactDto>(okResult.Value);
+            Assert.Equal(contactId, dto.Id);
+            Assert.Equal("Alice", dto.Name);
+        }
+
+        [Fact]
+        public async Task Get_NotFound_Returns404()
+        {
+            var contactId = Guid.NewGuid();
+
+            partnerContactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerContact)null);
+
+            var result = await controller.Get(contactId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_Authorized_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var dto = new PartnerContactDto
+            {
+                PartnerId = partnerId,
+                Name = "New Contact",
+                Email = "new@test.com",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            partnerContactManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerContact>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PartnerContact
+                {
+                    Id = Guid.NewGuid(),
+                    PartnerId = partnerId,
+                    Name = "New Contact",
+                    Email = "new@test.com",
+                });
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultDto = Assert.IsType<PartnerContactDto>(okResult.Value);
+            Assert.Equal("New Contact", resultDto.Name);
+        }
+
+        [Fact]
+        public async Task Add_PartnerNotFound_Returns404()
+        {
+            var dto = new PartnerContactDto
+            {
+                PartnerId = Guid.NewGuid(),
+                Name = "Contact",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(dto.PartnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_Authorized_ReturnsNoContent()
+        {
+            SetupAuthSuccess();
+
+            var contactId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+
+            partnerContactManager
+                .Setup(m => m.GetPartnerForContact(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            partnerContactManager
+                .Setup(m => m.DeleteAsync(contactId, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(0));
+
+            var result = await controller.Delete(contactId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_PartnerNotFound_Returns404()
+        {
+            var contactId = Guid.NewGuid();
+
+            partnerContactManager
+                .Setup(m => m.GetPartnerForContact(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.Delete(contactId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerDocumentsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerDocumentsV2ControllerTests.cs
@@ -1,0 +1,254 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerDocumentsV2ControllerTests
+    {
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IPartnerDocumentManager> documentManager = new();
+        private readonly Mock<IPartnerDocumentStorageManager> storageManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerDocumentsV2Controller>> logger = new();
+        private readonly PartnerDocumentsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerDocumentsV2ControllerTests()
+        {
+            controller = new PartnerDocumentsV2Controller(
+                partnerManager.Object,
+                documentManager.Object,
+                storageManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetByPartner_Authorized_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var documents = new List<PartnerDocument>
+            {
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Name = "Doc 1", DocumentTypeId = 1 },
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Name = "Doc 2", DocumentTypeId = 2 },
+            };
+
+            partnerManager.Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            SetupAuthSuccess();
+            documentManager.Setup(m => m.GetByParentIdAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(documents);
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerDocumentDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetByPartner_Unauthorized_ReturnsForbid()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+
+            partnerManager.Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task Get_Found_ReturnsOk()
+        {
+            var documentId = Guid.NewGuid();
+            var document = new PartnerDocument
+            {
+                Id = documentId,
+                PartnerId = Guid.NewGuid(),
+                Name = "Test Document",
+                DocumentTypeId = 1,
+                ContentType = "application/pdf",
+            };
+
+            documentManager.Setup(m => m.GetAsync(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(document);
+
+            var result = await controller.Get(documentId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerDocumentDto>(okResult.Value);
+            Assert.Equal("Test Document", dto.Name);
+        }
+
+        [Fact]
+        public async Task Get_NotFound_ReturnsNotFound()
+        {
+            var documentId = Guid.NewGuid();
+
+            documentManager.Setup(m => m.GetAsync(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerDocument)null);
+
+            var result = await controller.Get(documentId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_Authorized_ReturnsCreated()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var dto = new PartnerDocumentDto
+            {
+                PartnerId = partnerId,
+                Name = "New Document",
+                DocumentTypeId = 1,
+                Url = "https://example.com/doc.pdf",
+            };
+            var created = new PartnerDocument
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Name = "New Document",
+                DocumentTypeId = 1,
+                Url = "https://example.com/doc.pdf",
+            };
+
+            partnerManager.Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            SetupAuthSuccess();
+            documentManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerDocument>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<PartnerDocumentDto>(createdResult.Value);
+            Assert.Equal("New Document", resultDto.Name);
+        }
+
+        [Fact]
+        public async Task Delete_Authorized_ReturnsNoContent()
+        {
+            var documentId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+            var document = new PartnerDocument
+            {
+                Id = documentId,
+                PartnerId = partner.Id,
+                Name = "Doc to Delete",
+                BlobStoragePath = "partners/doc.pdf",
+            };
+
+            documentManager
+                .Setup(m => m.GetPartnerForDocument(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            SetupAuthSuccess();
+            documentManager
+                .Setup(m => m.GetAsync(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(document);
+            storageManager
+                .Setup(m => m.DeleteDocumentAsync(document.BlobStoragePath, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            documentManager
+                .Setup(m => m.DeleteAsync(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(documentId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            storageManager.Verify(
+                m => m.DeleteDocumentAsync(document.BlobStoragePath, It.IsAny<CancellationToken>()), Times.Once);
+            documentManager.Verify(
+                m => m.DeleteAsync(documentId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete_Unauthorized_ReturnsForbid()
+        {
+            var documentId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+
+            documentManager
+                .Setup(m => m.GetPartnerForDocument(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.Delete(documentId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_NoBlobPath_SkipsStorageDeletion()
+        {
+            var documentId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+            var document = new PartnerDocument
+            {
+                Id = documentId,
+                PartnerId = partner.Id,
+                Name = "External URL Doc",
+                BlobStoragePath = null,
+            };
+
+            documentManager
+                .Setup(m => m.GetPartnerForDocument(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            SetupAuthSuccess();
+            documentManager
+                .Setup(m => m.GetAsync(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(document);
+            documentManager
+                .Setup(m => m.DeleteAsync(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(documentId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            storageManager.Verify(
+                m => m.DeleteDocumentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerLocationContactsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerLocationContactsV2ControllerTests.cs
@@ -1,0 +1,203 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerLocationContactsV2ControllerTests
+    {
+        private readonly Mock<IPartnerLocationManager> partnerLocationManager = new();
+        private readonly Mock<IPartnerLocationContactManager> partnerLocationContactManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerLocationContactsV2Controller>> logger = new();
+        private readonly PartnerLocationContactsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerLocationContactsV2ControllerTests()
+        {
+            controller = new PartnerLocationContactsV2Controller(
+                partnerLocationManager.Object,
+                partnerLocationContactManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetByLocation_ReturnsOkWithList()
+        {
+            var partnerLocationId = Guid.NewGuid();
+            var contacts = new List<PartnerLocationContact>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    PartnerLocationId = partnerLocationId,
+                    Name = "John Doe",
+                    Email = "john@example.com",
+                    Phone = "555-1234",
+                    IsActive = true,
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    PartnerLocationId = partnerLocationId,
+                    Name = "Jane Smith",
+                    Email = "jane@example.com",
+                    IsActive = true,
+                },
+            };
+
+            partnerLocationContactManager
+                .Setup(m => m.GetByParentIdAsync(partnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contacts);
+
+            var result = await controller.GetByLocation(partnerLocationId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerLocationContactDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+            Assert.Equal("John Doe", dtos.First().Name);
+        }
+
+        [Fact]
+        public async Task Get_Found_ReturnsOk()
+        {
+            var contactId = Guid.NewGuid();
+            var contact = new PartnerLocationContact
+            {
+                Id = contactId,
+                PartnerLocationId = Guid.NewGuid(),
+                Name = "Contact Person",
+                Email = "contact@example.com",
+                IsActive = true,
+            };
+
+            partnerLocationContactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contact);
+
+            var result = await controller.Get(contactId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerLocationContactDto>(okResult.Value);
+            Assert.Equal(contactId, dto.Id);
+            Assert.Equal("Contact Person", dto.Name);
+        }
+
+        [Fact]
+        public async Task Get_NotFound_ReturnsNotFound()
+        {
+            var contactId = Guid.NewGuid();
+
+            partnerLocationContactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerLocationContact)null);
+
+            var result = await controller.Get(contactId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_Authorized_ReturnsCreated()
+        {
+            var partnerLocationId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+            var dto = new PartnerLocationContactDto
+            {
+                PartnerLocationId = partnerLocationId,
+                Name = "New Contact",
+                Email = "new@example.com",
+                Phone = "555-9999",
+                IsActive = true,
+            };
+
+            var createdEntity = new PartnerLocationContact
+            {
+                Id = Guid.NewGuid(),
+                PartnerLocationId = partnerLocationId,
+                Name = "New Contact",
+                Email = "new@example.com",
+                Phone = "555-9999",
+                IsActive = true,
+            };
+
+            partnerLocationManager
+                .Setup(m => m.GetPartnerForLocationAsync(partnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            partnerLocationContactManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerLocationContact>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdEntity);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<PartnerLocationContactDto>(createdResult.Value);
+            Assert.Equal("New Contact", resultDto.Name);
+        }
+
+        [Fact]
+        public async Task Delete_Authorized_ReturnsNoContent()
+        {
+            var contactId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+
+            partnerLocationContactManager
+                .Setup(m => m.GetPartnerForLocationContact(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            partnerLocationContactManager
+                .Setup(m => m.DeleteAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(contactId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_PartnerNotFound_ReturnsNotFound()
+        {
+            var contactId = Guid.NewGuid();
+
+            partnerLocationContactManager
+                .Setup(m => m.GetPartnerForLocationContact(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.Delete(contactId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerLocationServicesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerLocationServicesV2ControllerTests.cs
@@ -1,0 +1,233 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerLocationServicesV2ControllerTests
+    {
+        private readonly Mock<IBaseManager<PartnerLocationService>> partnerLocationServiceManager = new();
+        private readonly Mock<IPartnerLocationManager> partnerLocationManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerLocationServicesV2Controller>> logger = new();
+        private readonly PartnerLocationServicesV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerLocationServicesV2ControllerTests()
+        {
+            controller = new PartnerLocationServicesV2Controller(
+                partnerLocationServiceManager.Object,
+                partnerLocationManager.Object,
+                partnerManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetByLocation_ReturnsOkWithList()
+        {
+            var partnerLocationId = Guid.NewGuid();
+            var services = new List<PartnerLocationService>
+            {
+                new()
+                {
+                    PartnerLocationId = partnerLocationId,
+                    ServiceTypeId = 1,
+                    IsAutoApproved = true,
+                    IsAdvanceNoticeRequired = false,
+                    Notes = "Dumpster available",
+                },
+                new()
+                {
+                    PartnerLocationId = partnerLocationId,
+                    ServiceTypeId = 2,
+                    IsAutoApproved = false,
+                    IsAdvanceNoticeRequired = true,
+                },
+            };
+
+            partnerLocationServiceManager
+                .Setup(m => m.GetByParentIdAsync(partnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(services);
+
+            var result = await controller.GetByLocation(partnerLocationId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerLocationServiceDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+            Assert.Equal(1, dtos.First().ServiceTypeId);
+        }
+
+        [Fact]
+        public async Task Get_Found_ReturnsOk()
+        {
+            var partnerLocationId = Guid.NewGuid();
+            var serviceTypeId = 1;
+            var service = new PartnerLocationService
+            {
+                PartnerLocationId = partnerLocationId,
+                ServiceTypeId = serviceTypeId,
+                IsAutoApproved = true,
+                IsAdvanceNoticeRequired = false,
+            };
+
+            partnerLocationServiceManager
+                .Setup(m => m.GetAsync(partnerLocationId, serviceTypeId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(service);
+
+            var result = await controller.Get(partnerLocationId, serviceTypeId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerLocationServiceDto>(okResult.Value);
+            Assert.Equal(partnerLocationId, dto.PartnerLocationId);
+            Assert.Equal(serviceTypeId, dto.ServiceTypeId);
+        }
+
+        [Fact]
+        public async Task Get_NotFound_ReturnsNotFound()
+        {
+            var partnerLocationId = Guid.NewGuid();
+
+            partnerLocationServiceManager
+                .Setup(m => m.GetAsync(partnerLocationId, 99, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerLocationService)null);
+
+            var result = await controller.Get(partnerLocationId, 99, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_Authorized_ReturnsCreated()
+        {
+            var partnerLocationId = Guid.NewGuid();
+            var partnerId = Guid.NewGuid();
+            var partnerLocation = new PartnerLocation
+            {
+                Id = partnerLocationId,
+                PartnerId = partnerId,
+                Name = "Test Location",
+            };
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+
+            var dto = new PartnerLocationServiceDto
+            {
+                PartnerLocationId = partnerLocationId,
+                ServiceTypeId = 1,
+                IsAutoApproved = true,
+                IsAdvanceNoticeRequired = false,
+                Notes = "Available weekdays",
+            };
+
+            var createdEntity = new PartnerLocationService
+            {
+                PartnerLocationId = partnerLocationId,
+                ServiceTypeId = 1,
+                IsAutoApproved = true,
+                IsAdvanceNoticeRequired = false,
+                Notes = "Available weekdays",
+            };
+
+            partnerLocationManager
+                .Setup(m => m.GetAsync(partnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partnerLocation);
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            partnerLocationServiceManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerLocationService>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdEntity);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<PartnerLocationServiceDto>(createdResult.Value);
+            Assert.Equal(1, resultDto.ServiceTypeId);
+        }
+
+        [Fact]
+        public async Task Add_LocationNotFound_ReturnsNotFound()
+        {
+            var dto = new PartnerLocationServiceDto
+            {
+                PartnerLocationId = Guid.NewGuid(),
+                ServiceTypeId = 1,
+            };
+
+            partnerLocationManager
+                .Setup(m => m.GetAsync(dto.PartnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerLocation)null);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_Authorized_ReturnsNoContent()
+        {
+            var partnerLocationId = Guid.NewGuid();
+            var serviceTypeId = 1;
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+
+            partnerLocationManager
+                .Setup(m => m.GetPartnerForLocationAsync(partnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            partnerLocationServiceManager
+                .Setup(m => m.Delete(partnerLocationId, serviceTypeId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(partnerLocationId, serviceTypeId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_PartnerNotFound_ReturnsNotFound()
+        {
+            var partnerLocationId = Guid.NewGuid();
+
+            partnerLocationManager
+                .Setup(m => m.GetPartnerForLocationAsync(partnerLocationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.Delete(partnerLocationId, 1, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerLocationsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerLocationsV2ControllerTests.cs
@@ -1,0 +1,224 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerLocationsV2ControllerTests
+    {
+        private readonly Mock<IPartnerLocationManager> partnerLocationManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerLocationsV2Controller>> logger = new();
+        private readonly PartnerLocationsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerLocationsV2ControllerTests()
+        {
+            controller = new PartnerLocationsV2Controller(
+                partnerLocationManager.Object,
+                partnerManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetByPartner_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var locations = new List<PartnerLocation>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    PartnerId = partnerId,
+                    Name = "Downtown Office",
+                    City = "Seattle",
+                    Region = "WA",
+                    Country = "US",
+                    IsActive = true,
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    PartnerId = partnerId,
+                    Name = "Eastside Branch",
+                    City = "Bellevue",
+                    Region = "WA",
+                    Country = "US",
+                    IsActive = true,
+                },
+            };
+
+            partnerLocationManager
+                .Setup(m => m.GetByParentIdAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(locations);
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerLocationDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+            Assert.Equal("Downtown Office", dtos.First().Name);
+        }
+
+        [Fact]
+        public async Task Get_Found_ReturnsOk()
+        {
+            var locationId = Guid.NewGuid();
+            var location = new PartnerLocation
+            {
+                Id = locationId,
+                PartnerId = Guid.NewGuid(),
+                Name = "Main Location",
+                City = "Portland",
+                Region = "OR",
+                Country = "US",
+                IsActive = true,
+            };
+
+            partnerLocationManager
+                .Setup(m => m.GetAsync(locationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(location);
+
+            var result = await controller.Get(locationId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerLocationDto>(okResult.Value);
+            Assert.Equal(locationId, dto.Id);
+            Assert.Equal("Main Location", dto.Name);
+        }
+
+        [Fact]
+        public async Task Get_NotFound_ReturnsNotFound()
+        {
+            var locationId = Guid.NewGuid();
+
+            partnerLocationManager
+                .Setup(m => m.GetAsync(locationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerLocation)null);
+
+            var result = await controller.Get(locationId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_Authorized_Returns201()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner", PartnerStatusId = 1 };
+            var dto = new PartnerLocationDto
+            {
+                PartnerId = partnerId,
+                Name = "New Location",
+                City = "Tacoma",
+                Region = "WA",
+                Country = "US",
+                IsActive = true,
+            };
+
+            var createdEntity = new PartnerLocation
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Name = "New Location",
+                City = "Tacoma",
+                Region = "WA",
+                Country = "US",
+                IsActive = true,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            partnerLocationManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerLocation>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdEntity);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<PartnerLocationDto>(createdResult.Value);
+            Assert.Equal("New Location", resultDto.Name);
+        }
+
+        [Fact]
+        public async Task Add_EmptyPartnerId_ReturnsBadRequest()
+        {
+            var dto = new PartnerLocationDto
+            {
+                PartnerId = Guid.Empty,
+                Name = "Bad Location",
+            };
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_Authorized_ReturnsNoContent()
+        {
+            var locationId = Guid.NewGuid();
+            var partner = new Partner { Id = Guid.NewGuid(), Name = "Test Partner" };
+
+            partnerLocationManager
+                .Setup(m => m.GetPartnerForLocationAsync(locationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+
+            partnerLocationManager
+                .Setup(m => m.DeleteAsync(locationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(locationId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_PartnerNotFound_ReturnsNotFound()
+        {
+            var locationId = Guid.NewGuid();
+
+            partnerLocationManager
+                .Setup(m => m.GetPartnerForLocationAsync(locationId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.Delete(locationId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerRequestsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerRequestsV2ControllerTests.cs
@@ -1,0 +1,201 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerRequestsV2ControllerTests
+    {
+        private readonly Mock<IPartnerRequestManager> partnerRequestManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerRequestsV2Controller>> logger = new();
+        private readonly PartnerRequestsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerRequestsV2ControllerTests()
+        {
+            controller = new PartnerRequestsV2Controller(
+                partnerRequestManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task Add_ValidInput_Returns201()
+        {
+            var dto = new PartnerRequestDto
+            {
+                Name = "New Partner Org",
+                Email = "partner@test.com",
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                PartnerTypeId = 1,
+            };
+            var created = new PartnerRequest
+            {
+                Id = Guid.NewGuid(),
+                Name = "New Partner Org",
+                Email = "partner@test.com",
+                City = "Seattle",
+                Region = "WA",
+                Country = "US",
+                PartnerTypeId = 1,
+            };
+
+            partnerRequestManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerRequest>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<PartnerRequestDto>(createdResult.Value);
+            Assert.Equal("New Partner Org", resultDto.Name);
+        }
+
+        [Fact]
+        public async Task Approve_ReturnsOk()
+        {
+            var requestId = Guid.NewGuid();
+            var approved = new PartnerRequest
+            {
+                Id = requestId,
+                Name = "Approved Partner",
+                PartnerRequestStatusId = 2,
+            };
+
+            partnerRequestManager
+                .Setup(m => m.ApproveBecomeAPartnerAsync(requestId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(approved);
+
+            var result = await controller.Approve(requestId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerRequestDto>(okResult.Value);
+            Assert.Equal("Approved Partner", dto.Name);
+        }
+
+        [Fact]
+        public async Task Deny_ReturnsOk()
+        {
+            var requestId = Guid.NewGuid();
+            var denied = new PartnerRequest
+            {
+                Id = requestId,
+                Name = "Denied Partner",
+                PartnerRequestStatusId = 3,
+            };
+
+            partnerRequestManager
+                .Setup(m => m.DenyBecomeAPartnerAsync(requestId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(denied);
+
+            var result = await controller.Deny(requestId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerRequestDto>(okResult.Value);
+            Assert.Equal("Denied Partner", dto.Name);
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsOkWithList()
+        {
+            var requests = new List<PartnerRequest>
+            {
+                new() { Id = Guid.NewGuid(), Name = "Partner A", PartnerRequestStatusId = 1, PartnerTypeId = 1 },
+                new() { Id = Guid.NewGuid(), Name = "Partner B", PartnerRequestStatusId = 2, PartnerTypeId = 2 },
+            };
+
+            partnerRequestManager
+                .Setup(m => m.GetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(requests);
+
+            var result = await controller.GetAll(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerRequestDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task Get_ReturnsOk_WhenFound()
+        {
+            var requestId = Guid.NewGuid();
+            var request = new PartnerRequest
+            {
+                Id = requestId,
+                Name = "Test Partner",
+                Email = "test@test.com",
+                PartnerTypeId = 1,
+            };
+
+            partnerRequestManager
+                .Setup(m => m.GetAsync(requestId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(request);
+
+            var result = await controller.Get(requestId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerRequestDto>(okResult.Value);
+            Assert.Equal("Test Partner", dto.Name);
+        }
+
+        [Fact]
+        public async Task Get_ReturnsNotFound_WhenMissing()
+        {
+            var requestId = Guid.NewGuid();
+
+            partnerRequestManager
+                .Setup(m => m.GetAsync(requestId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerRequest)null);
+
+            var result = await controller.Get(requestId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetByUser_ReturnsOkWithList()
+        {
+            var userId = Guid.NewGuid();
+            var requests = new List<PartnerRequest>
+            {
+                new() { Id = Guid.NewGuid(), Name = "My Request", PartnerTypeId = 1 },
+            };
+
+            partnerRequestManager
+                .Setup(m => m.GetByCreatedUserIdAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(requests);
+
+            var result = await controller.GetByUser(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerRequestDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PartnerSocialMediaAccountsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PartnerSocialMediaAccountsV2ControllerTests.cs
@@ -1,0 +1,232 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class PartnerSocialMediaAccountsV2ControllerTests
+    {
+        private readonly Mock<IPartnerSocialMediaAccountManager> socialMediaAccountManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<PartnerSocialMediaAccountsV2Controller>> logger = new();
+        private readonly PartnerSocialMediaAccountsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PartnerSocialMediaAccountsV2ControllerTests()
+        {
+            controller = new PartnerSocialMediaAccountsV2Controller(
+                socialMediaAccountManager.Object, partnerManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetByPartner_Authorized_ReturnsOkWithList()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var accounts = new List<PartnerSocialMediaAccount>
+            {
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, AccountIdentifier = "@partner_twitter", SocialMediaAccountTypeId = 1 },
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, AccountIdentifier = "partner_insta", SocialMediaAccountTypeId = 2 },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            socialMediaAccountManager
+                .Setup(m => m.GetByParentIdAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(accounts);
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PartnerSocialMediaAccountDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetByPartner_PartnerNotFound_Returns404()
+        {
+            var partnerId = Guid.NewGuid();
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.GetByPartner(partnerId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Get_Found_ReturnsOk()
+        {
+            var accountId = Guid.NewGuid();
+            var account = new PartnerSocialMediaAccount
+            {
+                Id = accountId,
+                PartnerId = Guid.NewGuid(),
+                AccountIdentifier = "@partner",
+                SocialMediaAccountTypeId = 1,
+            };
+
+            socialMediaAccountManager
+                .Setup(m => m.GetAsync(accountId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(account);
+
+            var result = await controller.Get(accountId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<PartnerSocialMediaAccountDto>(okResult.Value);
+            Assert.Equal(accountId, dto.Id);
+            Assert.Equal("@partner", dto.AccountIdentifier);
+        }
+
+        [Fact]
+        public async Task Get_NotFound_Returns404()
+        {
+            var accountId = Guid.NewGuid();
+
+            socialMediaAccountManager
+                .Setup(m => m.GetAsync(accountId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerSocialMediaAccount)null);
+
+            var result = await controller.Get(accountId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Add_Authorized_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var dto = new PartnerSocialMediaAccountDto
+            {
+                PartnerId = partnerId,
+                AccountIdentifier = "@new_account",
+                SocialMediaAccountTypeId = 1,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            socialMediaAccountManager
+                .Setup(m => m.AddAsync(It.IsAny<PartnerSocialMediaAccount>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PartnerSocialMediaAccount
+                {
+                    Id = Guid.NewGuid(),
+                    PartnerId = partnerId,
+                    AccountIdentifier = "@new_account",
+                    SocialMediaAccountTypeId = 1,
+                });
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var resultDto = Assert.IsType<PartnerSocialMediaAccountDto>(okResult.Value);
+            Assert.Equal("@new_account", resultDto.AccountIdentifier);
+        }
+
+        [Fact]
+        public async Task Add_PartnerNotFound_Returns404()
+        {
+            var dto = new PartnerSocialMediaAccountDto
+            {
+                PartnerId = Guid.NewGuid(),
+                AccountIdentifier = "@account",
+                SocialMediaAccountTypeId = 1,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(dto.PartnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.Add(dto, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_Authorized_ReturnsNoContent()
+        {
+            SetupAuthSuccess();
+
+            var accountId = Guid.NewGuid();
+            var partnerId = Guid.NewGuid();
+            var account = new PartnerSocialMediaAccount
+            {
+                Id = accountId,
+                PartnerId = partnerId,
+                AccountIdentifier = "@delete_me",
+                SocialMediaAccountTypeId = 1,
+            };
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+
+            socialMediaAccountManager
+                .Setup(m => m.GetAsync(accountId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(account);
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+
+            socialMediaAccountManager
+                .Setup(m => m.DeleteAsync(accountId, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(0));
+
+            var result = await controller.Delete(accountId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_AccountNotFound_Returns404()
+        {
+            var accountId = Guid.NewGuid();
+
+            socialMediaAccountManager
+                .Setup(m => m.GetAsync(accountId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PartnerSocialMediaAccount)null);
+
+            var result = await controller.Delete(accountId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerAdminInvitationsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerAdminInvitationsV2Controller.cs
@@ -1,0 +1,280 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner administrator invitations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-admin-invitations")]
+    [Authorize]
+    public class PartnerAdminInvitationsV2Controller(
+        IKeyedManager<User> userManager,
+        IPartnerAdminInvitationManager partnerAdminInvitationManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerAdminInvitationsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all partner admin invitations for a given partner.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of partner admin invitations.</returns>
+        /// <response code="200">Returns the invitation list.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpGet("{partnerId}")]
+        [ProducesResponseType(typeof(IEnumerable<PartnerAdminInvitationDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetByPartner(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetByPartner Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var invitations = await partnerAdminInvitationManager.GetByParentIdAsync(partnerId, cancellationToken);
+
+            return Ok(invitations.Select(i => i.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets all partner admin invitations for a given user.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of display partner admin invitations for the user.</returns>
+        /// <response code="200">Returns the invitation list.</response>
+        [HttpGet("by-user/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<DisplayPartnerAdminInvitation>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByUser(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetByUser User={UserId}", userId);
+
+            var results = await partnerAdminInvitationManager.GetInvitationsForUser(userId, cancellationToken);
+
+            return Ok(results);
+        }
+
+        /// <summary>
+        /// Gets a specific partner admin invitation by partner ID and email.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="email">The email of the invited admin.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The partner admin invitation if found.</returns>
+        /// <response code="200">Returns the invitation.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Invitation not found.</response>
+        [HttpGet("{partnerId}/{email}")]
+        [ProducesResponseType(typeof(PartnerAdminInvitationDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetByPartnerAndEmail(Guid partnerId, string email,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetByPartnerAndEmail Partner={PartnerId} Email={Email}", partnerId, email);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var invitation = (await partnerAdminInvitationManager.GetByParentIdAsync(partnerId, cancellationToken))
+                .FirstOrDefault(i => i.Email == email);
+
+            if (invitation is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(invitation.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a new partner admin invitation.
+        /// </summary>
+        /// <param name="dto">The partner admin invitation to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created invitation.</returns>
+        /// <response code="201">Invitation created.</response>
+        /// <response code="400">Invalid request data.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">User with specified email not found.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerAdminInvitationDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Add([FromBody] PartnerAdminInvitationDto dto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerAdminInvitation Partner={PartnerId}", dto.PartnerId);
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            if (dto.PartnerId == Guid.Empty)
+            {
+                return Problem("PartnerId is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (string.IsNullOrWhiteSpace(dto.Email))
+            {
+                return Problem("Email is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var addUser = await userManager.GetAsync(p => p.Email == dto.Email, cancellationToken);
+
+            if (addUser is null)
+            {
+                return NotFound();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerAdminInvitationManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetByPartnerAndEmail),
+                new { partnerId = result.PartnerId, email = result.Email }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Resends an existing partner admin invitation.
+        /// </summary>
+        /// <param name="id">The partner admin invitation ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The resent invitation.</returns>
+        /// <response code="200">Invitation resent.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpPost("{id}/resend")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerAdminInvitationDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Resend(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ResendPartnerAdminInvitation Invitation={InvitationId}", id);
+
+            var partner = await partnerAdminInvitationManager.GetPartnerForInvitation(id, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var result = await partnerAdminInvitationManager
+                .ResendPartnerAdminInvitationAsync(id, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Accepts a partner admin invitation.
+        /// </summary>
+        /// <param name="id">The partner admin invitation ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Invitation accepted.</response>
+        [HttpPost("{id}/accept")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<IActionResult> Accept(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AcceptPartnerAdminInvitation Invitation={InvitationId}", id);
+
+            await partnerAdminInvitationManager.AcceptInvitationAsync(id, UserId, cancellationToken);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Declines a partner admin invitation.
+        /// </summary>
+        /// <param name="id">The partner admin invitation ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Invitation declined.</response>
+        [HttpPost("{id}/decline")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<IActionResult> Decline(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeclinePartnerAdminInvitation Invitation={InvitationId}", id);
+
+            await partnerAdminInvitationManager.DeclineInvitationAsync(id, UserId, cancellationToken);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Deletes a partner admin invitation.
+        /// </summary>
+        /// <param name="id">The partner admin invitation ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Invitation deleted.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePartnerAdminInvitation Invitation={InvitationId}", id);
+
+            var partner = await partnerAdminInvitationManager.GetPartnerForInvitation(id, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await partnerAdminInvitationManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerAdminsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerAdminsV2Controller.cs
@@ -1,0 +1,196 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner administrators.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-admins")]
+    public class PartnerAdminsV2Controller(
+        IPartnerAdminManager partnerAdminManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerAdminsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all administrator users for a partner.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner admin users.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpGet("{partnerId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<UserDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAdmins(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerAdmins for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var admins = await partnerAdminManager.GetAdminsForPartnerAsync(partnerId, cancellationToken);
+            return Ok(admins.Select(u => u.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets all partners that a user is an administrator of.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partners the user administers.</response>
+        /// <response code="401">Not authenticated.</response>
+        [HttpGet("partners-for-user/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetPartnersForUser(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnersForUser for User={UserId}", userId);
+
+            var partners = await partnerAdminManager.GetPartnersByUserIdAsync(userId, cancellationToken);
+            return Ok(partners.Select(p => p.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets all partners that the current user is an administrator of.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partners the current user administers.</response>
+        /// <response code="401">Not authenticated.</response>
+        [HttpGet("my")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetMyPartners(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetMyPartners for User={UserId}", UserId);
+
+            var partners = await partnerAdminManager.GetPartnersByUserIdAsync(UserId, cancellationToken);
+            return Ok(partners.Select(p => p.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a specific partner admin record.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner admin record.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or admin record not found.</response>
+        [HttpGet("{partnerId}/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerAdminDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetPartnerUser(Guid partnerId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerUser for Partner={PartnerId}, User={UserId}", partnerId, userId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var admins = await partnerAdminManager.GetByParentIdAsync(partnerId, cancellationToken);
+            var admin = admins.FirstOrDefault(a => a.UserId == userId);
+            if (admin is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(admin.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a user as an administrator for a partner.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="userId">The user ID to add as admin.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Partner admin created.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPost("{partnerId}/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerAdminDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> AddPartnerUser(Guid partnerId, Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerUser for Partner={PartnerId}, User={UserId}", partnerId, userId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = new PartnerAdmin
+            {
+                PartnerId = partnerId,
+                UserId = userId,
+            };
+
+            var result = await partnerAdminManager.AddAsync(entity, UserId, cancellationToken);
+            return StatusCode(StatusCodes.Status201Created, result.ToV2Dto());
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerContactsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerContactsV2Controller.cs
@@ -1,0 +1,194 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner contacts.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-contacts")]
+    public class PartnerContactsV2Controller(
+        IKeyedManager<Partner> partnerManager,
+        IPartnerContactManager partnerContactManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerContactsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all contacts for a partner.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner contacts.</response>
+        /// <response code="401">Not authenticated.</response>
+        [HttpGet("by-partner/{partnerId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerContactDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetByPartner(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerContacts for Partner={PartnerId}", partnerId);
+
+            var contacts = await partnerContactManager.GetByParentIdAsync(partnerId, cancellationToken);
+            return Ok(contacts.Select(c => c.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single partner contact by ID.
+        /// </summary>
+        /// <param name="id">The partner contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner contact.</response>
+        /// <response code="401">Not authenticated.</response>
+        /// <response code="404">Partner contact not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerContact for Id={PartnerContactId}", id);
+
+            var contact = await partnerContactManager.GetAsync(id, cancellationToken);
+            if (contact is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(contact.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a new partner contact.
+        /// </summary>
+        /// <param name="dto">The partner contact to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the created partner contact.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Add(PartnerContactDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerContact for Partner={PartnerId}", dto.PartnerId);
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerContactManager.AddAsync(entity, UserId, cancellationToken);
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing partner contact.
+        /// </summary>
+        /// <param name="dto">The partner contact to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated partner contact.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(PartnerContactDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdatePartnerContact for Id={PartnerContactId}", dto.Id);
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerContactManager.UpdateAsync(entity, UserId, cancellationToken);
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a partner contact.
+        /// </summary>
+        /// <param name="id">The partner contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Partner contact deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePartnerContact for Id={PartnerContactId}", id);
+
+            var partner = await partnerContactManager.GetPartnerForContact(id, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await partnerContactManager.DeleteAsync(id, cancellationToken);
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerDocumentsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerDocumentsV2Controller.cs
@@ -1,0 +1,372 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner documents, including file upload, download, and admin operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-documents")]
+    [Authorize]
+    public class PartnerDocumentsV2Controller(
+        IKeyedManager<Partner> partnerManager,
+        IPartnerDocumentManager documentManager,
+        IPartnerDocumentStorageManager storageManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerDocumentsV2Controller> logger) : ControllerBase
+    {
+        private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "image/png",
+            "image/jpeg",
+        };
+
+        private const long MaxFileSizeBytes = 25 * 1024 * 1024; // 25 MB
+        private const long MaxPartnerStorageBytes = 500 * 1024 * 1024; // 500 MB
+
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all documents for a given partner.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of partner documents.</returns>
+        /// <response code="200">Returns the document list.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpGet("by-partner/{partnerId}")]
+        [ProducesResponseType(typeof(IEnumerable<PartnerDocumentDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetByPartner(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetByPartner Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var documents = await documentManager.GetByParentIdAsync(partnerId, cancellationToken);
+
+            return Ok(documents.Select(d => d.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a partner document by its unique identifier.
+        /// </summary>
+        /// <param name="id">The partner document ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The partner document.</returns>
+        /// <response code="200">Returns the document.</response>
+        /// <response code="404">Document not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerDocumentDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerDocument Document={DocumentId}", id);
+
+            var document = await documentManager.GetAsync(id, cancellationToken);
+
+            if (document is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(document.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a new partner document (metadata only, for external URL documents).
+        /// </summary>
+        /// <param name="dto">The partner document to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created document.</returns>
+        /// <response code="201">Document created.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerDocumentDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Add([FromBody] PartnerDocumentDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerDocument Partner={PartnerId}", dto.PartnerId);
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await documentManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Uploads a document file to Azure Blob Storage and creates the document metadata.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="name">The document name.</param>
+        /// <param name="documentTypeId">The document type identifier.</param>
+        /// <param name="expirationDate">Optional expiration date.</param>
+        /// <param name="formFile">The file to upload.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Document uploaded and created.</response>
+        /// <response code="400">Invalid file or storage limit exceeded.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpPost("upload")]
+        [RequestSizeLimit(26_214_400)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerDocumentDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Upload(
+            [FromForm] Guid partnerId,
+            [FromForm] string name,
+            [FromForm] int documentTypeId,
+            [FromForm] DateTimeOffset? expirationDate,
+            IFormFile formFile,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadPartnerDocument Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            if (formFile is null || formFile.Length == 0)
+            {
+                return Problem("No file provided.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (formFile.Length > MaxFileSizeBytes)
+            {
+                return Problem(
+                    $"File size exceeds the maximum allowed size of {MaxFileSizeBytes / (1024 * 1024)} MB.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (!AllowedContentTypes.Contains(formFile.ContentType))
+            {
+                return Problem(
+                    $"File type '{formFile.ContentType}' is not allowed. Allowed types: PDF, Word, Excel, PNG, JPEG.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var currentUsage = await storageManager.GetPartnerStorageUsageBytesAsync(partnerId, cancellationToken);
+
+            if (currentUsage + formFile.Length > MaxPartnerStorageBytes)
+            {
+                return Problem(
+                    $"Uploading this file would exceed the partner storage limit of {MaxPartnerStorageBytes / (1024 * 1024)} MB.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var document = new PartnerDocument
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Name = name,
+                ContentType = formFile.ContentType,
+                FileSizeBytes = formFile.Length,
+                DocumentTypeId = documentTypeId,
+                ExpirationDate = expirationDate,
+            };
+
+            await documentManager.AddAsync(document, UserId, cancellationToken);
+
+            var blobPath = await storageManager.UploadDocumentAsync(partnerId, document.Id, formFile, cancellationToken);
+            document.BlobStoragePath = blobPath;
+            await documentManager.UpdateAsync(document, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = document.Id }, document.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Generates a time-limited download URL for a partner document.
+        /// </summary>
+        /// <param name="id">The partner document ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the download URL.</response>
+        /// <response code="400">Document has no uploaded file.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpGet("{id}/download")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Download(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DownloadPartnerDocument Document={DocumentId}", id);
+
+            var partner = await documentManager.GetPartnerForDocument(id, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var document = await documentManager.GetAsync(id, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(document?.BlobStoragePath))
+            {
+                return Problem("This document has no uploaded file.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var downloadUrl = await storageManager.GetDownloadUrlAsync(document.BlobStoragePath, cancellationToken);
+
+            return Ok(new { downloadUrl });
+        }
+
+        /// <summary>
+        /// Gets storage usage in bytes for a partner, including the total limit.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the storage usage information.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpGet("storage-usage/{partnerId}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetStorageUsage(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetStorageUsage Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var usageBytes = await storageManager.GetPartnerStorageUsageBytesAsync(partnerId, cancellationToken);
+
+            return Ok(new { usageBytes, limitBytes = MaxPartnerStorageBytes });
+        }
+
+        /// <summary>
+        /// Updates an existing partner document.
+        /// </summary>
+        /// <param name="dto">The partner document to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated document.</returns>
+        /// <response code="200">Document updated.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerDocumentDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Update([FromBody] PartnerDocumentDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdatePartnerDocument Document={DocumentId}", dto.Id);
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await documentManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a partner document by its unique identifier, including any uploaded blob.
+        /// </summary>
+        /// <param name="id">The partner document ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Document deleted.</response>
+        /// <response code="403">User is not authorized.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePartnerDocument Document={DocumentId}", id);
+
+            var partner = await documentManager.GetPartnerForDocument(id, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var document = await documentManager.GetAsync(id, cancellationToken);
+
+            if (!string.IsNullOrWhiteSpace(document?.BlobStoragePath))
+            {
+                await storageManager.DeleteDocumentAsync(document.BlobStoragePath, cancellationToken);
+            }
+
+            await documentManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Gets all partner documents across all partners, with partner information included. Admin only.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of all partner documents.</returns>
+        /// <response code="200">Returns all partner documents.</response>
+        /// <response code="403">User is not an admin.</response>
+        [HttpGet("admin/all")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerDocumentDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> AdminGetAll(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AdminGetAllPartnerDocuments");
+
+            var results = await documentManager.GetAllWithPartnerAsync(cancellationToken);
+
+            return Ok(results.Select(d => d.ToV2Dto()));
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerLocationContactsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerLocationContactsV2Controller.cs
@@ -1,0 +1,200 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner location contacts.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-location-contacts")]
+    public class PartnerLocationContactsV2Controller(
+        IPartnerLocationManager partnerLocationManager,
+        IPartnerLocationContactManager partnerLocationContactManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerLocationContactsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all contacts for a partner location.
+        /// </summary>
+        /// <param name="partnerLocationId">The partner location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner location contacts.</response>
+        [HttpGet("by-location/{partnerLocationId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerLocationContactDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetByLocation(Guid partnerLocationId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocationContacts for Location={PartnerLocationId}", partnerLocationId);
+
+            var results = await partnerLocationContactManager.GetByParentIdAsync(partnerLocationId, cancellationToken);
+
+            return Ok(results.Select(c => c.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single partner location contact by its identifier.
+        /// </summary>
+        /// <param name="id">The partner location contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner location contact.</response>
+        /// <response code="404">Contact not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerLocationContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocationContact for Id={ContactId}", id);
+
+            var contact = await partnerLocationContactManager.GetAsync(id, cancellationToken);
+
+            if (contact is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(contact.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new partner location contact.
+        /// </summary>
+        /// <param name="dto">The partner location contact to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Contact created.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner location not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerLocationContactDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Add(PartnerLocationContactDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerLocationContact for Location={PartnerLocationId}", dto.PartnerLocationId);
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(dto.PartnerLocationId, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerLocationContactManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing partner location contact.
+        /// </summary>
+        /// <param name="dto">The partner location contact to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Contact updated.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerLocationContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Update(PartnerLocationContactDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdatePartnerLocationContact for Id={ContactId}", dto.Id);
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(dto.PartnerLocationId, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerLocationContactManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a partner location contact.
+        /// </summary>
+        /// <param name="id">The partner location contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Contact deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePartnerLocationContact for Id={ContactId}", id);
+
+            var partner = await partnerLocationContactManager.GetPartnerForLocationContact(id, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await partnerLocationContactManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerLocationServicesV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerLocationServicesV2Controller.cs
@@ -1,0 +1,217 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner location services.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-location-services")]
+    public class PartnerLocationServicesV2Controller(
+        IBaseManager<PartnerLocationService> partnerLocationServiceManager,
+        IPartnerLocationManager partnerLocationManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerLocationServicesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all services for a partner location.
+        /// </summary>
+        /// <param name="partnerLocationId">The partner location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner location services.</response>
+        [HttpGet("by-location/{partnerLocationId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerLocationServiceDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetByLocation(Guid partnerLocationId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocationServices for Location={PartnerLocationId}", partnerLocationId);
+
+            var results = await partnerLocationServiceManager.GetByParentIdAsync(partnerLocationId, cancellationToken);
+
+            return Ok(results.Select(s => s.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single partner location service by its composite key.
+        /// </summary>
+        /// <param name="partnerLocationId">The partner location ID.</param>
+        /// <param name="serviceTypeId">The service type ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner location service.</response>
+        /// <response code="404">Service not found.</response>
+        [HttpGet("{partnerLocationId}/{serviceTypeId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerLocationServiceDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Get(Guid partnerLocationId, int serviceTypeId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocationService for Location={PartnerLocationId}, ServiceType={ServiceTypeId}",
+                partnerLocationId, serviceTypeId);
+
+            var service = await partnerLocationServiceManager.GetAsync(partnerLocationId, serviceTypeId, cancellationToken);
+
+            if (service is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(service.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new partner location service.
+        /// </summary>
+        /// <param name="dto">The partner location service to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Service created.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner location not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerLocationServiceDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Add(PartnerLocationServiceDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerLocationService for Location={PartnerLocationId}, ServiceType={ServiceTypeId}",
+                dto.PartnerLocationId, dto.ServiceTypeId);
+
+            var partnerLocation = await partnerLocationManager.GetAsync(dto.PartnerLocationId, cancellationToken);
+
+            if (partnerLocation is null)
+            {
+                return NotFound(new ProblemDetails
+                {
+                    Title = "Not found",
+                    Detail = "Partner location not found.",
+                    Status = StatusCodes.Status404NotFound,
+                });
+            }
+
+            var partner = await partnerManager.GetAsync(partnerLocation.PartnerId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerLocationServiceManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get),
+                new { partnerLocationId = result.PartnerLocationId, serviceTypeId = result.ServiceTypeId },
+                result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing partner location service.
+        /// </summary>
+        /// <param name="dto">The partner location service to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Service updated.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerLocationServiceDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Update(PartnerLocationServiceDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdatePartnerLocationService for Location={PartnerLocationId}, ServiceType={ServiceTypeId}",
+                dto.PartnerLocationId, dto.ServiceTypeId);
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(dto.PartnerLocationId, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerLocationServiceManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a partner location service.
+        /// </summary>
+        /// <param name="partnerLocationId">The partner location ID.</param>
+        /// <param name="serviceTypeId">The service type ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Service deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpDelete("{partnerLocationId}/{serviceTypeId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Delete(Guid partnerLocationId, int serviceTypeId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePartnerLocationService for Location={PartnerLocationId}, ServiceType={ServiceTypeId}",
+                partnerLocationId, serviceTypeId);
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationId, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await partnerLocationServiceManager.Delete(partnerLocationId, serviceTypeId, cancellationToken);
+
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerLocationsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerLocationsV2Controller.cs
@@ -1,0 +1,275 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner locations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-locations")]
+    public class PartnerLocationsV2Controller(
+        IPartnerLocationManager partnerLocationManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerLocationsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all locations for a partner.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner locations.</response>
+        [HttpGet("by-partner/{partnerId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerLocationDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetByPartner(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocationsByPartner for Partner={PartnerId}", partnerId);
+
+            var results = await partnerLocationManager.GetByParentIdAsync(partnerId, cancellationToken);
+
+            return Ok(results.Select(pl => pl.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single partner location by its identifier.
+        /// </summary>
+        /// <param name="id">The partner location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner location.</response>
+        /// <response code="404">Partner location not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerLocationDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocation for Id={PartnerLocationId}", id);
+
+            var partnerLocation = await partnerLocationManager.GetAsync(id, cancellationToken);
+
+            if (partnerLocation is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(partnerLocation.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new partner location.
+        /// </summary>
+        /// <param name="dto">The partner location to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Partner location created.</response>
+        /// <response code="400">Invalid input.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerLocationDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Add(PartnerLocationDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerLocation for Partner={PartnerId}", dto.PartnerId);
+
+            if (dto.PartnerId == Guid.Empty)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid request",
+                    Detail = "PartnerId is required.",
+                    Status = StatusCodes.Status400BadRequest,
+                });
+            }
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound(new ProblemDetails
+                {
+                    Title = "Not found",
+                    Detail = "Partner not found.",
+                    Status = StatusCodes.Status404NotFound,
+                });
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerLocationManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing partner location.
+        /// </summary>
+        /// <param name="dto">The partner location to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Partner location updated.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerLocationDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Update(PartnerLocationDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdatePartnerLocation for Id={PartnerLocationId}", dto.Id);
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(dto.Id, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerLocationManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a partner location.
+        /// </summary>
+        /// <param name="id">The partner location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Partner location deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePartnerLocation for Id={PartnerLocationId}", id);
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(id, cancellationToken);
+
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await partnerLocationManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Finds partners with locations near a specified point.
+        /// </summary>
+        /// <param name="latitude">The latitude of the search center.</param>
+        /// <param name="longitude">The longitude of the search center.</param>
+        /// <param name="radiusMiles">The search radius in miles (default: 25).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the nearby partners.</response>
+        /// <response code="400">Invalid coordinates or radius.</response>
+        [AllowAnonymous]
+        [HttpGet("nearby")]
+        [ProducesResponseType(typeof(IEnumerable<PartnerDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetNearby(
+            [FromQuery] double latitude,
+            [FromQuery] double longitude,
+            [FromQuery] double radiusMiles = 25,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetNearbyPartners at Lat={Latitude}, Lon={Longitude}, Radius={RadiusMiles}",
+                latitude, longitude, radiusMiles);
+
+            if (latitude < -90 || latitude > 90)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid request",
+                    Detail = "Latitude must be between -90 and 90.",
+                    Status = StatusCodes.Status400BadRequest,
+                });
+            }
+
+            if (longitude < -180 || longitude > 180)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid request",
+                    Detail = "Longitude must be between -180 and 180.",
+                    Status = StatusCodes.Status400BadRequest,
+                });
+            }
+
+            if (radiusMiles <= 0 || radiusMiles > 500)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Invalid request",
+                    Detail = "Radius must be between 0 and 500 miles.",
+                    Status = StatusCodes.Status400BadRequest,
+                });
+            }
+
+            var partners = await partnerLocationManager.GetNearbyPartnersAsync(
+                latitude, longitude, radiusMiles, cancellationToken);
+
+            return Ok(partners.Select(p => p.ToV2Dto()));
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerRequestsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerRequestsV2Controller.cs
@@ -1,0 +1,181 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner requests, including creation, approval, and denial.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-requests")]
+    [Authorize]
+    public class PartnerRequestsV2Controller(
+        IPartnerRequestManager partnerRequestManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerRequestsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Adds a new partner request.
+        /// </summary>
+        /// <param name="dto">The partner request to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created partner request.</returns>
+        /// <response code="201">Partner request created.</response>
+        /// <response code="400">Invalid request data.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerRequestDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Add([FromBody] PartnerRequestDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerRequest Name={Name}", dto.Name);
+
+            var entity = dto.ToEntity();
+            var result = await partnerRequestManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Approves a partner request. Admin only.
+        /// </summary>
+        /// <param name="id">The partner request ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The approved partner request.</returns>
+        /// <response code="200">Partner request approved.</response>
+        /// <response code="403">User is not an admin.</response>
+        [HttpPut("{id}/approve")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerRequestDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Approve(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ApprovePartnerRequest Request={RequestId}", id);
+
+            var result = await partnerRequestManager.ApproveBecomeAPartnerAsync(id, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Denies a partner request. Admin only.
+        /// </summary>
+        /// <param name="id">The partner request ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The denied partner request.</returns>
+        /// <response code="200">Partner request denied.</response>
+        /// <response code="403">User is not an admin.</response>
+        [HttpPut("{id}/deny")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerRequestDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Deny(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DenyPartnerRequest Request={RequestId}", id);
+
+            var result = await partnerRequestManager.DenyBecomeAPartnerAsync(id, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets all partner requests. Admin only.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of all partner requests.</returns>
+        /// <response code="200">Returns the partner request list.</response>
+        /// <response code="403">User is not an admin.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerRequestDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAllPartnerRequests");
+
+            var results = await partnerRequestManager.GetAsync(cancellationToken);
+
+            return Ok(results.Select(r => r.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a partner request by its unique identifier. Admin only.
+        /// </summary>
+        /// <param name="id">The partner request ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The partner request.</returns>
+        /// <response code="200">Returns the partner request.</response>
+        /// <response code="403">User is not an admin.</response>
+        /// <response code="404">Partner request not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [ProducesResponseType(typeof(PartnerRequestDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerRequest Request={RequestId}", id);
+
+            var result = await partnerRequestManager.GetAsync(id, cancellationToken);
+
+            if (result is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets partner requests by user ID.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of partner requests for the user.</returns>
+        /// <response code="200">Returns the partner request list.</response>
+        [HttpGet("by-user/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerRequestDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByUser(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerRequestsByUser User={UserId}", userId);
+
+            var results = await partnerRequestManager.GetByCreatedUserIdAsync(userId, cancellationToken);
+
+            return Ok(results.Select(r => r.ToV2Dto()));
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PartnerSocialMediaAccountsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerSocialMediaAccountsV2Controller.cs
@@ -1,0 +1,213 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner social media accounts.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partner-social-media-accounts")]
+    public class PartnerSocialMediaAccountsV2Controller(
+        IPartnerSocialMediaAccountManager partnerSocialMediaAccountManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerSocialMediaAccountsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all social media accounts for a partner.
+        /// </summary>
+        /// <param name="partnerId">The partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner social media accounts.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpGet("by-partner/{partnerId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IEnumerable<PartnerSocialMediaAccountDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetByPartner(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerSocialMediaAccounts for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var accounts = await partnerSocialMediaAccountManager.GetByParentIdAsync(partnerId, cancellationToken);
+            return Ok(accounts.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single partner social media account by ID.
+        /// </summary>
+        /// <param name="id">The social media account ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the partner social media account.</response>
+        /// <response code="401">Not authenticated.</response>
+        /// <response code="404">Social media account not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerSocialMediaAccountDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerSocialMediaAccount for Id={AccountId}", id);
+
+            var account = await partnerSocialMediaAccountManager.GetAsync(id, cancellationToken);
+            if (account is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(account.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Adds a new partner social media account.
+        /// </summary>
+        /// <param name="dto">The social media account to add.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the created social media account.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerSocialMediaAccountDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Add(PartnerSocialMediaAccountDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddPartnerSocialMediaAccount for Partner={PartnerId}", dto.PartnerId);
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerSocialMediaAccountManager.AddAsync(entity, UserId, cancellationToken);
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing partner social media account.
+        /// </summary>
+        /// <param name="dto">The social media account to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated social media account.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPut]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerSocialMediaAccountDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(PartnerSocialMediaAccountDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdatePartnerSocialMediaAccount for Id={AccountId}", dto.Id);
+
+            var partner = await partnerManager.GetAsync(dto.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = dto.ToEntity();
+            var result = await partnerSocialMediaAccountManager.UpdateAsync(entity, UserId, cancellationToken);
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a partner social media account.
+        /// </summary>
+        /// <param name="id">The social media account ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Social media account deleted.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Social media account or partner not found.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeletePartnerSocialMediaAccount for Id={AccountId}", id);
+
+            var account = await partnerSocialMediaAccountManager.GetAsync(id, cancellationToken);
+            if (account is null)
+            {
+                return NotFound();
+            }
+
+            var partner = await partnerManager.GetAsync(account.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await partnerSocialMediaAccountManager.DeleteAsync(id, cancellationToken);
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add 9 new v2 controllers covering all partner management endpoints (locations, contacts, services, admins, invitations, requests, documents, social media)
- 9 new DTOs with consolidated `PartnerManagementMappingsV2` mapping file
- Partner location event services already covered by `EventPartnerLocationServicesV2Controller` (Phase 2a)
- Partner document admin endpoint folded into `PartnerDocumentsV2Controller` (`GET admin/all`)
- 68 new unit tests across 9 test classes
- All endpoints use DTO-only responses with proper `UserIsPartnerUserOrIsAdmin` auth pattern

## Test plan
- [x] All 68 new controller tests pass
- [x] Solution builds with no errors or warnings
- [ ] Verify partner CRUD operations on dev after merge
- [ ] Verify document upload/download on dev after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)