### PR TITLE
API v2: Team admin & portals (Phase 2f)

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 1, 2a–2e complete — 40+ v2 controllers, 75+ DTOs, 40+ test suites; Phases 2f–2i, 3, 4 remaining) |
+| **Status** | In Progress (Phases 1, 2a–2f complete — 47+ v2 controllers, 77+ DTOs, 47+ test suites; Phases 2g–2i, 3, 4 remaining) |
 | **Priority** | High |
 | **Risk** | Medium |
 | **Size** | Very Large |
@@ -196,13 +196,15 @@ Community administration and area adoption features — 10 v1 controllers, all c
 
 Team admin, sponsor portals, and professional company portals — 7 v1 controllers.
 
-- [ ] **Team admin** - `TeamAdminController`: site admin team management
-- [ ] **Team adoptions** - `TeamAdoptionsController`: team adoption applications
-- [ ] **Team invites** - `TeamInvitesController`: team lead bulk email invites
-- [ ] **Sponsor portal** - `SponsorPortalController`: sponsors view adoptions + cleanup logs
-- [ ] **Sponsor reports** - `SponsorReportsController`: reports on sponsored adoptions
-- [ ] **Professional cleanup logs** - `ProfessionalCleanupLogsController`: professional company cleanup logging
-- [ ] **Professional company portal** - `ProfessionalCompanyPortalController`: professional company listing
+- [x] **Team admin** - `TeamAdminV2Controller`: 3 endpoints (get all, delete, reactivate) ✅
+- [x] **Team adoptions** - `TeamAdoptionsV2Controller`: 3 endpoints (list, submit application, active) ✅
+- [x] **Team invites** - `TeamInvitesV2Controller`: 3 endpoints (batches, batch detail, create batch) ✅
+- [x] **Sponsor portal** - `SponsorPortalV2Controller`: 3 endpoints (my sponsors, cleanup logs, CSV export) ✅
+- [x] **Sponsor reports** - `SponsorReportsV2Controller`: 2 endpoints (adoptions, adoption reports) ✅
+- [x] **Professional cleanup logs** - `ProfessionalCleanupLogsV2Controller`: 3 endpoints (logs, log cleanup, assignments) ✅
+- [x] **Professional company portal** - `ProfessionalCompanyPortalV2Controller`: 1 endpoint (my companies) ✅
+
+**Phase 2f totals:** 7 controllers, 18 endpoints, 2 DTOs, 1 mapping file, 30 tests
 
 ### Phase 2g - Admin & Moderation (Site Admin)
 

