### PR TITLE
API v2: Community & adoption management (Phase 2e)

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phase 1 complete; Phase 2a complete — 30 v2 controllers, 64 DTOs, 30+ test suites; Phases 2b–2i, 3, 4 remaining) |
+| **Status** | In Progress (Phases 1, 2a–2e complete — 40+ v2 controllers, 75+ DTOs, 40+ test suites; Phases 2f–2i, 3, 4 remaining) |
 | **Priority** | High |
 | **Risk** | Medium |
 | **Size** | Very Large |
@@ -179,16 +179,18 @@ All partner management endpoints migrated to v2 with DTO-only responses. 9 new c
 
 Community administration and area adoption features — 10 v1 controllers, all community admin/site admin features.
 
-- [ ] **Adoptable areas** - `AdoptableAreasController`: manage adoptable cleanup areas per community
-- [ ] **Area generation** - `AreaGenerationController`: AI-powered area generation for adoption zones
-- [ ] **Staged areas** - `StagedAreasController`: review AI-generated areas before approval
-- [ ] **Community adoptions** - `CommunityAdoptionsController`: view/manage pending adoption applications
-- [ ] **Adoption events** - `AdoptionEventsController`: link events to team adoptions
-- [ ] **Community sponsored adoptions** - `CommunitySponsoredAdoptionsController`: sponsored cleanup adoptions
-- [ ] **Community sponsors** - `CommunitySponsorsController`: sponsor organizations per community
-- [ ] **Community invites** - `CommunityInvitesController`: bulk email invites for communities
-- [ ] **Community professional companies** - `CommunityProfessionalCompaniesController`: professional cleaning companies
-- [ ] **Community prospects** - `CommunityProspectsController`: CRM pipeline for prospecting new community partnerships (site admin only)
+- [x] **Adoptable areas** - `AdoptableAreasV2Controller`: 11 endpoints, `AdoptableAreaDto` DTO ✅
+- [x] **Area generation** - `AreaGenerationV2Controller`: 5 endpoints, `AreaGenerationBatchDto` DTO ✅
+- [x] **Staged areas** - `StagedAreasV2Controller`: 7 endpoints, `StagedAdoptableAreaDto` DTO ✅
+- [x] **Community adoptions** - `CommunityAdoptionsV2Controller`: 7 endpoints, `TeamAdoptionDto` DTO ✅
+- [x] **Adoption events** - `AdoptionEventsV2Controller`: 3 endpoints, `TeamAdoptionEventDto` DTO ✅
+- [x] **Community sponsored adoptions** - `CommunitySponsoredAdoptionsV2Controller`: 5 endpoints, `SponsoredAdoptionDto` DTO ✅
+- [x] **Community sponsors** - `CommunitySponsorsV2Controller`: 6 endpoints, `SponsorDto` DTO ✅
+- [x] **Community invites** - `CommunityInvitesV2Controller`: 3 endpoints ✅
+- [x] **Community professional companies** - `CommunityProfessionalCompaniesV2Controller`: 7 endpoints, `ProfessionalCompanyDto` + `ProfessionalCompanyUserDto` DTOs ✅
+- [x] **Community prospects** - `CommunityProspectsV2Controller`: 18 endpoints, `CommunityProspectDto` + `ProspectActivityDto` DTOs ✅
+
+**Phase 2e totals:** 10 controllers, 72 endpoints, 11 DTOs, 1 mapping file, 38 tests
 
 ### Phase 2f - Team Administration & Portals (Web Admin)
 

