### PR TITLE
Add v2 API controllers for infrastructure & webhooks (Phase 2i)

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 1, 2a–2h complete — 64+ v2 controllers, 93+ DTOs, 64+ test suites; Phase 2i, 3, 4 remaining) |
+| **Status** | In Progress (Phases 1, 2a–2i complete — 72+ v2 controllers, 100+ DTOs, 72+ test suites; Phases 3, 4 remaining) |
 | **Priority** | High |
 | **Risk** | Medium |
 | **Size** | Very Large |
@@ -239,15 +239,17 @@ Fundraising and donor relationship management — 10 v1 controllers. All site ad
 
 Infrastructure, auth, config, and webhook endpoints. These may not all need v2 equivalents — evaluate case by case.
 
-- [ ] **Newsletter webhooks** - `NewsletterWebhooksController`: SendGrid webhook receiver (tracking)
-- [ ] **Newsletters** - `NewslettersController`: admin newsletter creation/sending
-- [ ] **Privo webhooks** - `PrivoWebhooksController`: Privo consent webhook receiver
-- [ ] **Authentication** - `AuthenticationController`: validates new user creation
-- [ ] **Secrets** - `SecretsController`: retrieves config secrets by name
-- [ ] **Config** - `ConfigController`: client-side config (App Insights, Entra settings)
-- [ ] **Email invites** - `EmailInvitesController`: admin bulk email invite batches
-- [ ] **Job opportunities** - `JobOpportunityController`: job listings (GET public, PUT admin)
-- [ ] **Route simulation** - `RouteSimulationController`: dev/QA fake GPS route generator (non-prod only)
+- [x] **Newsletter webhooks** - `NewsletterWebhooksV2Controller`: SendGrid webhook receiver (tracking) ✅
+- [x] **Newsletters** - `NewslettersAdminV2Controller`: 9 endpoints (CRUD + schedule/send/test/templates) ✅
+- [x] **Privo webhooks** - `PrivoWebhooksV2Controller`: Privo consent webhook receiver ✅
+- [x] **Authentication** - `AuthenticationV2Controller`: 5 endpoints (validate/signup/update/delete user) ✅
+- [x] **Secrets** - `SecretsV2Controller`: retrieves config secrets by name ✅
+- [x] **Config** - `ConfigV2Controller`: client-side config (App Insights, Entra settings) ✅
+- [x] **Email invites** - `EmailInvitesV2Controller`: already existed (user-facing with rate limiting) ✅
+- [x] **Job opportunities** - `JobOpportunitiesV2Controller`: 4 endpoints (GET public, CRUD admin) ✅
+- [x] **Route simulation** - `RouteSimulationV2Controller`: dev/QA fake GPS route generator (non-prod only) ✅
+
+**Phase 2i totals:** 8 controllers (1 pre-existing), 22 endpoints, 7 DTOs, 2 mapping files, 27 tests
 
 ### Phase 3 - Client Migration
 