--- a/TrashMob.Models/Extensions/V2/TeamPortalMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamPortalMappingsV2.cs
@@ -1,0 +1,53 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping team and portal entities to V2 DTOs.
+    /// </summary>
+    public static class TeamPortalMappingsV2
+    {
+        #region ProfessionalCleanupLog
+
+        /// <summary>
+        /// Maps a ProfessionalCleanupLog entity to a V2 ProfessionalCleanupLogDto.
+        /// </summary>
+        public static ProfessionalCleanupLogDto ToV2Dto(this ProfessionalCleanupLog entity)
+        {
+            return new ProfessionalCleanupLogDto
+            {
+                Id = entity.Id,
+                SponsoredAdoptionId = entity.SponsoredAdoptionId,
+                ProfessionalCompanyId = entity.ProfessionalCompanyId,
+                CleanupDate = entity.CleanupDate,
+                DurationMinutes = entity.DurationMinutes,
+                BagsCollected = entity.BagsCollected,
+                WeightInPounds = entity.WeightInPounds,
+                WeightInKilograms = entity.WeightInKilograms,
+                Notes = entity.Notes,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 ProfessionalCleanupLogDto to a ProfessionalCleanupLog entity.
+        /// </summary>
+        public static ProfessionalCleanupLog ToEntity(this ProfessionalCleanupLogDto dto)
+        {
+            return new ProfessionalCleanupLog
+            {
+                Id = dto.Id,
+                SponsoredAdoptionId = dto.SponsoredAdoptionId,
+                ProfessionalCompanyId = dto.ProfessionalCompanyId,
+                CleanupDate = dto.CleanupDate,
+                DurationMinutes = dto.DurationMinutes,
+                BagsCollected = dto.BagsCollected,
+                WeightInPounds = dto.WeightInPounds,
+                WeightInKilograms = dto.WeightInKilograms,
+                Notes = dto.Notes ?? string.Empty,
+            };
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Models/Poco/V2/ProfessionalCleanupLogDto.cs
+++ b/TrashMob.Models/Poco/V2/ProfessionalCleanupLogDto.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a professional cleanup log entry.
+    /// </summary>
+    public class ProfessionalCleanupLogDto
+    {
+        /// <summary>Gets or sets the unique identifier.</summary>
+        public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the sponsored adoption this cleanup is for.</summary>
+        public Guid SponsoredAdoptionId { get; set; }
+
+        /// <summary>Gets or sets the professional company that performed the cleanup.</summary>
+        public Guid ProfessionalCompanyId { get; set; }
+
+        /// <summary>Gets or sets the date the cleanup was performed.</summary>
+        public DateTimeOffset CleanupDate { get; set; }
+
+        /// <summary>Gets or sets the duration of the cleanup in minutes.</summary>
+        public int DurationMinutes { get; set; }
+
+        /// <summary>Gets or sets the number of bags collected.</summary>
+        public int BagsCollected { get; set; }
+
+        /// <summary>Gets or sets the weight of trash collected in pounds.</summary>
+        public decimal? WeightInPounds { get; set; }
+
+        /// <summary>Gets or sets the weight of trash collected in kilograms.</summary>
+        public decimal? WeightInKilograms { get; set; }
+
+        /// <summary>Gets or sets notes about the cleanup.</summary>
+        public string? Notes { get; set; }
+
+        /// <summary>Gets or sets when the log was created.</summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/SubmitAdoptionRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/SubmitAdoptionRequestDto.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API request body for submitting a team adoption application.
+    /// </summary>
+    public class SubmitAdoptionRequestDto
+    {
+        /// <summary>Gets or sets the adoptable area being applied for.</summary>
+        public Guid AdoptableAreaId { get; set; }
+
+        /// <summary>Gets or sets optional notes from the team about their application.</summary>
+        public string? ApplicationNotes { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ProfessionalCleanupLogsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ProfessionalCleanupLogsV2ControllerTests.cs
@@ -1,0 +1,177 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class ProfessionalCleanupLogsV2ControllerTests
+    {
+        private readonly Mock<IProfessionalCleanupLogManager> logManager = new();
+        private readonly Mock<IProfessionalCompanyManager> companyManager = new();
+        private readonly Mock<ISponsoredAdoptionManager> adoptionManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<ProfessionalCleanupLogsV2Controller>> logger = new();
+        private readonly ProfessionalCleanupLogsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public ProfessionalCleanupLogsV2ControllerTests()
+        {
+            controller = new ProfessionalCleanupLogsV2Controller(
+                logManager.Object, companyManager.Object, adoptionManager.Object,
+                authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetLogs_CompanyNotFound_ReturnsNotFound()
+        {
+            var companyId = Guid.NewGuid();
+
+            companyManager
+                .Setup(m => m.GetAsync(companyId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProfessionalCompany)null);
+
+            var result = await controller.GetLogs(companyId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetLogs_Success_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var companyId = Guid.NewGuid();
+            var company = new ProfessionalCompany { Id = companyId, Name = "Test Company", PartnerId = Guid.NewGuid(), IsActive = true };
+            var logs = new List<ProfessionalCleanupLog>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SponsoredAdoptionId = Guid.NewGuid(),
+                    ProfessionalCompanyId = companyId,
+                    CleanupDate = DateTimeOffset.UtcNow,
+                    DurationMinutes = 60,
+                    BagsCollected = 5,
+                    Notes = "Test cleanup",
+                },
+            };
+
+            companyManager
+                .Setup(m => m.GetAsync(companyId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(company);
+            logManager
+                .Setup(m => m.GetByCompanyIdAsync(companyId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(logs);
+
+            var result = await controller.GetLogs(companyId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ProfessionalCleanupLogDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task LogCleanup_Success_ReturnsCreated()
+        {
+            SetupAuthSuccess();
+
+            var companyId = Guid.NewGuid();
+            var company = new ProfessionalCompany { Id = companyId, Name = "Test Company", PartnerId = Guid.NewGuid(), IsActive = true };
+            var logDto = new ProfessionalCleanupLogDto
+            {
+                SponsoredAdoptionId = Guid.NewGuid(),
+                CleanupDate = DateTimeOffset.UtcNow,
+                DurationMinutes = 45,
+                BagsCollected = 3,
+                Notes = "Log cleanup test",
+            };
+            var createdLog = new ProfessionalCleanupLog
+            {
+                Id = Guid.NewGuid(),
+                SponsoredAdoptionId = logDto.SponsoredAdoptionId,
+                ProfessionalCompanyId = companyId,
+                CleanupDate = logDto.CleanupDate,
+                DurationMinutes = logDto.DurationMinutes,
+                BagsCollected = logDto.BagsCollected,
+                Notes = logDto.Notes,
+            };
+
+            companyManager
+                .Setup(m => m.GetAsync(companyId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(company);
+            logManager
+                .Setup(m => m.LogCleanupAsync(It.IsAny<ProfessionalCleanupLog>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<ProfessionalCleanupLog>.Success(createdLog));
+
+            var result = await controller.LogCleanup(companyId, logDto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var dto = Assert.IsType<ProfessionalCleanupLogDto>(createdResult.Value);
+            Assert.Equal(logDto.Notes, dto.Notes);
+        }
+
+        [Fact]
+        public async Task GetAssignments_Success_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var companyId = Guid.NewGuid();
+            var company = new ProfessionalCompany { Id = companyId, Name = "Test Company", PartnerId = Guid.NewGuid(), IsActive = true };
+            var adoptions = new List<SponsoredAdoption>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SponsorId = Guid.NewGuid(),
+                    AdoptableAreaId = Guid.NewGuid(),
+                    ProfessionalCompanyId = companyId,
+                    StartDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                    Status = "Active",
+                },
+            };
+
+            companyManager
+                .Setup(m => m.GetAsync(companyId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(company);
+            adoptionManager
+                .Setup(m => m.GetByCompanyIdAsync(companyId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoptions);
+
+            var result = await controller.GetAssignments(companyId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<SponsoredAdoptionDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ProfessionalCompanyPortalV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ProfessionalCompanyPortalV2ControllerTests.cs
@@ -1,0 +1,74 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class ProfessionalCompanyPortalV2ControllerTests
+    {
+        private readonly Mock<IProfessionalCompanyUserManager> companyUserManager = new();
+        private readonly Mock<ILogger<ProfessionalCompanyPortalV2Controller>> logger = new();
+        private readonly ProfessionalCompanyPortalV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public ProfessionalCompanyPortalV2ControllerTests()
+        {
+            controller = new ProfessionalCompanyPortalV2Controller(
+                companyUserManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetMyCompanies_ReturnsOk()
+        {
+            var companies = new List<ProfessionalCompany>
+            {
+                new() { Id = Guid.NewGuid(), Name = "Company A", PartnerId = Guid.NewGuid(), IsActive = true },
+                new() { Id = Guid.NewGuid(), Name = "Company B", PartnerId = Guid.NewGuid(), IsActive = true },
+            };
+
+            companyUserManager
+                .Setup(m => m.GetCompaniesByUserIdAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(companies);
+
+            var result = await controller.GetMyCompanies(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ProfessionalCompanyDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetMyCompanies_Empty_ReturnsOkWithEmptyList()
+        {
+            companyUserManager
+                .Setup(m => m.GetCompaniesByUserIdAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ProfessionalCompany>());
+
+            var result = await controller.GetMyCompanies(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ProfessionalCompanyDto>>(okResult.Value);
+            Assert.Empty(dtos);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/SponsorPortalV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/SponsorPortalV2ControllerTests.cs
@@ -1,0 +1,171 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class SponsorPortalV2ControllerTests
+    {
+        private readonly Mock<ISponsorManager> sponsorManager = new();
+        private readonly Mock<IPartnerAdminManager> partnerAdminManager = new();
+        private readonly Mock<IProfessionalCleanupLogManager> logManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<SponsorPortalV2Controller>> logger = new();
+        private readonly SponsorPortalV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public SponsorPortalV2ControllerTests()
+        {
+            controller = new SponsorPortalV2Controller(
+                sponsorManager.Object, partnerAdminManager.Object, logManager.Object,
+                partnerManager.Object, authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetMySponsors_ReturnsOk()
+        {
+            var partnerId = Guid.NewGuid();
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var sponsors = new List<Sponsor>
+            {
+                new() { Id = Guid.NewGuid(), Name = "Sponsor A", PartnerId = partnerId, IsActive = true },
+                new() { Id = Guid.NewGuid(), Name = "Sponsor B", PartnerId = partnerId, IsActive = true },
+            };
+
+            partnerAdminManager
+                .Setup(m => m.GetPartnersByUserIdAsync(testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<Partner> { partner });
+            sponsorManager
+                .Setup(m => m.GetByCommunityAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sponsors);
+
+            var result = await controller.GetMySponsors(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<SponsorDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetSponsorCleanupLogs_SponsorNotFound_ReturnsNotFound()
+        {
+            var sponsorId = Guid.NewGuid();
+
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Sponsor)null);
+
+            var result = await controller.GetSponsorCleanupLogs(sponsorId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetSponsorCleanupLogs_Success_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var sponsorId = Guid.NewGuid();
+            var sponsor = new Sponsor { Id = sponsorId, PartnerId = partnerId, Name = "Test Sponsor", IsActive = true };
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var logs = new List<ProfessionalCleanupLog>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SponsoredAdoptionId = Guid.NewGuid(),
+                    ProfessionalCompanyId = Guid.NewGuid(),
+                    CleanupDate = DateTimeOffset.UtcNow,
+                    DurationMinutes = 60,
+                    BagsCollected = 5,
+                    Notes = "Test cleanup",
+                },
+            };
+
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sponsor);
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            logManager
+                .Setup(m => m.GetBySponsorIdAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(logs);
+
+            var result = await controller.GetSponsorCleanupLogs(sponsorId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ProfessionalCleanupLogDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task ExportCleanupLogs_Success_ReturnsFile()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var sponsorId = Guid.NewGuid();
+            var sponsor = new Sponsor { Id = sponsorId, PartnerId = partnerId, Name = "Test Sponsor", IsActive = true };
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var logs = new List<ProfessionalCleanupLog>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SponsoredAdoptionId = Guid.NewGuid(),
+                    ProfessionalCompanyId = Guid.NewGuid(),
+                    CleanupDate = DateTimeOffset.UtcNow,
+                    DurationMinutes = 45,
+                    BagsCollected = 3,
+                    Notes = "Export test",
+                },
+            };
+
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sponsor);
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            logManager
+                .Setup(m => m.GetBySponsorIdAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(logs);
+
+            var result = await controller.ExportCleanupLogs(sponsorId, CancellationToken.None);
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("text/csv", fileResult.ContentType);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/SponsorReportsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/SponsorReportsV2ControllerTests.cs
@@ -1,0 +1,185 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class SponsorReportsV2ControllerTests
+    {
+        private readonly Mock<ISponsoredAdoptionManager> adoptionManager = new();
+        private readonly Mock<IProfessionalCleanupLogManager> logManager = new();
+        private readonly Mock<ISponsorManager> sponsorManager = new();
+        private readonly Mock<IKeyedManager<Partner>> partnerManager = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
+        private readonly Mock<ILogger<SponsorReportsV2Controller>> logger = new();
+        private readonly SponsorReportsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public SponsorReportsV2ControllerTests()
+        {
+            controller = new SponsorReportsV2Controller(
+                adoptionManager.Object, logManager.Object, sponsorManager.Object,
+                partnerManager.Object, authorizationService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupAuthSuccess()
+        {
+            authorizationService
+                .Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+        }
+
+        [Fact]
+        public async Task GetAdoptions_SponsorNotFound_ReturnsNotFound()
+        {
+            var sponsorId = Guid.NewGuid();
+
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Sponsor)null);
+
+            var result = await controller.GetAdoptions(sponsorId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetAdoptions_Success_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var sponsorId = Guid.NewGuid();
+            var sponsor = new Sponsor { Id = sponsorId, PartnerId = partnerId, Name = "Test Sponsor", IsActive = true };
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var adoptions = new List<SponsoredAdoption>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SponsorId = sponsorId,
+                    AdoptableAreaId = Guid.NewGuid(),
+                    ProfessionalCompanyId = Guid.NewGuid(),
+                    StartDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                    Status = "Active",
+                },
+            };
+
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sponsor);
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            adoptionManager
+                .Setup(m => m.GetBySponsorIdAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoptions);
+
+            var result = await controller.GetAdoptions(sponsorId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<SponsoredAdoptionDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task GetAdoptionReports_AdoptionNotFound_ReturnsNotFound()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var sponsorId = Guid.NewGuid();
+            var adoptionId = Guid.NewGuid();
+            var sponsor = new Sponsor { Id = sponsorId, PartnerId = partnerId, Name = "Test Sponsor", IsActive = true };
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sponsor);
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            adoptionManager
+                .Setup(m => m.GetAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((SponsoredAdoption)null);
+
+            var result = await controller.GetAdoptionReports(sponsorId, adoptionId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetAdoptionReports_Success_ReturnsOk()
+        {
+            SetupAuthSuccess();
+
+            var partnerId = Guid.NewGuid();
+            var sponsorId = Guid.NewGuid();
+            var adoptionId = Guid.NewGuid();
+            var sponsor = new Sponsor { Id = sponsorId, PartnerId = partnerId, Name = "Test Sponsor", IsActive = true };
+            var partner = new Partner { Id = partnerId, Name = "Test Partner" };
+            var adoption = new SponsoredAdoption
+            {
+                Id = adoptionId,
+                SponsorId = sponsorId,
+                AdoptableAreaId = Guid.NewGuid(),
+                ProfessionalCompanyId = Guid.NewGuid(),
+                StartDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                Status = "Active",
+            };
+            var logs = new List<ProfessionalCleanupLog>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SponsoredAdoptionId = adoptionId,
+                    ProfessionalCompanyId = Guid.NewGuid(),
+                    CleanupDate = DateTimeOffset.UtcNow,
+                    DurationMinutes = 30,
+                    BagsCollected = 2,
+                    Notes = "Report test",
+                },
+            };
+
+            sponsorManager
+                .Setup(m => m.GetAsync(sponsorId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(sponsor);
+            partnerManager
+                .Setup(m => m.GetAsync(partnerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partner);
+            adoptionManager
+                .Setup(m => m.GetAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoption);
+            logManager
+                .Setup(m => m.GetBySponsoredAdoptionIdAsync(adoptionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(logs);
+
+            var result = await controller.GetAdoptionReports(sponsorId, adoptionId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ProfessionalCleanupLogDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamAdminV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamAdminV2ControllerTests.cs
@@ -1,0 +1,155 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class TeamAdminV2ControllerTests
+    {
+        private readonly Mock<ITeamManager> teamManager = new();
+        private readonly Mock<ILogger<TeamAdminV2Controller>> logger = new();
+        private readonly TeamAdminV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public TeamAdminV2ControllerTests()
+        {
+            controller = new TeamAdminV2Controller(teamManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = userId.ToString();
+            var identity = new GenericIdentity("test", "Bearer");
+            var principal = new ClaimsPrincipal(identity);
+            httpContext.User = principal;
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task GetAllTeams_ReturnsOkWithTeamDtos()
+        {
+            var teams = new List<Team>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Team Alpha",
+                    IsActive = true,
+                    IsPublic = true,
+                    City = "Seattle",
+                    Region = "WA",
+                    Country = "US",
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Team Beta",
+                    IsActive = false,
+                    IsPublic = false,
+                    City = "Portland",
+                    Region = "OR",
+                    Country = "US",
+                },
+            };
+
+            teamManager
+                .Setup(m => m.GetAllTeamsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(teams);
+
+            var result = await controller.GetAllTeams(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<TeamDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task DeleteTeam_TeamNotFound_ReturnsNotFound()
+        {
+            var teamId = Guid.NewGuid();
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team)null);
+
+            var result = await controller.DeleteTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteTeam_TeamExists_ReturnsNoContent()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Doomed Team", IsActive = true };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            var result = await controller.DeleteTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            teamManager.Verify(m => m.DeleteAsync(teamId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ReactivateTeam_TeamNotFound_ReturnsNotFound()
+        {
+            var teamId = Guid.NewGuid();
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team)null);
+
+            var result = await controller.ReactivateTeam(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task ReactivateTeam_TeamExists_ReturnsOkWithDto()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team
+            {
+                Id = teamId,
+                Name = "Inactive Team",
+                IsActive = false,
+                City = "Denver",
+                Region = "CO",
+                Country = "US",
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamManager
+                .Setup(m => m.UpdateAsync(It.IsAny<Team>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team t, Guid _, CancellationToken _) => t);
+
+            var result = await controller.ReactivateTeam(teamId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<TeamDto>(okResult.Value);
+            Assert.Equal(teamId, dto.Id);
+            Assert.Equal("Inactive Team", dto.Name);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamAdoptionsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamAdoptionsV2ControllerTests.cs
@@ -1,0 +1,232 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class TeamAdoptionsV2ControllerTests
+    {
+        private readonly Mock<ITeamAdoptionManager> adoptionManager = new();
+        private readonly Mock<ITeamAdoptionEventManager> adoptionEventManager = new();
+        private readonly Mock<IKeyedManager<Team>> teamManager = new();
+        private readonly Mock<ITeamMemberManager> teamMemberManager = new();
+        private readonly Mock<ILogger<TeamAdoptionsV2Controller>> logger = new();
+        private readonly TeamAdoptionsV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public TeamAdoptionsV2ControllerTests()
+        {
+            controller = new TeamAdoptionsV2Controller(
+                adoptionManager.Object,
+                adoptionEventManager.Object,
+                teamManager.Object,
+                teamMemberManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = userId.ToString();
+            var identity = new GenericIdentity("test", "Bearer");
+            var principal = new ClaimsPrincipal(identity);
+            httpContext.User = principal;
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task GetTeamAdoptions_TeamNotFound_ReturnsNotFound()
+        {
+            var teamId = Guid.NewGuid();
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team)null);
+
+            var result = await controller.GetTeamAdoptions(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetTeamAdoptions_NotMember_ReturnsForbid()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsMemberAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.GetTeamAdoptions(teamId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task GetTeamAdoptions_Success_ReturnsOk()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+            var adoptions = new List<TeamAdoption>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    TeamId = teamId,
+                    AdoptableAreaId = Guid.NewGuid(),
+                    Status = "Approved",
+                    ApplicationDate = DateTimeOffset.UtcNow,
+                },
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsMemberAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            adoptionManager
+                .Setup(m => m.GetByTeamIdAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoptions);
+
+            var result = await controller.GetTeamAdoptions(teamId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<TeamAdoptionDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task SubmitApplication_NotTeamLead_ReturnsForbid()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+            var request = new SubmitAdoptionRequestDto
+            {
+                AdoptableAreaId = Guid.NewGuid(),
+                ApplicationNotes = "We want to adopt this area",
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.SubmitApplication(teamId, request, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task SubmitApplication_Success_ReturnsCreated()
+        {
+            var teamId = Guid.NewGuid();
+            var areaId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+            var request = new SubmitAdoptionRequestDto
+            {
+                AdoptableAreaId = areaId,
+                ApplicationNotes = "We want to adopt this area",
+            };
+
+            var adoption = new TeamAdoption
+            {
+                Id = Guid.NewGuid(),
+                TeamId = teamId,
+                AdoptableAreaId = areaId,
+                Status = "Pending",
+                ApplicationDate = DateTimeOffset.UtcNow,
+                ApplicationNotes = "We want to adopt this area",
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            adoptionManager
+                .Setup(m => m.SubmitApplicationAsync(
+                    teamId, areaId, It.IsAny<string>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ServiceResult<TeamAdoption>.Success(adoption));
+
+            var result = await controller.SubmitApplication(teamId, request, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            var dto = Assert.IsType<TeamAdoptionDto>(createdResult.Value);
+            Assert.Equal(adoption.Id, dto.Id);
+            Assert.Equal(teamId, dto.TeamId);
+        }
+
+        [Fact]
+        public async Task GetActiveAdoptions_Success_ReturnsOk()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+            var adoptions = new List<TeamAdoption>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    TeamId = teamId,
+                    AdoptableAreaId = Guid.NewGuid(),
+                    Status = "Approved",
+                    ApplicationDate = DateTimeOffset.UtcNow,
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    TeamId = teamId,
+                    AdoptableAreaId = Guid.NewGuid(),
+                    Status = "Approved",
+                    ApplicationDate = DateTimeOffset.UtcNow,
+                },
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsMemberAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            adoptionEventManager
+                .Setup(m => m.GetActiveAdoptionsForTeamAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adoptions);
+
+            var result = await controller.GetActiveAdoptions(teamId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<TeamAdoptionDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/TeamInvitesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/TeamInvitesV2ControllerTests.cs
@@ -1,0 +1,198 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class TeamInvitesV2ControllerTests
+    {
+        private readonly Mock<IEmailInviteManager> emailInviteManager = new();
+        private readonly Mock<IKeyedManager<Team>> teamManager = new();
+        private readonly Mock<ITeamMemberManager> teamMemberManager = new();
+        private readonly Mock<ILogger<TeamInvitesV2Controller>> logger = new();
+        private readonly TeamInvitesV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public TeamInvitesV2ControllerTests()
+        {
+            controller = new TeamInvitesV2Controller(
+                emailInviteManager.Object,
+                teamManager.Object,
+                teamMemberManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = userId.ToString();
+            var identity = new GenericIdentity("test", "Bearer");
+            var principal = new ClaimsPrincipal(identity);
+            httpContext.User = principal;
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task GetBatches_TeamNotFound_ReturnsNotFound()
+        {
+            var teamId = Guid.NewGuid();
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Team)null);
+
+            var result = await controller.GetBatches(teamId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetBatches_NotTeamLead_ReturnsForbid()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.GetBatches(teamId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task GetBatches_Success_ReturnsOk()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Active Team", IsActive = true };
+            var batches = new List<EmailInviteBatch>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    SenderUserId = userId,
+                    BatchType = "Team",
+                    TeamId = teamId,
+                    TotalCount = 5,
+                    SentCount = 5,
+                    Status = "Complete",
+                },
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            emailInviteManager
+                .Setup(m => m.GetTeamBatchesAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(batches);
+
+            var result = await controller.GetBatches(teamId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<EmailInviteBatchDto>>(okResult.Value);
+            Assert.Single(dtos);
+        }
+
+        [Fact]
+        public async Task CreateBatch_EmptyEmails_ReturnsBadRequest()
+        {
+            var teamId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+            var request = new CreateEmailInviteBatchDto { Emails = [] };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.CreateBatch(teamId, request, CancellationToken.None);
+
+            var problemResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, problemResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateBatch_Success_ReturnsCreated()
+        {
+            var teamId = Guid.NewGuid();
+            var batchId = Guid.NewGuid();
+            var team = new Team { Id = teamId, Name = "Test Team", IsActive = true };
+            var request = new CreateEmailInviteBatchDto
+            {
+                Emails = ["alice@example.com", "bob@example.com"],
+            };
+
+            var createdBatch = new EmailInviteBatch
+            {
+                Id = batchId,
+                SenderUserId = userId,
+                BatchType = "Team",
+                TeamId = teamId,
+                TotalCount = 2,
+                Status = "Pending",
+            };
+
+            var processedBatch = new EmailInviteBatch
+            {
+                Id = batchId,
+                SenderUserId = userId,
+                BatchType = "Team",
+                TeamId = teamId,
+                TotalCount = 2,
+                SentCount = 2,
+                Status = "Complete",
+            };
+
+            teamManager
+                .Setup(m => m.GetAsync(teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(team);
+
+            teamMemberManager
+                .Setup(m => m.IsTeamLeadAsync(teamId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            emailInviteManager
+                .Setup(m => m.CreateBatchAsync(
+                    It.IsAny<IEnumerable<string>>(), userId, "Team", null, teamId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdBatch);
+
+            emailInviteManager
+                .Setup(m => m.ProcessBatchAsync(batchId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(processedBatch);
+
+            var result = await controller.CreateBatch(teamId, request, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            var dto = Assert.IsType<EmailInviteBatchDto>(createdResult.Value);
+            Assert.Equal(batchId, dto.Id);
+            Assert.Equal("Complete", dto.Status);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ProfessionalCleanupLogsV2Controller.cs
+++ b/TrashMob/Controllers/V2/ProfessionalCleanupLogsV2Controller.cs
@@ -1,0 +1,166 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for professional company cleanup log operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/professional-companies/{companyId}/cleanup-logs")]
+    public class ProfessionalCleanupLogsV2Controller(
+        IProfessionalCleanupLogManager logManager,
+        IProfessionalCompanyManager companyManager,
+        ISponsoredAdoptionManager adoptionManager,
+        IAuthorizationService authorizationService,
+        ILogger<ProfessionalCleanupLogsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all cleanup logs for a professional company.
+        /// </summary>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the cleanup logs.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Company not found.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ProfessionalCleanupLogDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetLogs(Guid companyId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLogs for Company={CompanyId}", companyId);
+
+            var company = await companyManager.GetAsync(companyId, cancellationToken);
+            if (company is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var logs = await logManager.GetByCompanyIdAsync(companyId, cancellationToken);
+            return Ok(logs.Select(l => l.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Logs a professional cleanup for a company.
+        /// </summary>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="logDto">The cleanup log data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Cleanup log created.</response>
+        /// <response code="400">Invalid data or validation failure.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Company not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ProfessionalCleanupLogDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> LogCleanup(
+            Guid companyId,
+            [FromBody] ProfessionalCleanupLogDto logDto,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 LogCleanup for Company={CompanyId}", companyId);
+
+            var company = await companyManager.GetAsync(companyId, cancellationToken);
+            if (company is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = logDto.ToEntity();
+            entity.ProfessionalCompanyId = companyId;
+            entity.CreatedByUserId = UserId;
+            entity.LastUpdatedByUserId = UserId;
+
+            var result = await logManager.LogCleanupAsync(entity, UserId, cancellationToken);
+
+            if (result.IsSuccess)
+            {
+                return CreatedAtAction(nameof(GetLogs), new { companyId }, result.Data.ToV2Dto());
+            }
+
+            return BadRequest(result.ErrorMessage);
+        }
+
+        /// <summary>
+        /// Gets all sponsored adoption assignments for a professional company.
+        /// </summary>
+        /// <param name="companyId">The professional company ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the sponsored adoption assignments.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Company not found.</response>
+        [HttpGet("assignments")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<SponsoredAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAssignments(Guid companyId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAssignments for Company={CompanyId}", companyId);
+
+            var company = await companyManager.GetAsync(companyId, cancellationToken);
+            if (company is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(company, AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionManager.GetByCompanyIdAsync(companyId, cancellationToken);
+            return Ok(adoptions.Select(a => a.ToV2Dto()));
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ProfessionalCompanyPortalV2Controller.cs
+++ b/TrashMob/Controllers/V2/ProfessionalCompanyPortalV2Controller.cs
@@ -1,0 +1,53 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for professional company portal operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/professional-companies")]
+    public class ProfessionalCompanyPortalV2Controller(
+        IProfessionalCompanyUserManager companyUserManager,
+        ILogger<ProfessionalCompanyPortalV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all professional companies the current user is assigned to.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the professional companies.</response>
+        [HttpGet("mine")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ProfessionalCompanyDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMyCompanies(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetMyCompanies for User={UserId}", UserId);
+
+            var companies = await companyUserManager.GetCompaniesByUserIdAsync(UserId, cancellationToken);
+            return Ok(companies.Select(c => c.ToV2Dto()));
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/SponsorPortalV2Controller.cs
+++ b/TrashMob/Controllers/V2/SponsorPortalV2Controller.cs
@@ -1,0 +1,184 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for sponsor portal operations — viewing sponsors and their cleanup logs.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/sponsors")]
+    public class SponsorPortalV2Controller(
+        ISponsorManager sponsorManager,
+        IPartnerAdminManager partnerAdminManager,
+        IProfessionalCleanupLogManager logManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<SponsorPortalV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all sponsors across all communities the current user administers.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the sponsors.</response>
+        [HttpGet("mine")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<SponsorDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMySponsors(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetMySponsors for User={UserId}", UserId);
+
+            var partners = await partnerAdminManager.GetPartnersByUserIdAsync(UserId, cancellationToken);
+            var allSponsors = new List<SponsorDto>();
+
+            foreach (var partner in partners)
+            {
+                var sponsors = await sponsorManager.GetByCommunityAsync(partner.Id, cancellationToken);
+                allSponsors.AddRange(sponsors.Select(s => s.ToV2Dto()));
+            }
+
+            return Ok(allSponsors);
+        }
+
+        /// <summary>
+        /// Gets cleanup logs for a specific sponsor.
+        /// </summary>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the cleanup logs.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Sponsor or partner not found.</response>
+        [HttpGet("{sponsorId:guid}/cleanup-logs")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ProfessionalCleanupLogDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetSponsorCleanupLogs(Guid sponsorId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetSponsorCleanupLogs for Sponsor={SponsorId}", sponsorId);
+
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor is null)
+            {
+                return NotFound();
+            }
+
+            var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var logs = await logManager.GetBySponsorIdAsync(sponsorId, cancellationToken);
+            return Ok(logs.Select(l => l.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Exports cleanup logs for a specific sponsor as a CSV file.
+        /// </summary>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns a CSV file.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Sponsor or partner not found.</response>
+        [HttpGet("{sponsorId:guid}/cleanup-logs/export")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ExportCleanupLogs(Guid sponsorId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ExportCleanupLogs for Sponsor={SponsorId}", sponsorId);
+
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor is null)
+            {
+                return NotFound();
+            }
+
+            var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var logs = await logManager.GetBySponsorIdAsync(sponsorId, cancellationToken);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Date,Area,Duration (min),Bags,Weight (lbs),Notes");
+
+            foreach (var log in logs)
+            {
+                var date = log.CleanupDate.ToString("yyyy-MM-dd");
+                var area = EscapeCsvField(log.SponsoredAdoption?.AdoptableArea?.Name ?? string.Empty);
+                var duration = log.DurationMinutes.ToString();
+                var bags = log.BagsCollected.ToString();
+                var weight = log.WeightInPounds?.ToString("F1") ?? string.Empty;
+                var notes = EscapeCsvField(log.Notes ?? string.Empty);
+
+                sb.AppendLine($"{date},{area},{duration},{bags},{weight},{notes}");
+            }
+
+            var csvBytes = Encoding.UTF8.GetBytes(sb.ToString());
+            var filename = $"{sponsor.Name}_CleanupLogs_{DateTime.UtcNow:yyyyMMdd}.csv";
+
+            return File(csvBytes, "text/csv", filename);
+        }
+
+        private static string EscapeCsvField(string field)
+        {
+            if (field.Contains(',') || field.Contains('"') || field.Contains('\n') || field.Contains('\r'))
+            {
+                return "\"" + field.Replace("\"", "\"\"") + "\"";
+            }
+
+            return field;
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/SponsorReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/SponsorReportsV2Controller.cs
@@ -1,0 +1,136 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for sponsor adoption reports — viewing adoptions and their cleanup logs.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/sponsors/{sponsorId}/adoptions")]
+    public class SponsorReportsV2Controller(
+        ISponsoredAdoptionManager adoptionManager,
+        IProfessionalCleanupLogManager logManager,
+        ISponsorManager sponsorManager,
+        IKeyedManager<Partner> partnerManager,
+        IAuthorizationService authorizationService,
+        ILogger<SponsorReportsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all sponsored adoptions for a sponsor.
+        /// </summary>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the sponsored adoptions.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Sponsor or partner not found.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<SponsoredAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAdoptions(Guid sponsorId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAdoptions for Sponsor={SponsorId}", sponsorId);
+
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor is null)
+            {
+                return NotFound();
+            }
+
+            var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionManager.GetBySponsorIdAsync(sponsorId, cancellationToken);
+            return Ok(adoptions.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets cleanup log reports for a specific sponsored adoption.
+        /// </summary>
+        /// <param name="sponsorId">The sponsor ID.</param>
+        /// <param name="adoptionId">The sponsored adoption ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the cleanup logs.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Sponsor, partner, or adoption not found.</response>
+        [HttpGet("{adoptionId}/reports")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ProfessionalCleanupLogDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAdoptionReports(Guid sponsorId, Guid adoptionId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAdoptionReports for Sponsor={SponsorId}, Adoption={AdoptionId}", sponsorId, adoptionId);
+
+            var sponsor = await sponsorManager.GetAsync(sponsorId, cancellationToken);
+            if (sponsor is null)
+            {
+                return NotFound();
+            }
+
+            var partner = await partnerManager.GetAsync(sponsor.PartnerId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var adoption = await adoptionManager.GetAsync(adoptionId, cancellationToken);
+            if (adoption is null || adoption.SponsorId != sponsorId)
+            {
+                return NotFound();
+            }
+
+            var logs = await logManager.GetBySponsoredAdoptionIdAsync(adoptionId, cancellationToken);
+            return Ok(logs.Select(l => l.ToV2Dto()));
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/TeamAdminV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamAdminV2Controller.cs
@@ -1,0 +1,109 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 admin controller for team management. All endpoints require site admin privileges.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/admin/teams")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class TeamAdminV2Controller(
+        ITeamManager teamManager,
+        ILogger<TeamAdminV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all teams (including inactive and private) for admin review.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of all teams.</returns>
+        /// <response code="200">Returns all teams.</response>
+        [HttpGet]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<TeamDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAllTeams(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Admin GetAllTeams requested by User={UserId}", UserId);
+
+            var teams = await teamManager.GetAllTeamsAsync(cancellationToken);
+            return Ok(teams.Select(t => t.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Deletes a team. Admin-only hard delete.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Team deleted.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpDelete("{teamId}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteTeam(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Admin DeleteTeam Team={TeamId} by User={UserId}", teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            await teamManager.DeleteAsync(teamId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Reactivates a deactivated team.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The reactivated team.</returns>
+        /// <response code="200">Team reactivated.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpPost("{teamId}/reactivate")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ReactivateTeam(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Admin ReactivateTeam Team={TeamId} by User={UserId}", teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            team.IsActive = true;
+            team.LastUpdatedByUserId = UserId;
+            team.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var updatedTeam = await teamManager.UpdateAsync(team, UserId, cancellationToken);
+            return Ok(updatedTeam.ToV2Dto());
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/TeamAdoptionsV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamAdoptionsV2Controller.cs
@@ -1,0 +1,164 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for team adoption operations. Requires team membership for access.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/teams/{teamId}/adoptions")]
+    public class TeamAdoptionsV2Controller(
+        ITeamAdoptionManager adoptionManager,
+        ITeamAdoptionEventManager adoptionEventManager,
+        IKeyedManager<Team> teamManager,
+        ITeamMemberManager teamMemberManager,
+        ILogger<TeamAdoptionsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all adoption applications for a team.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of the team's adoptions.</returns>
+        /// <response code="200">Returns the team's adoptions.</response>
+        /// <response code="403">User is not a team member.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpGet]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<TeamAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetTeamAdoptions(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetTeamAdoptions Team={TeamId} User={UserId}", teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+            if (!isMember)
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionManager.GetByTeamIdAsync(teamId, cancellationToken);
+            return Ok(adoptions.Select(a => a.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Submits an adoption application for a team. Only team leads can submit.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="request">The adoption application request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created adoption application.</returns>
+        /// <response code="201">Adoption application submitted.</response>
+        /// <response code="400">Invalid request or application already exists.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(TeamAdoptionDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SubmitApplication(
+            Guid teamId,
+            [FromBody] SubmitAdoptionRequestDto request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SubmitApplication Team={TeamId} Area={AreaId} User={UserId}",
+                teamId, request.AdoptableAreaId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var result = await adoptionManager.SubmitApplicationAsync(
+                teamId,
+                request.AdoptableAreaId,
+                request.ApplicationNotes ?? string.Empty,
+                UserId,
+                cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return BadRequest(result.ErrorMessage);
+            }
+
+            return CreatedAtAction(
+                nameof(GetTeamAdoptions),
+                new { teamId },
+                result.Data.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets active adoptions for a team that can have events linked to them.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of the team's active adoptions.</returns>
+        /// <response code="200">Returns the team's active adoptions.</response>
+        /// <response code="403">User is not a team member.</response>
+        /// <response code="404">Team not found.</response>
+        [HttpGet("active")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<TeamAdoptionDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetActiveAdoptions(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetActiveAdoptions Team={TeamId} User={UserId}", teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            var isMember = await teamMemberManager.IsMemberAsync(teamId, UserId, cancellationToken);
+            if (!isMember)
+            {
+                return Forbid();
+            }
+
+            var adoptions = await adoptionEventManager.GetActiveAdoptionsForTeamAsync(teamId, cancellationToken);
+            return Ok(adoptions.Select(a => a.ToV2Dto()));
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/TeamInvitesV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamInvitesV2Controller.cs
@@ -1,0 +1,186 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for team email invitation operations. Requires team lead privileges.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/teams/{teamId}/invites")]
+    public class TeamInvitesV2Controller(
+        IEmailInviteManager emailInviteManager,
+        IKeyedManager<Team> teamManager,
+        ITeamMemberManager teamMemberManager,
+        ILogger<TeamInvitesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all email invite batches for a team.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of batches for the team with summary statistics.</returns>
+        /// <response code="200">Returns the batch list.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team not found or inactive.</response>
+        [HttpGet("batches")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<EmailInviteBatchDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetBatches(Guid teamId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetBatches for Team={TeamId} User={UserId}", teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            if (!team.IsActive)
+            {
+                return NotFound("Team is not active.");
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var batches = await emailInviteManager.GetTeamBatchesAsync(teamId, cancellationToken);
+            return Ok(batches.Select(b => b.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a specific email invite batch with its individual invite details.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="batchId">The batch identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The batch with invite details.</returns>
+        /// <response code="200">Returns the batch.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team or batch not found.</response>
+        [HttpGet("batches/{batchId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(EmailInviteBatchDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetBatch(Guid teamId, Guid batchId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetBatch Batch={BatchId} for Team={TeamId} User={UserId}", batchId, teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            if (!team.IsActive)
+            {
+                return NotFound("Team is not active.");
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            var batch = await emailInviteManager.GetBatchDetailsAsync(batchId, cancellationToken);
+            if (batch is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(batch.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates and sends a new batch of email invites for a team.
+        /// </summary>
+        /// <param name="teamId">The team identifier.</param>
+        /// <param name="request">The batch creation request containing email addresses.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created batch with send results.</returns>
+        /// <response code="201">Batch created and sent.</response>
+        /// <response code="400">Invalid request data or empty email list.</response>
+        /// <response code="403">User is not a team lead.</response>
+        /// <response code="404">Team not found or inactive.</response>
+        [HttpPost("batch")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EmailInviteBatchDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CreateBatch(
+            Guid teamId,
+            [FromBody] CreateEmailInviteBatchDto request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateBatch for Team={TeamId} User={UserId}", teamId, UserId);
+
+            var team = await teamManager.GetAsync(teamId, cancellationToken);
+            if (team is null)
+            {
+                return NotFound();
+            }
+
+            if (!team.IsActive)
+            {
+                return NotFound("Team is not active.");
+            }
+
+            var isLead = await teamMemberManager.IsTeamLeadAsync(teamId, UserId, cancellationToken);
+            if (!isLead)
+            {
+                return Forbid();
+            }
+
+            if (request is null || request.Emails is null || !request.Emails.Any())
+            {
+                return Problem("Email list is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            logger.LogInformation("V2 CreateBatch: {Count} emails for Team={TeamId}",
+                request.Emails.Count(), teamId);
+
+            var batch = await emailInviteManager.CreateBatchAsync(
+                request.Emails,
+                UserId,
+                "Team",
+                null,
+                teamId,
+                cancellationToken);
+
+            var result = await emailInviteManager.ProcessBatchAsync(batch.Id, cancellationToken);
+
+            return CreatedAtAction(nameof(GetBatch), new { teamId, batchId = result.Id }, result.ToV2Dto());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add 7 v2 controllers for team administration and portal features: team admin, team adoptions, team invites, sponsor portal, sponsor reports, professional cleanup logs, and professional company portal
- Create 2 new DTOs (`ProfessionalCleanupLogDto`, `SubmitAdoptionRequestDto`) with mapping extensions
- Add 30 unit tests across 7 test files

## Details
**Controllers (18 endpoints total):**
- `TeamAdminV2Controller` (3 endpoints) - site admin team management (get all, delete, reactivate)
- `TeamAdoptionsV2Controller` (3 endpoints) - team adoption applications with team lead authorization
- `TeamInvitesV2Controller` (3 endpoints) - team lead bulk email invites
- `SponsorPortalV2Controller` (3 endpoints) - sponsor viewing + cleanup log CSV export
- `SponsorReportsV2Controller` (2 endpoints) - sponsored adoption reports with cleanup logs
- `ProfessionalCleanupLogsV2Controller` (3 endpoints) - cleanup logging with ServiceResult validation
- `ProfessionalCompanyPortalV2Controller` (1 endpoint) - user's assigned companies

## Test plan
- [x] All 30 Phase 2f tests pass
- [x] Solution builds with 0 errors, 0 warnings
- [x] Project plan updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)