--- a/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
@@ -1,0 +1,517 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping community management entities to V2 DTOs.
+    /// </summary>
+    public static class CommunityManagementMappingsV2
+    {
+        #region AdoptableArea
+
+        /// <summary>
+        /// Maps an AdoptableArea entity to a V2 AdoptableAreaDto.
+        /// </summary>
+        public static AdoptableAreaDto ToV2Dto(this AdoptableArea entity)
+        {
+            return new AdoptableAreaDto
+            {
+                Id = entity.Id,
+                PartnerId = entity.PartnerId,
+                Name = entity.Name,
+                Description = entity.Description,
+                AreaType = entity.AreaType,
+                Status = entity.Status,
+                GeoJson = entity.GeoJson,
+                StartLatitude = entity.StartLatitude,
+                StartLongitude = entity.StartLongitude,
+                EndLatitude = entity.EndLatitude,
+                EndLongitude = entity.EndLongitude,
+                CleanupFrequencyDays = entity.CleanupFrequencyDays,
+                MinEventsPerYear = entity.MinEventsPerYear,
+                SafetyRequirements = entity.SafetyRequirements,
+                AllowCoAdoption = entity.AllowCoAdoption,
+                IsActive = entity.IsActive,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 AdoptableAreaDto to an AdoptableArea entity.
+        /// </summary>
+        public static AdoptableArea ToEntity(this AdoptableAreaDto dto)
+        {
+            return new AdoptableArea
+            {
+                Id = dto.Id,
+                PartnerId = dto.PartnerId,
+                Name = dto.Name ?? string.Empty,
+                Description = dto.Description,
+                AreaType = dto.AreaType,
+                Status = dto.Status ?? "Available",
+                GeoJson = dto.GeoJson,
+                StartLatitude = dto.StartLatitude,
+                StartLongitude = dto.StartLongitude,
+                EndLatitude = dto.EndLatitude,
+                EndLongitude = dto.EndLongitude,
+                CleanupFrequencyDays = dto.CleanupFrequencyDays,
+                MinEventsPerYear = dto.MinEventsPerYear,
+                SafetyRequirements = dto.SafetyRequirements,
+                AllowCoAdoption = dto.AllowCoAdoption,
+                IsActive = dto.IsActive,
+            };
+        }
+
+        #endregion
+
+        #region StagedAdoptableArea
+
+        /// <summary>
+        /// Maps a StagedAdoptableArea entity to a V2 StagedAdoptableAreaDto.
+        /// </summary>
+        public static StagedAdoptableAreaDto ToV2Dto(this StagedAdoptableArea entity)
+        {
+            return new StagedAdoptableAreaDto
+            {
+                Id = entity.Id,
+                BatchId = entity.BatchId,
+                PartnerId = entity.PartnerId,
+                Name = entity.Name,
+                Description = entity.Description,
+                AreaType = entity.AreaType,
+                GeoJson = entity.GeoJson,
+                CenterLatitude = entity.CenterLatitude,
+                CenterLongitude = entity.CenterLongitude,
+                ReviewStatus = entity.ReviewStatus,
+                Confidence = entity.Confidence,
+                IsPotentialDuplicate = entity.IsPotentialDuplicate,
+                DuplicateOfName = entity.DuplicateOfName,
+                OsmId = entity.OsmId,
+                OsmTags = entity.OsmTags,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 StagedAdoptableAreaDto to a StagedAdoptableArea entity.
+        /// </summary>
+        public static StagedAdoptableArea ToEntity(this StagedAdoptableAreaDto dto)
+        {
+            return new StagedAdoptableArea
+            {
+                Id = dto.Id,
+                BatchId = dto.BatchId,
+                PartnerId = dto.PartnerId,
+                Name = dto.Name ?? string.Empty,
+                Description = dto.Description,
+                AreaType = dto.AreaType,
+                GeoJson = dto.GeoJson,
+                CenterLatitude = dto.CenterLatitude,
+                CenterLongitude = dto.CenterLongitude,
+                ReviewStatus = dto.ReviewStatus ?? "Pending",
+                Confidence = dto.Confidence ?? "Medium",
+                IsPotentialDuplicate = dto.IsPotentialDuplicate,
+                DuplicateOfName = dto.DuplicateOfName,
+                OsmId = dto.OsmId,
+                OsmTags = dto.OsmTags,
+            };
+        }
+
+        #endregion
+
+        #region AreaGenerationBatch
+
+        /// <summary>
+        /// Maps an AreaGenerationBatch entity to a V2 AreaGenerationBatchDto.
+        /// </summary>
+        public static AreaGenerationBatchDto ToV2Dto(this AreaGenerationBatch entity)
+        {
+            return new AreaGenerationBatchDto
+            {
+                Id = entity.Id,
+                PartnerId = entity.PartnerId,
+                Category = entity.Category,
+                Status = entity.Status,
+                DiscoveredCount = entity.DiscoveredCount,
+                ProcessedCount = entity.ProcessedCount,
+                SkippedCount = entity.SkippedCount,
+                StagedCount = entity.StagedCount,
+                ApprovedCount = entity.ApprovedCount,
+                RejectedCount = entity.RejectedCount,
+                CreatedCount = entity.CreatedCount,
+                ErrorMessage = entity.ErrorMessage,
+                CompletedDate = entity.CompletedDate,
+                BoundsNorth = entity.BoundsNorth,
+                BoundsSouth = entity.BoundsSouth,
+                BoundsEast = entity.BoundsEast,
+                BoundsWest = entity.BoundsWest,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 AreaGenerationBatchDto to an AreaGenerationBatch entity.
+        /// </summary>
+        public static AreaGenerationBatch ToEntity(this AreaGenerationBatchDto dto)
+        {
+            return new AreaGenerationBatch
+            {
+                Id = dto.Id,
+                PartnerId = dto.PartnerId,
+                Category = dto.Category,
+                Status = dto.Status ?? "Queued",
+                DiscoveredCount = dto.DiscoveredCount,
+                ProcessedCount = dto.ProcessedCount,
+                SkippedCount = dto.SkippedCount,
+                StagedCount = dto.StagedCount,
+                ApprovedCount = dto.ApprovedCount,
+                RejectedCount = dto.RejectedCount,
+                CreatedCount = dto.CreatedCount,
+                ErrorMessage = dto.ErrorMessage,
+                CompletedDate = dto.CompletedDate,
+                BoundsNorth = dto.BoundsNorth,
+                BoundsSouth = dto.BoundsSouth,
+                BoundsEast = dto.BoundsEast,
+                BoundsWest = dto.BoundsWest,
+            };
+        }
+
+        #endregion
+
+        #region TeamAdoption
+
+        /// <summary>
+        /// Maps a TeamAdoption entity to a V2 TeamAdoptionDto.
+        /// </summary>
+        public static TeamAdoptionDto ToV2Dto(this TeamAdoption entity)
+        {
+            return new TeamAdoptionDto
+            {
+                Id = entity.Id,
+                TeamId = entity.TeamId,
+                AdoptableAreaId = entity.AdoptableAreaId,
+                ApplicationDate = entity.ApplicationDate,
+                ApplicationNotes = entity.ApplicationNotes,
+                Status = entity.Status,
+                ReviewedByUserId = entity.ReviewedByUserId,
+                ReviewedDate = entity.ReviewedDate,
+                RejectionReason = entity.RejectionReason,
+                AdoptionStartDate = entity.AdoptionStartDate,
+                AdoptionEndDate = entity.AdoptionEndDate,
+                LastEventDate = entity.LastEventDate,
+                EventCount = entity.EventCount,
+                IsCompliant = entity.IsCompliant,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 TeamAdoptionDto to a TeamAdoption entity.
+        /// </summary>
+        public static TeamAdoption ToEntity(this TeamAdoptionDto dto)
+        {
+            return new TeamAdoption
+            {
+                Id = dto.Id,
+                TeamId = dto.TeamId,
+                AdoptableAreaId = dto.AdoptableAreaId,
+                ApplicationDate = dto.ApplicationDate,
+                ApplicationNotes = dto.ApplicationNotes,
+                Status = dto.Status ?? "Pending",
+                ReviewedByUserId = dto.ReviewedByUserId,
+                ReviewedDate = dto.ReviewedDate,
+                RejectionReason = dto.RejectionReason,
+                AdoptionStartDate = dto.AdoptionStartDate,
+                AdoptionEndDate = dto.AdoptionEndDate,
+                LastEventDate = dto.LastEventDate,
+                EventCount = dto.EventCount,
+                IsCompliant = dto.IsCompliant,
+            };
+        }
+
+        #endregion
+
+        #region TeamAdoptionEvent
+
+        /// <summary>
+        /// Maps a TeamAdoptionEvent entity to a V2 TeamAdoptionEventDto.
+        /// </summary>
+        public static TeamAdoptionEventDto ToV2Dto(this TeamAdoptionEvent entity)
+        {
+            return new TeamAdoptionEventDto
+            {
+                Id = entity.Id,
+                TeamAdoptionId = entity.TeamAdoptionId,
+                EventId = entity.EventId,
+                Notes = entity.Notes,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 TeamAdoptionEventDto to a TeamAdoptionEvent entity.
+        /// </summary>
+        public static TeamAdoptionEvent ToEntity(this TeamAdoptionEventDto dto)
+        {
+            return new TeamAdoptionEvent
+            {
+                Id = dto.Id,
+                TeamAdoptionId = dto.TeamAdoptionId,
+                EventId = dto.EventId,
+                Notes = dto.Notes,
+            };
+        }
+
+        #endregion
+
+        #region SponsoredAdoption
+
+        /// <summary>
+        /// Maps a SponsoredAdoption entity to a V2 SponsoredAdoptionDto.
+        /// </summary>
+        public static SponsoredAdoptionDto ToV2Dto(this SponsoredAdoption entity)
+        {
+            return new SponsoredAdoptionDto
+            {
+                Id = entity.Id,
+                AdoptableAreaId = entity.AdoptableAreaId,
+                SponsorId = entity.SponsorId,
+                ProfessionalCompanyId = entity.ProfessionalCompanyId,
+                StartDate = entity.StartDate,
+                EndDate = entity.EndDate,
+                CleanupFrequencyDays = entity.CleanupFrequencyDays,
+                Status = entity.Status,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 SponsoredAdoptionDto to a SponsoredAdoption entity.
+        /// </summary>
+        public static SponsoredAdoption ToEntity(this SponsoredAdoptionDto dto)
+        {
+            return new SponsoredAdoption
+            {
+                Id = dto.Id,
+                AdoptableAreaId = dto.AdoptableAreaId,
+                SponsorId = dto.SponsorId,
+                ProfessionalCompanyId = dto.ProfessionalCompanyId,
+                StartDate = dto.StartDate,
+                EndDate = dto.EndDate,
+                CleanupFrequencyDays = dto.CleanupFrequencyDays,
+                Status = dto.Status ?? "Active",
+            };
+        }
+
+        #endregion
+
+        #region Sponsor
+
+        /// <summary>
+        /// Maps a Sponsor entity to a V2 SponsorDto.
+        /// </summary>
+        public static SponsorDto ToV2Dto(this Sponsor entity)
+        {
+            return new SponsorDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                ContactEmail = entity.ContactEmail,
+                ContactPhone = entity.ContactPhone,
+                LogoUrl = entity.LogoUrl,
+                PartnerId = entity.PartnerId,
+                IsActive = entity.IsActive,
+                ShowOnPublicMap = entity.ShowOnPublicMap,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 SponsorDto to a Sponsor entity.
+        /// </summary>
+        public static Sponsor ToEntity(this SponsorDto dto)
+        {
+            return new Sponsor
+            {
+                Id = dto.Id,
+                Name = dto.Name ?? string.Empty,
+                ContactEmail = dto.ContactEmail,
+                ContactPhone = dto.ContactPhone,
+                LogoUrl = dto.LogoUrl,
+                PartnerId = dto.PartnerId,
+                IsActive = dto.IsActive,
+                ShowOnPublicMap = dto.ShowOnPublicMap,
+            };
+        }
+
+        #endregion
+
+        #region ProfessionalCompany
+
+        /// <summary>
+        /// Maps a ProfessionalCompany entity to a V2 ProfessionalCompanyDto.
+        /// </summary>
+        public static ProfessionalCompanyDto ToV2Dto(this ProfessionalCompany entity)
+        {
+            return new ProfessionalCompanyDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                ContactEmail = entity.ContactEmail,
+                ContactPhone = entity.ContactPhone,
+                PartnerId = entity.PartnerId,
+                IsActive = entity.IsActive,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 ProfessionalCompanyDto to a ProfessionalCompany entity.
+        /// </summary>
+        public static ProfessionalCompany ToEntity(this ProfessionalCompanyDto dto)
+        {
+            return new ProfessionalCompany
+            {
+                Id = dto.Id,
+                Name = dto.Name ?? string.Empty,
+                ContactEmail = dto.ContactEmail,
+                ContactPhone = dto.ContactPhone,
+                PartnerId = dto.PartnerId,
+                IsActive = dto.IsActive,
+            };
+        }
+
+        #endregion
+
+        #region ProfessionalCompanyUser
+
+        /// <summary>
+        /// Maps a ProfessionalCompanyUser entity to a V2 ProfessionalCompanyUserDto.
+        /// </summary>
+        public static ProfessionalCompanyUserDto ToV2Dto(this ProfessionalCompanyUser entity)
+        {
+            return new ProfessionalCompanyUserDto
+            {
+                ProfessionalCompanyId = entity.ProfessionalCompanyId,
+                UserId = entity.UserId,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 ProfessionalCompanyUserDto to a ProfessionalCompanyUser entity.
+        /// </summary>
+        public static ProfessionalCompanyUser ToEntity(this ProfessionalCompanyUserDto dto)
+        {
+            return new ProfessionalCompanyUser
+            {
+                ProfessionalCompanyId = dto.ProfessionalCompanyId,
+                UserId = dto.UserId,
+            };
+        }
+
+        #endregion
+
+        #region CommunityProspect
+
+        /// <summary>
+        /// Maps a CommunityProspect entity to a V2 CommunityProspectDto.
+        /// </summary>
+        public static CommunityProspectDto ToV2Dto(this CommunityProspect entity)
+        {
+            return new CommunityProspectDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                Type = entity.Type,
+                City = entity.City,
+                Region = entity.Region,
+                Country = entity.Country,
+                Latitude = entity.Latitude,
+                Longitude = entity.Longitude,
+                Population = entity.Population,
+                Website = entity.Website,
+                ContactEmail = entity.ContactEmail,
+                ContactName = entity.ContactName,
+                ContactTitle = entity.ContactTitle,
+                ContactPhone = entity.ContactPhone,
+                PipelineStage = entity.PipelineStage,
+                FitScore = entity.FitScore,
+                Notes = entity.Notes,
+                LastContactedDate = entity.LastContactedDate,
+                NextFollowUpDate = entity.NextFollowUpDate,
+                ConvertedPartnerId = entity.ConvertedPartnerId,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 CommunityProspectDto to a CommunityProspect entity.
+        /// </summary>
+        public static CommunityProspect ToEntity(this CommunityProspectDto dto)
+        {
+            return new CommunityProspect
+            {
+                Id = dto.Id,
+                Name = dto.Name ?? string.Empty,
+                Type = dto.Type,
+                City = dto.City,
+                Region = dto.Region,
+                Country = dto.Country,
+                Latitude = dto.Latitude,
+                Longitude = dto.Longitude,
+                Population = dto.Population,
+                Website = dto.Website,
+                ContactEmail = dto.ContactEmail,
+                ContactName = dto.ContactName,
+                ContactTitle = dto.ContactTitle,
+                ContactPhone = dto.ContactPhone,
+                PipelineStage = dto.PipelineStage,
+                FitScore = dto.FitScore,
+                Notes = dto.Notes,
+                LastContactedDate = dto.LastContactedDate,
+                NextFollowUpDate = dto.NextFollowUpDate,
+                ConvertedPartnerId = dto.ConvertedPartnerId,
+            };
+        }
+
+        #endregion
+
+        #region ProspectActivity
+
+        /// <summary>
+        /// Maps a ProspectActivity entity to a V2 ProspectActivityDto.
+        /// </summary>
+        public static ProspectActivityDto ToV2Dto(this ProspectActivity entity)
+        {
+            return new ProspectActivityDto
+            {
+                Id = entity.Id,
+                ProspectId = entity.ProspectId,
+                ActivityType = entity.ActivityType,
+                Subject = entity.Subject,
+                Details = entity.Details,
+                SentimentScore = entity.SentimentScore,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 ProspectActivityDto to a ProspectActivity entity.
+        /// </summary>
+        public static ProspectActivity ToEntity(this ProspectActivityDto dto)
+        {
+            return new ProspectActivity
+            {
+                Id = dto.Id,
+                ProspectId = dto.ProspectId,
+                ActivityType = dto.ActivityType ?? string.Empty,
+                Subject = dto.Subject,
+                Details = dto.Details,
+                SentimentScore = dto.SentimentScore,
+            };
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Models/Poco/V2/AdoptableAreaDto.cs
+++ b/TrashMob.Models/Poco/V2/AdoptableAreaDto.cs
@@ -1,0 +1,97 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of an adoptable area. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class AdoptableAreaDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the community (partner) this area belongs to.
+        /// </summary>
+        public Guid PartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the area name.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the area description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of area (Highway, Park, School, Trail, Waterway, Street, Spot).
+        /// </summary>
+        public string? AreaType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the adoption status (Available, Adopted, Unavailable).
+        /// </summary>
+        public string Status { get; set; } = "Available";
+
+        /// <summary>
+        /// Gets or sets the GeoJSON representation of the area boundary/route.
+        /// </summary>
+        public string? GeoJson { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start point latitude (for linear areas).
+        /// </summary>
+        public double? StartLatitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start point longitude (for linear areas).
+        /// </summary>
+        public double? StartLongitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end point latitude (for linear areas).
+        /// </summary>
+        public double? EndLatitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end point longitude (for linear areas).
+        /// </summary>
+        public double? EndLongitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets how often cleanup is required (in days).
+        /// </summary>
+        public int CleanupFrequencyDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum events required per year.
+        /// </summary>
+        public int MinEventsPerYear { get; set; }
+
+        /// <summary>
+        /// Gets or sets safety requirements and guidelines.
+        /// </summary>
+        public string? SafetyRequirements { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this area can be co-adopted by multiple teams.
+        /// </summary>
+        public bool AllowCoAdoption { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this area is active.
+        /// </summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the area was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/AreaGenerationBatchDto.cs
+++ b/TrashMob.Models/Poco/V2/AreaGenerationBatchDto.cs
@@ -1,0 +1,102 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of an area generation batch. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class AreaGenerationBatchDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the community (partner) this batch belongs to.
+        /// </summary>
+        public Guid PartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category of areas to discover (e.g., "School", "Park").
+        /// </summary>
+        public string? Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the batch status (Queued, Discovering, Processing, Complete, Failed, Cancelled).
+        /// </summary>
+        public string Status { get; set; } = "Queued";
+
+        /// <summary>
+        /// Gets or sets the number of features discovered from OSM.
+        /// </summary>
+        public int DiscoveredCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of features processed so far.
+        /// </summary>
+        public int ProcessedCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of features skipped.
+        /// </summary>
+        public int SkippedCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of features staged for review.
+        /// </summary>
+        public int StagedCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of staged areas approved by a reviewer.
+        /// </summary>
+        public int ApprovedCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of staged areas rejected by a reviewer.
+        /// </summary>
+        public int RejectedCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of approved areas promoted to real adoptable areas.
+        /// </summary>
+        public int CreatedCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error message if the batch failed.
+        /// </summary>
+        public string? ErrorMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the batch completed (or failed/cancelled).
+        /// </summary>
+        public DateTimeOffset? CompletedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the northern latitude bound for sub-region filtering.
+        /// </summary>
+        public double? BoundsNorth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the southern latitude bound for sub-region filtering.
+        /// </summary>
+        public double? BoundsSouth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the eastern longitude bound for sub-region filtering.
+        /// </summary>
+        public double? BoundsEast { get; set; }
+
+        /// <summary>
+        /// Gets or sets the western longitude bound for sub-region filtering.
+        /// </summary>
+        public double? BoundsWest { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the batch was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/CommunityProspectDto.cs
+++ b/TrashMob.Models/Poco/V2/CommunityProspectDto.cs
@@ -1,0 +1,117 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a community prospect. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class CommunityProspectDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the prospect name.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the prospect type.
+        /// </summary>
+        public string? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the city.
+        /// </summary>
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Gets or sets the region (state/province).
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets the country.
+        /// </summary>
+        public string? Country { get; set; }
+
+        /// <summary>
+        /// Gets or sets the latitude.
+        /// </summary>
+        public double? Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude.
+        /// </summary>
+        public double? Longitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the population.
+        /// </summary>
+        public int? Population { get; set; }
+
+        /// <summary>
+        /// Gets or sets the website URL.
+        /// </summary>
+        public string? Website { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact email.
+        /// </summary>
+        public string? ContactEmail { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact name.
+        /// </summary>
+        public string? ContactName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact title.
+        /// </summary>
+        public string? ContactTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact phone.
+        /// </summary>
+        public string? ContactPhone { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pipeline stage.
+        /// </summary>
+        public int PipelineStage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fit score.
+        /// </summary>
+        public int FitScore { get; set; }
+
+        /// <summary>
+        /// Gets or sets notes about the prospect.
+        /// </summary>
+        public string? Notes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date of last contact.
+        /// </summary>
+        public DateTimeOffset? LastContactedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the next follow-up date.
+        /// </summary>
+        public DateTimeOffset? NextFollowUpDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the partner identifier if this prospect was converted.
+        /// </summary>
+        public Guid? ConvertedPartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the prospect was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/ProfessionalCompanyDto.cs
+++ b/TrashMob.Models/Poco/V2/ProfessionalCompanyDto.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a professional cleanup company. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class ProfessionalCompanyDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the company name.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the company's contact email.
+        /// </summary>
+        public string? ContactEmail { get; set; }
+
+        /// <summary>
+        /// Gets or sets the company's contact phone number.
+        /// </summary>
+        public string? ContactPhone { get; set; }
+
+        /// <summary>
+        /// Gets or sets the community (partner) this company is assigned to.
+        /// </summary>
+        public Guid PartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this company is active.
+        /// </summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the company was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/ProfessionalCompanyUserDto.cs
+++ b/TrashMob.Models/Poco/V2/ProfessionalCompanyUserDto.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a professional company user association. Composite key DTO (no Id).
+    /// </summary>
+    public class ProfessionalCompanyUserDto
+    {
+        /// <summary>
+        /// Gets or sets the professional company identifier.
+        /// </summary>
+        public Guid ProfessionalCompanyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user identifier.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the association was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/ProspectActivityDto.cs
+++ b/TrashMob.Models/Poco/V2/ProspectActivityDto.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a prospect activity. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class ProspectActivityDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the prospect identifier.
+        /// </summary>
+        public Guid ProspectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the activity type.
+        /// </summary>
+        public string ActivityType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the subject.
+        /// </summary>
+        public string? Subject { get; set; }
+
+        /// <summary>
+        /// Gets or sets the details.
+        /// </summary>
+        public string? Details { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sentiment score.
+        /// </summary>
+        public string? SentimentScore { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the activity was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/SponsorDto.cs
+++ b/TrashMob.Models/Poco/V2/SponsorDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a sponsor. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class SponsorDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sponsor's name.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the sponsor's contact email.
+        /// </summary>
+        public string? ContactEmail { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sponsor's contact phone number.
+        /// </summary>
+        public string? ContactPhone { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL to the sponsor's logo image.
+        /// </summary>
+        public string? LogoUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the community (partner) this sponsor belongs to.
+        /// </summary>
+        public Guid PartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this sponsor is active.
+        /// </summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this sponsor's name should be displayed on the public community map.
+        /// </summary>
+        public bool ShowOnPublicMap { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the sponsor was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/SponsoredAdoptionDto.cs
+++ b/TrashMob.Models/Poco/V2/SponsoredAdoptionDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a sponsored adoption. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class SponsoredAdoptionDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the adoptable area being sponsored.
+        /// </summary>
+        public Guid AdoptableAreaId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sponsor funding this adoption.
+        /// </summary>
+        public Guid SponsorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the professional company servicing this area.
+        /// </summary>
+        public Guid ProfessionalCompanyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start date of the sponsored adoption.
+        /// </summary>
+        public DateOnly StartDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end date of the sponsored adoption (null for open-ended).
+        /// </summary>
+        public DateOnly? EndDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expected cleanup frequency in days.
+        /// </summary>
+        public int CleanupFrequencyDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the status (Active, Expired, Terminated).
+        /// </summary>
+        public string Status { get; set; } = "Active";
+
+        /// <summary>
+        /// Gets or sets when the sponsored adoption was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/StagedAdoptableAreaDto.cs
+++ b/TrashMob.Models/Poco/V2/StagedAdoptableAreaDto.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a staged adoptable area awaiting review. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class StagedAdoptableAreaDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the batch that produced this staged area.
+        /// </summary>
+        public Guid BatchId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the community (partner) this staged area belongs to.
+        /// </summary>
+        public Guid PartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the area name (from OSM or AI-generated).
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the area description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of area (School, Park, etc.).
+        /// </summary>
+        public string? AreaType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the GeoJSON representation of the area boundary.
+        /// </summary>
+        public string? GeoJson { get; set; }
+
+        /// <summary>
+        /// Gets or sets the center latitude of the area.
+        /// </summary>
+        public double CenterLatitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the center longitude of the area.
+        /// </summary>
+        public double CenterLongitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the review status (Pending, Approved, Rejected).
+        /// </summary>
+        public string ReviewStatus { get; set; } = "Pending";
+
+        /// <summary>
+        /// Gets or sets the confidence level (High, Medium, Low).
+        /// </summary>
+        public string Confidence { get; set; } = "Medium";
+
+        /// <summary>
+        /// Gets or sets whether this area is a potential duplicate of an existing adoptable area.
+        /// </summary>
+        public bool IsPotentialDuplicate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the existing area this may duplicate.
+        /// </summary>
+        public string? DuplicateOfName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OpenStreetMap identifier for traceability.
+        /// </summary>
+        public string? OsmId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a JSON representation of relevant OSM tags.
+        /// </summary>
+        public string? OsmTags { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the staged area was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/TeamAdoptionDto.cs
+++ b/TrashMob.Models/Poco/V2/TeamAdoptionDto.cs
@@ -1,0 +1,87 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a team adoption. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class TeamAdoptionDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the team applying for adoption.
+        /// </summary>
+        public Guid TeamId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the adoptable area.
+        /// </summary>
+        public Guid AdoptableAreaId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the application was submitted.
+        /// </summary>
+        public DateTimeOffset ApplicationDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional notes from the team about their application.
+        /// </summary>
+        public string? ApplicationNotes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the status of the adoption application (Pending, Approved, Rejected, Revoked).
+        /// </summary>
+        public string Status { get; set; } = "Pending";
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who reviewed the application.
+        /// </summary>
+        public Guid? ReviewedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the application was reviewed.
+        /// </summary>
+        public DateTimeOffset? ReviewedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reason for rejection (if rejected).
+        /// </summary>
+        public string? RejectionReason { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start date of the adoption period.
+        /// </summary>
+        public DateOnly? AdoptionStartDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end date of the adoption period.
+        /// </summary>
+        public DateOnly? AdoptionEndDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date of the most recent linked cleanup event.
+        /// </summary>
+        public DateTimeOffset? LastEventDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total count of cleanup events linked to this adoption.
+        /// </summary>
+        public int EventCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the team is currently compliant with cleanup requirements.
+        /// </summary>
+        public bool IsCompliant { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the adoption was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/TeamAdoptionEventDto.cs
+++ b/TrashMob.Models/Poco/V2/TeamAdoptionEventDto.cs
@@ -1,0 +1,37 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a team adoption event link. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class TeamAdoptionEventDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the team adoption.
+        /// </summary>
+        public Guid TeamAdoptionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the cleanup event.
+        /// </summary>
+        public Guid EventId { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional notes about why this event is linked to the adoption.
+        /// </summary>
+        public string? Notes { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the link was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/AdoptableAreasV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/AdoptableAreasV2ControllerTests.cs
@@ -1,0 +1,186 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Areas;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class AdoptableAreasV2ControllerTests
+    {
+        private readonly Mock<IAdoptableAreaManager> areaManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAreaSuggestionService> areaSuggestionService = new();
+        private readonly Mock<IAreaFileParser> areaFileParser = new();
+        private readonly Mock<IAreaGenerationBatchManager> batchManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<AdoptableAreasV2Controller>> logger = new();
+        private readonly AdoptableAreasV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public AdoptableAreasV2ControllerTests()
+        {
+            controller = new AdoptableAreasV2Controller(
+                areaManager.Object,
+                partnerManager.Object,
+                areaSuggestionService.Object,
+                areaFileParser.Object,
+                batchManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, testUserId.ToString())], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAreas_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+            var areas = new List<AdoptableArea>
+            {
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Name = "Park A" },
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Name = "Trail B" },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            areaManager
+                .Setup(m => m.GetByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(areas);
+
+            var result = await controller.GetAreas(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<AdoptableAreaDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetAreas_ReturnsNotFound_WhenPartnerMissing()
+        {
+            var partnerId = Guid.NewGuid();
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null);
+
+            var result = await controller.GetAreas(partnerId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetArea_Found_ReturnsOk()
+        {
+            var partnerId = Guid.NewGuid();
+            var areaId = Guid.NewGuid();
+            var area = new AdoptableArea { Id = areaId, PartnerId = partnerId, Name = "Park A" };
+
+            areaManager
+                .Setup(m => m.GetAsync(areaId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(area);
+
+            var result = await controller.GetArea(partnerId, areaId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<AdoptableAreaDto>(okResult.Value);
+            Assert.Equal("Park A", dto.Name);
+        }
+
+        [Fact]
+        public async Task GetArea_ReturnsNotFound_WhenAreaMissing()
+        {
+            var partnerId = Guid.NewGuid();
+            var areaId = Guid.NewGuid();
+
+            areaManager
+                .Setup(m => m.GetAsync(areaId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((AdoptableArea)null);
+
+            var result = await controller.GetArea(partnerId, areaId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateArea_Authorized_ReturnsCreated()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+            var areaDto = new AdoptableAreaDto { Name = "New Park", AreaType = "Park" };
+            var createdArea = new AdoptableArea
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Name = "New Park",
+                AreaType = "Park",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            areaManager
+                .Setup(m => m.IsNameAvailableAsync(partnerId, "New Park", null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            areaManager
+                .Setup(m => m.AddAsync(It.IsAny<AdoptableArea>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdArea);
+
+            var result = await controller.CreateArea(partnerId, areaDto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(201, createdResult.StatusCode);
+            var dto = Assert.IsType<AdoptableAreaDto>(createdResult.Value);
+            Assert.Equal("New Park", dto.Name);
+        }
+
+        [Fact]
+        public async Task DeleteArea_Authorized_ReturnsNoContent()
+        {
+            var partnerId = Guid.NewGuid();
+            var areaId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+            var area = new AdoptableArea { Id = areaId, PartnerId = partnerId, Name = "Park A", IsActive = true };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            areaManager
+                .Setup(m => m.GetAsync(areaId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(area);
+            areaManager
+                .Setup(m => m.UpdateAsync(It.IsAny<AdoptableArea>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(area);
+
+            var result = await controller.DeleteArea(partnerId, areaId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            areaManager.Verify(
+                m => m.UpdateAsync(It.Is<AdoptableArea>(a => !a.IsActive), testUserId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/AdoptionEventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/AdoptionEventsV2ControllerTests.cs
@@ -1,0 +1,149 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class AdoptionEventsV2ControllerTests
+    {
+        private readonly Mock<ITeamAdoptionEventManager> adoptionEventManager = new();
+        private readonly Mock<ITeamAdoptionManager> adoptionManager = new();
+        private readonly Mock<ITeamMemberManager> teamMemberManager = new();
+        private readonly Mock<ILogger<AdoptionEventsV2Controller>> logger = new();
+        private readonly AdoptionEventsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public AdoptionEventsV2ControllerTests()
+        {
+            controller = new AdoptionEventsV2Controller(
+                adoptionEventManager.Object,
+                adoptionManager.Object,
+                teamMemberManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, testUserId.ToString())], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetLinkedEvents_ReturnsOkWithList()
+        {
+            var adoptionId = Guid.NewGuid();
+            var teamId = Guid.NewGuid();
+            var adoption = new TeamAdoption { Id = adoptionId, TeamId = teamId };
+            var events = new List<TeamAdoptionEvent>
+            {
+                new() { Id = Guid.NewGuid(), TeamAdoptionId = adoptionId, EventId = Guid.NewGuid() },
+                new() { Id = Guid.NewGuid(), TeamAdoptionId = adoptionId, EventId = Guid.NewGuid() },
+            };
+
+            adoptionManager
+                .Setup(m => m.GetAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoption);
+            teamMemberManager
+                .Setup(m => m.IsMemberAsync(teamId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            adoptionEventManager
+                .Setup(m => m.GetByAdoptionIdAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(events);
+
+            var result = await controller.GetLinkedEvents(adoptionId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<TeamAdoptionEventDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetLinkedEvents_ReturnsForbid_WhenNotTeamMember()
+        {
+            var adoptionId = Guid.NewGuid();
+            var teamId = Guid.NewGuid();
+            var adoption = new TeamAdoption { Id = adoptionId, TeamId = teamId };
+
+            adoptionManager
+                .Setup(m => m.GetAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoption);
+            teamMemberManager
+                .Setup(m => m.IsMemberAsync(teamId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.GetLinkedEvents(adoptionId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task LinkEvent_ReturnsCreated()
+        {
+            var adoptionId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var teamId = Guid.NewGuid();
+            var adoption = new TeamAdoption { Id = adoptionId, TeamId = teamId };
+            var adoptionEvent = new TeamAdoptionEvent
+            {
+                Id = Guid.NewGuid(),
+                TeamAdoptionId = adoptionId,
+                EventId = eventId,
+            };
+            var request = new LinkEventRequest { Notes = "Cleanup event" };
+
+            adoptionManager
+                .Setup(m => m.GetAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoption);
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            adoptionEventManager
+                .Setup(m => m.LinkEventAsync(adoptionId, eventId, "Cleanup event", testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<TeamAdoptionEvent>.Success(adoptionEvent));
+
+            var result = await controller.LinkEvent(adoptionId, eventId, request, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(201, createdResult.StatusCode);
+            var dto = Assert.IsType<TeamAdoptionEventDto>(createdResult.Value);
+            Assert.Equal(adoptionId, dto.TeamAdoptionId);
+        }
+
+        [Fact]
+        public async Task UnlinkEvent_ReturnsNoContent()
+        {
+            var adoptionId = Guid.NewGuid();
+            var adoptionEventId = Guid.NewGuid();
+            var teamId = Guid.NewGuid();
+            var adoption = new TeamAdoption { Id = adoptionId, TeamId = teamId };
+
+            adoptionManager
+                .Setup(m => m.GetAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoption);
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            adoptionEventManager
+                .Setup(m => m.UnlinkEventAsync(adoptionEventId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<bool>.Success(true));
+
+            var result = await controller.UnlinkEvent(adoptionId, adoptionEventId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/AreaGenerationV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/AreaGenerationV2ControllerTests.cs
@@ -1,0 +1,141 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Services;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class AreaGenerationV2ControllerTests
+    {
+        private readonly Mock<IAreaGenerationBatchManager> batchManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAreaGenerationQueue> queue = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<AreaGenerationV2Controller>> logger = new();
+        private readonly AreaGenerationV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public AreaGenerationV2ControllerTests()
+        {
+            controller = new AreaGenerationV2Controller(
+                batchManager.Object,
+                partnerManager.Object,
+                queue.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, testUserId.ToString())], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task StartGeneration_Authorized_ReturnsCreated()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+            var request = new AreaGenerationRequest { Category = "Park" };
+            var batch = new AreaGenerationBatch
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Category = "Park",
+                Status = "Queued",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            batchManager
+                .Setup(m => m.GetActiveByPartnerAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((AreaGenerationBatch)null);
+            batchManager
+                .Setup(m => m.AddAsync(It.IsAny<AreaGenerationBatch>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(batch);
+
+            var result = await controller.StartGeneration(partnerId, request, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(201, createdResult.StatusCode);
+            var dto = Assert.IsType<AreaGenerationBatchDto>(createdResult.Value);
+            Assert.Equal("Park", dto.Category);
+        }
+
+        [Fact]
+        public async Task GetStatus_ReturnsOk()
+        {
+            var partnerId = Guid.NewGuid();
+            var batch = new AreaGenerationBatch
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Category = "Park",
+                Status = "Running",
+            };
+
+            batchManager
+                .Setup(m => m.GetActiveByPartnerAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(batch);
+
+            var result = await controller.GetStatus(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<AreaGenerationBatchDto>(okResult.Value);
+            Assert.Equal("Running", dto.Status);
+        }
+
+        [Fact]
+        public async Task GetStatus_ReturnsNotFound_WhenNoBatchActive()
+        {
+            var partnerId = Guid.NewGuid();
+
+            batchManager
+                .Setup(m => m.GetActiveByPartnerAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((AreaGenerationBatch)null);
+
+            var result = await controller.GetStatus(partnerId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetBatches_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var batches = new List<AreaGenerationBatch>
+            {
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Category = "Park", Status = "Complete" },
+                new() { Id = Guid.NewGuid(), PartnerId = partnerId, Category = "School", Status = "Queued" },
+            };
+
+            batchManager
+                .Setup(m => m.GetByPartnerAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(batches);
+
+            var result = await controller.GetBatches(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<AreaGenerationBatchDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunityAdoptionsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunityAdoptionsV2ControllerTests.cs
@@ -1,0 +1,154 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class CommunityAdoptionsV2ControllerTests
+    {
+        private readonly Mock<ITeamAdoptionManager> adoptionManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<CommunityAdoptionsV2Controller>> logger = new();
+        private readonly CommunityAdoptionsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public CommunityAdoptionsV2ControllerTests()
+        {
+            controller = new CommunityAdoptionsV2Controller(
+                adoptionManager.Object,
+                partnerManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, testUserId.ToString())], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetPendingApplications_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+            var adoptions = new List<TeamAdoption>
+            {
+                new() { Id = Guid.NewGuid(), TeamId = Guid.NewGuid(), AdoptableAreaId = Guid.NewGuid(), Status = "Pending" },
+                new() { Id = Guid.NewGuid(), TeamId = Guid.NewGuid(), AdoptableAreaId = Guid.NewGuid(), Status = "Pending" },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            adoptionManager
+                .Setup(m => m.GetPendingByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoptions);
+
+            var result = await controller.GetPendingApplications(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<TeamAdoptionDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task ApproveApplication_ReturnsOk()
+        {
+            var partnerId = Guid.NewGuid();
+            var adoptionId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+            var adoption = new TeamAdoption
+            {
+                Id = adoptionId,
+                TeamId = Guid.NewGuid(),
+                AdoptableAreaId = Guid.NewGuid(),
+                Status = "Approved",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            adoptionManager
+                .Setup(m => m.ApproveApplicationAsync(adoptionId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<TeamAdoption>.Success(adoption));
+
+            var result = await controller.ApproveApplication(partnerId, adoptionId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<TeamAdoptionDto>(okResult.Value);
+            Assert.Equal(adoptionId, dto.Id);
+        }
+
+        [Fact]
+        public async Task GetComplianceStats_ReturnsOk()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+            var stats = new AdoptionComplianceStats
+            {
+                TotalAdoptions = 10,
+                CompliantAdoptions = 8,
+                DelinquentAdoptions = 2,
+                TotalAvailableAreas = 20,
+                AdoptedAreas = 10,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            adoptionManager
+                .Setup(m => m.GetComplianceStatsByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(stats);
+
+            var result = await controller.GetComplianceStats(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedStats = Assert.IsType<AdoptionComplianceStats>(okResult.Value);
+            Assert.Equal(10, returnedStats.TotalAdoptions);
+            Assert.Equal(8, returnedStats.CompliantAdoptions);
+        }
+
+        [Fact]
+        public async Task GetPendingApplications_ReturnsForbid_WhenNotAuthorized()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.GetPendingApplications(partnerId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunityInvitesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunityInvitesV2ControllerTests.cs
@@ -1,0 +1,159 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class CommunityInvitesV2ControllerTests
+    {
+        private readonly Mock<IEmailInviteManager> emailInviteManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<CommunityInvitesV2Controller>> logger = new();
+        private readonly CommunityInvitesV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public CommunityInvitesV2ControllerTests()
+        {
+            controller = new CommunityInvitesV2Controller(
+                emailInviteManager.Object, partnerManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetBatches_Authorized_ReturnsOkWithList()
+        {
+            SetupAuthSuccess();
+
+            var communityId = Guid.NewGuid();
+            var partner = new Partner { Id = communityId, Name = "Test Community" };
+            var batches = new List<EmailInviteBatch>
+            {
+                new() { Id = Guid.NewGuid(), BatchType = "Community", CommunityId = communityId, TotalCount = 5, Status = "Complete" },
+                new() { Id = Guid.NewGuid(), BatchType = "Community", CommunityId = communityId, TotalCount = 3, Status = "Pending" },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(communityId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            emailInviteManager
+                .Setup(m => m.GetCommunityBatchesAsync(communityId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(batches);
+
+            var result = await controller.GetBatches(communityId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<EmailInviteBatchDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+        }
+
+        [Fact]
+        public async Task GetBatch_Found_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var communityId = Guid.NewGuid();
+            var batchId = Guid.NewGuid();
+            var partner = new Partner { Id = communityId, Name = "Test Community" };
+            var batch = new EmailInviteBatch
+            {
+                Id = batchId,
+                BatchType = "Community",
+                CommunityId = communityId,
+                TotalCount = 10,
+                SentCount = 8,
+                Status = "Complete",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(communityId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            emailInviteManager
+                .Setup(m => m.GetBatchDetailsAsync(batchId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(batch);
+
+            var result = await controller.GetBatch(communityId, batchId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EmailInviteBatchDto>(okResult.Value);
+            Assert.Equal(batchId, dto.Id);
+            Assert.Equal(10, dto.TotalCount);
+        }
+
+        [Fact]
+        public async Task CreateBatch_Authorized_ReturnsCreated()
+        {
+            SetupAuthSuccess();
+
+            var communityId = Guid.NewGuid();
+            var partner = new Partner { Id = communityId, Name = "Test Community" };
+            var dto = new CreateEmailInviteBatchDto
+            {
+                Emails = new List<string> { "user1@test.com", "user2@test.com" },
+            };
+            var createdBatch = new EmailInviteBatch
+            {
+                Id = Guid.NewGuid(),
+                BatchType = "Community",
+                CommunityId = communityId,
+                TotalCount = 2,
+                Status = "Pending",
+            };
+            var processedBatch = new EmailInviteBatch
+            {
+                Id = createdBatch.Id,
+                BatchType = "Community",
+                CommunityId = communityId,
+                TotalCount = 2,
+                SentCount = 2,
+                Status = "Complete",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(communityId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            emailInviteManager
+                .Setup(m => m.CreateBatchAsync(
+                    It.IsAny<IEnumerable<string>>(), testUserId, "Community", communityId, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdBatch);
+            emailInviteManager
+                .Setup(m => m.ProcessBatchAsync(createdBatch.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(processedBatch);
+
+            var result = await controller.CreateBatch(communityId, dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var batchDto = Assert.IsType<EmailInviteBatchDto>(createdResult.Value);
+            Assert.Equal(2, batchDto.SentCount);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunityProfessionalCompaniesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunityProfessionalCompaniesV2ControllerTests.cs
@@ -1,0 +1,156 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class CommunityProfessionalCompaniesV2ControllerTests
+    {
+        private readonly Mock<IProfessionalCompanyManager> companyManager = new();
+        private readonly Mock<IProfessionalCompanyUserManager> companyUserManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<CommunityProfessionalCompaniesV2Controller>> logger = new();
+        private readonly CommunityProfessionalCompaniesV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public CommunityProfessionalCompaniesV2ControllerTests()
+        {
+            controller = new CommunityProfessionalCompaniesV2Controller(
+                companyManager.Object, companyUserManager.Object, partnerManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetCompanies_Authorized_ReturnsOkWithList()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var companies = new List<ProfessionalCompany>
+            {
+                new() { Id = Guid.NewGuid(), Name = "Company A", PartnerId = partnerId, IsActive = true },
+                new() { Id = Guid.NewGuid(), Name = "Company B", PartnerId = partnerId, IsActive = true },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            companyManager
+                .Setup(m => m.GetByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(companies);
+
+            var result = await controller.GetCompanies(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ProfessionalCompanyDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+            Assert.Equal("Company A", dtos.First().Name);
+        }
+
+        [Fact]
+        public async Task CreateCompany_Authorized_ReturnsCreated()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var companyDto = new ProfessionalCompanyDto
+            {
+                Name = "New Company",
+                ContactEmail = "company@test.com",
+                IsActive = true,
+            };
+            var createdCompany = new ProfessionalCompany
+            {
+                Id = Guid.NewGuid(),
+                Name = "New Company",
+                ContactEmail = "company@test.com",
+                PartnerId = partnerId,
+                IsActive = true,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            companyManager
+                .Setup(m => m.AddAsync(It.IsAny<ProfessionalCompany>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdCompany);
+
+            var result = await controller.CreateCompany(partnerId, companyDto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var dto = Assert.IsType<ProfessionalCompanyDto>(createdResult.Value);
+            Assert.Equal("New Company", dto.Name);
+        }
+
+        [Fact]
+        public async Task AssignUser_Authorized_ReturnsCreated()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var companyId = Guid.NewGuid();
+            var assignedUserId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var company = new ProfessionalCompany { Id = companyId, Name = "Test Company", PartnerId = partnerId };
+            var companyUserDto = new ProfessionalCompanyUserDto
+            {
+                ProfessionalCompanyId = companyId,
+                UserId = assignedUserId,
+            };
+            var createdUser = new ProfessionalCompanyUser
+            {
+                ProfessionalCompanyId = companyId,
+                UserId = assignedUserId,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            companyManager
+                .Setup(m => m.GetAsync(companyId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(company);
+            companyUserManager
+                .Setup(m => m.AddAsync(It.IsAny<ProfessionalCompanyUser>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdUser);
+
+            var result = await controller.AssignUser(partnerId, companyId, companyUserDto, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, objectResult.StatusCode);
+            var dto = Assert.IsType<ProfessionalCompanyUserDto>(objectResult.Value);
+            Assert.Equal(assignedUserId, dto.UserId);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunityProspectsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunityProspectsV2ControllerTests.cs
@@ -1,0 +1,162 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Managers.Prospects;
+    using Xunit;
+
+    public class CommunityProspectsV2ControllerTests
+    {
+        private readonly Mock<ICommunityProspectManager> communityProspectManager = new();
+        private readonly Mock<IProspectActivityManager> prospectActivityManager = new();
+        private readonly Mock<IClaudeDiscoveryService> claudeDiscoveryService = new();
+        private readonly Mock<IProspectScoringManager> prospectScoringManager = new();
+        private readonly Mock<ICsvImportManager> csvImportManager = new();
+        private readonly Mock<IProspectOutreachManager> prospectOutreachManager = new();
+        private readonly Mock<IPipelineAnalyticsManager> pipelineAnalyticsManager = new();
+        private readonly Mock<IProspectConversionManager> prospectConversionManager = new();
+        private readonly Mock<ILogger<CommunityProspectsV2Controller>> logger = new();
+        private readonly CommunityProspectsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public CommunityProspectsV2ControllerTests()
+        {
+            controller = new CommunityProspectsV2Controller(
+                communityProspectManager.Object,
+                prospectActivityManager.Object,
+                claudeDiscoveryService.Object,
+                prospectScoringManager.Object,
+                csvImportManager.Object,
+                prospectOutreachManager.Object,
+                pipelineAnalyticsManager.Object,
+                prospectConversionManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsOkWithList()
+        {
+            var prospects = new List<CommunityProspect>
+            {
+                new() { Id = Guid.NewGuid(), Name = "City of Seattle", City = "Seattle", Region = "WA", PipelineStage = 1 },
+                new() { Id = Guid.NewGuid(), Name = "City of Portland", City = "Portland", Region = "OR", PipelineStage = 2 },
+            };
+
+            communityProspectManager
+                .Setup(m => m.GetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(prospects);
+
+            var result = await controller.GetAll(null, null, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<CommunityProspectDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+            Assert.Equal("City of Seattle", dtos[0].Name);
+        }
+
+        [Fact]
+        public async Task GetById_Found_ReturnsOk()
+        {
+            var prospectId = Guid.NewGuid();
+            var prospect = new CommunityProspect
+            {
+                Id = prospectId,
+                Name = "City of Seattle",
+                City = "Seattle",
+                Region = "WA",
+                PipelineStage = 1,
+                FitScore = 85,
+            };
+
+            communityProspectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(prospect);
+
+            var result = await controller.GetById(prospectId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<CommunityProspectDto>(okResult.Value);
+            Assert.Equal(prospectId, dto.Id);
+            Assert.Equal("City of Seattle", dto.Name);
+            Assert.Equal(85, dto.FitScore);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var prospectDto = new CommunityProspectDto
+            {
+                Name = "City of Bellevue",
+                City = "Bellevue",
+                Region = "WA",
+                Country = "United States",
+                PipelineStage = 0,
+            };
+            var createdProspect = new CommunityProspect
+            {
+                Id = Guid.NewGuid(),
+                Name = "City of Bellevue",
+                City = "Bellevue",
+                Region = "WA",
+                Country = "United States",
+                PipelineStage = 0,
+            };
+
+            communityProspectManager
+                .Setup(m => m.AddAsync(It.IsAny<CommunityProspect>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdProspect);
+
+            var result = await controller.Create(prospectDto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var dto = Assert.IsType<CommunityProspectDto>(createdResult.Value);
+            Assert.Equal("City of Bellevue", dto.Name);
+        }
+
+        [Fact]
+        public async Task UpdateStage_ReturnsOk()
+        {
+            var prospectId = Guid.NewGuid();
+            var updatedProspect = new CommunityProspect
+            {
+                Id = prospectId,
+                Name = "City of Seattle",
+                City = "Seattle",
+                Region = "WA",
+                PipelineStage = 3,
+            };
+            var request = new UpdateStageRequest { Stage = 3 };
+
+            communityProspectManager
+                .Setup(m => m.UpdatePipelineStageAsync(prospectId, 3, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(updatedProspect);
+
+            var result = await controller.UpdateStage(prospectId, request, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<CommunityProspectDto>(okResult.Value);
+            Assert.Equal(3, dto.PipelineStage);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunitySponsoredAdoptionsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunitySponsoredAdoptionsV2ControllerTests.cs
@@ -1,0 +1,151 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class CommunitySponsoredAdoptionsV2ControllerTests
+    {
+        private readonly Mock<ISponsoredAdoptionManager> adoptionManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<CommunitySponsoredAdoptionsV2Controller>> logger = new();
+        private readonly CommunitySponsoredAdoptionsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public CommunitySponsoredAdoptionsV2ControllerTests()
+        {
+            controller = new CommunitySponsoredAdoptionsV2Controller(
+                adoptionManager.Object, partnerManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetSponsoredAdoptions_Authorized_ReturnsOkWithList()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var adoptions = new List<SponsoredAdoption>
+            {
+                new() { Id = Guid.NewGuid(), SponsorId = Guid.NewGuid(), AdoptableAreaId = Guid.NewGuid(), ProfessionalCompanyId = Guid.NewGuid(), StartDate = DateOnly.FromDateTime(DateTime.Today), Status = "Active" },
+                new() { Id = Guid.NewGuid(), SponsorId = Guid.NewGuid(), AdoptableAreaId = Guid.NewGuid(), ProfessionalCompanyId = Guid.NewGuid(), StartDate = DateOnly.FromDateTime(DateTime.Today), Status = "Expired" },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            adoptionManager
+                .Setup(m => m.GetByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoptions);
+
+            var result = await controller.GetSponsoredAdoptions(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<SponsoredAdoptionDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task CreateSponsoredAdoption_Authorized_ReturnsCreated()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var adoptionDto = new SponsoredAdoptionDto
+            {
+                AdoptableAreaId = Guid.NewGuid(),
+                SponsorId = Guid.NewGuid(),
+                ProfessionalCompanyId = Guid.NewGuid(),
+                StartDate = DateOnly.FromDateTime(DateTime.Today),
+                CleanupFrequencyDays = 14,
+                Status = "Active",
+            };
+            var createdAdoption = new SponsoredAdoption
+            {
+                Id = Guid.NewGuid(),
+                AdoptableAreaId = adoptionDto.AdoptableAreaId,
+                SponsorId = adoptionDto.SponsorId,
+                ProfessionalCompanyId = adoptionDto.ProfessionalCompanyId,
+                StartDate = adoptionDto.StartDate,
+                CleanupFrequencyDays = 14,
+                Status = "Active",
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            adoptionManager
+                .Setup(m => m.AddAsync(It.IsAny<SponsoredAdoption>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdAdoption);
+
+            var result = await controller.CreateSponsoredAdoption(partnerId, adoptionDto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var dto = Assert.IsType<SponsoredAdoptionDto>(createdResult.Value);
+            Assert.Equal(createdAdoption.Id, dto.Id);
+        }
+
+        [Fact]
+        public async Task GetComplianceStats_Authorized_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var stats = new SponsoredAdoptionComplianceStats
+            {
+                TotalSponsoredAdoptions = 10,
+                ActiveAdoptions = 8,
+                AdoptionsOnSchedule = 6,
+                AdoptionsOverdue = 2,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            adoptionManager
+                .Setup(m => m.GetComplianceByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(stats);
+
+            var result = await controller.GetComplianceStats(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var returnedStats = Assert.IsType<SponsoredAdoptionComplianceStats>(okResult.Value);
+            Assert.Equal(10, returnedStats.TotalSponsoredAdoptions);
+            Assert.Equal(8, returnedStats.ActiveAdoptions);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunitySponsorsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunitySponsorsV2ControllerTests.cs
@@ -1,0 +1,151 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class CommunitySponsorsV2ControllerTests
+    {
+        private readonly Mock<ISponsorManager> sponsorManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IImageManager> imageManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<CommunitySponsorsV2Controller>> logger = new();
+        private readonly CommunitySponsorsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public CommunitySponsorsV2ControllerTests()
+        {
+            controller = new CommunitySponsorsV2Controller(
+                sponsorManager.Object, partnerManager.Object, imageManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetSponsors_Authorized_ReturnsOkWithList()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var sponsors = new List<Sponsor>
+            {
+                new() { Id = Guid.NewGuid(), Name = "Sponsor A", PartnerId = partnerId, IsActive = true },
+                new() { Id = Guid.NewGuid(), Name = "Sponsor B", PartnerId = partnerId, IsActive = true },
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            sponsorManager
+                .Setup(m => m.GetByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sponsors);
+
+            var result = await controller.GetSponsors(partnerId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<SponsorDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+            Assert.Equal("Sponsor A", dtos.First().Name);
+        }
+
+        [Fact]
+        public async Task CreateSponsor_Authorized_ReturnsCreated()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var sponsorDto = new SponsorDto
+            {
+                Name = "New Sponsor",
+                ContactEmail = "sponsor@test.com",
+                IsActive = true,
+            };
+            var createdSponsor = new Sponsor
+            {
+                Id = Guid.NewGuid(),
+                Name = "New Sponsor",
+                ContactEmail = "sponsor@test.com",
+                PartnerId = partnerId,
+                IsActive = true,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            sponsorManager
+                .Setup(m => m.AddAsync(It.IsAny<Sponsor>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdSponsor);
+
+            var result = await controller.CreateSponsor(partnerId, sponsorDto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var dto = Assert.IsType<SponsorDto>(createdResult.Value);
+            Assert.Equal("New Sponsor", dto.Name);
+        }
+
+        [Fact]
+        public async Task DeactivateSponsor_Authorized_ReturnsNoContent()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var sponsorId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var existingSponsor = new Sponsor
+            {
+                Id = sponsorId,
+                Name = "Sponsor To Deactivate",
+                PartnerId = partnerId,
+                IsActive = true,
+            };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingSponsor);
+            sponsorManager
+                .Setup(m => m.UpdateAsync(It.IsAny<Sponsor>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingSponsor);
+
+            var result = await controller.DeactivateSponsor(partnerId, sponsorId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            sponsorManager.Verify(
+                m => m.UpdateAsync(It.Is<Sponsor>(s => !s.IsActive), testUserId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/StagedAreasV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/StagedAreasV2ControllerTests.cs
@@ -1,0 +1,131 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class StagedAreasV2ControllerTests
+    {
+        private readonly Mock<IStagedAdoptableAreaManager> stagedManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<StagedAreasV2Controller>> logger = new();
+        private readonly StagedAreasV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public StagedAreasV2ControllerTests()
+        {
+            controller = new StagedAreasV2Controller(
+                stagedManager.Object,
+                partnerManager.Object,
+                authorizationService.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, testUserId.ToString())], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetStagedAreas_ReturnsOkWithList()
+        {
+            var partnerId = Guid.NewGuid();
+            var batchId = Guid.NewGuid();
+            var areas = new List<StagedAdoptableArea>
+            {
+                new() { Id = Guid.NewGuid(), BatchId = batchId, Name = "Staged Park A" },
+                new() { Id = Guid.NewGuid(), BatchId = batchId, Name = "Staged Trail B" },
+            };
+
+            stagedManager
+                .Setup(m => m.GetByBatchAsync(batchId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(areas);
+
+            var result = await controller.GetStagedAreas(partnerId, batchId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<StagedAdoptableAreaDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task Approve_Authorized_ReturnsNoContent()
+        {
+            var partnerId = Guid.NewGuid();
+            var areaId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            stagedManager
+                .Setup(m => m.ApproveAsync(areaId, testUserId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.Approve(partnerId, areaId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            stagedManager.Verify(m => m.ApproveAsync(areaId, testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Reject_Authorized_ReturnsNoContent()
+        {
+            var partnerId = Guid.NewGuid();
+            var areaId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            stagedManager
+                .Setup(m => m.RejectAsync(areaId, testUserId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.Reject(partnerId, areaId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            stagedManager.Verify(m => m.RejectAsync(areaId, testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Approve_ReturnsForbid_WhenNotAuthorized()
+        {
+            var partnerId = Guid.NewGuid();
+            var areaId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Community" };
+
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.Approve(partnerId, areaId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/AdoptableAreasV2Controller.cs
+++ b/TrashMob/Controllers/V2/AdoptableAreasV2Controller.cs
@@ -1,0 +1,694 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Areas;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing adoptable areas within a community.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{partnerId}/areas")]
+    public class AdoptableAreasV2Controller(
+        IAdoptableAreaManager areaManager,
+        IKeyedManager<Partner> partnerManager,
+        IAreaSuggestionService areaSuggestionService,
+        IAreaFileParser areaFileParser,
+        IAreaGenerationBatchManager batchManager,
+        IAuthorizationService authorizationService,
+        ILogger<AdoptableAreasV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all adoptable areas for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<AdoptableAreaDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAreas(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAreas for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            var areas = await areaManager.GetByCommunityAsync(partnerId, cancellationToken);
+            return Ok(areas.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets all available adoptable areas for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("available")]
+        [ProducesResponseType(typeof(IEnumerable<AdoptableAreaDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAvailableAreas(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAvailableAreas for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            var areas = await areaManager.GetAvailableByCommunityAsync(partnerId, cancellationToken);
+            return Ok(areas.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a specific adoptable area.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="areaId">The area ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("{areaId}")]
+        [ProducesResponseType(typeof(AdoptableAreaDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetArea(Guid partnerId, Guid areaId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetArea Partner={PartnerId}, Area={AreaId}", partnerId, areaId);
+
+            var area = await areaManager.GetAsync(areaId, cancellationToken);
+            if (area is null || area.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            return Ok(area.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Checks if an area name is available within a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="name">The area name to check.</param>
+        /// <param name="excludeAreaId">Optional area ID to exclude (for updates).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("check-name")]
+        [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+        public async Task<IActionResult> CheckAreaName(
+            Guid partnerId,
+            [FromQuery] string name,
+            [FromQuery] Guid? excludeAreaId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CheckAreaName Partner={PartnerId}, Name={Name}", partnerId, name);
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return Ok(false);
+            }
+
+            var isAvailable = await areaManager.IsNameAvailableAsync(partnerId, name, excludeAreaId, cancellationToken);
+            return Ok(isAvailable);
+        }
+
+        /// <summary>
+        /// Uses AI to suggest an area geometry from a natural language description.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="request">The suggestion request containing the area description.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("suggest")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(AreaSuggestionResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SuggestArea(
+            Guid partnerId,
+            [FromBody] AreaSuggestionRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SuggestArea for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Description))
+            {
+                return BadRequest("A description is required.");
+            }
+
+            var result = await areaSuggestionService.SuggestAreaAsync(request, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Creates a new adoptable area. Only community admins can create areas.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="areaDto">The area to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(AdoptableAreaDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CreateArea(
+            Guid partnerId,
+            [FromBody] AdoptableAreaDto areaDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateArea for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var isAvailable = await areaManager.IsNameAvailableAsync(partnerId, areaDto.Name, cancellationToken: cancellationToken);
+            if (!isAvailable)
+            {
+                return BadRequest("An area with this name already exists in this community.");
+            }
+
+            var area = areaDto.ToEntity();
+            area.Id = Guid.NewGuid();
+            area.PartnerId = partnerId;
+            area.IsActive = true;
+            area.CreatedByUserId = UserId;
+            area.CreatedDate = DateTimeOffset.UtcNow;
+            area.LastUpdatedByUserId = UserId;
+            area.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var createdArea = await areaManager.AddAsync(area, UserId, cancellationToken);
+            return CreatedAtAction(nameof(GetArea), new { partnerId, areaId = createdArea.Id }, createdArea.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an adoptable area. Only community admins can update areas.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="areaId">The area ID.</param>
+        /// <param name="areaDto">The updated area data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPut("{areaId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(AdoptableAreaDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateArea(
+            Guid partnerId,
+            Guid areaId,
+            [FromBody] AdoptableAreaDto areaDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateArea Partner={PartnerId}, Area={AreaId}", partnerId, areaId);
+
+            if (areaId != areaDto.Id)
+            {
+                return BadRequest("Area ID mismatch.");
+            }
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var existingArea = await areaManager.GetAsync(areaId, cancellationToken);
+            if (existingArea is null || existingArea.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            if (!string.Equals(existingArea.Name, areaDto.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                var isAvailable = await areaManager.IsNameAvailableAsync(partnerId, areaDto.Name, areaId, cancellationToken);
+                if (!isAvailable)
+                {
+                    return BadRequest("An area with this name already exists in this community.");
+                }
+            }
+
+            existingArea.Name = areaDto.Name;
+            existingArea.Description = areaDto.Description;
+            existingArea.AreaType = areaDto.AreaType;
+            existingArea.Status = areaDto.Status;
+            existingArea.GeoJson = areaDto.GeoJson;
+            existingArea.StartLatitude = areaDto.StartLatitude;
+            existingArea.StartLongitude = areaDto.StartLongitude;
+            existingArea.EndLatitude = areaDto.EndLatitude;
+            existingArea.EndLongitude = areaDto.EndLongitude;
+            existingArea.CleanupFrequencyDays = areaDto.CleanupFrequencyDays;
+            existingArea.MinEventsPerYear = areaDto.MinEventsPerYear;
+            existingArea.SafetyRequirements = areaDto.SafetyRequirements;
+            existingArea.AllowCoAdoption = areaDto.AllowCoAdoption;
+            existingArea.IsActive = areaDto.IsActive;
+            existingArea.LastUpdatedByUserId = UserId;
+            existingArea.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var updatedArea = await areaManager.UpdateAsync(existingArea, UserId, cancellationToken);
+            return Ok(updatedArea.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Parses an uploaded area file (GeoJSON, KML, KMZ, or Shapefile) and returns normalized features.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="file">The uploaded file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("import/parse")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [RequestSizeLimit(10 * 1024 * 1024)]
+        [ProducesResponseType(typeof(AreaImportParseResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ParseImportFile(
+            Guid partnerId,
+            IFormFile file,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ParseImportFile for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            if (file is null || file.Length == 0)
+            {
+                return BadRequest("A file is required.");
+            }
+
+            var allowedExtensions = new[] { ".geojson", ".json", ".kml", ".kmz", ".zip" };
+            var extension = System.IO.Path.GetExtension(file.FileName).ToLowerInvariant();
+            if (!allowedExtensions.Contains(extension))
+            {
+                return BadRequest(
+                    $"Unsupported file format: {extension}. Accepted formats: .geojson, .json, .kml, .kmz, .zip (Shapefile)");
+            }
+
+            using var stream = file.OpenReadStream();
+            var result = await areaFileParser.ParseFileAsync(stream, file.FileName, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Bulk imports areas into a community. Only community admins can import areas.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="areas">The areas to import.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("import")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(AreaBulkImportResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> BulkImportAreas(
+            Guid partnerId,
+            [FromBody] List<AdoptableArea> areas,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 BulkImportAreas for Partner={PartnerId}, Count={Count}", partnerId, areas?.Count ?? 0);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            if (areas is null || areas.Count == 0)
+            {
+                return BadRequest("At least one area is required.");
+            }
+
+            if (areas.Count > 500)
+            {
+                return BadRequest("Maximum 500 areas per import. Please split into smaller batches.");
+            }
+
+            var result = await areaManager.BulkCreateAsync(partnerId, UserId, areas, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Exports all adoptable areas for a community as GeoJSON or KML.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="format">The export format: geojson or kml.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("export")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ExportAreas(
+            Guid partnerId,
+            [FromQuery] string format,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ExportAreas for Partner={PartnerId}, Format={Format}", partnerId, format);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var areas = await areaManager.GetByCommunityAsync(partnerId, cancellationToken);
+            var areaList = areas.ToList();
+
+            var safeName = partner.Name.Replace(" ", "_", StringComparison.Ordinal);
+            var dateSuffix = DateTime.UtcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+            if (string.Equals(format, "kml", StringComparison.OrdinalIgnoreCase))
+            {
+                var kml = BuildKml(partner.Name, areaList);
+                var bytes = Encoding.UTF8.GetBytes(kml);
+                return File(bytes, "application/vnd.google-earth.kml+xml", $"{safeName}_Areas_{dateSuffix}.kml");
+            }
+
+            // Default to GeoJSON
+            var geoJson = BuildGeoJson(areaList);
+            var geoJsonBytes = Encoding.UTF8.GetBytes(geoJson);
+            return File(geoJsonBytes, "application/geo+json", $"{safeName}_Areas_{dateSuffix}.geojson");
+        }
+
+        /// <summary>
+        /// Deletes (deactivates) an adoptable area. Only community admins can delete areas.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="areaId">The area ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpDelete("{areaId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteArea(
+            Guid partnerId,
+            Guid areaId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteArea Partner={PartnerId}, Area={AreaId}", partnerId, areaId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var existingArea = await areaManager.GetAsync(areaId, cancellationToken);
+            if (existingArea is null || existingArea.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            existingArea.IsActive = false;
+            existingArea.LastUpdatedByUserId = UserId;
+            existingArea.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            await areaManager.UpdateAsync(existingArea, UserId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Clears all adoptable areas, staged areas, and generation batches for a community.
+        /// Areas without adoptions are hard-deleted; areas with adoptions are soft-deleted (deactivated).
+        /// Generation batches and staged areas are hard-deleted.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpDelete("clear-all")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(AreaBulkClearResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ClearAll(
+            Guid partnerId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ClearAll for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var areasDeactivated = await areaManager.ClearAllByPartnerAsync(partnerId, UserId, cancellationToken);
+            var (batchesDeleted, stagedAreasDeleted) = await batchManager.DeleteAllByPartnerAsync(partnerId, cancellationToken);
+
+            return Ok(new AreaBulkClearResult
+            {
+                AreasRemoved = areasDeactivated,
+                StagedAreasDeleted = stagedAreasDeleted,
+                BatchesDeleted = batchesDeleted,
+            });
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+
+        #region Export Helpers
+
+        private static readonly JsonSerializerOptions GeoJsonSerializerOptions = new() { WriteIndented = true };
+
+        private static string BuildGeoJson(List<AdoptableArea> areas)
+        {
+            var features = new List<object>();
+
+            foreach (var area in areas)
+            {
+                object geometry = null;
+                if (!string.IsNullOrWhiteSpace(area.GeoJson))
+                {
+                    try
+                    {
+                        geometry = JsonSerializer.Deserialize<JsonElement>(area.GeoJson);
+                    }
+                    catch (JsonException)
+                    {
+                        // Skip malformed geometry
+                    }
+                }
+
+                features.Add(new
+                {
+                    type = "Feature",
+                    geometry,
+                    properties = new
+                    {
+                        name = area.Name,
+                        description = area.Description ?? "",
+                        areaType = area.AreaType,
+                        status = area.Status,
+                        cleanupFrequencyDays = area.CleanupFrequencyDays,
+                        minEventsPerYear = area.MinEventsPerYear,
+                        safetyRequirements = area.SafetyRequirements ?? "",
+                        allowCoAdoption = area.AllowCoAdoption,
+                    },
+                });
+            }
+
+            var featureCollection = new
+            {
+                type = "FeatureCollection",
+                features,
+            };
+
+            return JsonSerializer.Serialize(featureCollection, GeoJsonSerializerOptions);
+        }
+
+        private static string BuildKml(string communityName, List<AdoptableArea> areas)
+        {
+            XNamespace kmlNs = "http://www.opengis.net/kml/2.2";
+
+            var placemarks = new List<XElement>();
+
+            foreach (var area in areas)
+            {
+                var placemark = new XElement(kmlNs + "Placemark",
+                    new XElement(kmlNs + "name", area.Name),
+                    new XElement(kmlNs + "description", area.Description ?? ""),
+                    new XElement(kmlNs + "ExtendedData",
+                        KmlDataElement(kmlNs, "areaType", area.AreaType),
+                        KmlDataElement(kmlNs, "status", area.Status),
+                        KmlDataElement(kmlNs, "cleanupFrequencyDays", area.CleanupFrequencyDays.ToString(CultureInfo.InvariantCulture)),
+                        KmlDataElement(kmlNs, "minEventsPerYear", area.MinEventsPerYear.ToString(CultureInfo.InvariantCulture)),
+                        KmlDataElement(kmlNs, "safetyRequirements", area.SafetyRequirements ?? ""),
+                        KmlDataElement(kmlNs, "allowCoAdoption", area.AllowCoAdoption.ToString())));
+
+                var geometryElement = GeoJsonToKmlGeometry(kmlNs, area.GeoJson);
+                if (geometryElement != null)
+                {
+                    placemark.Add(geometryElement);
+                }
+
+                placemarks.Add(placemark);
+            }
+
+            var doc = new XDocument(
+                new XDeclaration("1.0", "UTF-8", null),
+                new XElement(kmlNs + "kml",
+                    new XElement(kmlNs + "Document",
+                        new XElement(kmlNs + "name", $"{communityName} Areas"),
+                        placemarks)));
+
+            return doc.Declaration + Environment.NewLine + doc;
+        }
+
+        private static XElement KmlDataElement(XNamespace kmlNs, string name, string value)
+        {
+            return new XElement(kmlNs + "Data",
+                new XAttribute("name", name),
+                new XElement(kmlNs + "value", value));
+        }
+
+        private static XElement GeoJsonToKmlGeometry(XNamespace kmlNs, string geoJson)
+        {
+            if (string.IsNullOrWhiteSpace(geoJson))
+            {
+                return null;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(geoJson);
+                var root = doc.RootElement;
+                var type = root.GetProperty("type").GetString();
+
+                if (type == "Polygon")
+                {
+                    var coords = root.GetProperty("coordinates");
+                    var outerRing = coords[0];
+                    return new XElement(kmlNs + "Polygon",
+                        new XElement(kmlNs + "outerBoundaryIs",
+                            new XElement(kmlNs + "LinearRing",
+                                new XElement(kmlNs + "coordinates", CoordinateArrayToKml(outerRing)))));
+                }
+
+                if (type == "LineString")
+                {
+                    var coords = root.GetProperty("coordinates");
+                    return new XElement(kmlNs + "LineString",
+                        new XElement(kmlNs + "coordinates", CoordinateArrayToKml(coords)));
+                }
+
+                return null;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
+        private static string CoordinateArrayToKml(JsonElement coordinates)
+        {
+            var sb = new StringBuilder();
+            foreach (var coord in coordinates.EnumerateArray())
+            {
+                var lon = coord[0].GetDouble().ToString(CultureInfo.InvariantCulture);
+                var lat = coord[1].GetDouble().ToString(CultureInfo.InvariantCulture);
+                var alt = coord.GetArrayLength() > 2
+                    ? coord[2].GetDouble().ToString(CultureInfo.InvariantCulture)
+                    : "0";
+                sb.Append($"{lon},{lat},{alt} ");
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob/Controllers/V2/AdoptionEventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/AdoptionEventsV2Controller.cs
@@ -1,0 +1,161 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing event links to team adoptions.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/adoptions/{adoptionId}/events")]
+    public class AdoptionEventsV2Controller(
+        ITeamAdoptionEventManager adoptionEventManager,
+        ITeamAdoptionManager adoptionManager,
+        ITeamMemberManager teamMemberManager,
+        ILogger<AdoptionEventsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all events linked to an adoption.
+        /// </summary>
+        /// <param name="adoptionId">The adoption ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<TeamAdoptionEventDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetLinkedEvents(Guid adoptionId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLinkedEvents for Adoption={AdoptionId}", adoptionId);
+
+            var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
+            if (adoption is null)
+            {
+                return NotFound();
+            }
+
+            // Only team members can view adoption events
+            var isMember = await teamMemberManager.IsMemberAsync(adoption.TeamId, UserId, cancellationToken);
+            if (!isMember)
+            {
+                return Forbid();
+            }
+
+            var events = await adoptionEventManager.GetByAdoptionIdAsync(adoptionId, cancellationToken);
+            return Ok(events.Select(e => e.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Links an event to an adoption. Only team leads can link events.
+        /// </summary>
+        /// <param name="adoptionId">The adoption ID.</param>
+        /// <param name="eventId">The event ID to link.</param>
+        /// <param name="request">Optional request body with notes.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("{eventId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamAdoptionEventDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> LinkEvent(
+            Guid adoptionId,
+            Guid eventId,
+            [FromBody] LinkEventRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 LinkEvent Adoption={AdoptionId}, Event={EventId}", adoptionId, eventId);
+
+            var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
+            if (adoption is null)
+            {
+                return NotFound();
+            }
+
+            // Only team leads can link events to adoptions
+            var isLead = await teamMemberManager.IsTeamLeadAsync(adoption.TeamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var result = await adoptionEventManager.LinkEventAsync(
+                adoptionId,
+                eventId,
+                request?.Notes,
+                UserId,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return CreatedAtAction(nameof(GetLinkedEvents), new { adoptionId }, result.Data.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Unlinks an event from an adoption. Only team leads can unlink events.
+        /// </summary>
+        /// <param name="adoptionId">The adoption ID.</param>
+        /// <param name="adoptionEventId">The adoption event link ID to remove.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpDelete("{adoptionEventId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UnlinkEvent(
+            Guid adoptionId,
+            Guid adoptionEventId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UnlinkEvent Adoption={AdoptionId}, AdoptionEvent={AdoptionEventId}", adoptionId, adoptionEventId);
+
+            var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
+            if (adoption is null)
+            {
+                return NotFound();
+            }
+
+            // Only team leads can unlink events from adoptions
+            var isLead = await teamMemberManager.IsTeamLeadAsync(adoption.TeamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var result = await adoptionEventManager.UnlinkEventAsync(adoptionEventId, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/AreaGenerationV2Controller.cs
+++ b/TrashMob/Controllers/V2/AreaGenerationV2Controller.cs
@@ -1,0 +1,220 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Services;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for AI-powered area generation within a community.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{partnerId}/areas/generate")]
+    public class AreaGenerationV2Controller(
+        IAreaGenerationBatchManager batchManager,
+        IKeyedManager<Partner> partnerManager,
+        IAreaGenerationQueue queue,
+        IAuthorizationService authorizationService,
+        ILogger<AreaGenerationV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Starts a new area generation batch.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="request">The generation request with category and optional bounds.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(AreaGenerationBatchDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        public async Task<IActionResult> StartGeneration(
+            Guid partnerId,
+            [FromBody] AreaGenerationRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 StartGeneration for Partner={PartnerId}, Category={Category}", partnerId, request.Category);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Category))
+            {
+                return BadRequest("Category is required.");
+            }
+
+            var active = await batchManager.GetActiveByPartnerAsync(partnerId, cancellationToken);
+            if (active != null)
+            {
+                return Conflict("A generation batch is already running for this community.");
+            }
+
+            var batch = new AreaGenerationBatch
+            {
+                Id = Guid.NewGuid(),
+                PartnerId = partnerId,
+                Category = request.Category,
+                Status = "Queued",
+                BoundsNorth = request.BoundsNorth,
+                BoundsSouth = request.BoundsSouth,
+                BoundsEast = request.BoundsEast,
+                BoundsWest = request.BoundsWest,
+                CreatedByUserId = UserId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = UserId,
+                LastUpdatedDate = DateTimeOffset.UtcNow,
+            };
+
+            var created = await batchManager.AddAsync(batch, UserId, cancellationToken);
+
+            await queue.QueueAsync(created.Id, cancellationToken);
+
+            return CreatedAtAction(nameof(GetBatch), new { partnerId, batchId = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets the active (running) batch status for polling.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("status")]
+        [ProducesResponseType(typeof(AreaGenerationBatchDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetStatus(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetStatus for Partner={PartnerId}", partnerId);
+
+            var active = await batchManager.GetActiveByPartnerAsync(partnerId, cancellationToken);
+            if (active is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(active.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Lists all generation batches for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("batches")]
+        [ProducesResponseType(typeof(IEnumerable<AreaGenerationBatchDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetBatches(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetBatches for Partner={PartnerId}", partnerId);
+
+            var batches = await batchManager.GetByPartnerAsync(partnerId, cancellationToken);
+            return Ok(batches.Select(b => b.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a specific batch.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="batchId">The batch ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("batches/{batchId}")]
+        [ProducesResponseType(typeof(AreaGenerationBatchDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetBatch(Guid partnerId, Guid batchId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetBatch Partner={PartnerId}, Batch={BatchId}", partnerId, batchId);
+
+            var batch = await batchManager.GetAsync(batchId, cancellationToken);
+            if (batch is null || batch.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            return Ok(batch.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Cancels a running generation batch.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="batchId">The batch ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpDelete("batches/{batchId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CancelBatch(
+            Guid partnerId,
+            Guid batchId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CancelBatch Partner={PartnerId}, Batch={BatchId}", partnerId, batchId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var batch = await batchManager.GetAsync(batchId, cancellationToken);
+            if (batch is null || batch.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            batch.Status = "Cancelled";
+            batch.CompletedDate = DateTimeOffset.UtcNow;
+            batch.LastUpdatedByUserId = UserId;
+            batch.LastUpdatedDate = DateTimeOffset.UtcNow;
+            await batchManager.UpdateAsync(batch, cancellationToken);
+
+            return NoContent();
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/CommunityAdoptionsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunityAdoptionsV2Controller.cs
@@ -1,0 +1,325 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for community admin adoption management.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{partnerId}/adoptions")]
+    public class CommunityAdoptionsV2Controller(
+        ITeamAdoptionManager adoptionManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<CommunityAdoptionsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all pending adoption applications for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("pending")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<TeamAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetPendingApplications(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPendingApplications for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var applications = await adoptionManager.GetPendingByCommunityAsync(partnerId, cancellationToken);
+            return Ok(applications.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets all approved adoptions for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("approved")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<TeamAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetApprovedAdoptions(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetApprovedAdoptions for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionManager.GetApprovedByCommunityAsync(partnerId, cancellationToken);
+            return Ok(adoptions.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Approves an adoption application. Only community admins can approve.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="adoptionId">The adoption application ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("{adoptionId}/approve")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamAdoptionDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ApproveApplication(
+            Guid partnerId,
+            Guid adoptionId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ApproveApplication Partner={PartnerId}, Adoption={AdoptionId}", partnerId, adoptionId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var result = await adoptionManager.ApproveApplicationAsync(adoptionId, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Ok(result.Data.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Rejects an adoption application. Only community admins can reject.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="adoptionId">The adoption application ID.</param>
+        /// <param name="request">The rejection request with reason.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("{adoptionId}/reject")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamAdoptionDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> RejectApplication(
+            Guid partnerId,
+            Guid adoptionId,
+            [FromBody] RejectAdoptionRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 RejectApplication Partner={PartnerId}, Adoption={AdoptionId}", partnerId, adoptionId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var result = await adoptionManager.RejectApplicationAsync(
+                adoptionId,
+                request.RejectionReason,
+                UserId,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return Ok(result.Data.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets delinquent adoptions for a community (teams not meeting cleanup requirements).
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("delinquent")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<TeamAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetDelinquentAdoptions(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetDelinquentAdoptions for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionManager.GetDelinquentByCommunityAsync(partnerId, cancellationToken);
+            return Ok(adoptions.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets compliance statistics for a community's adoption program.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("stats")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(AdoptionComplianceStats), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetComplianceStats(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetComplianceStats for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var stats = await adoptionManager.GetComplianceStatsByCommunityAsync(partnerId, cancellationToken);
+            return Ok(stats);
+        }
+
+        /// <summary>
+        /// Exports all adoptions for a community in CSV format for signage updates.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet("export")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ExportAdoptions(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ExportAdoptions for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionManager.GetAllForExportByCommunityAsync(partnerId, cancellationToken);
+
+            var csv = new System.Text.StringBuilder();
+            csv.AppendLine("Area Name,Area Type,Team Name,Status,Compliant,Event Count,Last Event Date,Adoption Start,Adoption End,Safety Requirements");
+
+            foreach (var adoption in adoptions)
+            {
+                var areaName = EscapeCsvField(adoption.AdoptableArea?.Name ?? "");
+                var areaType = EscapeCsvField(adoption.AdoptableArea?.AreaType ?? "");
+                var teamName = EscapeCsvField(adoption.Team?.Name ?? "");
+                var status = adoption.Status;
+                var isCompliant = adoption.IsCompliant ? "Yes" : "No";
+                var eventCount = adoption.EventCount.ToString();
+                var lastEventDate = adoption.LastEventDate?.ToString("yyyy-MM-dd") ?? "";
+                var startDate = adoption.AdoptionStartDate?.ToString("yyyy-MM-dd") ?? "";
+                var endDate = adoption.AdoptionEndDate?.ToString("yyyy-MM-dd") ?? "";
+                var safetyReqs = EscapeCsvField(adoption.AdoptableArea?.SafetyRequirements ?? "");
+
+                csv.AppendLine($"{areaName},{areaType},{teamName},{status},{isCompliant},{eventCount},{lastEventDate},{startDate},{endDate},{safetyReqs}");
+            }
+
+            var bytes = System.Text.Encoding.UTF8.GetBytes(csv.ToString());
+            var fileName = $"{partner.Name.Replace(" ", "_")}_Adoptions_{System.DateTime.UtcNow:yyyyMMdd}.csv";
+
+            return File(bytes, "text/csv", fileName);
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+
+        private static string EscapeCsvField(string field)
+        {
+            if (string.IsNullOrWhiteSpace(field))
+            {
+                return "";
+            }
+
+            if (field.Contains(',') || field.Contains('"') || field.Contains('\n') || field.Contains('\r'))
+            {
+                return $"\"{field.Replace("\"", "\"\"")}\"";
+            }
+
+            return field;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/CommunityInvitesV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunityInvitesV2Controller.cs
@@ -1,0 +1,163 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for community email invitation operations.
+    /// Endpoints require community admin privileges.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{communityId}/invites")]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+    public class CommunityInvitesV2Controller(
+        IEmailInviteManager emailInviteManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<CommunityInvitesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all email invite batches for a community.
+        /// </summary>
+        /// <param name="communityId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of batches for the community with summary statistics.</returns>
+        /// <response code="200">Returns the batch list.</response>
+        /// <response code="403">Not authorized for this community.</response>
+        [HttpGet("batches")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<EmailInviteBatchDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetBatches(Guid communityId, CancellationToken cancellationToken)
+        {
+            var partner = await partnerManager.GetAsync(communityId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            logger.LogInformation("V2 GetBatches for community {CommunityId}", communityId);
+
+            var batches = await emailInviteManager.GetCommunityBatchesAsync(communityId, cancellationToken);
+            var dtos = batches.Select(b => b.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a batch with its individual invite details for a community.
+        /// </summary>
+        /// <param name="communityId">The community (partner) ID.</param>
+        /// <param name="id">Batch ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The batch or 404 if not found.</returns>
+        /// <response code="200">Returns the batch.</response>
+        /// <response code="403">Not authorized for this community.</response>
+        /// <response code="404">Batch not found.</response>
+        [HttpGet("batches/{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(EmailInviteBatchDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetBatch(Guid communityId, Guid id, CancellationToken cancellationToken)
+        {
+            var partner = await partnerManager.GetAsync(communityId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var batch = await emailInviteManager.GetBatchDetailsAsync(id, cancellationToken);
+
+            if (batch is null || batch.CommunityId != communityId)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 GetBatch {BatchId} for community {CommunityId}", id, communityId);
+
+            return Ok(batch.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates and sends a new batch of email invites for a community.
+        /// </summary>
+        /// <param name="communityId">The community (partner) ID.</param>
+        /// <param name="dto">The batch creation request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created batch with send results.</returns>
+        /// <response code="201">Batch created and sent.</response>
+        /// <response code="400">Invalid request data.</response>
+        /// <response code="403">Not authorized for this community.</response>
+        [HttpPost("batch")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EmailInviteBatchDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> CreateBatch(
+            Guid communityId,
+            [FromBody] CreateEmailInviteBatchDto dto,
+            CancellationToken cancellationToken)
+        {
+            var partner = await partnerManager.GetAsync(communityId, cancellationToken);
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            if (dto is null || dto.Emails is null || !dto.Emails.Any())
+            {
+                return Problem("Email list is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            logger.LogInformation("V2 CreateBatch: {Count} emails for community {CommunityId}",
+                dto.Emails.Count(), communityId);
+
+            var batch = await emailInviteManager.CreateBatchAsync(
+                dto.Emails,
+                UserId,
+                "Community",
+                communityId,
+                null,
+                cancellationToken);
+
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken);
+
+            return CreatedAtAction(nameof(GetBatch), new { communityId, id = result.Id }, result.ToV2Dto());
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/CommunityProfessionalCompaniesV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunityProfessionalCompaniesV2Controller.cs
@@ -1,0 +1,355 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing professional cleanup companies within a community.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{partnerId}/professional-companies")]
+    public class CommunityProfessionalCompaniesV2Controller(
+        IProfessionalCompanyManager companyManager,
+        IProfessionalCompanyUserManager companyUserManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<CommunityProfessionalCompaniesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all active professional companies for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the professional companies.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ProfessionalCompanyDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetCompanies(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetCompanies for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var companies = await companyManager.GetByCommunityAsync(partnerId, cancellationToken);
+            return Ok(companies.Select(c => c.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single professional company by ID.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the professional company.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or company not found.</response>
+        [HttpGet("{companyId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(ProfessionalCompanyDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetCompany(Guid partnerId, Guid companyId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetCompany for Partner={PartnerId}, Company={CompanyId}", partnerId, companyId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var company = await companyManager.GetAsync(companyId, cancellationToken);
+            if (company is null || company.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            return Ok(company.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new professional company for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="companyDto">The professional company to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Professional company created.</response>
+        /// <response code="400">Invalid data.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ProfessionalCompanyDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CreateCompany(
+            Guid partnerId,
+            [FromBody] ProfessionalCompanyDto companyDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateCompany for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = companyDto.ToEntity();
+            entity.PartnerId = partnerId;
+            entity.CreatedByUserId = UserId;
+            entity.LastUpdatedByUserId = UserId;
+
+            var created = await companyManager.AddAsync(entity, UserId, cancellationToken);
+            return CreatedAtAction(nameof(GetCompany), new { partnerId, companyId = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing professional company.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="companyDto">The updated company data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated professional company.</response>
+        /// <response code="400">Invalid data.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or company not found.</response>
+        [HttpPut("{companyId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ProfessionalCompanyDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateCompany(
+            Guid partnerId,
+            Guid companyId,
+            [FromBody] ProfessionalCompanyDto companyDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateCompany for Partner={PartnerId}, Company={CompanyId}", partnerId, companyId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var existing = await companyManager.GetAsync(companyId, cancellationToken);
+            if (existing is null || existing.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            var entity = companyDto.ToEntity();
+            entity.Id = companyId;
+            entity.PartnerId = partnerId;
+            entity.LastUpdatedByUserId = UserId;
+
+            var updated = await companyManager.UpdateAsync(entity, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Assigns a user to a professional company.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="companyUserDto">The company user assignment.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">User assigned to company.</response>
+        /// <response code="400">Invalid data.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or company not found.</response>
+        [HttpPost("{companyId}/users")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ProfessionalCompanyUserDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> AssignUser(
+            Guid partnerId,
+            Guid companyId,
+            [FromBody] ProfessionalCompanyUserDto companyUserDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AssignUser for Partner={PartnerId}, Company={CompanyId}", partnerId, companyId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var company = await companyManager.GetAsync(companyId, cancellationToken);
+            if (company is null || company.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            var entity = companyUserDto.ToEntity();
+            entity.ProfessionalCompanyId = companyId;
+            entity.CreatedByUserId = UserId;
+            entity.LastUpdatedByUserId = UserId;
+
+            var created = await companyUserManager.AddAsync(entity, UserId, cancellationToken);
+            return StatusCode(StatusCodes.Status201Created, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Removes a user from a professional company.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="userId">The user ID to remove.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">User removed from company.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or company not found.</response>
+        [HttpDelete("{companyId}/users/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> RemoveUser(
+            Guid partnerId,
+            Guid companyId,
+            Guid userId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 RemoveUser for Partner={PartnerId}, Company={CompanyId}, User={TargetUserId}",
+                partnerId, companyId, userId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var company = await companyManager.GetAsync(companyId, cancellationToken);
+            if (company is null || company.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            await companyUserManager.Delete(companyId, userId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Gets all users assigned to a professional company.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the company users.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or company not found.</response>
+        [HttpGet("{companyId}/users")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<UserDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetUsers(Guid partnerId, Guid companyId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetCompanyUsers for Partner={PartnerId}, Company={CompanyId}", partnerId, companyId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var company = await companyManager.GetAsync(companyId, cancellationToken);
+            if (company is null || company.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            var users = await companyUserManager.GetUsersForCompanyAsync(companyId, cancellationToken);
+            return Ok(users.Select(u => u.ToV2Dto()));
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/CommunityProspectsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunityProspectsV2Controller.cs
@@ -1,0 +1,438 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Managers.Prospects;
+
+    /// <summary>
+    /// V2 controller for community prospect management (admin only).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/community-prospects")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    [RequiredScope(Constants.TrashMobWriteScope)]
+    public class CommunityProspectsV2Controller(
+        ICommunityProspectManager communityProspectManager,
+        IProspectActivityManager prospectActivityManager,
+        IClaudeDiscoveryService claudeDiscoveryService,
+        IProspectScoringManager prospectScoringManager,
+        ICsvImportManager csvImportManager,
+        IProspectOutreachManager prospectOutreachManager,
+        IPipelineAnalyticsManager pipelineAnalyticsManager,
+        IProspectConversionManager prospectConversionManager,
+        ILogger<CommunityProspectsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all community prospects, optionally filtered by pipeline stage or search term.
+        /// </summary>
+        /// <param name="stage">Optional pipeline stage filter.</param>
+        /// <param name="search">Optional search term.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the prospect list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<CommunityProspectDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAll(
+            [FromQuery] int? stage,
+            [FromQuery] string search,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAll prospects with stage={Stage}, search={Search}", stage, search);
+
+            IEnumerable<CommunityProspect> prospects;
+
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                prospects = await communityProspectManager.SearchAsync(search, cancellationToken);
+            }
+            else if (stage.HasValue)
+            {
+                prospects = await communityProspectManager.GetByPipelineStageAsync(stage.Value, cancellationToken);
+            }
+            else
+            {
+                prospects = await communityProspectManager.GetAsync(cancellationToken);
+            }
+
+            var dtos = prospects.Select(p => p.ToV2Dto()).ToList();
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a community prospect by ID.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the prospect.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(CommunityProspectDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
+        {
+            var prospect = await communityProspectManager.GetAsync(id, cancellationToken);
+
+            if (prospect is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(prospect.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new community prospect.
+        /// </summary>
+        /// <param name="dto">The prospect data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Prospect created.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(CommunityProspectDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create([FromBody] CommunityProspectDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Create prospect {Name}", dto.Name);
+
+            var entity = dto.ToEntity();
+            var result = await communityProspectManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a community prospect.
+        /// </summary>
+        /// <param name="dto">The updated prospect data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Prospect updated.</response>
+        [HttpPut]
+        [ProducesResponseType(typeof(CommunityProspectDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update([FromBody] CommunityProspectDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Update prospect {ProspectId}", dto.Id);
+
+            var entity = dto.ToEntity();
+            var result = await communityProspectManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a community prospect.
+        /// </summary>
+        /// <param name="id">The prospect ID to delete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Prospect deleted.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Delete prospect {ProspectId}", id);
+
+            await communityProspectManager.DeleteAsync(id, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Updates the pipeline stage of a community prospect.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="request">The new pipeline stage.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Stage updated.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpPut("{id}/stage")]
+        [ProducesResponseType(typeof(CommunityProspectDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateStage(Guid id, [FromBody] UpdateStageRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateStage prospect {ProspectId} to stage {Stage}", id, request.Stage);
+
+            var result = await communityProspectManager.UpdatePipelineStageAsync(id, request.Stage, UserId, cancellationToken);
+
+            if (result is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets all activities for a community prospect.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the activity list.</response>
+        [HttpGet("{id}/activities")]
+        [ProducesResponseType(typeof(IEnumerable<ProspectActivityDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetActivities(Guid id, CancellationToken cancellationToken)
+        {
+            var activities = await prospectActivityManager.GetByProspectIdAsync(id, cancellationToken);
+            var dtos = activities.Select(a => a.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Creates a new activity for a community prospect.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="dto">The activity data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Activity created.</response>
+        [HttpPost("{id}/activities")]
+        [ProducesResponseType(typeof(ProspectActivityDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> CreateActivity(Guid id, [FromBody] ProspectActivityDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateActivity for prospect {ProspectId}", id);
+
+            var entity = dto.ToEntity();
+            entity.ProspectId = id;
+            var result = await prospectActivityManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetActivities), new { id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Discovers new community prospects using AI.
+        /// </summary>
+        /// <param name="request">The discovery request with optional prompt or location.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the discovery results.</response>
+        [HttpPost("discover")]
+        [ProducesResponseType(typeof(DiscoveryResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Discover([FromBody] DiscoveryRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Discover prospects");
+
+            var result = await claudeDiscoveryService.DiscoverProspectsAsync(request, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets the FitScore breakdown for a specific prospect.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the score breakdown.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpGet("{id}/score")]
+        [ProducesResponseType(typeof(FitScoreBreakdown), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetScoreBreakdown(Guid id, CancellationToken cancellationToken)
+        {
+            var breakdown = await prospectScoringManager.CalculateFitScoreAsync(id, cancellationToken);
+
+            if (breakdown is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(breakdown);
+        }
+
+        /// <summary>
+        /// Recalculates FitScores for all prospects.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the number of prospects updated.</response>
+        [HttpPost("rescore")]
+        [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+        public async Task<IActionResult> RescoreAll(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 RescoreAll prospects by user {UserId}", UserId);
+
+            var count = await prospectScoringManager.RecalculateAllScoresAsync(UserId, cancellationToken);
+            return Ok(count);
+        }
+
+        /// <summary>
+        /// Gets geographic areas with events but no active community partner.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the geographic gaps.</response>
+        [HttpGet("gaps")]
+        [ProducesResponseType(typeof(IEnumerable<GeographicGap>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetGeographicGaps(CancellationToken cancellationToken)
+        {
+            var gaps = await prospectScoringManager.GetGeographicGapsAsync(cancellationToken);
+            return Ok(gaps);
+        }
+
+        /// <summary>
+        /// Imports community prospects from a CSV file.
+        /// </summary>
+        /// <param name="file">The CSV file to import.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the import results.</response>
+        /// <response code="400">Invalid file.</response>
+        [HttpPost("import")]
+        [ProducesResponseType(typeof(CsvImportResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> ImportCsv(IFormFile file, CancellationToken cancellationToken)
+        {
+            if (file is null || file.Length == 0)
+            {
+                return Problem("No file provided.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (!file.FileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+            {
+                return Problem("Only .csv files are supported.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            logger.LogInformation("V2 ImportCsv: {FileName} ({Size} bytes)", file.FileName, file.Length);
+
+            using var stream = file.OpenReadStream();
+            var result = await csvImportManager.ImportProspectsAsync(stream, UserId, cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Generates a preview of the next outreach email for a prospect without sending.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the outreach preview.</response>
+        [HttpPost("{id}/outreach/preview")]
+        [ProducesResponseType(typeof(OutreachPreview), StatusCodes.Status200OK)]
+        public async Task<IActionResult> PreviewOutreach(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 PreviewOutreach for prospect {ProspectId}", id);
+
+            var preview = await prospectOutreachManager.PreviewOutreachAsync(id, cancellationToken);
+            return Ok(preview);
+        }
+
+        /// <summary>
+        /// Sends an outreach email to a prospect.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the send result.</response>
+        [HttpPost("{id}/outreach")]
+        [ProducesResponseType(typeof(OutreachSendResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> SendOutreach(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SendOutreach to prospect {ProspectId}", id);
+
+            var result = await prospectOutreachManager.SendOutreachAsync(id, UserId, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets the outreach email history for a prospect.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the outreach history.</response>
+        [HttpGet("{id}/outreach/history")]
+        [ProducesResponseType(typeof(IEnumerable<ProspectOutreachEmail>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetOutreachHistory(Guid id, CancellationToken cancellationToken)
+        {
+            var history = await prospectOutreachManager.GetOutreachHistoryAsync(id, cancellationToken);
+            return Ok(history);
+        }
+
+        /// <summary>
+        /// Sends outreach emails to multiple prospects.
+        /// </summary>
+        /// <param name="request">The batch outreach request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the batch send results.</response>
+        [HttpPost("outreach/batch")]
+        [ProducesResponseType(typeof(BatchOutreachResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> SendBatchOutreach([FromBody] BatchOutreachRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SendBatchOutreach for {Count} prospects", request.ProspectIds.Count);
+
+            var result = await prospectOutreachManager.SendBatchOutreachAsync(request.ProspectIds, UserId, cancellationToken);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Gets the current outreach configuration settings.
+        /// </summary>
+        /// <response code="200">Returns the outreach settings.</response>
+        [HttpGet("outreach/settings")]
+        [ProducesResponseType(typeof(OutreachSettings), StatusCodes.Status200OK)]
+        public IActionResult GetOutreachSettings()
+        {
+            var settings = prospectOutreachManager.GetOutreachSettings();
+            return Ok(settings);
+        }
+
+        /// <summary>
+        /// Gets pipeline analytics including funnel metrics, outreach effectiveness, and conversion rates.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the analytics data.</response>
+        [HttpGet("analytics")]
+        [ProducesResponseType(typeof(PipelineAnalytics), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAnalytics(CancellationToken cancellationToken)
+        {
+            var analytics = await pipelineAnalyticsManager.GetAnalyticsAsync(cancellationToken);
+            return Ok(analytics);
+        }
+
+        /// <summary>
+        /// Converts a prospect to a partner organization.
+        /// </summary>
+        /// <param name="id">The prospect ID.</param>
+        /// <param name="request">The conversion request with partner type and email options.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the conversion result.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpPost("{id}/convert")]
+        [ProducesResponseType(typeof(ProspectConversionResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ConvertToPartner(Guid id, [FromBody] ProspectConversionRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ConvertToPartner for prospect {ProspectId}", id);
+
+            request.ProspectId = id;
+            var result = await prospectConversionManager.ConvertToPartnerAsync(request, UserId, cancellationToken);
+
+            if (!result.Success && result.ErrorMessage?.Contains("not found") == true)
+            {
+                return NotFound();
+            }
+
+            return Ok(result);
+        }
+    }
+
+    /// <summary>
+    /// Request body for updating a prospect's pipeline stage (V2).
+    /// </summary>
+    public class UpdateStageRequest
+    {
+        /// <summary>
+        /// Gets or sets the new pipeline stage value.
+        /// </summary>
+        public int Stage { get; set; }
+    }
+}

--- a/TrashMob/Controllers/V2/CommunitySponsoredAdoptionsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunitySponsoredAdoptionsV2Controller.cs
@@ -1,0 +1,248 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for managing sponsored adoptions within a community.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{partnerId}/sponsored-adoptions")]
+    public class CommunitySponsoredAdoptionsV2Controller(
+        ISponsoredAdoptionManager adoptionManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<CommunitySponsoredAdoptionsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all sponsored adoptions for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the sponsored adoptions.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<SponsoredAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetSponsoredAdoptions(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetSponsoredAdoptions for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionManager.GetByCommunityAsync(partnerId, cancellationToken);
+            return Ok(adoptions.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single sponsored adoption by ID.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="id">The sponsored adoption ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the sponsored adoption.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or adoption not found.</response>
+        [HttpGet("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(SponsoredAdoptionDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetSponsoredAdoption(Guid partnerId, Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetSponsoredAdoption for Partner={PartnerId}, Id={AdoptionId}", partnerId, id);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoption = await adoptionManager.GetAsync(id, cancellationToken);
+            if (adoption is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(adoption.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new sponsored adoption.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="adoptionDto">The sponsored adoption to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Sponsored adoption created.</response>
+        /// <response code="400">Invalid data.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(SponsoredAdoptionDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CreateSponsoredAdoption(
+            Guid partnerId,
+            [FromBody] SponsoredAdoptionDto adoptionDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateSponsoredAdoption for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = adoptionDto.ToEntity();
+            entity.CreatedByUserId = UserId;
+            entity.LastUpdatedByUserId = UserId;
+
+            var created = await adoptionManager.AddAsync(entity, UserId, cancellationToken);
+            return CreatedAtAction(nameof(GetSponsoredAdoption), new { partnerId, id = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing sponsored adoption.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="id">The sponsored adoption ID.</param>
+        /// <param name="adoptionDto">The updated sponsored adoption data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated sponsored adoption.</response>
+        /// <response code="400">Invalid data.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or adoption not found.</response>
+        [HttpPut("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(SponsoredAdoptionDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateSponsoredAdoption(
+            Guid partnerId,
+            Guid id,
+            [FromBody] SponsoredAdoptionDto adoptionDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateSponsoredAdoption for Partner={PartnerId}, Id={AdoptionId}", partnerId, id);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var existing = await adoptionManager.GetAsync(id, cancellationToken);
+            if (existing is null)
+            {
+                return NotFound();
+            }
+
+            var entity = adoptionDto.ToEntity();
+            entity.Id = id;
+            entity.LastUpdatedByUserId = UserId;
+
+            var updated = await adoptionManager.UpdateAsync(entity, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets compliance statistics for a community's sponsored adoption program.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the compliance statistics.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpGet("compliance")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(SponsoredAdoptionComplianceStats), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetComplianceStats(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetComplianceStats for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var stats = await adoptionManager.GetComplianceByCommunityAsync(partnerId, cancellationToken);
+            return Ok(stats);
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/CommunitySponsorsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunitySponsorsV2Controller.cs
@@ -1,0 +1,313 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for managing sponsors within a community's sponsored adoption program.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{partnerId}/sponsors")]
+    public class CommunitySponsorsV2Controller(
+        ISponsorManager sponsorManager,
+        IKeyedManager<Partner> partnerManager,
+        IImageManager imageManager,
+        IAuthorizationService authorizationService,
+        ILogger<CommunitySponsorsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all active sponsors for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the sponsors.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<SponsorDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetSponsors(Guid partnerId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetSponsors for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var sponsors = await sponsorManager.GetByCommunityAsync(partnerId, cancellationToken);
+            return Ok(sponsors.Select(s => s.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a single sponsor by ID.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the sponsor.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or sponsor not found.</response>
+        [HttpGet("{sponsorId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(SponsorDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetSponsor(Guid partnerId, Guid sponsorId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetSponsor for Partner={PartnerId}, Sponsor={SponsorId}", partnerId, sponsorId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor is null || sponsor.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            return Ok(sponsor.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new sponsor for a community.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="sponsorDto">The sponsor to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Sponsor created.</response>
+        /// <response code="400">Invalid data.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(SponsorDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CreateSponsor(
+            Guid partnerId,
+            [FromBody] SponsorDto sponsorDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateSponsor for Partner={PartnerId}", partnerId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = sponsorDto.ToEntity();
+            entity.PartnerId = partnerId;
+            entity.CreatedByUserId = UserId;
+            entity.LastUpdatedByUserId = UserId;
+
+            var created = await sponsorManager.AddAsync(entity, UserId, cancellationToken);
+            return CreatedAtAction(nameof(GetSponsor), new { partnerId, sponsorId = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing sponsor.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="sponsorDto">The updated sponsor data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated sponsor.</response>
+        /// <response code="400">Invalid data.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or sponsor not found.</response>
+        [HttpPut("{sponsorId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(SponsorDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateSponsor(
+            Guid partnerId,
+            Guid sponsorId,
+            [FromBody] SponsorDto sponsorDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateSponsor for Partner={PartnerId}, Sponsor={SponsorId}", partnerId, sponsorId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var existing = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (existing is null || existing.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            var entity = sponsorDto.ToEntity();
+            entity.Id = sponsorId;
+            entity.PartnerId = partnerId;
+            entity.LastUpdatedByUserId = UserId;
+
+            var updated = await sponsorManager.UpdateAsync(entity, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deactivates a sponsor (soft delete).
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Sponsor deactivated.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or sponsor not found.</response>
+        [HttpDelete("{sponsorId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeactivateSponsor(Guid partnerId, Guid sponsorId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeactivateSponsor for Partner={PartnerId}, Sponsor={SponsorId}", partnerId, sponsorId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var existing = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (existing is null || existing.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            existing.IsActive = false;
+            existing.LastUpdatedByUserId = UserId;
+            await sponsorManager.UpdateAsync(existing, UserId, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Uploads a sponsor logo image (resized to 200x200).
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="imageUpload">The image file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the uploaded logo URL.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Partner or sponsor not found.</response>
+        [HttpPost("{sponsorId}/logo")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadSponsorLogo(
+            Guid partnerId,
+            Guid sponsorId,
+            [FromForm] ImageUpload imageUpload,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadSponsorLogo for Partner={PartnerId}, Sponsor={SponsorId}", partnerId, sponsorId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor is null || sponsor.PartnerId != partnerId)
+            {
+                return NotFound();
+            }
+
+            imageUpload.ParentId = sponsorId;
+            imageUpload.ImageType = ImageTypeEnum.SponsorLogo;
+            var url = await imageManager.UploadImageWithSizeAsync(imageUpload, 200, 200);
+
+            sponsor.LogoUrl = url;
+            sponsor.LastUpdatedByUserId = UserId;
+            await sponsorManager.UpdateAsync(sponsor, UserId, cancellationToken);
+
+            return Ok(new { url });
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/StagedAreasV2Controller.cs
+++ b/TrashMob/Controllers/V2/StagedAreasV2Controller.cs
@@ -1,0 +1,274 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for reviewing staged adoptable areas produced by AI generation.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{partnerId}/areas/staged")]
+    public class StagedAreasV2Controller(
+        IStagedAdoptableAreaManager stagedManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<StagedAreasV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets staged areas for a batch.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="batchId">The batch ID to filter by.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<StagedAdoptableAreaDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetStagedAreas(
+            Guid partnerId,
+            [FromQuery] Guid batchId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetStagedAreas Partner={PartnerId}, Batch={BatchId}", partnerId, batchId);
+
+            var areas = await stagedManager.GetByBatchAsync(batchId, cancellationToken);
+            return Ok(areas.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Approves a single staged area.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="id">The staged area ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPut("{id}/approve")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Approve(
+            Guid partnerId,
+            Guid id,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Approve staged area Partner={PartnerId}, Id={Id}", partnerId, id);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await stagedManager.ApproveAsync(id, UserId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Rejects a single staged area.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="id">The staged area ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPut("{id}/reject")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Reject(
+            Guid partnerId,
+            Guid id,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Reject staged area Partner={PartnerId}, Id={Id}", partnerId, id);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await stagedManager.RejectAsync(id, UserId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Bulk-approves staged areas in a batch.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="request">The bulk review request with batch ID and optional area IDs.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("approve-batch")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> BulkApprove(
+            Guid partnerId,
+            [FromBody] BulkReviewRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 BulkApprove Partner={PartnerId}, Batch={BatchId}", partnerId, request.BatchId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var count = await stagedManager.BulkApproveAsync(request.BatchId, UserId, request.Ids, cancellationToken);
+            return Ok(count);
+        }
+
+        /// <summary>
+        /// Bulk-rejects staged areas in a batch.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="request">The bulk review request with batch ID and optional area IDs.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("reject-batch")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> BulkReject(
+            Guid partnerId,
+            [FromBody] BulkReviewRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 BulkReject Partner={PartnerId}, Batch={BatchId}", partnerId, request.BatchId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var count = await stagedManager.BulkRejectAsync(request.BatchId, UserId, request.Ids, cancellationToken);
+            return Ok(count);
+        }
+
+        /// <summary>
+        /// Updates the name of a staged area.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="id">The staged area ID.</param>
+        /// <param name="request">The request containing the new name.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPut("{id}/name")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateName(
+            Guid partnerId,
+            Guid id,
+            [FromBody] UpdateStagedAreaNameRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateName staged area Partner={PartnerId}, Id={Id}", partnerId, id);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            await stagedManager.UpdateNameAsync(id, request.Name, UserId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Promotes all approved staged areas to real adoptable areas.
+        /// </summary>
+        /// <param name="partnerId">The community (partner) ID.</param>
+        /// <param name="request">The bulk review request with batch ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        [HttpPost("create-approved")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(AreaBulkImportResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CreateApprovedAreas(
+            Guid partnerId,
+            [FromBody] BulkReviewRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateApprovedAreas Partner={PartnerId}, Batch={BatchId}", partnerId, request.BatchId);
+
+            var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var result = await stagedManager.CreateApprovedAreasAsync(request.BatchId, UserId, cancellationToken);
+            return Ok(result);
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add 10 v2 controllers for community and adoption management: adoptable areas, area generation, staged areas, community adoptions, adoption events, sponsored adoptions, sponsors, invites, professional companies, and community prospects
- Create 11 DTOs with DTO-only request/response pattern and consolidated mapping extensions
- Add 38 unit tests across 10 test files

## Details
**Controllers (72 endpoints total):**
- `AdoptableAreasV2Controller` (11 endpoints) - CRUD + community-scoped queries
- `AreaGenerationV2Controller` (5 endpoints) - AI area generation batches
- `StagedAreasV2Controller` (7 endpoints) - staged area review/approval
- `CommunityAdoptionsV2Controller` (7 endpoints) - adoption management
- `AdoptionEventsV2Controller` (3 endpoints) - adoption-event linking
- `CommunitySponsoredAdoptionsV2Controller` (5 endpoints) - sponsored adoptions
- `CommunitySponsorsV2Controller` (6 endpoints) - sponsor CRUD
- `CommunityInvitesV2Controller` (3 endpoints) - bulk email invites
- `CommunityProfessionalCompaniesV2Controller` (7 endpoints) - professional companies + users
- `CommunityProspectsV2Controller` (18 endpoints) - full CRM prospect pipeline

**DTOs:** `AdoptableAreaDto`, `StagedAdoptableAreaDto`, `AreaGenerationBatchDto`, `TeamAdoptionDto`, `TeamAdoptionEventDto`, `SponsoredAdoptionDto`, `SponsorDto`, `ProfessionalCompanyDto`, `ProfessionalCompanyUserDto`, `CommunityProspectDto`, `ProspectActivityDto`

## Test plan
- [x] All 38 Phase 2e tests pass
- [x] Solution builds without errors
- [x] Project plan updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)