--- a/TrashMob.Models/Extensions/V2/JobOpportunityMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/JobOpportunityMappingsV2.cs
@@ -1,0 +1,42 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 mapping extensions for job opportunities.
+    /// </summary>
+    public static class JobOpportunityMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="JobOpportunity"/> to a <see cref="JobOpportunityDto"/>.
+        /// </summary>
+        public static JobOpportunityDto ToV2Dto(this JobOpportunity entity)
+        {
+            return new JobOpportunityDto
+            {
+                Id = entity.Id,
+                Title = entity.Title ?? string.Empty,
+                TagLine = entity.TagLine ?? string.Empty,
+                FullDescription = entity.FullDescription ?? string.Empty,
+                IsActive = entity.IsActive,
+                CreatedDate = entity.CreatedDate ?? DateTimeOffset.MinValue,
+                LastUpdatedDate = entity.LastUpdatedDate ?? DateTimeOffset.MinValue,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="JobOpportunityDto"/> to a <see cref="JobOpportunity"/> entity.
+        /// </summary>
+        public static JobOpportunity ToEntity(this JobOpportunityDto dto)
+        {
+            return new JobOpportunity
+            {
+                Id = dto.Id,
+                Title = dto.Title,
+                TagLine = dto.TagLine,
+                FullDescription = dto.FullDescription,
+                IsActive = dto.IsActive,
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/NewsletterMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/NewsletterMappingsV2.cs
@@ -3,7 +3,7 @@ namespace TrashMob.Models.Extensions.V2
     using TrashMob.Models.Poco.V2;
 
     /// <summary>
-    /// V2 mapping extensions for newsletter categories.
+    /// V2 mapping extensions for newsletter-related entities.
     /// </summary>
     public static class NewsletterMappingsV2
     {
@@ -18,6 +18,53 @@ namespace TrashMob.Models.Extensions.V2
                 Name = entity.Name ?? string.Empty,
                 Description = entity.Description ?? string.Empty,
                 IsDefault = entity.IsDefault,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="Newsletter"/> to a <see cref="NewsletterDto"/>.
+        /// </summary>
+        public static NewsletterDto ToV2Dto(this Newsletter entity)
+        {
+            return new NewsletterDto
+            {
+                Id = entity.Id,
+                CategoryId = entity.CategoryId,
+                CategoryName = entity.Category?.Name ?? string.Empty,
+                Subject = entity.Subject ?? string.Empty,
+                PreviewText = entity.PreviewText ?? string.Empty,
+                HtmlContent = entity.HtmlContent ?? string.Empty,
+                TextContent = entity.TextContent ?? string.Empty,
+                TargetType = entity.TargetType ?? string.Empty,
+                TargetId = entity.TargetId,
+                Status = entity.Status ?? string.Empty,
+                ScheduledDate = entity.ScheduledDate,
+                SentDate = entity.SentDate,
+                RecipientCount = entity.RecipientCount,
+                SentCount = entity.SentCount,
+                DeliveredCount = entity.DeliveredCount,
+                OpenCount = entity.OpenCount,
+                ClickCount = entity.ClickCount,
+                BounceCount = entity.BounceCount,
+                UnsubscribeCount = entity.UnsubscribeCount,
+                CreatedDate = entity.CreatedDate ?? DateTimeOffset.MinValue,
+                LastUpdatedDate = entity.LastUpdatedDate ?? DateTimeOffset.MinValue,
+            };
+        }
+
+        /// <summary>
+        /// Maps a <see cref="NewsletterTemplate"/> to a <see cref="NewsletterTemplateDto"/>.
+        /// </summary>
+        public static NewsletterTemplateDto ToV2Dto(this NewsletterTemplate entity)
+        {
+            return new NewsletterTemplateDto
+            {
+                Id = entity.Id,
+                Name = entity.Name ?? string.Empty,
+                Description = entity.Description ?? string.Empty,
+                HtmlContent = entity.HtmlContent ?? string.Empty,
+                TextContent = entity.TextContent ?? string.Empty,
+                ThumbnailUrl = entity.ThumbnailUrl,
             };
         }
     }

--- a/TrashMob.Models/Poco/V2/CreateNewsletterDto.cs
+++ b/TrashMob.Models/Poco/V2/CreateNewsletterDto.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 DTO for creating a newsletter draft.
+    /// </summary>
+    public class CreateNewsletterDto
+    {
+        /// <summary>Gets or sets the category ID.</summary>
+        public int CategoryId { get; set; }
+
+        /// <summary>Gets or sets the email subject line.</summary>
+        public string Subject { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the preview text.</summary>
+        public string? PreviewText { get; set; }
+
+        /// <summary>Gets or sets the HTML content.</summary>
+        public string? HtmlContent { get; set; }
+
+        /// <summary>Gets or sets the plain text content.</summary>
+        public string? TextContent { get; set; }
+
+        /// <summary>Gets or sets the target type (All, Community, Team).</summary>
+        public string? TargetType { get; set; }
+
+        /// <summary>Gets or sets the target ID.</summary>
+        public Guid? TargetId { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/JobOpportunityDto.cs
+++ b/TrashMob.Models/Poco/V2/JobOpportunityDto.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 DTO for job opportunity data.
+    /// </summary>
+    public class JobOpportunityDto
+    {
+        /// <summary>Gets or sets the job opportunity ID.</summary>
+        public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the title.</summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the tagline.</summary>
+        public string TagLine { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the full description.</summary>
+        public string FullDescription { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets whether the opportunity is active.</summary>
+        public bool IsActive { get; set; }
+
+        /// <summary>Gets or sets the created date.</summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>Gets or sets the last updated date.</summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/NewsletterDto.cs
+++ b/TrashMob.Models/Poco/V2/NewsletterDto.cs
@@ -1,0 +1,75 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 DTO for newsletter data.
+    /// </summary>
+    public class NewsletterDto
+    {
+        /// <summary>Gets or sets the newsletter ID.</summary>
+        public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the category ID.</summary>
+        public int CategoryId { get; set; }
+
+        /// <summary>Gets or sets the category name.</summary>
+        public string CategoryName { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the email subject line.</summary>
+        public string Subject { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the preview text.</summary>
+        public string PreviewText { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the HTML content.</summary>
+        public string HtmlContent { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the plain text content.</summary>
+        public string TextContent { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the target type (All, Community, Team).</summary>
+        public string TargetType { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the target ID.</summary>
+        public Guid? TargetId { get; set; }
+
+        /// <summary>Gets or sets the newsletter status.</summary>
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the scheduled send date.</summary>
+        public DateTimeOffset? ScheduledDate { get; set; }
+
+        /// <summary>Gets or sets when the newsletter was sent.</summary>
+        public DateTimeOffset? SentDate { get; set; }
+
+        /// <summary>Gets or sets the total recipient count.</summary>
+        public int RecipientCount { get; set; }
+
+        /// <summary>Gets or sets the sent count.</summary>
+        public int SentCount { get; set; }
+
+        /// <summary>Gets or sets the delivered count.</summary>
+        public int DeliveredCount { get; set; }
+
+        /// <summary>Gets or sets the open count.</summary>
+        public int OpenCount { get; set; }
+
+        /// <summary>Gets or sets the click count.</summary>
+        public int ClickCount { get; set; }
+
+        /// <summary>Gets or sets the bounce count.</summary>
+        public int BounceCount { get; set; }
+
+        /// <summary>Gets or sets the unsubscribe count.</summary>
+        public int UnsubscribeCount { get; set; }
+
+        /// <summary>Gets or sets the created date.</summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>Gets or sets the last updated date.</summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/NewsletterTemplateDto.cs
+++ b/TrashMob.Models/Poco/V2/NewsletterTemplateDto.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// V2 DTO for newsletter template data.
+    /// </summary>
+    public class NewsletterTemplateDto
+    {
+        /// <summary>Gets or sets the template ID.</summary>
+        public int Id { get; set; }
+
+        /// <summary>Gets or sets the template name.</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the template description.</summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the HTML content template.</summary>
+        public string HtmlContent { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the plain text content template.</summary>
+        public string TextContent { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets a URL to a thumbnail preview.</summary>
+        public string? ThumbnailUrl { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/ScheduleNewsletterDto.cs
+++ b/TrashMob.Models/Poco/V2/ScheduleNewsletterDto.cs
@@ -1,0 +1,15 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 DTO for scheduling a newsletter.
+    /// </summary>
+    public class ScheduleNewsletterDto
+    {
+        /// <summary>Gets or sets the scheduled send date and time.</summary>
+        public DateTimeOffset ScheduledDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/TestSendNewsletterDto.cs
+++ b/TrashMob.Models/Poco/V2/TestSendNewsletterDto.cs
@@ -1,0 +1,15 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// V2 DTO for sending a test newsletter email.
+    /// </summary>
+    public class TestSendNewsletterDto
+    {
+        /// <summary>Gets or sets the list of email addresses to send the test to.</summary>
+        public List<string> Emails { get; set; } = [];
+    }
+}

--- a/TrashMob.Models/Poco/V2/UpdateNewsletterDto.cs
+++ b/TrashMob.Models/Poco/V2/UpdateNewsletterDto.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 DTO for updating a newsletter draft.
+    /// </summary>
+    public class UpdateNewsletterDto
+    {
+        /// <summary>Gets or sets the category ID.</summary>
+        public int? CategoryId { get; set; }
+
+        /// <summary>Gets or sets the email subject line.</summary>
+        public string? Subject { get; set; }
+
+        /// <summary>Gets or sets the preview text.</summary>
+        public string? PreviewText { get; set; }
+
+        /// <summary>Gets or sets the HTML content.</summary>
+        public string? HtmlContent { get; set; }
+
+        /// <summary>Gets or sets the plain text content.</summary>
+        public string? TextContent { get; set; }
+
+        /// <summary>Gets or sets the target type (All, Community, Team).</summary>
+        public string? TargetType { get; set; }
+
+        /// <summary>Gets or sets the target ID.</summary>
+        public Guid? TargetId { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/AuthenticationV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/AuthenticationV2ControllerTests.cs
@@ -1,0 +1,100 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    public class AuthenticationV2ControllerTests
+    {
+        private readonly Mock<IActiveDirectoryManager> activeDirectoryManager = new();
+        private readonly Mock<ILogger<AuthenticationV2Controller>> logger = new();
+        private readonly AuthenticationV2Controller controller;
+
+        public AuthenticationV2ControllerTests()
+        {
+            controller = new AuthenticationV2Controller(
+                activeDirectoryManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        #region ValidateUser
+
+        [Fact]
+        public async Task ValidateUser_ReturnsOk_WhenValid()
+        {
+            var request = new ActiveDirectoryValidateNewUserRequest { email = "test@example.com" };
+
+            activeDirectoryManager
+                .Setup(m => m.ValidateNewUserAsync(It.IsAny<ActiveDirectoryValidateNewUserRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ActiveDirectoryContinuationResponse { action = "Continue", version = "1.0.0" });
+
+            var result = await controller.ValidateUser(request, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
+        public async Task ValidateUser_ReturnsConflict_WhenValidationError()
+        {
+            var request = new ActiveDirectoryValidateNewUserRequest { email = "test@example.com" };
+
+            activeDirectoryManager
+                .Setup(m => m.ValidateNewUserAsync(It.IsAny<ActiveDirectoryValidateNewUserRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ActiveDirectoryValidationFailedResponse { action = "ValidationError", version = "1.0.0", userMessage = "exists" });
+
+            var result = await controller.ValidateUser(request, CancellationToken.None);
+
+            Assert.IsType<ConflictObjectResult>(result);
+        }
+
+        #endregion
+
+        #region SignUpUser
+
+        [Fact]
+        public async Task SignUpUser_ReturnsOk_WhenValid()
+        {
+            var request = new ActiveDirectoryNewUserRequest { email = "test@example.com", objectId = Guid.NewGuid(), userName = "testuser" };
+
+            activeDirectoryManager
+                .Setup(m => m.CreateUserAsync(It.IsAny<ActiveDirectoryNewUserRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ActiveDirectoryContinuationResponse { action = "Continue", version = "1.0.0" });
+
+            var result = await controller.SignUpUser(request, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        #endregion
+
+        #region DeleteUser
+
+        [Fact]
+        public async Task DeleteUser_ReturnsOk()
+        {
+            var objectId = Guid.NewGuid();
+            var request = new ActiveDirectoryDeleteUserRequest { objectId = objectId };
+
+            activeDirectoryManager
+                .Setup(m => m.DeleteUserAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ActiveDirectoryContinuationResponse { action = "Continue", version = "1.0.0" });
+
+            var result = await controller.DeleteUser(request, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/ConfigV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ConfigV2ControllerTests.cs
@@ -1,0 +1,87 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using Xunit;
+
+    public class ConfigV2ControllerTests
+    {
+        private readonly Mock<IConfiguration> configuration = new();
+        private readonly Mock<ILogger<ConfigV2Controller>> logger = new();
+        private readonly ConfigV2Controller controller;
+
+        public ConfigV2ControllerTests()
+        {
+            controller = new ConfigV2Controller(
+                configuration.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        #region GetConfig
+
+        [Fact]
+        public void GetConfig_ReturnsOk_WithConfigData()
+        {
+            configuration
+                .Setup(c => c["ApplicationInsights:ConnectionString"])
+                .Returns("InstrumentationKey=test-key;IngestionEndpoint=https://test");
+
+            configuration
+                .Setup(c => c["AzureAdEntra:Instance"])
+                .Returns("https://test.ciamlogin.com");
+
+            configuration
+                .Setup(c => c["AzureAdEntra:Domain"])
+                .Returns("test.domain");
+
+            configuration
+                .Setup(c => c["AzureAdEntra:FrontendClientId"])
+                .Returns("client-id");
+
+            configuration
+                .Setup(c => c["AzureAdEntra:TenantId"])
+                .Returns("tenant-id");
+
+            var result = controller.GetConfig();
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public void GetConfig_ReturnsOk_WhenConfigMissing()
+        {
+            configuration
+                .Setup(c => c["ApplicationInsights:ConnectionString"])
+                .Returns((string)null);
+
+            configuration
+                .Setup(c => c["AzureAdEntra:Instance"])
+                .Returns((string)null);
+
+            configuration
+                .Setup(c => c["AzureAdEntra:Domain"])
+                .Returns((string)null);
+
+            configuration
+                .Setup(c => c["AzureAdEntra:FrontendClientId"])
+                .Returns((string)null);
+
+            configuration
+                .Setup(c => c["AzureAdEntra:TenantId"])
+                .Returns((string)null);
+
+            var result = controller.GetConfig();
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/JobOpportunitiesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/JobOpportunitiesV2ControllerTests.cs
@@ -1,0 +1,124 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class JobOpportunitiesV2ControllerTests
+    {
+        private readonly Mock<IKeyedManager<JobOpportunity>> jobOpportunityManager = new();
+        private readonly Mock<ILogger<JobOpportunitiesV2Controller>> logger = new();
+        private readonly JobOpportunitiesV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public JobOpportunitiesV2ControllerTests()
+        {
+            controller = new JobOpportunitiesV2Controller(jobOpportunityManager.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity([], "Bearer")),
+            };
+            httpContext.Items["UserId"] = userId.ToString();
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task Get_ReturnsOk_WhenFound()
+        {
+            var id = Guid.NewGuid();
+            var entity = new JobOpportunity { Id = id, Title = "Test Job" };
+
+            jobOpportunityManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entity);
+
+            var result = await controller.Get(id, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Get_ReturnsNotFound_WhenNull()
+        {
+            var id = Guid.NewGuid();
+
+            jobOpportunityManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((JobOpportunity)null);
+
+            var result = await controller.Get(id, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsCreated()
+        {
+            var dto = new JobOpportunityDto { Title = "New Job" };
+            var created = new JobOpportunity { Id = Guid.NewGuid(), Title = "New Job" };
+
+            jobOpportunityManager
+                .Setup(m => m.AddAsync(It.IsAny<JobOpportunity>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+
+            var result = await controller.Create(dto, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task Update_ReturnsOk_WhenFound()
+        {
+            var id = Guid.NewGuid();
+            var existing = new JobOpportunity { Id = id, Title = "Old Job" };
+            var updated = new JobOpportunity { Id = id, Title = "Updated Job" };
+            var dto = new JobOpportunityDto { Title = "Updated Job" };
+
+            jobOpportunityManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existing);
+
+            jobOpportunityManager
+                .Setup(m => m.UpdateAsync(It.IsAny<JobOpportunity>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(updated);
+
+            var result = await controller.Update(id, dto, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNoContent_WhenFound()
+        {
+            var id = Guid.NewGuid();
+            var existing = new JobOpportunity { Id = id, Title = "To Delete" };
+
+            jobOpportunityManager
+                .Setup(m => m.GetAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existing);
+
+            jobOpportunityManager
+                .Setup(m => m.DeleteAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.Delete(id, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/NewsletterWebhooksV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/NewsletterWebhooksV2ControllerTests.cs
@@ -1,0 +1,95 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using Xunit;
+
+    public class NewsletterWebhooksV2ControllerTests
+    {
+        private readonly Mock<INewsletterManager> newsletterManager = new();
+        private readonly Mock<ILogger<NewsletterWebhooksV2Controller>> logger = new();
+        private readonly NewsletterWebhooksV2Controller controller;
+
+        public NewsletterWebhooksV2ControllerTests()
+        {
+            controller = new NewsletterWebhooksV2Controller(
+                newsletterManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        #region ProcessNewsletterEvents
+
+        [Fact]
+        public async Task ProcessNewsletterEvents_ReturnsOk_WhenEventsProcessed()
+        {
+            var newsletterId = Guid.NewGuid();
+            var events = new List<SendGridEvent>
+            {
+                new() { Event = "delivered", NewsletterId = newsletterId.ToString() },
+                new() { Event = "open", NewsletterId = newsletterId.ToString() },
+            };
+
+            newsletterManager
+                .Setup(m => m.UpdateStatisticsAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var result = await controller.ProcessNewsletterEvents(events, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
+        public async Task ProcessNewsletterEvents_ReturnsOk_WhenEventsNull()
+        {
+            var result = await controller.ProcessNewsletterEvents(null, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
+        public async Task ProcessNewsletterEvents_ReturnsOk_WhenEventsFail()
+        {
+            var newsletterId = Guid.NewGuid();
+            var events = new List<SendGridEvent>
+            {
+                new() { Event = "delivered", NewsletterId = newsletterId.ToString() },
+            };
+
+            newsletterManager
+                .Setup(m => m.UpdateStatisticsAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("SendGrid error"));
+
+            var result = await controller.ProcessNewsletterEvents(events, CancellationToken.None);
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/NewslettersAdminV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/NewslettersAdminV2ControllerTests.cs
@@ -1,0 +1,206 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using Xunit;
+
+    public class NewslettersAdminV2ControllerTests
+    {
+        private readonly Mock<INewsletterManager> newsletterManager = new();
+        private readonly Mock<ILookupRepository<NewsletterTemplate>> templateRepository = new();
+        private readonly Mock<ILogger<NewslettersAdminV2Controller>> logger = new();
+        private readonly NewslettersAdminV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+
+        public NewslettersAdminV2ControllerTests()
+        {
+            controller = new NewslettersAdminV2Controller(
+                newsletterManager.Object,
+                templateRepository.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity([], "Bearer"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        #region GetNewsletters
+
+        [Fact]
+        public async Task GetNewsletters_ReturnsOk_WithNewsletterDtos()
+        {
+            var newsletters = new List<Newsletter>
+            {
+                new() { Id = Guid.NewGuid(), Subject = "Test Newsletter", Status = NewsletterStatus.Draft },
+            };
+
+            newsletterManager
+                .Setup(m => m.GetNewslettersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newsletters);
+
+            var result = await controller.GetNewsletters(null, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(okResult.Value);
+        }
+
+        #endregion
+
+        #region GetNewsletter
+
+        [Fact]
+        public async Task GetNewsletter_ReturnsOk_WhenFound()
+        {
+            var newsletterId = Guid.NewGuid();
+            var newsletter = new Newsletter { Id = newsletterId, Subject = "Test" };
+
+            newsletterManager
+                .Setup(m => m.GetAsync(newsletterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newsletter);
+
+            var result = await controller.GetNewsletter(newsletterId, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetNewsletter_ReturnsNotFound_WhenNull()
+        {
+            var newsletterId = Guid.NewGuid();
+
+            newsletterManager
+                .Setup(m => m.GetAsync(newsletterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Newsletter)null);
+
+            var result = await controller.GetNewsletter(newsletterId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        #endregion
+
+        #region CreateNewsletter
+
+        [Fact]
+        public async Task CreateNewsletter_ReturnsCreated()
+        {
+            var created = new Newsletter { Id = Guid.NewGuid(), Subject = "Test", Status = NewsletterStatus.Draft };
+
+            newsletterManager
+                .Setup(m => m.AddAsync(It.IsAny<Newsletter>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+
+            var dto = new CreateNewsletterDto { Subject = "Test" };
+
+            var result = await controller.CreateNewsletter(dto, CancellationToken.None);
+
+            Assert.IsType<CreatedAtActionResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateNewsletter_ReturnsBadRequest_WhenSubjectEmpty()
+        {
+            var dto = new CreateNewsletterDto { Subject = "" };
+
+            var result = await controller.CreateNewsletter(dto, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        #endregion
+
+        #region UpdateNewsletter
+
+        [Fact]
+        public async Task UpdateNewsletter_ReturnsOk_WhenDraft()
+        {
+            var newsletterId = Guid.NewGuid();
+            var newsletter = new Newsletter { Id = newsletterId, Subject = "Original", Status = NewsletterStatus.Draft };
+
+            newsletterManager
+                .Setup(m => m.GetAsync(newsletterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newsletter);
+
+            newsletterManager
+                .Setup(m => m.UpdateAsync(It.IsAny<Newsletter>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newsletter);
+
+            var dto = new UpdateNewsletterDto { Subject = "Updated" };
+
+            var result = await controller.UpdateNewsletter(newsletterId, dto, CancellationToken.None);
+
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task UpdateNewsletter_ReturnsBadRequest_WhenNotDraft()
+        {
+            var newsletterId = Guid.NewGuid();
+            var newsletter = new Newsletter { Id = newsletterId, Subject = "Original", Status = "Sent" };
+
+            newsletterManager
+                .Setup(m => m.GetAsync(newsletterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newsletter);
+
+            var dto = new UpdateNewsletterDto { Subject = "Updated" };
+
+            var result = await controller.UpdateNewsletter(newsletterId, dto, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        #endregion
+
+        #region DeleteNewsletter
+
+        [Fact]
+        public async Task DeleteNewsletter_ReturnsNoContent_WhenDraft()
+        {
+            var newsletterId = Guid.NewGuid();
+            var newsletter = new Newsletter { Id = newsletterId, Status = NewsletterStatus.Draft };
+
+            newsletterManager
+                .Setup(m => m.GetAsync(newsletterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newsletter);
+
+            newsletterManager
+                .Setup(m => m.DeleteAsync(newsletterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.DeleteNewsletter(newsletterId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteNewsletter_ReturnsBadRequest_WhenNotDraft()
+        {
+            var newsletterId = Guid.NewGuid();
+            var newsletter = new Newsletter { Id = newsletterId, Status = "Sent" };
+
+            newsletterManager
+                .Setup(m => m.GetAsync(newsletterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(newsletter);
+
+            var result = await controller.DeleteNewsletter(newsletterId, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/PrivoWebhooksV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/PrivoWebhooksV2ControllerTests.cs
@@ -1,0 +1,35 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models.Poco;
+    using Xunit;
+
+    public class PrivoWebhooksV2ControllerTests
+    {
+        private readonly Mock<ILogger<PrivoWebhooksV2Controller>> logger = new();
+        private readonly PrivoWebhooksV2Controller controller;
+
+        public PrivoWebhooksV2ControllerTests()
+        {
+            controller = new PrivoWebhooksV2Controller(logger.Object);
+        }
+
+        [Fact]
+        public void ProcessConsentEvent_ReturnsOk()
+        {
+            var consentEvent = new PrivoConsentEvent
+            {
+                EventType = "consent_granted",
+                ConsentRequestId = "req-123",
+                Status = "granted",
+            };
+
+            var result = controller.ProcessConsentEvent(consentEvent);
+
+            Assert.IsType<OkResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/RouteSimulationV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/RouteSimulationV2ControllerTests.cs
@@ -1,0 +1,74 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using Xunit;
+
+    public class RouteSimulationV2ControllerTests
+    {
+        private readonly Mock<IEventAttendeeRouteManager> routeManager = new();
+        private readonly Mock<IKeyedRepository<Event>> eventRepository = new();
+        private readonly Mock<ILogger<RouteSimulationV2Controller>> logger = new();
+        private readonly RouteSimulationV2Controller controller;
+        private readonly Guid userId = Guid.NewGuid();
+
+        public RouteSimulationV2ControllerTests()
+        {
+            controller = new RouteSimulationV2Controller(routeManager.Object, eventRepository.Object, logger.Object);
+
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity([], "Bearer")),
+            };
+            httpContext.Items["UserId"] = userId.ToString();
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task GenerateSimulatedRoute_ReturnsNotFound_WhenEventNotFound()
+        {
+            var eventId = Guid.NewGuid();
+
+            eventRepository
+                .Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Event)null);
+
+            controller.ControllerContext.HttpContext.Request.Host = new HostString("localhost");
+
+            var result = await controller.GenerateSimulatedRoute(eventId, cancellationToken: CancellationToken.None);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GenerateSimulatedRoute_ReturnsNotFound_OnProductionHost()
+        {
+            var eventId = Guid.NewGuid();
+            var eventData = new Event { Id = eventId, Name = "Test Event" };
+
+            eventRepository
+                .Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(eventData);
+
+            controller.ControllerContext.HttpContext.Request.Host = new HostString("www.trashmob.eco");
+
+            var result = await controller.GenerateSimulatedRoute(eventId, cancellationToken: CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/SecretsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/SecretsV2ControllerTests.cs
@@ -1,0 +1,50 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using Xunit;
+
+    public class SecretsV2ControllerTests
+    {
+        private readonly Mock<ISecretRepository> secretRepository = new();
+        private readonly Mock<ILogger<SecretsV2Controller>> logger = new();
+        private readonly SecretsV2Controller controller;
+
+        public SecretsV2ControllerTests()
+        {
+            controller = new SecretsV2Controller(secretRepository.Object, logger.Object);
+
+            var userId = Guid.NewGuid();
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity([], "Bearer")),
+            };
+            httpContext.Items["UserId"] = userId.ToString();
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext,
+            };
+        }
+
+        [Fact]
+        public async Task GetSecret_ReturnsOk_WithSecretValue()
+        {
+            secretRepository
+                .Setup(r => r.Get("test-name"))
+                .Returns("test-value");
+
+            var result = await controller.GetSecret("test-name");
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("test-value", okResult.Value);
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/AuthenticationV2Controller.cs
+++ b/TrashMob/Controllers/V2/AuthenticationV2Controller.cs
@@ -1,0 +1,189 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for Active Directory authentication operations.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/authentication")]
+    public class AuthenticationV2Controller(
+        IActiveDirectoryManager activeDirectoryManager,
+        ILogger<AuthenticationV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Validates whether a new user can be created in Active Directory.
+        /// </summary>
+        /// <param name="request">The new user details to validate.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>OK if valid, 409 if validation error, 500 if failed.</returns>
+        [HttpPost("validateuser")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ActiveDirectoryValidationFailedResponse), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ActiveDirectoryBlockingResponse), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> ValidateUser([FromBody] ActiveDirectoryValidateNewUserRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ValidateUser request received for email: {Email}", request?.email);
+
+            var createResponse = await activeDirectoryManager.ValidateNewUserAsync(request, cancellationToken);
+
+            return createResponse.action switch
+            {
+                "ValidationError" => Conflict(new ActiveDirectoryValidationFailedResponse
+                {
+                    action = createResponse.action,
+                    version = createResponse.version,
+                    userMessage = (createResponse as ActiveDirectoryValidationFailedResponse)?.userMessage,
+                    status = ((int)StatusCodes.Status409Conflict).ToString()
+                }),
+                "Failed" => StatusCode(StatusCodes.Status500InternalServerError, createResponse as ActiveDirectoryBlockingResponse),
+                _ => Ok()
+            };
+        }
+
+        /// <summary>
+        /// Creates a new user in Active Directory.
+        /// </summary>
+        /// <param name="request">The new user details used to create the account.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>OK if created, 409 if validation error, 500 if failed.</returns>
+        [HttpPost("signupuser")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ActiveDirectoryValidationFailedResponse), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ActiveDirectoryBlockingResponse), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> SignUpUser([FromBody] ActiveDirectoryNewUserRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SignUpUser request received for email: {Email}", request?.email);
+
+            var createResponse = await activeDirectoryManager.CreateUserAsync(request, cancellationToken);
+
+            return createResponse.action switch
+            {
+                "ValidationError" => Conflict(new ActiveDirectoryValidationFailedResponse
+                {
+                    action = createResponse.action,
+                    version = createResponse.version,
+                    userMessage = (createResponse as ActiveDirectoryValidationFailedResponse)?.userMessage,
+                    status = ((int)StatusCodes.Status409Conflict).ToString()
+                }),
+                "Failed" => StatusCode(StatusCodes.Status500InternalServerError, createResponse as ActiveDirectoryBlockingResponse),
+                _ => Ok()
+            };
+        }
+
+        /// <summary>
+        /// Validates updates to an existing user's profile in Active Directory.
+        /// </summary>
+        /// <param name="request">The updated user profile details to validate.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>OK if valid, 404 if user not found, 409 if validation error, 500 if failed.</returns>
+        [HttpPost("validateuserprofile")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ActiveDirectoryValidationFailedResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ActiveDirectoryValidationFailedResponse), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ActiveDirectoryBlockingResponse), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> ValidateUserProfile([FromBody] ActiveDirectoryUpdateUserProfileRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ValidateUserProfile request received for objectId: {ObjectId}", request?.objectId);
+
+            var validateResponse = await activeDirectoryManager.ValidateUpdateUserProfileAsync(request, cancellationToken);
+
+            return validateResponse.action switch
+            {
+                "UserNotFound" => NotFound(validateResponse as ActiveDirectoryValidationFailedResponse),
+                "ValidationError" => Conflict(new ActiveDirectoryValidationFailedResponse
+                {
+                    action = validateResponse.action,
+                    version = validateResponse.version,
+                    userMessage = (validateResponse as ActiveDirectoryValidationFailedResponse)?.userMessage,
+                    status = ((int)StatusCodes.Status409Conflict).ToString()
+                }),
+                "Failed" => StatusCode(StatusCodes.Status500InternalServerError, validateResponse as ActiveDirectoryBlockingResponse),
+                _ => Ok()
+            };
+        }
+
+        /// <summary>
+        /// Updates an existing user's profile in Active Directory.
+        /// </summary>
+        /// <param name="request">The updated user profile details.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>OK if updated, 404 if user not found, 409 if validation error, 500 if failed.</returns>
+        [HttpPost("updateuserprofile")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ActiveDirectoryValidationFailedResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ActiveDirectoryValidationFailedResponse), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ActiveDirectoryBlockingResponse), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> UpdateUserProfile([FromBody] ActiveDirectoryUpdateUserProfileRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateUserProfile request received for objectId: {ObjectId}", request?.objectId);
+
+            var updateResponse = await activeDirectoryManager.UpdateUserProfileAsync(request, cancellationToken);
+
+            return updateResponse.action switch
+            {
+                "UserNotFound" => NotFound(updateResponse as ActiveDirectoryValidationFailedResponse),
+                "ValidationError" => Conflict(new ActiveDirectoryValidationFailedResponse
+                {
+                    action = updateResponse.action,
+                    version = updateResponse.version,
+                    userMessage = (updateResponse as ActiveDirectoryValidationFailedResponse)?.userMessage,
+                    status = ((int)StatusCodes.Status409Conflict).ToString()
+                }),
+                "Failed" => StatusCode(StatusCodes.Status500InternalServerError, updateResponse as ActiveDirectoryBlockingResponse),
+                _ => Ok()
+            };
+        }
+
+        /// <summary>
+        /// Deletes a user from Active Directory.
+        /// </summary>
+        /// <param name="request">The request containing the object ID of the user to delete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>OK if deleted or user not found, 500 if failed.</returns>
+        [HttpPost("deleteuser")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ActiveDirectoryValidationFailedResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ActiveDirectoryBlockingResponse), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> DeleteUser([FromBody] ActiveDirectoryDeleteUserRequest request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 Deleting User with objectId {ObjectId}", request?.objectId);
+
+            try
+            {
+                var deleteResponse = await activeDirectoryManager.DeleteUserAsync(request.objectId, cancellationToken);
+
+                return deleteResponse.action switch
+                {
+                    "UserNotFound" => Ok(deleteResponse as ActiveDirectoryValidationFailedResponse),
+                    _ => Ok(deleteResponse)
+                };
+            }
+            catch (Exception ex)
+            {
+                var blockingResponse = new ActiveDirectoryBlockingResponse
+                {
+                    action = "Failed",
+                    version = "1.0.0",
+                    userMessage = "User failed to delete.",
+                };
+
+                logger.LogError(ex, "V2 User with objectId {ObjectId} failed to delete. Message: {Message}, InnerException: {InnerException}",
+                    request?.objectId, ex.Message, ex.InnerException);
+
+                return StatusCode(StatusCodes.Status500InternalServerError, blockingResponse);
+            }
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/ConfigV2Controller.cs
+++ b/TrashMob/Controllers/V2/ConfigV2Controller.cs
@@ -1,0 +1,89 @@
+namespace TrashMob.Controllers.V2
+{
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// V2 controller for retrieving client-side configuration settings.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/config")]
+    public class ConfigV2Controller(
+        IConfiguration configuration,
+        ILogger<ConfigV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets client-side configuration settings including Application Insights
+        /// and Azure AD Entra External ID settings for authentication.
+        /// </summary>
+        /// <returns>Configuration object with instrumentation key and Entra settings.</returns>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public IActionResult GetConfig()
+        {
+            logger.LogInformation("V2 GetConfig");
+
+            var connectionString = configuration["ApplicationInsights:ConnectionString"];
+
+            // Extract instrumentation key from connection string
+            // Format: InstrumentationKey=xxx;IngestionEndpoint=xxx;LiveEndpoint=xxx
+            string instrumentationKey = null;
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                foreach (var part in connectionString.Split(';'))
+                {
+                    if (part.StartsWith("InstrumentationKey="))
+                    {
+                        instrumentationKey = part.Substring("InstrumentationKey=".Length);
+                        break;
+                    }
+                }
+            }
+
+            var entraInstance = configuration["AzureAdEntra:Instance"]?.TrimEnd('/');
+            var entraDomain = configuration["AzureAdEntra:Domain"];
+            var entraFrontendClientId = configuration["AzureAdEntra:FrontendClientId"];
+            var entraTenantId = configuration["AzureAdEntra:TenantId"];
+
+            string authority = null;
+            string authorityDomain = null;
+
+            if (!string.IsNullOrWhiteSpace(entraInstance) && !string.IsNullOrWhiteSpace(entraTenantId))
+            {
+                // Entra External ID authority: https://{tenant}.ciamlogin.com/{tenantId}
+                authority = $"{entraInstance}/{entraTenantId}";
+
+                if (entraInstance.StartsWith("https://"))
+                {
+                    authorityDomain = entraInstance.Substring("https://".Length);
+                }
+            }
+
+            return Ok(new
+            {
+                applicationInsightsKey = instrumentationKey,
+                authProvider = "entra",
+                azureAdEntra = new
+                {
+                    clientId = entraFrontendClientId,
+                    authorityDomain,
+                    authority,
+                    scopes = entraDomain is not null
+                        ? new[]
+                        {
+                            $"https://{entraDomain}/api/TrashMob.Read",
+                            $"https://{entraDomain}/api/TrashMob.Writes",
+                            "email",
+                        }
+                        : null,
+                },
+            });
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/JobOpportunitiesV2Controller.cs
+++ b/TrashMob/Controllers/V2/JobOpportunitiesV2Controller.cs
@@ -1,0 +1,137 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing job opportunities.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/jobopportunities")]
+    public class JobOpportunitiesV2Controller(
+        IKeyedManager<JobOpportunity> jobOpportunityManager,
+        ILogger<JobOpportunitiesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets a job opportunity by its identifier.
+        /// </summary>
+        /// <param name="id">The job opportunity identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The job opportunity.</returns>
+        /// <response code="200">Returns the job opportunity.</response>
+        /// <response code="404">Job opportunity not found.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(JobOpportunityDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetJobOpportunity requested for Id={JobOpportunityId}", id);
+
+            var entity = await jobOpportunityManager.GetAsync(id, cancellationToken);
+            if (entity == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(entity.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new job opportunity. Requires admin privileges.
+        /// </summary>
+        /// <param name="dto">The job opportunity data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created job opportunity.</returns>
+        /// <response code="201">Job opportunity created successfully.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(JobOpportunityDto), StatusCodes.Status201Created)]
+        public async Task<IActionResult> Create(JobOpportunityDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CreateJobOpportunity requested by User={UserId}", UserId);
+
+            var entity = dto.ToEntity();
+            var created = await jobOpportunityManager.AddAsync(entity, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(Get), new { id = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing job opportunity. Requires admin privileges.
+        /// </summary>
+        /// <param name="id">The job opportunity identifier.</param>
+        /// <param name="dto">The updated job opportunity data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated job opportunity.</returns>
+        /// <response code="200">Job opportunity updated successfully.</response>
+        /// <response code="404">Job opportunity not found.</response>
+        [HttpPut("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(JobOpportunityDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(Guid id, JobOpportunityDto dto, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateJobOpportunity requested for Id={JobOpportunityId} by User={UserId}", id, UserId);
+
+            var existing = await jobOpportunityManager.GetAsync(id, cancellationToken);
+            if (existing == null)
+            {
+                return NotFound();
+            }
+
+            var entity = dto.ToEntity();
+            entity.Id = id;
+
+            var updated = await jobOpportunityManager.UpdateAsync(entity, UserId, cancellationToken);
+
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a job opportunity. Requires admin privileges.
+        /// </summary>
+        /// <param name="id">The job opportunity identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Job opportunity deleted successfully.</response>
+        /// <response code="404">Job opportunity not found.</response>
+        [HttpDelete("{id}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteJobOpportunity requested for Id={JobOpportunityId} by User={UserId}", id, UserId);
+
+            var existing = await jobOpportunityManager.GetAsync(id, cancellationToken);
+            if (existing == null)
+            {
+                return NotFound();
+            }
+
+            await jobOpportunityManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/NewsletterWebhooksV2Controller.cs
+++ b/TrashMob/Controllers/V2/NewsletterWebhooksV2Controller.cs
@@ -1,0 +1,81 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Controllers;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for processing SendGrid webhook events for newsletter tracking.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/webhooks/sendgrid")]
+    public class NewsletterWebhooksV2Controller(
+        INewsletterManager newsletterManager,
+        ILogger<NewsletterWebhooksV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Processes SendGrid webhook events for newsletter tracking.
+        /// </summary>
+        /// <param name="events">The list of SendGrid events.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>OK status regardless of processing outcome.</returns>
+        [HttpPost("newsletter")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<IActionResult> ProcessNewsletterEvents([FromBody] List<SendGridEvent> events, CancellationToken cancellationToken = default)
+        {
+            if (events == null || !events.Any())
+            {
+                return Ok();
+            }
+
+            logger.LogInformation("V2 Received {Count} SendGrid events", events.Count);
+
+            var eventsByNewsletter = events
+                .Where(e => e.NewsletterIdValue.HasValue)
+                .GroupBy(e => e.NewsletterIdValue.Value);
+
+            foreach (var group in eventsByNewsletter)
+            {
+                var newsletterId = group.Key;
+                var deliveredCount = group.Count(e => e.Event == "delivered");
+                var openCount = group.Count(e => e.Event == "open");
+                var clickCount = group.Count(e => e.Event == "click");
+                var bounceCount = group.Count(e => e.Event == "bounce" || e.Event == "dropped");
+                var unsubscribeCount = group.Count(e => e.Event == "unsubscribe" || e.Event == "group_unsubscribe");
+
+                try
+                {
+                    await newsletterManager.UpdateStatisticsAsync(
+                        newsletterId,
+                        deliveredCount,
+                        openCount,
+                        clickCount,
+                        bounceCount,
+                        unsubscribeCount,
+                        cancellationToken);
+
+                    logger.LogInformation(
+                        "V2 Updated newsletter {NewsletterId} stats: delivered={Delivered}, opened={Opened}, clicked={Clicked}, bounced={Bounced}, unsubscribed={Unsubscribed}",
+                        newsletterId, deliveredCount, openCount, clickCount, bounceCount, unsubscribeCount);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "V2 Failed to update statistics for newsletter {NewsletterId}", newsletterId);
+                }
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/NewslettersAdminV2Controller.cs
+++ b/TrashMob/Controllers/V2/NewslettersAdminV2Controller.cs
@@ -1,0 +1,292 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing newsletters (admin only).
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/admin/newsletters")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    public class NewslettersAdminV2Controller(
+        INewsletterManager newsletterManager,
+        ILookupRepository<NewsletterTemplate> templateRepository,
+        ILogger<NewslettersAdminV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all newsletters with optional status filter.
+        /// </summary>
+        /// <param name="status">Optional status filter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of newsletters.</returns>
+        [HttpGet]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<NewsletterDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetNewsletters([FromQuery] string status = null, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetNewsletters Status={Status}", status);
+
+            var newsletters = await newsletterManager.GetNewslettersAsync(status, cancellationToken);
+
+            return Ok(newsletters.Select(n => n.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a newsletter by ID.
+        /// </summary>
+        /// <param name="id">The newsletter ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The newsletter.</returns>
+        [HttpGet("{id}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(NewsletterDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetNewsletter(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetNewsletter Id={Id}", id);
+
+            var newsletter = await newsletterManager.GetAsync(id, cancellationToken);
+            if (newsletter == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(newsletter.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new newsletter draft.
+        /// </summary>
+        /// <param name="request">The create newsletter request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created newsletter.</returns>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(NewsletterDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CreateNewsletter([FromBody] CreateNewsletterDto request, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 CreateNewsletter Subject={Subject}", request?.Subject);
+
+            if (string.IsNullOrWhiteSpace(request?.Subject))
+            {
+                return BadRequest("Subject is required.");
+            }
+
+            var newsletter = new Newsletter
+            {
+                CategoryId = request.CategoryId,
+                Subject = request.Subject,
+                PreviewText = request.PreviewText,
+                HtmlContent = request.HtmlContent,
+                TextContent = request.TextContent,
+                TargetType = request.TargetType ?? "All",
+                TargetId = request.TargetId,
+                Status = NewsletterStatus.Draft
+            };
+
+            var created = await newsletterManager.AddAsync(newsletter, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetNewsletter), new { id = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates an existing newsletter draft.
+        /// </summary>
+        /// <param name="id">The newsletter ID.</param>
+        /// <param name="request">The update newsletter request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated newsletter.</returns>
+        [HttpPut("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(NewsletterDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateNewsletter(Guid id, [FromBody] UpdateNewsletterDto request, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdateNewsletter Id={Id}", id);
+
+            var newsletter = await newsletterManager.GetAsync(id, cancellationToken);
+            if (newsletter == null)
+            {
+                return NotFound();
+            }
+
+            if (newsletter.Status != NewsletterStatus.Draft)
+            {
+                return BadRequest("Only draft newsletters can be updated.");
+            }
+
+            newsletter.CategoryId = request.CategoryId ?? newsletter.CategoryId;
+            newsletter.Subject = request.Subject ?? newsletter.Subject;
+            newsletter.PreviewText = request.PreviewText ?? newsletter.PreviewText;
+            newsletter.HtmlContent = request.HtmlContent ?? newsletter.HtmlContent;
+            newsletter.TextContent = request.TextContent ?? newsletter.TextContent;
+            newsletter.TargetType = request.TargetType ?? newsletter.TargetType;
+            newsletter.TargetId = request.TargetId ?? newsletter.TargetId;
+
+            var updated = await newsletterManager.UpdateAsync(newsletter, UserId, cancellationToken);
+
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Schedules a newsletter for sending at a specified date.
+        /// </summary>
+        /// <param name="id">The newsletter ID.</param>
+        /// <param name="request">The schedule request containing the scheduled date.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The scheduled newsletter.</returns>
+        [HttpPost("{id}/schedule")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(NewsletterDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> ScheduleNewsletter(Guid id, [FromBody] ScheduleNewsletterDto request, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 ScheduleNewsletter Id={Id} ScheduledDate={ScheduledDate}", id, request?.ScheduledDate);
+
+            try
+            {
+                var newsletter = await newsletterManager.ScheduleNewsletterAsync(id, request.ScheduledDate, UserId, cancellationToken);
+
+                return Ok(newsletter.ToV2Dto());
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Sends a newsletter immediately.
+        /// </summary>
+        /// <param name="id">The newsletter ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The newsletter being sent with a status message.</returns>
+        [HttpPost("{id}/send")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SendNewsletter(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 SendNewsletter Id={Id}", id);
+
+            try
+            {
+                var newsletter = await newsletterManager.SendNewsletterAsync(id, UserId, cancellationToken);
+
+                return Ok(new { message = "Newsletter queued for sending.", newsletter = newsletter.ToV2Dto() });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Sends a test email for a newsletter to specified addresses.
+        /// </summary>
+        /// <param name="id">The newsletter ID.</param>
+        /// <param name="request">The test send request containing email addresses.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Success message.</returns>
+        [HttpPost("{id}/test")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SendTestEmail(Guid id, [FromBody] TestSendNewsletterDto request, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 SendTestEmail Id={Id}", id);
+
+            if (request.Emails == null || !request.Emails.Any())
+            {
+                return BadRequest("At least one email address is required.");
+            }
+
+            try
+            {
+                await newsletterManager.SendTestEmailAsync(id, request.Emails, cancellationToken);
+
+                return Ok(new { message = $"Test email sent to {request.Emails.Count} addresses." });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Deletes a draft newsletter.
+        /// </summary>
+        /// <param name="id">The newsletter ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>No content on success.</returns>
+        [HttpDelete("{id}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteNewsletter(Guid id, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 DeleteNewsletter Id={Id}", id);
+
+            var newsletter = await newsletterManager.GetAsync(id, cancellationToken);
+            if (newsletter == null)
+            {
+                return NotFound();
+            }
+
+            if (newsletter.Status != NewsletterStatus.Draft)
+            {
+                return BadRequest("Only draft newsletters can be deleted.");
+            }
+
+            await newsletterManager.DeleteAsync(id, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Gets available newsletter templates.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of active newsletter templates.</returns>
+        [HttpGet("templates")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<NewsletterTemplateDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetTemplates(CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetTemplates");
+
+            var templates = await templateRepository.Get(t => t.IsActive == true).ToListAsync(cancellationToken);
+
+            return Ok(templates.OrderBy(t => t.DisplayOrder).Select(t => t.ToV2Dto()));
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PrivoWebhooksV2Controller.cs
+++ b/TrashMob/Controllers/V2/PrivoWebhooksV2Controller.cs
@@ -1,0 +1,48 @@
+namespace TrashMob.Controllers.V2
+{
+    using System.Threading;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+
+    /// <summary>
+    /// V2 controller for processing PRIVO consent webhook events.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/webhooks/privo")]
+    [TypeFilter(typeof(PrivoApiKeyAuthenticationFilter))]
+    public class PrivoWebhooksV2Controller(
+        ILogger<PrivoWebhooksV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Receives consent status updates from PRIVO.
+        /// </summary>
+        /// <param name="consentEvent">The consent event payload.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>200 OK on successful receipt.</returns>
+        /// <response code="200">Consent event received successfully.</response>
+        /// <response code="401">API key authentication failed.</response>
+        [HttpPost("consent")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public IActionResult ProcessConsentEvent([FromBody] PrivoConsentEvent consentEvent, CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation(
+                "V2 Received PRIVO consent event: Type={EventType}, ConsentRequestId={ConsentRequestId}, Status={Status}",
+                consentEvent.EventType,
+                consentEvent.ConsentRequestId,
+                consentEvent.Status);
+
+            // TODO: Process consent status update when PRIVO payload spec is finalized
+            // Will update DependentInvitation status based on consent result
+
+            return Ok();
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/RouteSimulationV2Controller.cs
+++ b/TrashMob/Controllers/V2/RouteSimulationV2Controller.cs
@@ -1,0 +1,192 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using NetTopologySuite.Geometries;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// V2 controller that generates simulated GPS routes for dev/QA testing. Not available in production.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/routes/simulate")]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+    public class RouteSimulationV2Controller(
+        IEventAttendeeRouteManager routeManager,
+        IKeyedRepository<Event> eventRepository,
+        ILogger<RouteSimulationV2Controller> logger) : ControllerBase
+    {
+        private static readonly HashSet<string> ProductionHosts = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "www.trashmob.eco",
+            "trashmob.eco",
+        };
+        private const double EarthRadiusMeters = 6_371_000;
+        private static readonly Random Rng = new();
+
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Generates a simulated GPS route around an event's location.
+        /// Only available in non-production environments.
+        /// </summary>
+        /// <param name="eventId">The event to simulate a route for.</param>
+        /// <param name="distanceMeters">Target total distance in meters.</param>
+        /// <param name="durationMinutes">Target duration in minutes.</param>
+        /// <param name="pointCount">Number of GPS waypoints to generate.</param>
+        /// <param name="gpsJitterMeters">GPS noise standard deviation in meters.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The generated route.</returns>
+        /// <response code="200">Returns the simulated route.</response>
+        /// <response code="404">Event not found or request made in production.</response>
+        [HttpPost("{eventId}")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(DisplayEventAttendeeRoute), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GenerateSimulatedRoute(
+            Guid eventId,
+            [FromQuery] int distanceMeters = 1000,
+            [FromQuery] int durationMinutes = 30,
+            [FromQuery] int pointCount = 50,
+            [FromQuery] int gpsJitterMeters = 3,
+            CancellationToken cancellationToken = default)
+        {
+            if (ProductionHosts.Contains(Request.Host.Host))
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 GenerateSimulatedRoute requested for Event={EventId} by User={UserId}", eventId, UserId);
+
+            var eventData = await eventRepository.GetAsync(eventId, cancellationToken);
+            if (eventData is null)
+            {
+                return NotFound($"Event {eventId} not found");
+            }
+
+            var centerLat = eventData.Latitude ?? 47.6062;
+            var centerLon = eventData.Longitude ?? -122.3321;
+
+            var coordinates = GenerateWalkingLoop(centerLat, centerLon, distanceMeters, pointCount, gpsJitterMeters);
+
+            var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+            var userPath = factory.CreateLineString(coordinates.ToArray());
+
+            var startTime = DateTimeOffset.UtcNow.AddMinutes(-durationMinutes);
+            var endTime = DateTimeOffset.UtcNow;
+
+            var route = new EventAttendeeRoute
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                UserId = UserId,
+                UserPath = userPath,
+                StartTime = startTime,
+                EndTime = endTime,
+                PrivacyLevel = "EventOnly",
+                Notes = "Simulated route for testing",
+                BagsCollected = Rng.Next(1, 6),
+                WeightCollected = Math.Round((decimal)(Rng.NextDouble() * 10 + 1), 1),
+            };
+
+            var created = await routeManager.AddAsync(route, UserId, cancellationToken);
+
+            return Ok(created.ToDisplayEventAttendeeRoute());
+        }
+
+        private static List<Coordinate> GenerateWalkingLoop(
+            double centerLat, double centerLon,
+            int totalDistanceMeters, int pointCount, int jitterMeters)
+        {
+            var stepDistance = (double)totalDistanceMeters / pointCount;
+            var bearing = Rng.NextDouble() * 360;
+            List<Coordinate> coordinates = [];
+
+            var currentLat = centerLat;
+            var currentLon = centerLon;
+            coordinates.Add(new Coordinate(currentLon, currentLat));
+
+            for (var i = 1; i < pointCount; i++)
+            {
+                var progress = (double)i / pointCount;
+
+                if (progress > 0.8)
+                {
+                    // Curve back toward start in the final 20%
+                    var targetBearing = BearingTo(currentLat, currentLon, centerLat, centerLon);
+                    bearing = bearing + (targetBearing - bearing) * 0.3;
+                }
+                else
+                {
+                    // Random walk with gentle direction changes
+                    bearing += (Rng.NextDouble() - 0.5) * 30;
+                }
+
+                var (newLat, newLon) = OffsetLatLon(currentLat, currentLon, bearing, stepDistance);
+
+                // Add GPS jitter
+                if (jitterMeters > 0)
+                {
+                    var jitterLat = (Rng.NextDouble() - 0.5) * 2 * jitterMeters / EarthRadiusMeters * (180 / Math.PI);
+                    var jitterLon = jitterLat / Math.Cos(newLat * Math.PI / 180);
+                    newLat += jitterLat;
+                    newLon += jitterLon;
+                }
+
+                coordinates.Add(new Coordinate(newLon, newLat));
+                currentLat = newLat;
+                currentLon = newLon;
+            }
+
+            return coordinates;
+        }
+
+        private static (double Lat, double Lon) OffsetLatLon(double lat, double lon, double bearingDeg, double distanceMeters)
+        {
+            var latRad = lat * Math.PI / 180;
+            var lonRad = lon * Math.PI / 180;
+            var bearingRad = bearingDeg * Math.PI / 180;
+            var angularDistance = distanceMeters / EarthRadiusMeters;
+
+            var newLatRad = Math.Asin(
+                Math.Sin(latRad) * Math.Cos(angularDistance) +
+                Math.Cos(latRad) * Math.Sin(angularDistance) * Math.Cos(bearingRad));
+
+            var newLonRad = lonRad + Math.Atan2(
+                Math.Sin(bearingRad) * Math.Sin(angularDistance) * Math.Cos(latRad),
+                Math.Cos(angularDistance) - Math.Sin(latRad) * Math.Sin(newLatRad));
+
+            return (newLatRad * 180 / Math.PI, newLonRad * 180 / Math.PI);
+        }
+
+        private static double BearingTo(double lat1, double lon1, double lat2, double lon2)
+        {
+            var lat1Rad = lat1 * Math.PI / 180;
+            var lat2Rad = lat2 * Math.PI / 180;
+            var dLonRad = (lon2 - lon1) * Math.PI / 180;
+
+            var y = Math.Sin(dLonRad) * Math.Cos(lat2Rad);
+            var x = Math.Cos(lat1Rad) * Math.Sin(lat2Rad) -
+                    Math.Sin(lat1Rad) * Math.Cos(lat2Rad) * Math.Cos(dLonRad);
+
+            return Math.Atan2(y, x) * 180 / Math.PI;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/SecretsV2Controller.cs
+++ b/TrashMob/Controllers/V2/SecretsV2Controller.cs
@@ -1,0 +1,44 @@
+namespace TrashMob.Controllers.V2
+{
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing application secrets.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/secrets")]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+    public class SecretsV2Controller(
+        ISecretRepository secretRepository,
+        ILogger<SecretsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets a secret by name. Requires a valid user.
+        /// </summary>
+        /// <param name="name">The name of the secret.</param>
+        /// <returns>The secret value.</returns>
+        /// <response code="200">Returns the secret value.</response>
+        [HttpGet("{name}")]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetSecret(string name)
+        {
+            logger.LogInformation("V2 GetSecret requested for Name={SecretName}", name);
+
+            var secret = await Task.FromResult(secretRepository.Get(name));
+            return Ok(secret);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **8 new V2 controllers** covering infrastructure, webhook, and config endpoints (Phase 2i of Project 24)
- **7 new DTOs** for newsletters (CRUD + schedule/test) and job opportunities
- **2 mapping extension files** (Newsletter/NewsletterTemplate, JobOpportunity) with bidirectional mappings
- **8 test suites, 27 tests** — all passing
- EmailInvitesV2Controller already existed from a prior phase

### Controllers created
| Controller | Endpoints | Auth | Notes |
|---|---|---|---|
| `NewslettersAdminV2Controller` | 9 | Admin | CRUD + schedule/send/test/templates |
| `NewsletterWebhooksV2Controller` | 1 | None (webhook) | SendGrid event aggregation |
| `AuthenticationV2Controller` | 5 | None (public) | AD user lifecycle |
| `ConfigV2Controller` | 1 | None (public) | Client-side config |
| `SecretsV2Controller` | 1 | ValidUser | Config secret lookup |
| `PrivoWebhooksV2Controller` | 1 | API key filter | Consent webhook (stub) |
| `JobOpportunitiesV2Controller` | 4 | Public GET, Admin CRUD | Job listings |
| `RouteSimulationV2Controller` | 1 | ValidUser | Dev/QA GPS simulation |

## Test plan
- [x] All 27 new Phase 2i tests pass
- [x] Full solution builds with 0 errors, 0 warnings
- [ ] Verify endpoints appear in Swagger UI under v2.0 doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)