### PR TITLE
API v2: CRM & fundraising (Phase 2h)

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 1, 2a–2g complete — 54+ v2 controllers, 84+ DTOs, 54+ test suites; Phases 2h–2i, 3, 4 remaining) |
+| **Status** | In Progress (Phases 1, 2a–2h complete — 64+ v2 controllers, 93+ DTOs, 64+ test suites; Phase 2i, 3, 4 remaining) |
 | **Priority** | High |
 | **Risk** | Medium |
 | **Size** | Very Large |
@@ -222,16 +222,18 @@ Site-wide administration and content moderation — 5 v1 controllers. All requir
 
 Fundraising and donor relationship management — 10 v1 controllers. All site admin only. Web-only.
 
-- [ ] **Contacts** - `ContactsController`: CRM contact management (search, filter by type/tag)
-- [ ] **Contact notes** - `ContactNotesController`: notes on fundraising contacts
-- [ ] **Contact tags** - `ContactTagsController`: tag-based contact organization
-- [ ] **Donations** - `DonationsController`: donation log management
-- [ ] **Pledges** - `PledgesController`: pledge/commitment tracking
-- [ ] **Grants** - `GrantsController`: grant discovery + management
-- [ ] **Grant tasks** - `GrantTasksController`: grant application task tracking
-- [ ] **Fundraising appeals** - `FundraisingAppealsController`: send appeal emails
-- [ ] **Fundraising analytics** - `FundraisingAnalyticsController`: engagement scoring for donors
-- [ ] **CMS proxy** - `CmsController`: Strapi CMS content proxy
+- [x] **Contacts** - `ContactsV2Controller`: 7 endpoints (CRUD + search/filter + tag management) ✅
+- [x] **Contact notes** - `ContactNotesV2Controller`: 4 endpoints (CRUD by contact) ✅
+- [x] **Contact tags** - `ContactTagsV2Controller`: 4 endpoints (CRUD) ✅
+- [x] **Donations** - `DonationsV2Controller`: 8 endpoints (CRUD + by contact + thank-you/receipt emails) ✅
+- [x] **Pledges** - `PledgesV2Controller`: 6 endpoints (CRUD + by contact) ✅
+- [x] **Grants** - `GrantsV2Controller`: 6 endpoints (CRUD + status filter + AI discovery) ✅
+- [x] **Grant tasks** - `GrantTasksV2Controller`: 4 endpoints (CRUD by grant) ✅
+- [x] **Fundraising appeals** - `FundraisingAppealsV2Controller`: 2 endpoints (single + bulk appeal) ✅
+- [x] **Fundraising analytics** - `FundraisingAnalyticsV2Controller`: 7 endpoints (scores, dashboard, pipeline, LYBUNT, CSV exports) ✅
+- [x] **CMS proxy** - `CmsV2Controller`: 8 endpoints (Strapi proxy + RSS feed + admin URL) ✅
+
+**Phase 2h totals:** 10 controllers, 56 endpoints, 9 DTOs, 1 mapping file, 35 tests
 
 ### Phase 2i - Infrastructure & Webhook Endpoints
 

--- a/TrashMob.Models/Extensions/V2/CrmFundraisingMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/CrmFundraisingMappingsV2.cs
@@ -1,0 +1,254 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    public static class CrmFundraisingMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="Contact"/> entity to a <see cref="ContactDto"/>.
+        /// </summary>
+        public static ContactDto ToV2Dto(this Contact entity) => new()
+        {
+            Id = entity.Id,
+            FirstName = entity.FirstName,
+            LastName = entity.LastName,
+            Email = entity.Email,
+            Phone = entity.Phone,
+            OrganizationName = entity.OrganizationName,
+            Title = entity.Title,
+            Address = entity.Address,
+            City = entity.City,
+            Region = entity.Region,
+            PostalCode = entity.PostalCode,
+            Country = entity.Country,
+            ContactType = entity.ContactType,
+            Source = entity.Source,
+            UserId = entity.UserId,
+            PartnerId = entity.PartnerId,
+            Notes = entity.Notes,
+            IsActive = entity.IsActive,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="ContactDto"/> to a <see cref="Contact"/> entity.
+        /// </summary>
+        public static Contact ToEntity(this ContactDto dto) => new()
+        {
+            Id = dto.Id,
+            FirstName = dto.FirstName ?? string.Empty,
+            LastName = dto.LastName ?? string.Empty,
+            Email = dto.Email ?? string.Empty,
+            Phone = dto.Phone ?? string.Empty,
+            OrganizationName = dto.OrganizationName ?? string.Empty,
+            Title = dto.Title ?? string.Empty,
+            Address = dto.Address ?? string.Empty,
+            City = dto.City ?? string.Empty,
+            Region = dto.Region ?? string.Empty,
+            PostalCode = dto.PostalCode ?? string.Empty,
+            Country = dto.Country ?? string.Empty,
+            ContactType = dto.ContactType,
+            Source = dto.Source ?? string.Empty,
+            UserId = dto.UserId,
+            PartnerId = dto.PartnerId,
+            Notes = dto.Notes ?? string.Empty,
+            IsActive = dto.IsActive,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="ContactNote"/> entity to a <see cref="ContactNoteDto"/>.
+        /// </summary>
+        public static ContactNoteDto ToV2Dto(this ContactNote entity) => new()
+        {
+            Id = entity.Id,
+            ContactId = entity.ContactId,
+            NoteType = entity.NoteType,
+            Subject = entity.Subject,
+            Body = entity.Body,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="ContactNoteDto"/> to a <see cref="ContactNote"/> entity.
+        /// </summary>
+        public static ContactNote ToEntity(this ContactNoteDto dto) => new()
+        {
+            Id = dto.Id,
+            ContactId = dto.ContactId,
+            NoteType = dto.NoteType,
+            Subject = dto.Subject ?? string.Empty,
+            Body = dto.Body ?? string.Empty,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="ContactTag"/> entity to a <see cref="ContactTagDto"/>.
+        /// </summary>
+        public static ContactTagDto ToV2Dto(this ContactTag entity) => new()
+        {
+            Id = entity.Id,
+            Name = entity.Name,
+            Color = entity.Color,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="ContactTagDto"/> to a <see cref="ContactTag"/> entity.
+        /// </summary>
+        public static ContactTag ToEntity(this ContactTagDto dto) => new()
+        {
+            Id = dto.Id,
+            Name = dto.Name ?? string.Empty,
+            Color = dto.Color ?? string.Empty,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="Donation"/> entity to a <see cref="DonationDto"/>.
+        /// </summary>
+        public static DonationDto ToV2Dto(this Donation entity) => new()
+        {
+            Id = entity.Id,
+            ContactId = entity.ContactId,
+            Amount = entity.Amount,
+            DonationDate = entity.DonationDate,
+            DonationType = entity.DonationType,
+            Campaign = entity.Campaign,
+            IsRecurring = entity.IsRecurring,
+            RecurringFrequency = entity.RecurringFrequency,
+            PledgeId = entity.PledgeId,
+            InKindDescription = entity.InKindDescription,
+            MatchingGiftEmployer = entity.MatchingGiftEmployer,
+            Notes = entity.Notes,
+            ReceiptSent = entity.ReceiptSent,
+            ThankYouSent = entity.ThankYouSent,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="DonationDto"/> to a <see cref="Donation"/> entity.
+        /// </summary>
+        public static Donation ToEntity(this DonationDto dto) => new()
+        {
+            Id = dto.Id,
+            ContactId = dto.ContactId,
+            Amount = dto.Amount,
+            DonationDate = dto.DonationDate,
+            DonationType = dto.DonationType,
+            Campaign = dto.Campaign ?? string.Empty,
+            IsRecurring = dto.IsRecurring,
+            RecurringFrequency = dto.RecurringFrequency,
+            PledgeId = dto.PledgeId,
+            InKindDescription = dto.InKindDescription ?? string.Empty,
+            MatchingGiftEmployer = dto.MatchingGiftEmployer ?? string.Empty,
+            Notes = dto.Notes ?? string.Empty,
+            ReceiptSent = dto.ReceiptSent,
+            ThankYouSent = dto.ThankYouSent,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="Pledge"/> entity to a <see cref="PledgeDto"/>.
+        /// </summary>
+        public static PledgeDto ToV2Dto(this Pledge entity) => new()
+        {
+            Id = entity.Id,
+            ContactId = entity.ContactId,
+            TotalAmount = entity.TotalAmount,
+            StartDate = entity.StartDate,
+            EndDate = entity.EndDate,
+            Frequency = entity.Frequency,
+            Status = entity.Status,
+            Notes = entity.Notes,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="PledgeDto"/> to a <see cref="Pledge"/> entity.
+        /// </summary>
+        public static Pledge ToEntity(this PledgeDto dto) => new()
+        {
+            Id = dto.Id,
+            ContactId = dto.ContactId,
+            TotalAmount = dto.TotalAmount,
+            StartDate = dto.StartDate,
+            EndDate = dto.EndDate,
+            Frequency = dto.Frequency,
+            Status = dto.Status,
+            Notes = dto.Notes ?? string.Empty,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="Grant"/> entity to a <see cref="GrantDto"/>.
+        /// </summary>
+        public static GrantDto ToV2Dto(this Grant entity) => new()
+        {
+            Id = entity.Id,
+            FunderName = entity.FunderName,
+            ProgramName = entity.ProgramName,
+            Description = entity.Description,
+            AmountMin = entity.AmountMin,
+            AmountMax = entity.AmountMax,
+            AmountAwarded = entity.AmountAwarded,
+            Status = entity.Status,
+            SubmissionDeadline = entity.SubmissionDeadline,
+            AwardDate = entity.AwardDate,
+            ReportingDeadline = entity.ReportingDeadline,
+            RenewalDate = entity.RenewalDate,
+            FunderContactId = entity.FunderContactId,
+            GrantUrl = entity.GrantUrl,
+            Notes = entity.Notes,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="GrantDto"/> to a <see cref="Grant"/> entity.
+        /// </summary>
+        public static Grant ToEntity(this GrantDto dto) => new()
+        {
+            Id = dto.Id,
+            FunderName = dto.FunderName ?? string.Empty,
+            ProgramName = dto.ProgramName ?? string.Empty,
+            Description = dto.Description ?? string.Empty,
+            AmountMin = dto.AmountMin,
+            AmountMax = dto.AmountMax,
+            AmountAwarded = dto.AmountAwarded,
+            Status = dto.Status,
+            SubmissionDeadline = dto.SubmissionDeadline,
+            AwardDate = dto.AwardDate,
+            ReportingDeadline = dto.ReportingDeadline,
+            RenewalDate = dto.RenewalDate,
+            FunderContactId = dto.FunderContactId,
+            GrantUrl = dto.GrantUrl ?? string.Empty,
+            Notes = dto.Notes ?? string.Empty,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="GrantTask"/> entity to a <see cref="GrantTaskDto"/>.
+        /// </summary>
+        public static GrantTaskDto ToV2Dto(this GrantTask entity) => new()
+        {
+            Id = entity.Id,
+            GrantId = entity.GrantId,
+            Title = entity.Title,
+            DueDate = entity.DueDate,
+            IsCompleted = entity.IsCompleted,
+            CompletedDate = entity.CompletedDate,
+            SortOrder = entity.SortOrder,
+            Notes = entity.Notes,
+            CreatedDate = entity.CreatedDate,
+        };
+
+        /// <summary>
+        /// Maps a <see cref="GrantTaskDto"/> to a <see cref="GrantTask"/> entity.
+        /// </summary>
+        public static GrantTask ToEntity(this GrantTaskDto dto) => new()
+        {
+            Id = dto.Id,
+            GrantId = dto.GrantId,
+            Title = dto.Title ?? string.Empty,
+            DueDate = dto.DueDate,
+            IsCompleted = dto.IsCompleted,
+            CompletedDate = dto.CompletedDate,
+            SortOrder = dto.SortOrder,
+            Notes = dto.Notes ?? string.Empty,
+        };
+    }
+}

--- a/TrashMob.Models/Poco/V2/AppealRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/AppealRequestDto.cs
@@ -1,0 +1,11 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class AppealRequestDto
+    {
+        public Guid ContactId { get; set; }
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Models/Poco/V2/BulkAppealRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/BulkAppealRequestDto.cs
@@ -1,0 +1,12 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    using System.Collections.Generic;
+    public class BulkAppealRequestDto
+    {
+        public List<Guid> ContactIds { get; set; } = [];
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+    }
+}

--- a/TrashMob.Models/Poco/V2/ContactDto.cs
+++ b/TrashMob.Models/Poco/V2/ContactDto.cs
@@ -1,0 +1,27 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class ContactDto
+    {
+        public Guid Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? OrganizationName { get; set; }
+        public string? Title { get; set; }
+        public string? Address { get; set; }
+        public string? City { get; set; }
+        public string? Region { get; set; }
+        public string? PostalCode { get; set; }
+        public string? Country { get; set; }
+        public int ContactType { get; set; }
+        public string? Source { get; set; }
+        public Guid? UserId { get; set; }
+        public Guid? PartnerId { get; set; }
+        public string? Notes { get; set; }
+        public bool IsActive { get; set; } = true;
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/ContactNoteDto.cs
+++ b/TrashMob.Models/Poco/V2/ContactNoteDto.cs
@@ -1,0 +1,14 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class ContactNoteDto
+    {
+        public Guid Id { get; set; }
+        public Guid ContactId { get; set; }
+        public int NoteType { get; set; }
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/ContactTagDto.cs
+++ b/TrashMob.Models/Poco/V2/ContactTagDto.cs
@@ -1,0 +1,12 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class ContactTagDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/DonationDto.cs
+++ b/TrashMob.Models/Poco/V2/DonationDto.cs
@@ -1,0 +1,23 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class DonationDto
+    {
+        public Guid Id { get; set; }
+        public Guid ContactId { get; set; }
+        public decimal Amount { get; set; }
+        public DateTimeOffset DonationDate { get; set; }
+        public int DonationType { get; set; }
+        public string? Campaign { get; set; }
+        public bool IsRecurring { get; set; }
+        public int? RecurringFrequency { get; set; }
+        public Guid? PledgeId { get; set; }
+        public string? InKindDescription { get; set; }
+        public string? MatchingGiftEmployer { get; set; }
+        public string? Notes { get; set; }
+        public bool ReceiptSent { get; set; }
+        public bool ThankYouSent { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/GrantDto.cs
+++ b/TrashMob.Models/Poco/V2/GrantDto.cs
@@ -1,0 +1,24 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class GrantDto
+    {
+        public Guid Id { get; set; }
+        public string FunderName { get; set; } = string.Empty;
+        public string? ProgramName { get; set; }
+        public string? Description { get; set; }
+        public decimal? AmountMin { get; set; }
+        public decimal? AmountMax { get; set; }
+        public decimal? AmountAwarded { get; set; }
+        public int Status { get; set; }
+        public DateTimeOffset? SubmissionDeadline { get; set; }
+        public DateTimeOffset? AwardDate { get; set; }
+        public DateTimeOffset? ReportingDeadline { get; set; }
+        public DateTimeOffset? RenewalDate { get; set; }
+        public Guid? FunderContactId { get; set; }
+        public string? GrantUrl { get; set; }
+        public string? Notes { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/GrantTaskDto.cs
+++ b/TrashMob.Models/Poco/V2/GrantTaskDto.cs
@@ -1,0 +1,17 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class GrantTaskDto
+    {
+        public Guid Id { get; set; }
+        public Guid GrantId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public DateTimeOffset? DueDate { get; set; }
+        public bool IsCompleted { get; set; }
+        public DateTimeOffset? CompletedDate { get; set; }
+        public int SortOrder { get; set; }
+        public string? Notes { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/PledgeDto.cs
+++ b/TrashMob.Models/Poco/V2/PledgeDto.cs
@@ -1,0 +1,17 @@
+#nullable enable
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    public class PledgeDto
+    {
+        public Guid Id { get; set; }
+        public Guid ContactId { get; set; }
+        public decimal TotalAmount { get; set; }
+        public DateTimeOffset StartDate { get; set; }
+        public DateTimeOffset? EndDate { get; set; }
+        public int Frequency { get; set; }
+        public int Status { get; set; }
+        public string? Notes { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CmsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CmsV2ControllerTests.cs
@@ -1,0 +1,93 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Moq.Protected;
+    using TrashMob.Controllers.V2;
+    using Xunit;
+
+    public class CmsV2ControllerTests
+    {
+        private readonly Mock<IHttpClientFactory> mockFactory = new();
+        private readonly Mock<IConfiguration> mockConfig = new();
+        private readonly Mock<ILogger<CmsV2Controller>> logger = new();
+        private readonly CmsV2Controller controller;
+
+        public CmsV2ControllerTests()
+        {
+            mockConfig.Setup(c => c["StrapiBaseUrl"]).Returns("https://cms.test.com");
+
+            controller = new CmsV2Controller(mockFactory.Object, mockConfig.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        private void SetupHttpClient(string responseContent)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseContent, Encoding.UTF8, "application/json"),
+                });
+
+            var httpClient = new HttpClient(handler.Object);
+            mockFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+        }
+
+        [Fact]
+        public void GetAdminUrl_ReturnsOk()
+        {
+            var result = controller.GetAdminUrl();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetHeroSection_ReturnsStrapiContent()
+        {
+            SetupHttpClient("{\"data\":{\"title\":\"Welcome\"}}");
+
+            var result = await controller.GetHeroSection(CancellationToken.None);
+
+            var contentResult = Assert.IsType<ContentResult>(result);
+            Assert.Equal("application/json", contentResult.ContentType);
+            Assert.NotNull(contentResult.Content);
+        }
+
+        [Fact]
+        public async Task GetNewsCategories_ReturnsStrapiContent()
+        {
+            SetupHttpClient("{\"data\":[{\"id\":1,\"name\":\"Environment\"}]}");
+
+            var result = await controller.GetNewsCategories(CancellationToken.None);
+
+            var contentResult = Assert.IsType<ContentResult>(result);
+            Assert.Equal("application/json", contentResult.ContentType);
+            Assert.NotNull(contentResult.Content);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ContactNotesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ContactNotesV2ControllerTests.cs
@@ -1,0 +1,94 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using Xunit;
+
+    public class ContactNotesV2ControllerTests
+    {
+        private readonly Mock<IContactNoteManager> contactNoteManager = new();
+        private readonly Mock<ILogger<ContactNotesV2Controller>> logger = new();
+        private readonly ContactNotesV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public ContactNotesV2ControllerTests()
+        {
+            controller = new ContactNotesV2Controller(contactNoteManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetByContactId_ReturnsOk()
+        {
+            var contactId = Guid.NewGuid();
+            var notes = new List<ContactNote>
+            {
+                new() { Id = Guid.NewGuid(), ContactId = contactId, Subject = "Test", Body = "Note body" },
+                new() { Id = Guid.NewGuid(), ContactId = contactId, Subject = "Follow-up", Body = "Second note" },
+            };
+
+            contactNoteManager
+                .Setup(m => m.GetByContactIdAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(notes);
+
+            var result = await controller.GetByContactId(contactId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ContactNoteDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var note = new ContactNote { Id = Guid.NewGuid(), ContactId = Guid.NewGuid(), Subject = "Test", Body = "Note body" };
+
+            contactNoteManager
+                .Setup(m => m.AddAsync(It.IsAny<ContactNote>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(note);
+
+            var dto = new ContactNoteDto { ContactId = note.ContactId, Subject = "Test", Body = "Note body" };
+
+            var result = await controller.Create(dto, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent()
+        {
+            var noteId = Guid.NewGuid();
+
+            contactNoteManager
+                .Setup(m => m.DeleteAsync(noteId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(noteId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            contactNoteManager.Verify(
+                m => m.DeleteAsync(noteId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ContactTagsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ContactTagsV2ControllerTests.cs
@@ -1,0 +1,90 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class ContactTagsV2ControllerTests
+    {
+        private readonly Mock<IKeyedManager<ContactTag>> contactTagManager = new();
+        private readonly Mock<ILogger<ContactTagsV2Controller>> logger = new();
+        private readonly ContactTagsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public ContactTagsV2ControllerTests()
+        {
+            controller = new ContactTagsV2Controller(contactTagManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsOk()
+        {
+            var tags = new List<ContactTag>
+            {
+                new() { Id = Guid.NewGuid(), Name = "VIP", Color = "#FF0000" },
+                new() { Id = Guid.NewGuid(), Name = "Donor", Color = "#00FF00" },
+            };
+
+            contactTagManager
+                .Setup(m => m.GetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(tags);
+
+            var result = await controller.GetAll(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ContactTagDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var tag = new ContactTag { Id = Guid.NewGuid(), Name = "VIP", Color = "#FF0000" };
+
+            contactTagManager
+                .Setup(m => m.AddAsync(It.IsAny<ContactTag>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(tag);
+
+            var dto = new ContactTagDto { Name = "VIP", Color = "#FF0000" };
+
+            var result = await controller.Create(dto, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent()
+        {
+            var tagId = Guid.NewGuid();
+
+            contactTagManager
+                .Setup(m => m.DeleteAsync(tagId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(tagId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ContactsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ContactsV2ControllerTests.cs
@@ -1,0 +1,112 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class ContactsV2ControllerTests
+    {
+        private readonly Mock<IContactManager> contactManager = new();
+        private readonly Mock<IBaseManager<ContactContactTag>> contactContactTagManager = new();
+        private readonly Mock<ILogger<ContactsV2Controller>> logger = new();
+        private readonly ContactsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public ContactsV2ControllerTests()
+        {
+            controller = new ContactsV2Controller(
+                contactManager.Object, contactContactTagManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsOk()
+        {
+            var contacts = new List<Contact>
+            {
+                new() { Id = Guid.NewGuid(), FirstName = "Test", LastName = "User", Email = "test@test.com" },
+                new() { Id = Guid.NewGuid(), FirstName = "Jane", LastName = "Doe", Email = "jane@test.com" },
+            };
+
+            contactManager
+                .Setup(m => m.SearchAsync("Test", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contacts);
+
+            var result = await controller.GetAll(search: "Test", cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<ContactDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetById_NotFound_ReturnsNotFound()
+        {
+            var id = Guid.NewGuid();
+
+            contactManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Contact)null);
+
+            var result = await controller.GetById(id, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetById_Found_ReturnsOk()
+        {
+            var id = Guid.NewGuid();
+            var contact = new Contact { Id = id, FirstName = "Test", LastName = "User", Email = "test@test.com" };
+
+            contactManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contact);
+
+            var result = await controller.GetById(id, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ContactDto>(okResult.Value);
+            Assert.Equal("Test", dto.FirstName);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var contact = new Contact { Id = Guid.NewGuid(), FirstName = "Test", LastName = "User", Email = "test@test.com" };
+
+            contactManager
+                .Setup(m => m.AddAsync(It.IsAny<Contact>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contact);
+
+            var dto = new ContactDto { FirstName = "Test", LastName = "User", Email = "test@test.com" };
+
+            var result = await controller.Create(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<ContactDto>(createdResult.Value);
+            Assert.Equal("Test", resultDto.FirstName);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/DonationsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/DonationsV2ControllerTests.cs
@@ -1,0 +1,125 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using Xunit;
+
+    public class DonationsV2ControllerTests
+    {
+        private readonly Mock<IDonationManager> donationManager = new();
+        private readonly Mock<IDonationEmailManager> donationEmailManager = new();
+        private readonly Mock<ILogger<DonationsV2Controller>> logger = new();
+        private readonly DonationsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public DonationsV2ControllerTests()
+        {
+            controller = new DonationsV2Controller(
+                donationManager.Object, donationEmailManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsOk()
+        {
+            var donations = new List<Donation>
+            {
+                new() { Id = Guid.NewGuid(), ContactId = Guid.NewGuid(), Amount = 100m, DonationDate = DateTimeOffset.UtcNow },
+                new() { Id = Guid.NewGuid(), ContactId = Guid.NewGuid(), Amount = 250m, DonationDate = DateTimeOffset.UtcNow },
+            };
+
+            donationManager
+                .Setup(m => m.GetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(donations);
+
+            var result = await controller.GetAll(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<DonationDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetById_NotFound_ReturnsNotFound()
+        {
+            var id = Guid.NewGuid();
+
+            donationManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Donation)null);
+
+            var result = await controller.GetById(id, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetById_Found_ReturnsOk()
+        {
+            var id = Guid.NewGuid();
+            var donation = new Donation { Id = id, ContactId = Guid.NewGuid(), Amount = 100m, DonationDate = DateTimeOffset.UtcNow };
+
+            donationManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(donation);
+
+            var result = await controller.GetById(id, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<DonationDto>(okResult.Value);
+            Assert.Equal(100m, dto.Amount);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var donation = new Donation { Id = Guid.NewGuid(), ContactId = Guid.NewGuid(), Amount = 100m, DonationDate = DateTimeOffset.UtcNow };
+
+            donationManager
+                .Setup(m => m.AddAsync(It.IsAny<Donation>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(donation);
+
+            var dto = new DonationDto { ContactId = donation.ContactId, Amount = 100m, DonationDate = DateTimeOffset.UtcNow };
+
+            var result = await controller.Create(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<DonationDto>(createdResult.Value);
+            Assert.Equal(100m, resultDto.Amount);
+        }
+
+        [Fact]
+        public async Task SendThankYou_NotFound_ReturnsNotFound()
+        {
+            var id = Guid.NewGuid();
+
+            donationManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Donation)null);
+
+            var result = await controller.SendThankYou(id, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/FundraisingAnalyticsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/FundraisingAnalyticsV2ControllerTests.cs
@@ -1,0 +1,117 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class FundraisingAnalyticsV2ControllerTests
+    {
+        private readonly Mock<IFundraisingAnalyticsManager> analyticsManager = new();
+        private readonly Mock<ILogger<FundraisingAnalyticsV2Controller>> logger = new();
+        private readonly FundraisingAnalyticsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public FundraisingAnalyticsV2ControllerTests()
+        {
+            controller = new FundraisingAnalyticsV2Controller(analyticsManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetEngagementScores_ReturnsOk()
+        {
+            var scores = new List<ContactEngagementScore>
+            {
+                new ContactEngagementScore { ContactId = Guid.NewGuid(), ContactName = "Alice", EngagementScore = 85 },
+                new ContactEngagementScore { ContactId = Guid.NewGuid(), ContactName = "Bob", EngagementScore = 42 },
+            };
+
+            analyticsManager
+                .Setup(m => m.GetEngagementScoresAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(scores);
+
+            var result = await controller.GetEngagementScores(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetDashboard_ReturnsOk()
+        {
+            var dashboard = new FundraisingDashboard
+            {
+                TotalRaisedYtd = 50000m,
+                DonorCountYtd = 120,
+                AverageGiftSizeYtd = 416.67m,
+            };
+
+            analyticsManager
+                .Setup(m => m.GetDashboardAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dashboard);
+
+            var result = await controller.GetDashboard(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+
+        [Fact]
+        public async Task ExportDonorReport_ReturnsFile()
+        {
+            var csv = "ContactName,Email,TotalDonations\nAlice,alice@test.com,500.00\n";
+
+            analyticsManager
+                .Setup(m => m.GenerateDonorReportCsvAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(csv);
+
+            var result = await controller.ExportDonorReport(CancellationToken.None);
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("text/csv", fileResult.ContentType);
+            Assert.NotNull(fileResult.FileContents);
+            Assert.True(fileResult.FileContents.Length > 0);
+        }
+
+        [Fact]
+        public async Task GetLybuntContacts_ReturnsOk()
+        {
+            var contacts = new List<ContactEngagementScore>
+            {
+                new ContactEngagementScore { ContactId = Guid.NewGuid(), ContactName = "Lapsed Donor", IsLybunt = true },
+            };
+
+            analyticsManager
+                .Setup(m => m.GetLybuntContactsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(contacts);
+
+            var result = await controller.GetLybuntContacts(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/FundraisingAppealsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/FundraisingAppealsV2ControllerTests.cs
@@ -1,0 +1,98 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class FundraisingAppealsV2ControllerTests
+    {
+        private readonly Mock<IDonationEmailManager> donationEmailManager = new();
+        private readonly Mock<ILogger<FundraisingAppealsV2Controller>> logger = new();
+        private readonly FundraisingAppealsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public FundraisingAppealsV2ControllerTests()
+        {
+            controller = new FundraisingAppealsV2Controller(donationEmailManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task Send_ReturnsNoContent()
+        {
+            var request = new AppealRequestDto
+            {
+                ContactId = Guid.NewGuid(),
+                Subject = "Annual Appeal",
+                Body = "Please consider donating.",
+            };
+
+            donationEmailManager
+                .Setup(m => m.SendAppealAsync(
+                    request.ContactId, request.Subject, request.Body,
+                    testUserId, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.Send(request, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            donationEmailManager.Verify(
+                m => m.SendAppealAsync(
+                    request.ContactId, request.Subject, request.Body,
+                    testUserId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SendBulk_ReturnsOk()
+        {
+            var request = new BulkAppealRequestDto
+            {
+                ContactIds = [Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()],
+                Subject = "Bulk Appeal",
+                Body = "Thank you for your support.",
+            };
+
+            var bulkResult = new BulkAppealResult
+            {
+                SentCount = 5,
+                FailedCount = 0,
+                SkippedCount = 1,
+            };
+
+            donationEmailManager
+                .Setup(m => m.SendBulkAppealAsync(
+                    It.IsAny<IEnumerable<Guid>>(), request.Subject, request.Body,
+                    testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(bulkResult);
+
+            var result = await controller.SendBulk(request, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/GrantTasksV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/GrantTasksV2ControllerTests.cs
@@ -1,0 +1,93 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class GrantTasksV2ControllerTests
+    {
+        private readonly Mock<IGrantTaskManager> grantTaskManager = new();
+        private readonly Mock<ILogger<GrantTasksV2Controller>> logger = new();
+        private readonly GrantTasksV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public GrantTasksV2ControllerTests()
+        {
+            controller = new GrantTasksV2Controller(grantTaskManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetByGrantId_ReturnsOk()
+        {
+            var grantId = Guid.NewGuid();
+            var tasks = new List<GrantTask>
+            {
+                new GrantTask { Id = Guid.NewGuid(), GrantId = grantId, Title = "Submit application" },
+                new GrantTask { Id = Guid.NewGuid(), GrantId = grantId, Title = "Gather documents" },
+            };
+
+            grantTaskManager
+                .Setup(m => m.GetByGrantIdAsync(grantId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(tasks);
+
+            var result = await controller.GetByGrantId(grantId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var grantId = Guid.NewGuid();
+            var taskDto = new GrantTaskDto { Id = Guid.NewGuid(), GrantId = grantId, Title = "Submit application" };
+            var grantTask = new GrantTask { Id = taskDto.Id, GrantId = grantId, Title = "Submit application" };
+
+            grantTaskManager
+                .Setup(m => m.AddAsync(It.IsAny<GrantTask>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(grantTask);
+
+            var result = await controller.Create(taskDto, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent()
+        {
+            var id = Guid.NewGuid();
+
+            grantTaskManager
+                .Setup(m => m.DeleteAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(id, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/GrantsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/GrantsV2ControllerTests.cs
@@ -1,0 +1,113 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Security.Claims;
+    using System.Security.Principal;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class GrantsV2ControllerTests
+    {
+        private readonly Mock<IGrantManager> grantManager = new();
+        private readonly Mock<IGrantDiscoveryService> grantDiscoveryService = new();
+        private readonly Mock<ILogger<GrantsV2Controller>> logger = new();
+        private readonly GrantsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public GrantsV2ControllerTests()
+        {
+            controller = new GrantsV2Controller(
+                grantManager.Object, grantDiscoveryService.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsOk()
+        {
+            var grants = new List<Grant>
+            {
+                new Grant { Id = Guid.NewGuid(), FunderName = "Foundation", Status = 0 },
+                new Grant { Id = Guid.NewGuid(), FunderName = "Trust", Status = 1 },
+            };
+
+            grantManager
+                .Setup(m => m.GetAsync(It.IsAny<Expression<Func<Grant, bool>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(grants);
+
+            var result = await controller.GetAll(cancellationToken: CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+
+        [Fact]
+        public async Task GetById_NotFound_ReturnsNotFound()
+        {
+            var id = Guid.NewGuid();
+
+            grantManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Grant)null);
+
+            var result = await controller.GetById(id, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var grantDto = new GrantDto { Id = Guid.NewGuid(), FunderName = "Foundation" };
+            var grant = new Grant { Id = grantDto.Id, FunderName = "Foundation", Status = 0 };
+
+            grantManager
+                .Setup(m => m.AddAsync(It.IsAny<Grant>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(grant);
+
+            var result = await controller.Create(grantDto, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task Discover_ReturnsOk()
+        {
+            var request = new GrantDiscoveryRequest { FocusAreas = "Environmental" };
+            var discoveryResult = new GrantDiscoveryResult
+            {
+                Grants = new List<DiscoveredGrant>(),
+                TokensUsed = 100,
+            };
+
+            grantDiscoveryService
+                .Setup(s => s.DiscoverGrantsAsync(It.IsAny<GrantDiscoveryRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(discoveryResult);
+
+            var result = await controller.Discover(request, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PledgesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PledgesV2ControllerTests.cs
@@ -1,0 +1,106 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Contacts;
+    using Xunit;
+
+    public class PledgesV2ControllerTests
+    {
+        private readonly Mock<IPledgeManager> pledgeManager = new();
+        private readonly Mock<ILogger<PledgesV2Controller>> logger = new();
+        private readonly PledgesV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public PledgesV2ControllerTests()
+        {
+            controller = new PledgesV2Controller(pledgeManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsOk()
+        {
+            var pledges = new List<Pledge>
+            {
+                new() { Id = Guid.NewGuid(), ContactId = Guid.NewGuid(), TotalAmount = 500m, StartDate = DateTimeOffset.UtcNow },
+                new() { Id = Guid.NewGuid(), ContactId = Guid.NewGuid(), TotalAmount = 1000m, StartDate = DateTimeOffset.UtcNow },
+            };
+
+            pledgeManager
+                .Setup(m => m.GetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(pledges);
+
+            var result = await controller.GetAll(CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<PledgeDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count());
+        }
+
+        [Fact]
+        public async Task GetById_NotFound_ReturnsNotFound()
+        {
+            var id = Guid.NewGuid();
+
+            pledgeManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Pledge)null);
+
+            var result = await controller.GetById(id, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var pledge = new Pledge { Id = Guid.NewGuid(), ContactId = Guid.NewGuid(), TotalAmount = 500m, StartDate = DateTimeOffset.UtcNow };
+
+            pledgeManager
+                .Setup(m => m.AddAsync(It.IsAny<Pledge>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(pledge);
+
+            var dto = new PledgeDto { ContactId = pledge.ContactId, TotalAmount = 500m, StartDate = DateTimeOffset.UtcNow };
+
+            var result = await controller.Create(dto, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+            var resultDto = Assert.IsType<PledgeDto>(createdResult.Value);
+            Assert.Equal(500m, resultDto.TotalAmount);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent()
+        {
+            var pledgeId = Guid.NewGuid();
+
+            pledgeManager
+                .Setup(m => m.DeleteAsync(pledgeId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(pledgeId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/CmsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CmsV2Controller.cs
@@ -1,0 +1,385 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using System.Text.Json;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Security;
+
+    /// <summary>
+    /// V2 controller for proxying Strapi CMS content. Most endpoints are public.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/cms")]
+    public class CmsV2Controller(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<CmsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets the hero section content from the CMS.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Hero section JSON content.</returns>
+        /// <response code="200">Returns hero section content.</response>
+        /// <response code="503">CMS unavailable.</response>
+        [HttpGet("hero-section")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> GetHeroSection(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetHeroSection");
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            try
+            {
+                var client = httpClientFactory.CreateClient();
+                var response = await client.GetStringAsync($"{strapiBaseUrl}/api/hero-section?populate=*", cancellationToken);
+                var rewritten = RewriteMediaUrls(response, strapiBaseUrl);
+
+                return Content(rewritten, "application/json");
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "Failed to fetch hero section from CMS");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the "What is TrashMob" content from the CMS.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>What is TrashMob JSON content.</returns>
+        /// <response code="200">Returns content.</response>
+        /// <response code="503">CMS unavailable.</response>
+        [HttpGet("what-is-trashmob")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> GetWhatIsTrashmob(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetWhatIsTrashmob");
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            try
+            {
+                var client = httpClientFactory.CreateClient();
+                var response = await client.GetStringAsync($"{strapiBaseUrl}/api/what-is-trashmob?populate=*", cancellationToken);
+                var rewritten = RewriteMediaUrls(response, strapiBaseUrl);
+
+                return Content(rewritten, "application/json");
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "Failed to fetch what-is-trashmob from CMS");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the "Getting Started" content from the CMS.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Getting started JSON content.</returns>
+        /// <response code="200">Returns content.</response>
+        /// <response code="503">CMS unavailable.</response>
+        [HttpGet("getting-started")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> GetGettingStarted(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetGettingStarted");
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            try
+            {
+                var client = httpClientFactory.CreateClient();
+                var response = await client.GetStringAsync($"{strapiBaseUrl}/api/getting-started?populate=*", cancellationToken);
+                var rewritten = RewriteMediaUrls(response, strapiBaseUrl);
+
+                return Content(rewritten, "application/json");
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "Failed to fetch getting-started from CMS");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
+            }
+        }
+
+        /// <summary>
+        /// Gets paginated news posts from the CMS, optionally filtered by category.
+        /// </summary>
+        /// <param name="page">Page number (default 1).</param>
+        /// <param name="pageSize">Page size (1-100, default 10).</param>
+        /// <param name="category">Optional category slug filter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Paginated news posts JSON.</returns>
+        /// <response code="200">Returns news posts.</response>
+        /// <response code="400">Invalid page size.</response>
+        /// <response code="503">CMS unavailable.</response>
+        [HttpGet("news-posts")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> GetNewsPosts(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string category = "",
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetNewsPosts Page={Page} PageSize={PageSize} Category={Category}", page, pageSize, category);
+
+            if (pageSize < 1 || pageSize > 100)
+            {
+                return BadRequest("pageSize must be between 1 and 100.");
+            }
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            try
+            {
+                var url = $"{strapiBaseUrl}/api/news-posts?populate=*&sort=publishedAt:desc&pagination[page]={page}&pagination[pageSize]={pageSize}&filters[publishedAt][$notNull]=true";
+
+                if (!string.IsNullOrEmpty(category))
+                {
+                    url += $"&filters[news_category][slug][$eq]={category}";
+                }
+
+                var client = httpClientFactory.CreateClient();
+                var response = await client.GetStringAsync(url, cancellationToken);
+                var rewritten = RewriteMediaUrls(response, strapiBaseUrl);
+
+                return Content(rewritten, "application/json");
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "Failed to fetch news posts from CMS");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
+            }
+        }
+
+        /// <summary>
+        /// Gets a single news post by its slug.
+        /// </summary>
+        /// <param name="slug">The news post slug.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The news post JSON.</returns>
+        /// <response code="200">Returns the news post.</response>
+        /// <response code="404">News post not found.</response>
+        /// <response code="503">CMS unavailable.</response>
+        [HttpGet("news-posts/{slug}")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> GetNewsPostBySlug(string slug, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetNewsPostBySlug Slug={Slug}", slug);
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            try
+            {
+                var client = httpClientFactory.CreateClient();
+                var response = await client.GetStringAsync(
+                    $"{strapiBaseUrl}/api/news-posts?populate=*&filters[slug][$eq]={slug}",
+                    cancellationToken);
+
+                using var doc = JsonDocument.Parse(response);
+                var dataElement = doc.RootElement.GetProperty("data");
+
+                if (dataElement.GetArrayLength() == 0)
+                {
+                    return NotFound();
+                }
+
+                var rewritten = RewriteMediaUrls(response, strapiBaseUrl);
+
+                return Content(rewritten, "application/json");
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "Failed to fetch news post by slug from CMS");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
+            }
+        }
+
+        /// <summary>
+        /// Gets all news categories from the CMS.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>News categories JSON.</returns>
+        /// <response code="200">Returns news categories.</response>
+        /// <response code="503">CMS unavailable.</response>
+        [HttpGet("news-categories")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> GetNewsCategories(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetNewsCategories");
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            try
+            {
+                var client = httpClientFactory.CreateClient();
+                var response = await client.GetStringAsync($"{strapiBaseUrl}/api/news-categories?sort=name:asc", cancellationToken);
+
+                return Content(response, "application/json");
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "Failed to fetch news categories from CMS");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
+            }
+        }
+
+        /// <summary>
+        /// Gets an RSS 2.0 feed of news posts.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>RSS 2.0 XML feed.</returns>
+        /// <response code="200">Returns RSS feed.</response>
+        /// <response code="503">CMS unavailable.</response>
+        [HttpGet("news-feed")]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public async Task<IActionResult> GetNewsFeed(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetNewsFeed");
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            try
+            {
+                var client = httpClientFactory.CreateClient();
+                var response = await client.GetStringAsync(
+                    $"{strapiBaseUrl}/api/news-posts?populate=*&sort=publishedAt:desc&pagination[pageSize]=20&filters[publishedAt][$notNull]=true",
+                    cancellationToken);
+
+                using var doc = JsonDocument.Parse(response);
+                var dataElement = doc.RootElement.GetProperty("data");
+
+                var channel = new XElement("channel",
+                    new XElement("title", "TrashMob News"),
+                    new XElement("link", "https://www.trashmob.eco/news"),
+                    new XElement("description", "Latest news from TrashMob"));
+
+                foreach (var post in dataElement.EnumerateArray())
+                {
+                    var title = post.TryGetProperty("title", out var titleProp) ? titleProp.GetString() : string.Empty;
+                    var slug = post.TryGetProperty("slug", out var slugProp) ? slugProp.GetString() : string.Empty;
+                    var description = post.TryGetProperty("excerpt", out var excerptProp) ? excerptProp.GetString() : string.Empty;
+                    var publishedAt = post.TryGetProperty("publishedAt", out var pubProp) ? pubProp.GetString() : string.Empty;
+                    var postId = post.TryGetProperty("id", out var idProp) ? idProp.ToString() : string.Empty;
+
+                    var item = new XElement("item",
+                        new XElement("title", title),
+                        new XElement("link", $"https://www.trashmob.eco/news/{slug}"),
+                        new XElement("description", description),
+                        new XElement("guid", $"https://www.trashmob.eco/news/{postId}"),
+                        new XElement("pubDate", publishedAt));
+
+                    channel.Add(item);
+                }
+
+                var rss = new XDocument(
+                    new XDeclaration("1.0", "utf-8", null),
+                    new XElement("rss",
+                        new XAttribute("version", "2.0"),
+                        channel));
+
+                return Content(rss.ToString(), "application/rss+xml");
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "Failed to generate news feed from CMS");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the Strapi admin URL. Admin-only.
+        /// </summary>
+        /// <returns>The admin URL.</returns>
+        /// <response code="200">Returns the admin URL.</response>
+        /// <response code="503">CMS not configured.</response>
+        [HttpGet("admin-url")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public IActionResult GetAdminUrl()
+        {
+            logger.LogInformation("V2 GetAdminUrl");
+
+            var strapiBaseUrl = configuration["StrapiBaseUrl"];
+
+            if (string.IsNullOrEmpty(strapiBaseUrl))
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS not configured.");
+            }
+
+            return Ok(new { adminUrl = strapiBaseUrl + "/admin" });
+        }
+
+        private static string RewriteMediaUrls(string json, string strapiBaseUrl)
+        {
+            return json.Replace("/uploads/", $"{strapiBaseUrl}/uploads/");
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ContactNotesV2Controller.cs
+++ b/TrashMob/Controllers/V2/ContactNotesV2Controller.cs
@@ -1,0 +1,115 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+
+    /// <summary>
+    /// V2 controller for CRM contact note management (admin only).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/contactnotes")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class ContactNotesV2Controller(
+        IContactNoteManager contactNoteManager,
+        ILogger<ContactNotesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all notes for a specific contact.
+        /// </summary>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of contact notes.</returns>
+        /// <response code="200">Returns the note list.</response>
+        [HttpGet("bycontact/{contactId}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<ContactNoteDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByContactId(Guid contactId, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetContactNotesByContact: contactId={ContactId}", contactId);
+
+            var notes = await contactNoteManager.GetByContactIdAsync(contactId, cancellationToken);
+            var dtos = notes.Select(n => n.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Creates a new contact note.
+        /// </summary>
+        /// <param name="dto">The contact note data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created contact note.</returns>
+        /// <response code="201">Note created successfully.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ContactNoteDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create([FromBody] ContactNoteDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 CreateContactNote: contactId={ContactId}", dto.ContactId);
+
+            var entity = dto.ToEntity();
+            var result = await contactNoteManager.AddAsync(entity, UserId, cancellationToken);
+
+            return StatusCode(StatusCodes.Status201Created, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a contact note.
+        /// </summary>
+        /// <param name="dto">The updated contact note data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated contact note.</returns>
+        /// <response code="200">Note updated successfully.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ContactNoteDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update([FromBody] ContactNoteDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdateContactNote: id={Id}", dto.Id);
+
+            var entity = dto.ToEntity();
+            entity.LastUpdatedByUserId = UserId;
+            var result = await contactNoteManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a contact note.
+        /// </summary>
+        /// <param name="id">The note ID to delete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Note deleted successfully.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 DeleteContactNote: id={Id}", id);
+
+            await contactNoteManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ContactTagsV2Controller.cs
+++ b/TrashMob/Controllers/V2/ContactTagsV2Controller.cs
@@ -1,0 +1,115 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for CRM contact tag management (admin only).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/contacttags")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class ContactTagsV2Controller(
+        IKeyedManager<ContactTag> contactTagManager,
+        ILogger<ContactTagsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all contact tags.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of contact tags.</returns>
+        /// <response code="200">Returns the tag list.</response>
+        [HttpGet]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<ContactTagDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAll(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetAllContactTags");
+
+            var tags = await contactTagManager.GetAsync(cancellationToken);
+            var dtos = tags.Select(t => t.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Creates a new contact tag.
+        /// </summary>
+        /// <param name="dto">The contact tag data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created contact tag.</returns>
+        /// <response code="201">Tag created successfully.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ContactTagDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create([FromBody] ContactTagDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 CreateContactTag: name={Name}", dto.Name);
+
+            var entity = dto.ToEntity();
+            var result = await contactTagManager.AddAsync(entity, UserId, cancellationToken);
+
+            return StatusCode(StatusCodes.Status201Created, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a contact tag.
+        /// </summary>
+        /// <param name="dto">The updated contact tag data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated contact tag.</returns>
+        /// <response code="200">Tag updated successfully.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ContactTagDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update([FromBody] ContactTagDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdateContactTag: id={Id}", dto.Id);
+
+            var entity = dto.ToEntity();
+            entity.LastUpdatedByUserId = UserId;
+            var result = await contactTagManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a contact tag.
+        /// </summary>
+        /// <param name="id">The tag ID to delete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Tag deleted successfully.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 DeleteContactTag: id={Id}", id);
+
+            await contactTagManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ContactsV2Controller.cs
+++ b/TrashMob/Controllers/V2/ContactsV2Controller.cs
@@ -1,0 +1,215 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for CRM contact management (admin only).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/contacts")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class ContactsV2Controller(
+        IContactManager contactManager,
+        IBaseManager<ContactContactTag> contactContactTagManager,
+        ILogger<ContactsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all contacts, optionally filtered by search term, contact type, or tag.
+        /// </summary>
+        /// <param name="search">Optional search term.</param>
+        /// <param name="contactType">Optional contact type filter (-1 means no filter).</param>
+        /// <param name="tagId">Optional tag filter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of contacts.</returns>
+        /// <response code="200">Returns the contact list.</response>
+        [HttpGet]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<ContactDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAll(
+            [FromQuery] string search = null,
+            [FromQuery] int contactType = -1,
+            [FromQuery] Guid tagId = default,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetAllContacts: search={Search}, contactType={ContactType}, tagId={TagId}", search, contactType, tagId);
+
+            IEnumerable<Contact> contacts;
+
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                contacts = await contactManager.SearchAsync(search, cancellationToken);
+            }
+            else if (tagId != default)
+            {
+                contacts = await contactManager.GetByTagAsync(tagId, cancellationToken);
+            }
+            else if (contactType >= 0)
+            {
+                contacts = await contactManager.GetByContactTypeAsync(contactType, cancellationToken);
+            }
+            else
+            {
+                contacts = await contactManager.GetAsync(cancellationToken);
+            }
+
+            var dtos = contacts.Select(c => c.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a contact by ID.
+        /// </summary>
+        /// <param name="id">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The contact.</returns>
+        /// <response code="200">Returns the contact.</response>
+        /// <response code="404">Contact not found.</response>
+        [HttpGet("{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(ContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken = default)
+        {
+            var contact = await contactManager.GetAsync(id, cancellationToken);
+
+            if (contact is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(contact.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new contact.
+        /// </summary>
+        /// <param name="dto">The contact data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created contact.</returns>
+        /// <response code="201">Contact created successfully.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ContactDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create([FromBody] ContactDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 CreateContact");
+
+            var entity = dto.ToEntity();
+            var result = await contactManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a contact.
+        /// </summary>
+        /// <param name="dto">The updated contact data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated contact.</returns>
+        /// <response code="200">Contact updated successfully.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(ContactDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update([FromBody] ContactDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdateContact: id={Id}", dto.Id);
+
+            var entity = dto.ToEntity();
+            entity.LastUpdatedByUserId = UserId;
+            var result = await contactManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a contact.
+        /// </summary>
+        /// <param name="id">The contact ID to delete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Contact deleted successfully.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 DeleteContact: id={Id}", id);
+
+            await contactManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Replaces all tag assignments for a contact.
+        /// </summary>
+        /// <param name="id">The contact ID.</param>
+        /// <param name="tagIds">The tag IDs to assign.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Tags updated successfully.</response>
+        [HttpPut("{id}/tags")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UpdateTags(Guid id, [FromBody] Guid[] tagIds, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdateContactTags: contactId={Id}, tagCount={Count}", id, tagIds.Length);
+
+            var existing = await contactContactTagManager.GetAsync(ct => ct.ContactId == id, cancellationToken);
+
+            foreach (var tag in existing)
+            {
+                await contactContactTagManager.Delete(tag.ContactId, tag.ContactTagId, cancellationToken);
+            }
+
+            foreach (var tagId in tagIds)
+            {
+                var newTag = new ContactContactTag { ContactId = id, ContactTagId = tagId };
+                await contactContactTagManager.AddAsync(newTag, UserId, cancellationToken);
+            }
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Gets the tag IDs assigned to a contact.
+        /// </summary>
+        /// <param name="id">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of tag IDs.</returns>
+        /// <response code="200">Returns the tag ID list.</response>
+        [HttpGet("{id}/tags")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<Guid>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetTags(Guid id, CancellationToken cancellationToken = default)
+        {
+            var tags = await contactContactTagManager.GetAsync(ct => ct.ContactId == id, cancellationToken);
+            var tagIds = tags.Select(ct => ct.ContactTagId).ToList();
+
+            return Ok(tagIds);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/DonationsV2Controller.cs
+++ b/TrashMob/Controllers/V2/DonationsV2Controller.cs
@@ -1,0 +1,215 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+
+    /// <summary>
+    /// V2 controller for donation management (admin only).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/donations")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class DonationsV2Controller(
+        IDonationManager donationManager,
+        IDonationEmailManager donationEmailManager,
+        ILogger<DonationsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all donations.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of donations.</returns>
+        /// <response code="200">Returns the donation list.</response>
+        [HttpGet]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<DonationDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAll(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetAllDonations");
+
+            var donations = await donationManager.GetAsync(cancellationToken);
+            var dtos = donations.Select(d => d.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a donation by ID.
+        /// </summary>
+        /// <param name="id">The donation ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The donation.</returns>
+        /// <response code="200">Returns the donation.</response>
+        /// <response code="404">Donation not found.</response>
+        [HttpGet("{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(DonationDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken = default)
+        {
+            var donation = await donationManager.GetAsync(id, cancellationToken);
+
+            if (donation is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(donation.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets all donations for a specific contact.
+        /// </summary>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of donations for the contact.</returns>
+        /// <response code="200">Returns the donation list.</response>
+        [HttpGet("bycontact/{contactId}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<DonationDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByContactId(Guid contactId, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetDonationsByContact: contactId={ContactId}", contactId);
+
+            var donations = await donationManager.GetByContactIdAsync(contactId, cancellationToken);
+            var dtos = donations.Select(d => d.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Creates a new donation.
+        /// </summary>
+        /// <param name="dto">The donation data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created donation.</returns>
+        /// <response code="201">Donation created successfully.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DonationDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create([FromBody] DonationDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 CreateDonation: contactId={ContactId}", dto.ContactId);
+
+            var entity = dto.ToEntity();
+            var result = await donationManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a donation.
+        /// </summary>
+        /// <param name="dto">The updated donation data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated donation.</returns>
+        /// <response code="200">Donation updated successfully.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DonationDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update([FromBody] DonationDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdateDonation: id={Id}", dto.Id);
+
+            var entity = dto.ToEntity();
+            entity.LastUpdatedByUserId = UserId;
+            var result = await donationManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a donation.
+        /// </summary>
+        /// <param name="id">The donation ID to delete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Donation deleted successfully.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 DeleteDonation: id={Id}", id);
+
+            await donationManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Sends a thank-you email for a donation.
+        /// </summary>
+        /// <param name="id">The donation ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Thank-you email sent successfully.</response>
+        /// <response code="404">Donation not found.</response>
+        [HttpPost("{id}/send-thankyou")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SendThankYou(Guid id, CancellationToken cancellationToken = default)
+        {
+            var donation = await donationManager.GetAsync(id, cancellationToken);
+
+            if (donation is null)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 SendDonationThankYou: id={Id}", id);
+
+            await donationEmailManager.SendThankYouAsync(id, UserId, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Sends a tax receipt email with PDF attachment for a donation.
+        /// </summary>
+        /// <param name="id">The donation ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Receipt email sent successfully.</response>
+        /// <response code="404">Donation not found.</response>
+        [HttpPost("{id}/send-receipt")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SendReceipt(Guid id, CancellationToken cancellationToken = default)
+        {
+            var donation = await donationManager.GetAsync(id, cancellationToken);
+
+            if (donation is null)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 SendDonationReceipt: id={Id}", id);
+
+            await donationEmailManager.SendReceiptAsync(id, UserId, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/FundraisingAnalyticsV2Controller.cs
+++ b/TrashMob/Controllers/V2/FundraisingAnalyticsV2Controller.cs
@@ -1,0 +1,165 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+
+    /// <summary>
+    /// V2 admin controller for fundraising analytics and reporting.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/fundraising-analytics")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class FundraisingAnalyticsV2Controller(
+        IFundraisingAnalyticsManager analyticsManager,
+        ILogger<FundraisingAnalyticsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets engagement scores for all active contacts.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of engagement scores.</returns>
+        /// <response code="200">Returns engagement scores.</response>
+        [HttpGet("engagement-scores")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ContactEngagementScore>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEngagementScores(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEngagementScores by User={UserId}", UserId);
+
+            var scores = await analyticsManager.GetEngagementScoresAsync(cancellationToken);
+
+            return Ok(scores);
+        }
+
+        /// <summary>
+        /// Gets the engagement score for a single contact.
+        /// </summary>
+        /// <param name="contactId">The contact identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The engagement score.</returns>
+        /// <response code="200">Returns the engagement score.</response>
+        [HttpGet("engagement-scores/{contactId}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(ContactEngagementScore), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEngagementScore(Guid contactId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetEngagementScore Contact={ContactId} by User={UserId}", contactId, UserId);
+
+            var score = await analyticsManager.GetEngagementScoreAsync(contactId, cancellationToken);
+
+            return Ok(score);
+        }
+
+        /// <summary>
+        /// Gets the fundraising dashboard with aggregate metrics.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The fundraising dashboard.</returns>
+        /// <response code="200">Returns the dashboard.</response>
+        [HttpGet("dashboard")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FundraisingDashboard), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetDashboard(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetDashboard by User={UserId}", UserId);
+
+            var dashboard = await analyticsManager.GetDashboardAsync(cancellationToken);
+
+            return Ok(dashboard);
+        }
+
+        /// <summary>
+        /// Gets contacts in the volunteer-to-donor pipeline (high engagement, no donations).
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of pipeline contacts.</returns>
+        /// <response code="200">Returns pipeline contacts.</response>
+        [HttpGet("volunteer-pipeline")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ContactEngagementScore>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetVolunteerPipeline(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetVolunteerPipeline by User={UserId}", UserId);
+
+            var pipeline = await analyticsManager.GetVolunteerToDonorPipelineAsync(cancellationToken);
+
+            return Ok(pipeline);
+        }
+
+        /// <summary>
+        /// Gets LYBUNT (Last Year But Unfortunately Not This Year) contacts.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of LYBUNT contacts.</returns>
+        /// <response code="200">Returns LYBUNT contacts.</response>
+        [HttpGet("lybunt")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<ContactEngagementScore>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetLybuntContacts(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetLybuntContacts by User={UserId}", UserId);
+
+            var contacts = await analyticsManager.GetLybuntContactsAsync(cancellationToken);
+
+            return Ok(contacts);
+        }
+
+        /// <summary>
+        /// Exports a donor report as CSV.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A CSV file containing the donor report.</returns>
+        /// <response code="200">Returns the CSV file.</response>
+        [HttpGet("export/donors")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> ExportDonorReport(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ExportDonorReport by User={UserId}", UserId);
+
+            var csv = await analyticsManager.GenerateDonorReportCsvAsync(cancellationToken);
+            var bytes = Encoding.UTF8.GetBytes(csv);
+            var filename = $"DonorReport_{DateTime.UtcNow:yyyyMMdd}.csv";
+
+            return File(bytes, "text/csv", filename);
+        }
+
+        /// <summary>
+        /// Exports a fundraising summary as CSV.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A CSV file containing the fundraising summary.</returns>
+        /// <response code="200">Returns the CSV file.</response>
+        [HttpGet("export/summary")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> ExportFundraisingSummary(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ExportFundraisingSummary by User={UserId}", UserId);
+
+            var csv = await analyticsManager.GenerateFundraisingSummaryCsvAsync(cancellationToken);
+            var bytes = Encoding.UTF8.GetBytes(csv);
+            var filename = $"FundraisingSummary_{DateTime.UtcNow:yyyyMMdd}.csv";
+
+            return File(bytes, "text/csv", filename);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/FundraisingAppealsV2Controller.cs
+++ b/TrashMob/Controllers/V2/FundraisingAppealsV2Controller.cs
@@ -1,0 +1,70 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+
+    /// <summary>
+    /// V2 admin controller for sending fundraising appeal emails.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/fundraising-appeals")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class FundraisingAppealsV2Controller(
+        IDonationEmailManager donationEmailManager,
+        ILogger<FundraisingAppealsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Sends a fundraising appeal email to a single contact.
+        /// </summary>
+        /// <param name="request">The appeal request containing contact, subject, and body.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Appeal sent successfully.</response>
+        [HttpPost("send")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Send([FromBody] AppealRequestDto request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Send Appeal to Contact={ContactId} by User={UserId}", request.ContactId, UserId);
+
+            await donationEmailManager.SendAppealAsync(request.ContactId, request.Subject, request.Body, UserId, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Sends a fundraising appeal email to multiple contacts.
+        /// </summary>
+        /// <param name="request">The bulk appeal request containing contact IDs, subject, and body.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A summary of the bulk send operation.</returns>
+        /// <response code="200">Returns bulk send results.</response>
+        [HttpPost("send-bulk")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(BulkAppealResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> SendBulk([FromBody] BulkAppealRequestDto request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SendBulk Appeal to {Count} contacts by User={UserId}", request.ContactIds.Count, UserId);
+
+            var result = await donationEmailManager.SendBulkAppealAsync(request.ContactIds, request.Subject, request.Body, UserId, cancellationToken);
+
+            return Ok(result);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/GrantTasksV2Controller.cs
+++ b/TrashMob/Controllers/V2/GrantTasksV2Controller.cs
@@ -1,0 +1,122 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+
+    /// <summary>
+    /// V2 admin controller for grant task management.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/granttasks")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class GrantTasksV2Controller(
+        IGrantTaskManager grantTaskManager,
+        ILogger<GrantTasksV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all tasks for a specific grant.
+        /// </summary>
+        /// <param name="grantId">The grant identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of grant tasks.</returns>
+        /// <response code="200">Returns grant tasks.</response>
+        [HttpGet("bygrant/{grantId}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<GrantTaskDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByGrantId(Guid grantId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetByGrantId GrantTasks Grant={GrantId} by User={UserId}", grantId, UserId);
+
+            var tasks = await grantTaskManager.GetByGrantIdAsync(grantId, cancellationToken);
+
+            return Ok(tasks.Select(t => t.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Creates a new grant task.
+        /// </summary>
+        /// <param name="taskDto">The grant task to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created grant task.</returns>
+        /// <response code="201">Grant task created.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(GrantTaskDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create(GrantTaskDto taskDto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Create GrantTask for Grant={GrantId} by User={UserId}", taskDto.GrantId, UserId);
+
+            var entity = taskDto.ToEntity();
+            entity.CreatedByUserId = UserId;
+            entity.CreatedDate = DateTimeOffset.UtcNow;
+            entity.LastUpdatedByUserId = UserId;
+            entity.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var result = await grantTaskManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetByGrantId), new { grantId = result.GrantId }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing grant task.
+        /// </summary>
+        /// <param name="taskDto">The grant task to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated grant task.</returns>
+        /// <response code="200">Grant task updated.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(GrantTaskDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update(GrantTaskDto taskDto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Update GrantTask={TaskId} by User={UserId}", taskDto.Id, UserId);
+
+            var entity = taskDto.ToEntity();
+            entity.LastUpdatedByUserId = UserId;
+            entity.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var result = await grantTaskManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a grant task.
+        /// </summary>
+        /// <param name="id">The grant task identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Grant task deleted.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Delete GrantTask={TaskId} by User={UserId}", id, UserId);
+
+            await grantTaskManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/GrantsV2Controller.cs
+++ b/TrashMob/Controllers/V2/GrantsV2Controller.cs
@@ -1,0 +1,179 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 admin controller for grant management.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/grants")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class GrantsV2Controller(
+        IGrantManager grantManager,
+        IGrantDiscoveryService grantDiscoveryService,
+        ILogger<GrantsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all grants, optionally filtered by status.
+        /// </summary>
+        /// <param name="status">Optional status filter. Pass -1 or omit for all grants.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of grants.</returns>
+        /// <response code="200">Returns grants.</response>
+        [HttpGet]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<GrantDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAll([FromQuery] int status = -1, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetAll Grants Status={Status} by User={UserId}", status, UserId);
+
+            IEnumerable<Grant> grants;
+
+            if (status >= 0)
+            {
+                grants = await grantManager.GetByStatusAsync(status, cancellationToken);
+            }
+            else
+            {
+                grants = await grantManager.GetAsync(g => true, cancellationToken);
+            }
+
+            return Ok(grants.Select(g => g.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a grant by its identifier.
+        /// </summary>
+        /// <param name="id">The grant identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The grant.</returns>
+        /// <response code="200">Returns the grant.</response>
+        /// <response code="404">Grant not found.</response>
+        [HttpGet("{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(GrantDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetById Grant={GrantId} by User={UserId}", id, UserId);
+
+            var grant = await grantManager.GetAsync(id, cancellationToken);
+
+            if (grant is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(grant.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new grant.
+        /// </summary>
+        /// <param name="grantDto">The grant to create.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created grant.</returns>
+        /// <response code="201">Grant created.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(GrantDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create(GrantDto grantDto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Create Grant by User={UserId}", UserId);
+
+            var entity = grantDto.ToEntity();
+            entity.CreatedByUserId = UserId;
+            entity.CreatedDate = DateTimeOffset.UtcNow;
+            entity.LastUpdatedByUserId = UserId;
+            entity.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var result = await grantManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing grant.
+        /// </summary>
+        /// <param name="grantDto">The grant to update.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated grant.</returns>
+        /// <response code="200">Grant updated.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(GrantDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update(GrantDto grantDto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Update Grant={GrantId} by User={UserId}", grantDto.Id, UserId);
+
+            var entity = grantDto.ToEntity();
+            entity.LastUpdatedByUserId = UserId;
+            entity.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var result = await grantManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Discovers potential grant funding opportunities using AI.
+        /// </summary>
+        /// <param name="request">The grant discovery request parameters.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Discovered grant opportunities.</returns>
+        /// <response code="200">Returns discovered grants.</response>
+        [HttpPost("discover")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(GrantDiscoveryResult), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Discover([FromBody] GrantDiscoveryRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Discover Grants by User={UserId}", UserId);
+
+            var result = await grantDiscoveryService.DiscoverGrantsAsync(request, cancellationToken);
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Deletes a grant.
+        /// </summary>
+        /// <param name="id">The grant identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Grant deleted.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Delete Grant={GrantId} by User={UserId}", id, UserId);
+
+            await grantManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PledgesV2Controller.cs
+++ b/TrashMob/Controllers/V2/PledgesV2Controller.cs
@@ -1,0 +1,158 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Contacts;
+
+    /// <summary>
+    /// V2 controller for pledge management (admin only).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/pledges")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class PledgesV2Controller(
+        IPledgeManager pledgeManager,
+        ILogger<PledgesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all pledges.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of pledges.</returns>
+        /// <response code="200">Returns the pledge list.</response>
+        [HttpGet]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<PledgeDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAll(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetAllPledges");
+
+            var pledges = await pledgeManager.GetAsync(cancellationToken);
+            var dtos = pledges.Select(p => p.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets a pledge by ID.
+        /// </summary>
+        /// <param name="id">The pledge ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The pledge.</returns>
+        /// <response code="200">Returns the pledge.</response>
+        /// <response code="404">Pledge not found.</response>
+        [HttpGet("{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(PledgeDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken = default)
+        {
+            var pledge = await pledgeManager.GetAsync(id, cancellationToken);
+
+            if (pledge is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(pledge.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets all pledges for a specific contact.
+        /// </summary>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of pledges for the contact.</returns>
+        /// <response code="200">Returns the pledge list.</response>
+        [HttpGet("bycontact/{contactId}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IReadOnlyList<PledgeDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByContactId(Guid contactId, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetPledgesByContact: contactId={ContactId}", contactId);
+
+            var pledges = await pledgeManager.GetByContactIdAsync(contactId, cancellationToken);
+            var dtos = pledges.Select(p => p.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Creates a new pledge.
+        /// </summary>
+        /// <param name="dto">The pledge data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created pledge.</returns>
+        /// <response code="201">Pledge created successfully.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PledgeDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create([FromBody] PledgeDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 CreatePledge: contactId={ContactId}", dto.ContactId);
+
+            var entity = dto.ToEntity();
+            var result = await pledgeManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a pledge.
+        /// </summary>
+        /// <param name="dto">The updated pledge data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated pledge.</returns>
+        /// <response code="200">Pledge updated successfully.</response>
+        [HttpPut]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PledgeDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Update([FromBody] PledgeDto dto, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdatePledge: id={Id}", dto.Id);
+
+            var entity = dto.ToEntity();
+            entity.LastUpdatedByUserId = UserId;
+            var result = await pledgeManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(result.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a pledge.
+        /// </summary>
+        /// <param name="id">The pledge ID to delete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        /// <response code="204">Pledge deleted successfully.</response>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 DeletePledge: id={Id}", id);
+
+            await pledgeManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add 10 v2 controllers for CRM and fundraising: contacts, contact notes, contact tags, donations, pledges, grants, grant tasks, fundraising appeals, fundraising analytics, and Strapi CMS proxy
- Create 9 new DTOs with bidirectional mapping extensions
- Add 35 unit tests across 10 test files

## Details
**Controllers (56 endpoints total):**
- `ContactsV2Controller` (7 endpoints) - CRUD + search/filter by type/tag + tag management
- `ContactNotesV2Controller` (4 endpoints) - CRUD by contact
- `ContactTagsV2Controller` (4 endpoints) - tag CRUD
- `DonationsV2Controller` (8 endpoints) - CRUD + by contact + thank-you/receipt emails
- `PledgesV2Controller` (6 endpoints) - CRUD + by contact
- `GrantsV2Controller` (6 endpoints) - CRUD + status filter + AI grant discovery
- `GrantTasksV2Controller` (4 endpoints) - task CRUD by grant
- `FundraisingAppealsV2Controller` (2 endpoints) - single + bulk appeal emails
- `FundraisingAnalyticsV2Controller` (7 endpoints) - engagement scores, dashboard, volunteer pipeline, LYBUNT, CSV exports
- `CmsV2Controller` (8 endpoints) - Strapi CMS proxy + RSS feed + admin URL

**DTOs:** `ContactDto`, `ContactNoteDto`, `ContactTagDto`, `DonationDto`, `PledgeDto`, `GrantDto`, `GrantTaskDto`, `AppealRequestDto`, `BulkAppealRequestDto`

## Test plan
- [x] All 35 Phase 2h tests pass (48 total including related existing tests)
- [x] Solution builds with 0 errors, 0 warnings
- [x] Project plan updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)