### PR TITLE
Phase 3a: Migrate frontend services to v2 API endpoints

### DIFF
--- a/TrashMob/client-app/src/services/dependent-invitations.ts
+++ b/TrashMob/client-app/src/services/dependent-invitations.ts
@@ -35,7 +35,7 @@ export const VerifyDependentInvitation = (params: VerifyDependentInvitation_Para
     key: ['/dependentinvitations/verify', params.token],
     service: async () =>
         ApiService('public').fetchData<VerifyDependentInvitation_Response>({
-            url: `/dependentinvitations/verify?token=${encodeURIComponent(params.token)}`,
+            url: `/v2/dependentinvitations/verify?token=${encodeURIComponent(params.token)}`,
             method: 'get',
         }),
 });
@@ -50,7 +50,7 @@ export const GetDependentInvitations = (params: GetDependentInvitations_Params) 
     key: ['/dependentinvitations', params.userId, params.dependentId],
     service: async () =>
         ApiService('protected').fetchData<GetDependentInvitations_Response>({
-            url: `/dependentinvitations/users/${params.userId}/dependents/${params.dependentId}`,
+            url: `/v2/dependentinvitations/users/${params.userId}/dependents/${params.dependentId}`,
             method: 'get',
         }),
 });
@@ -62,7 +62,7 @@ export const CreateDependentInvitation = (params: CreateDependentInvitation_Para
     key: ['/dependentinvitations', 'create'],
     service: async (body: CreateDependentInvitation_Body) =>
         ApiService('protected').fetchData<CreateDependentInvitation_Response, CreateDependentInvitation_Body>({
-            url: `/dependentinvitations/users/${params.userId}/dependents/${params.dependentId}`,
+            url: `/v2/dependentinvitations/users/${params.userId}/dependents/${params.dependentId}`,
             method: 'post',
             data: body,
         }),
@@ -74,7 +74,7 @@ export const CancelDependentInvitation = (params: CancelDependentInvitation_Para
     key: ['/dependentinvitations', 'cancel'],
     service: async () =>
         ApiService('protected').fetchData<CancelDependentInvitation_Response>({
-            url: `/dependentinvitations/${params.invitationId}/cancel`,
+            url: `/v2/dependentinvitations/${params.invitationId}/cancel`,
             method: 'post',
         }),
 });
@@ -85,7 +85,7 @@ export const ResendDependentInvitation = (params: ResendDependentInvitation_Para
     key: ['/dependentinvitations', 'resend'],
     service: async () =>
         ApiService('protected').fetchData<ResendDependentInvitation_Response>({
-            url: `/dependentinvitations/${params.invitationId}/resend`,
+            url: `/v2/dependentinvitations/${params.invitationId}/resend`,
             method: 'post',
         }),
 });

--- a/TrashMob/client-app/src/services/dependents.ts
+++ b/TrashMob/client-app/src/services/dependents.ts
@@ -13,7 +13,7 @@ export const GetMyDependents = (params: GetMyDependents_Params) => ({
     key: ['/users', params.userId, 'dependents'],
     service: async () =>
         ApiService('protected').fetchData<GetMyDependents_Response>({
-            url: `/users/${params.userId}/dependents`,
+            url: `/v2/users/${params.userId}/dependents`,
             method: 'get',
         }),
 });
@@ -25,7 +25,7 @@ export const AddDependent = (params: AddDependent_Params) => ({
     key: ['/users', params.userId, 'dependents', 'create'],
     service: async (body: AddDependent_Body) =>
         ApiService('protected').fetchData<AddDependent_Response, AddDependent_Body>({
-            url: `/users/${params.userId}/dependents`,
+            url: `/v2/users/${params.userId}/dependents`,
             method: 'post',
             data: body,
         }),
@@ -38,7 +38,7 @@ export const UpdateDependent = (params: UpdateDependent_Params) => ({
     key: ['/users', params.userId, 'dependents', 'update'],
     service: async (body: UpdateDependent_Body) =>
         ApiService('protected').fetchData<UpdateDependent_Response, UpdateDependent_Body>({
-            url: `/users/${params.userId}/dependents/${body.id}`,
+            url: `/v2/users/${params.userId}/dependents/${body.id}`,
             method: 'put',
             data: body,
         }),
@@ -50,7 +50,7 @@ export const DeleteDependent = (params: DeleteDependent_Params) => ({
     key: ['/users', params.userId, 'dependents', 'delete'],
     service: async () =>
         ApiService('protected').fetchData<DeleteDependent_Response>({
-            url: `/users/${params.userId}/dependents/${params.dependentId}`,
+            url: `/v2/users/${params.userId}/dependents/${params.dependentId}`,
             method: 'delete',
         }),
 });
@@ -70,7 +70,7 @@ export const GetDependentCurrentWaiver = (params: GetDependentCurrentWaiver_Para
     key: ['/dependents', params.dependentId, 'waiver'],
     service: async () =>
         ApiService('protected').fetchData<GetDependentCurrentWaiver_Response>({
-            url: `/dependents/${params.dependentId}/waiver`,
+            url: `/v2/dependents/${params.dependentId}/waiver`,
             method: 'get',
         }),
 });
@@ -85,7 +85,7 @@ export const GetEventDependentCount = (params: GetEventDependentCount_Params) =>
     key: ['/events', params.eventId, 'dependents', 'count'],
     service: async () =>
         ApiService('protected').fetchData<GetEventDependentCount_Response>({
-            url: `/events/${params.eventId}/dependents/count`,
+            url: `/v2/events/${params.eventId}/dependents/count`,
             method: 'get',
         }),
 });
@@ -97,7 +97,7 @@ export const RegisterEventDependents = (params: RegisterEventDependents_Params) 
     key: ['/events', params.eventId, 'dependents', 'register'],
     service: async (body: RegisterEventDependents_Body) =>
         ApiService('protected').fetchData<RegisterEventDependents_Response, RegisterEventDependents_Body>({
-            url: `/events/${params.eventId}/dependents`,
+            url: `/v2/events/${params.eventId}/dependents`,
             method: 'post',
             data: body,
         }),
@@ -115,7 +115,7 @@ export const GetEventDependents = (params: GetEventDependents_Params) => ({
     key: ['/events', params.eventId, 'dependents'],
     service: async () =>
         ApiService('protected').fetchData<GetEventDependents_Response>({
-            url: `/events/${params.eventId}/dependents`,
+            url: `/v2/events/${params.eventId}/dependents`,
             method: 'get',
         }),
 });
@@ -126,7 +126,7 @@ export const UnregisterEventDependent = (params: UnregisterEventDependent_Params
     key: ['/events', params.eventId, 'dependents', 'unregister'],
     service: async () =>
         ApiService('protected').fetchData<UnregisterEventDependent_Response>({
-            url: `/events/${params.eventId}/dependents/${params.dependentId}`,
+            url: `/v2/events/${params.eventId}/dependents/${params.dependentId}`,
             method: 'delete',
         }),
 });

--- a/TrashMob/client-app/src/services/event-attendee-metrics.ts
+++ b/TrashMob/client-app/src/services/event-attendee-metrics.ts
@@ -16,7 +16,7 @@ export const GetMyMetrics = (params: GetMyMetrics_Params) => ({
     key: ['/events/', params.eventId, '/attendee-metrics/my-metrics'],
     service: async () =>
         ApiService('protected').fetchData<GetMyMetrics_Response>({
-            url: `/events/${params.eventId}/attendee-metrics/my-metrics`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/my-metrics`,
             method: 'get',
         }),
 });
@@ -28,7 +28,7 @@ export const SubmitMyMetrics = () => ({
     key: ['/events/attendee-metrics', 'submit'],
     service: async (params: SubmitMyMetrics_Params, body: SubmitMyMetrics_Body) =>
         ApiService('protected').fetchData<SubmitMyMetrics_Response, SubmitMyMetrics_Body>({
-            url: `/events/${params.eventId}/attendee-metrics/my-metrics`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/my-metrics`,
             method: 'post',
             data: body,
         }),
@@ -44,7 +44,7 @@ export const GetAllMetrics = (params: GetAllMetrics_Params) => ({
     key: ['/events/', params.eventId, '/attendee-metrics'],
     service: async () =>
         ApiService('protected').fetchData<GetAllMetrics_Response>({
-            url: `/events/${params.eventId}/attendee-metrics`,
+            url: `/v2/events/${params.eventId}/attendee-metrics`,
             method: 'get',
         }),
 });
@@ -55,7 +55,7 @@ export const GetPendingMetrics = (params: GetPendingMetrics_Params) => ({
     key: ['/events/', params.eventId, '/attendee-metrics/pending'],
     service: async () =>
         ApiService('protected').fetchData<GetPendingMetrics_Response>({
-            url: `/events/${params.eventId}/attendee-metrics/pending`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/pending`,
             method: 'get',
         }),
 });
@@ -66,7 +66,7 @@ export const ApproveMetrics = () => ({
     key: ['/events/attendee-metrics', 'approve'],
     service: async (params: ApproveMetrics_Params) =>
         ApiService('protected').fetchData<ApproveMetrics_Response>({
-            url: `/events/${params.eventId}/attendee-metrics/${params.metricsId}/approve`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/${params.metricsId}/approve`,
             method: 'post',
         }),
 });
@@ -78,7 +78,7 @@ export const RejectMetrics = () => ({
     key: ['/events/attendee-metrics', 'reject'],
     service: async (params: RejectMetrics_Params, body: RejectMetrics_Body) =>
         ApiService('protected').fetchData<RejectMetrics_Response, RejectMetrics_Body>({
-            url: `/events/${params.eventId}/attendee-metrics/${params.metricsId}/reject`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/${params.metricsId}/reject`,
             method: 'post',
             data: body,
         }),
@@ -97,7 +97,7 @@ export const AdjustMetrics = () => ({
     key: ['/events/attendee-metrics', 'adjust'],
     service: async (params: AdjustMetrics_Params, body: AdjustMetrics_Body) =>
         ApiService('protected').fetchData<AdjustMetrics_Response, AdjustMetrics_Body>({
-            url: `/events/${params.eventId}/attendee-metrics/${params.metricsId}/adjust`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/${params.metricsId}/adjust`,
             method: 'put',
             data: body,
         }),
@@ -109,7 +109,7 @@ export const ApproveAllPending = () => ({
     key: ['/events/attendee-metrics', 'approve-all'],
     service: async (params: ApproveAllPending_Params) =>
         ApiService('protected').fetchData<ApproveAllPending_Response>({
-            url: `/events/${params.eventId}/attendee-metrics/approve-all`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/approve-all`,
             method: 'post',
         }),
 });
@@ -120,7 +120,7 @@ export const GetMetricsTotals = (params: GetMetricsTotals_Params) => ({
     key: ['/events/', params.eventId, '/attendee-metrics/totals'],
     service: async () =>
         ApiService('protected').fetchData<GetMetricsTotals_Response>({
-            url: `/events/${params.eventId}/attendee-metrics/totals`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/totals`,
             method: 'get',
         }),
 });
@@ -135,7 +135,7 @@ export const GetPublicMetrics = (params: GetPublicMetrics_Params) => ({
     key: ['/events/', params.eventId, '/attendee-metrics/public'],
     service: async () =>
         ApiService('public').fetchData<GetPublicMetrics_Response>({
-            url: `/events/${params.eventId}/attendee-metrics/public`,
+            url: `/v2/events/${params.eventId}/attendee-metrics/public`,
             method: 'get',
         }),
 });
@@ -146,7 +146,7 @@ export const GetUserImpact = (params: GetUserImpact_Params) => ({
     key: ['/users/', params.userId, '/impact'],
     service: async () =>
         ApiService('protected').fetchData<GetUserImpact_Response>({
-            url: `/users/${params.userId}/impact`,
+            url: `/v2/users/${params.userId}/impact`,
             method: 'get',
         }),
 });

--- a/TrashMob/client-app/src/services/event-litter-reports.ts
+++ b/TrashMob/client-app/src/services/event-litter-reports.ts
@@ -7,7 +7,7 @@ export const GetEventLitterReports = (params: GetEventLitterReports_Params) => (
     key: ['/eventlitterreports', params.eventId],
     service: async () =>
         ApiService('protected').fetchData<GetEventLitterReports_Response>({
-            url: `/eventlitterreports/${params.eventId}`,
+            url: `/v2/eventlitterreports/by-event/${params.eventId}`,
             method: 'get',
         }),
 });
@@ -21,7 +21,7 @@ export const AddEventLitterReport = () => ({
     key: ['/eventlitterreports', 'add'],
     service: async (params: AddEventLitterReport_Params) =>
         ApiService('protected').fetchData<void>({
-            url: '/eventlitterreports',
+            url: '/v2/eventlitterreports',
             method: 'post',
             data: {
                 eventId: params.eventId,
@@ -36,7 +36,7 @@ export const DeleteEventLitterReport = (params: DeleteEventLitterReport_Params) 
     key: ['/eventlitterreports', 'delete', params.eventId, params.litterReportId],
     service: async () =>
         ApiService('protected').fetchData<void>({
-            url: `/eventlitterreports/${params.eventId}/${params.litterReportId}`,
+            url: `/v2/eventlitterreports/${params.eventId}/${params.litterReportId}`,
             method: 'delete',
         }),
 });

--- a/TrashMob/client-app/src/services/event-photos.ts
+++ b/TrashMob/client-app/src/services/event-photos.ts
@@ -21,7 +21,7 @@ export const GetEventPhotos = (params: GetEventPhotos_Params) => ({
         }
         const queryString = queryParams.toString();
         return ApiService('public').fetchData<GetEventPhotos_Response>({
-            url: `/events/${params.eventId}/photos${queryString ? `?${queryString}` : ''}`,
+            url: `/v2/events/${params.eventId}/photos${queryString ? `?${queryString}` : ''}`,
             method: 'get',
         });
     },
@@ -37,7 +37,7 @@ export const GetEventPhoto = (params: GetEventPhoto_Params) => ({
     key: ['/events', params.eventId, 'photos', params.photoId],
     service: async () =>
         ApiService('public').fetchData<GetEventPhoto_Response>({
-            url: `/events/${params.eventId}/photos/${params.photoId}`,
+            url: `/v2/events/${params.eventId}/photos/${params.photoId}`,
             method: 'get',
         }),
 });
@@ -54,7 +54,7 @@ export const UploadEventPhoto = () => ({
         const formData = new FormData();
         formData.append('formFile', file);
         return ApiService('protected').fetchData<UploadEventPhoto_Response>({
-            url: `/events/${params.eventId}/photos`,
+            url: `/v2/events/${params.eventId}/photos`,
             method: 'post',
             data: formData,
             headers: {
@@ -78,7 +78,7 @@ export const UpdateEventPhoto = () => ({
     key: ['/events/photos', 'update'],
     service: async (params: UpdateEventPhoto_Params, body: UpdateEventPhoto_Body) =>
         ApiService('protected').fetchData<UpdateEventPhoto_Response, UpdateEventPhoto_Body>({
-            url: `/events/${params.eventId}/photos/${params.photoId}`,
+            url: `/v2/events/${params.eventId}/photos/${params.photoId}`,
             method: 'put',
             data: body,
         }),
@@ -94,7 +94,7 @@ export const DeleteEventPhoto = () => ({
     key: ['/events/photos', 'delete'],
     service: async (params: DeleteEventPhoto_Params) =>
         ApiService('protected').fetchData<DeleteEventPhoto_Response>({
-            url: `/events/${params.eventId}/photos/${params.photoId}`,
+            url: `/v2/events/${params.eventId}/photos/${params.photoId}`,
             method: 'delete',
         }),
 });
@@ -110,7 +110,7 @@ export const FlagEventPhoto = () => ({
     key: ['/events/photos', 'flag'],
     service: async (params: FlagEventPhoto_Params, body: FlagEventPhoto_Body) =>
         ApiService('protected').fetchData<FlagEventPhoto_Response, FlagEventPhoto_Body>({
-            url: `/events/${params.eventId}/photos/${params.photoId}/flag`,
+            url: `/v2/events/${params.eventId}/photos/${params.photoId}/flag`,
             method: 'post',
             data: body,
         }),

--- a/TrashMob/client-app/src/services/event-routes.ts
+++ b/TrashMob/client-app/src/services/event-routes.ts
@@ -14,7 +14,7 @@ export const GetEventRoutes = (params: GetEventRoutes_Params) => ({
     key: ['/events/', params.eventId, '/routes'],
     service: async () =>
         ApiService('public').fetchData<GetEventRoutes_Response>({
-            url: `/events/${params.eventId}/routes`,
+            url: `/v2/events/${params.eventId}/routes`,
             method: 'get',
         }),
 });
@@ -25,7 +25,7 @@ export const GetEventRouteStats = (params: GetEventRouteStats_Params) => ({
     key: ['/events/', params.eventId, '/routes/stats'],
     service: async () =>
         ApiService('public').fetchData<GetEventRouteStats_Response>({
-            url: `/events/${params.eventId}/routes/stats`,
+            url: `/v2/events/${params.eventId}/routes/stats`,
             method: 'get',
         }),
 });
@@ -35,7 +35,7 @@ export const GetMyRoutes = () => ({
     key: ['/users/me/routes'],
     service: async () =>
         ApiService('protected').fetchData<GetMyRoutes_Response>({
-            url: '/users/me/routes',
+            url: '/v2/users/me/routes',
             method: 'get',
         }),
 });
@@ -45,7 +45,7 @@ export type TrimRouteTime_Response = DisplayEventAttendeeRoute;
 export const TrimRouteTime = (params: TrimRouteTime_Params) => ({
     service: async () =>
         ApiService('protected').fetchData<TrimRouteTime_Response>({
-            url: `/routes/${params.routeId}/trim-time`,
+            url: `/v2/eventattendeeroutes/${params.routeId}/trim-time`,
             method: 'put',
             data: { newEndTime: params.newEndTime },
         }),
@@ -56,7 +56,7 @@ export type RestoreRouteTime_Response = DisplayEventAttendeeRoute;
 export const RestoreRouteTime = (params: RestoreRouteTime_Params) => ({
     service: async () =>
         ApiService('protected').fetchData<RestoreRouteTime_Response>({
-            url: `/routes/${params.routeId}/restore-time`,
+            url: `/v2/eventattendeeroutes/${params.routeId}/restore-time`,
             method: 'put',
         }),
 });
@@ -67,7 +67,7 @@ export const GetEventSummaryPrefill = (params: GetEventSummaryPrefill_Params) =>
     key: ['/events/', params.eventId, '/routes/summary-prefill'],
     service: async () =>
         ApiService('protected').fetchData<GetEventSummaryPrefill_Response>({
-            url: `/events/${params.eventId}/routes/summary-prefill?weightUnitId=${params.weightUnitId ?? 1}`,
+            url: `/v2/events/${params.eventId}/routes/summary-prefill?weightUnitId=${params.weightUnitId ?? 1}`,
             method: 'get',
         }),
 });
@@ -78,7 +78,7 @@ export const GetEventAttendeeRoutesByEventId = (params: GetEventAttendeeRoutesBy
     key: ['/eventattendeeroutes/byeventid/', params.eventId],
     service: async () =>
         ApiService('protected').fetchData<GetEventAttendeeRoutesByEventId_Response>({
-            url: `/eventattendeeroutes/byeventid/${params.eventId}`,
+            url: `/v2/eventattendeeroutes/by-event/${params.eventId}`,
             method: 'get',
         }),
 });
@@ -87,7 +87,7 @@ export type UpdateRouteMetadata_Params = { routeId: string };
 export const UpdateRouteMetadata = (params: UpdateRouteMetadata_Params) => ({
     service: async (data: UpdateRouteMetadataRequest) =>
         ApiService('protected').fetchData<DisplayEventAttendeeRoute>({
-            url: `/routes/${params.routeId}`,
+            url: `/v2/eventattendeeroutes/${params.routeId}`,
             method: 'put',
             data,
         }),
@@ -97,7 +97,7 @@ export type DeleteEventAttendeeRoute_Params = { routeId: string };
 export const DeleteEventAttendeeRoute = (params: DeleteEventAttendeeRoute_Params) => ({
     service: async () =>
         ApiService('protected').fetchData<void>({
-            url: `/eventattendeeroutes/${params.routeId}`,
+            url: `/v2/eventattendeeroutes/${params.routeId}`,
             method: 'delete',
         }),
 });

--- a/TrashMob/client-app/src/services/events.ts
+++ b/TrashMob/client-app/src/services/events.ts
@@ -17,7 +17,7 @@ export const GetEventTypes = () => ({
     key: ['/eventtypes'],
     service: async () =>
         ApiService('public').fetchData<GetEventTypes_Response>({
-            url: '/eventtypes',
+            url: '/v2/lookups/event-types',
             method: 'get',
         }),
 });
@@ -36,7 +36,7 @@ export const GetFilteredEvents = (params: GetFilteredEvents_Params) => ({
     key: ['/events/filteredevents', params],
     service: () => {
         return ApiService('public').fetchData<GetFilteredEvents_Response>({
-            url: '/events/filteredevents',
+            url: '/v2/events/pagedfilteredevents',
             method: 'post',
             data: params,
         });
@@ -48,7 +48,7 @@ export const GetAllEvents = () => ({
     key: ['/events'],
     service: async () =>
         ApiService('protected').fetchData<GetAllEvents_Response>({
-            url: '/events',
+            url: '/v2/events',
             method: 'get',
         }),
 });
@@ -89,7 +89,7 @@ export const GetAllEventsBeingAttendedByUser = (params: GetAllEventsBeingAttende
     key: ['/events/eventsuserisattending/', params],
     service: async () =>
         ApiService('protected').fetchData<GetAllEventsBeingAttendedByUser_Response>({
-            url: `/events/eventsuserisattending/${params.userId}`,
+            url: `/v2/events/eventsuserisattending/${params.userId}`,
             method: 'get',
         }),
 });
@@ -116,7 +116,7 @@ export const GetEventById = (params: GetEventById_Params) => ({
     key: ['/Events/', params],
     service: async () =>
         ApiService('public').fetchData<GetEventById_Response>({
-            url: `/Events/${params.eventId}`,
+            url: `/v2/events/${params.eventId}`,
             method: 'get',
         }),
 });
@@ -127,7 +127,7 @@ export const CreateEvent = () => ({
     key: ['/Events', 'create'],
     service: async (body: CreateEvent_Body) =>
         ApiService('protected').fetchData<CreateEvent_Response, CreateEvent_Body>({
-            url: '/Events',
+            url: '/v2/events',
             method: 'post',
             data: body,
         }),
@@ -139,7 +139,7 @@ export const UpdateEvent = () => ({
     key: ['/Events', 'update'],
     service: async (body: UpdateEvent_Body) =>
         ApiService('protected').fetchData<UpdateEvent_Response, UpdateEvent_Body>({
-            url: '/Events',
+            url: '/v2/events',
             method: 'put',
             data: body,
         }),
@@ -151,7 +151,7 @@ export const DeleteEvent = () => ({
     key: ['/Events', 'delete'],
     service: async (body: DeleteEvent_Body) =>
         ApiService('protected').fetchData<DeleteEvent_Response, DeleteEvent_Body>({
-            url: '/Events',
+            url: '/v2/events',
             method: 'delete',
             data: body,
         }),
@@ -163,7 +163,7 @@ export const GetEventSummaryById = (params: GetEventSummaryById_Params) => ({
     key: ['/eventsummaries/', params],
     service: async () =>
         ApiService('public').fetchData<GetEventSummaryById_Response>({
-            url: `/eventsummaries/${params.eventId}`,
+            url: `/v2/events/${params.eventId}/summary`,
             method: 'get',
         }),
 });
@@ -174,7 +174,7 @@ export const CreateEventSummary = () => ({
     key: ['/eventsummaries', 'create'],
     service: async (body: CreateEventSummary_Body) =>
         ApiService('protected').fetchData<CreateEventSummary_Response, CreateEventSummary_Body>({
-            url: '/eventsummaries',
+            url: `/v2/events/${body.eventId}/summary`,
             method: 'post',
             data: body,
         }),
@@ -186,7 +186,7 @@ export const UpdateEventSummary = () => ({
     key: ['/eventsummaries', 'update'],
     service: async (body: UpdateEventSummary_Body) =>
         ApiService('protected').fetchData<UpdateEventSummary_Response, UpdateEventSummary_Body>({
-            url: '/eventsummaries',
+            url: `/v2/events/${body.eventId}/summary`,
             method: 'put',
             data: body,
         }),
@@ -198,7 +198,7 @@ export const GetEventAttendees = (params: GetEventAttendees_Params) => ({
     key: ['/eventattendees', params.eventId],
     service: async () =>
         ApiService('protected').fetchData<GetEventAttendees_Response>({
-            url: `/eventattendees/${params.eventId}`,
+            url: `/v2/events/${params.eventId}/attendees`,
             method: 'get',
         }),
 });
@@ -209,7 +209,7 @@ export const AddEventAttendee = () => ({
     key: ['/EventAttendees', 'add'],
     service: async (body: AddEventAttendee_Body) =>
         ApiService('protected').fetchData<AddEventAttendee_Response, AddEventAttendee_Body>({
-            url: '/EventAttendees',
+            url: `/v2/events/${body.eventId}/attendees`,
             method: 'post',
             data: body,
         }),
@@ -221,7 +221,7 @@ export const DeleteEventAttendee = () => ({
     key: ['/EventAttendees/', 'delete'],
     service: async (params: DeleteEventAttendee_Params) =>
         ApiService('protected').fetchData<DeleteEventAttendee_Response>({
-            url: `/EventAttendees/${params.eventId}/${params.userId}`,
+            url: `/v2/events/${params.eventId}/attendees/${params.userId}`,
             method: 'delete',
         }),
 });
@@ -232,7 +232,7 @@ export const GetUserEvents = (params: GetUserEvents_Params) => ({
     key: ['/events/userevents/', params, '/false'],
     service: async () =>
         ApiService('protected').fetchData<GetUserEvents_Response>({
-            url: `/events/userevents/${params.userId}/false`,
+            url: `/v2/events/userevents/${params.userId}/false`,
             method: 'get',
         }),
 });
@@ -244,7 +244,7 @@ export const GetEventLeads = (params: GetEventLeads_Params) => ({
     key: ['/eventattendees', params.eventId, 'leads'],
     service: async () =>
         ApiService('protected').fetchData<GetEventLeads_Response>({
-            url: `/eventattendees/${params.eventId}/leads`,
+            url: `/v2/events/${params.eventId}/attendees/leads`,
             method: 'get',
         }),
 });
@@ -255,7 +255,7 @@ export const PromoteToLead = () => ({
     key: ['/eventattendees', 'promote'],
     service: async (params: PromoteToLead_Params) =>
         ApiService('protected').fetchData<PromoteToLead_Response>({
-            url: `/eventattendees/${params.eventId}/${params.userId}/promote`,
+            url: `/v2/events/${params.eventId}/attendees/${params.userId}/promote`,
             method: 'put',
         }),
 });
@@ -266,7 +266,7 @@ export const DemoteFromLead = () => ({
     key: ['/eventattendees', 'demote'],
     service: async (params: DemoteFromLead_Params) =>
         ApiService('protected').fetchData<DemoteFromLead_Response>({
-            url: `/eventattendees/${params.eventId}/${params.userId}/demote`,
+            url: `/v2/events/${params.eventId}/attendees/${params.userId}/demote`,
             method: 'put',
         }),
 });
@@ -280,7 +280,7 @@ export const VerifyAttendeeWaiverStatus = (params: VerifyAttendeeWaiverStatus_Pa
     key: ['/eventattendees', params.eventId, 'attendees', params.userId, 'waiver-status'],
     service: async () =>
         ApiService('protected').fetchData<VerifyAttendeeWaiverStatus_Response>({
-            url: `/eventattendees/${params.eventId}/attendees/${params.userId}/waiver-status`,
+            url: `/v2/events/${params.eventId}/attendees/${params.userId}/waiver-status`,
             method: 'get',
         }),
 });

--- a/TrashMob/client-app/src/services/users.ts
+++ b/TrashMob/client-app/src/services/users.ts
@@ -6,7 +6,7 @@ export const GetAllUsers = () => ({
     key: ['/users', 'all users'],
     service: async () =>
         ApiService('protected').fetchData<GetAllUsers_Response>({
-            url: '/users',
+            url: '/v2/users',
             method: 'get',
         }),
 });
@@ -17,7 +17,7 @@ export const GetUserById = (params: GetUserById_Params) => ({
     key: ['/Users', params],
     service: async () =>
         ApiService('protected').fetchData<GetUserById_Response>({
-            url: `/Users/${params.userId}`,
+            url: `/v2/users/${params.userId}`,
             method: 'get',
         }),
 });
@@ -28,7 +28,7 @@ export const GetUserByEmail = (params: GetUserByEmail_Params) => ({
     key: ['/Users/getuserbyemail', params],
     service: async () =>
         ApiService('protected').fetchData<GetUserByEmail_Response>({
-            url: `/Users/getuserbyemail/${encodeURIComponent(params.email)}`,
+            url: `/v2/users/getuserbyemail/${encodeURIComponent(params.email)}`,
             method: 'get',
         }),
 });
@@ -39,7 +39,7 @@ export const GetUserByObjectId = (params: GetUserByObjectId_Params) => ({
     key: ['/Users/getbyobjectid', params],
     service: async () =>
         ApiService('protected').fetchData<GetUserByObjectId_Response>({
-            url: `/Users/getbyobjectid/${params.objectId}`,
+            url: `/v2/users/getbyobjectid/${params.objectId}`,
             method: 'get',
         }),
 });
@@ -50,7 +50,7 @@ export const UpdateUser = () => ({
     key: ['/users', 'update'],
     service: async (body: UpdateUser_Body) =>
         ApiService('protected').fetchData<UpdateUser_Response, UpdateUser_Body>({
-            url: '/users',
+            url: '/v2/users',
             method: 'put',
             data: body,
         }),
@@ -74,7 +74,7 @@ export const UploadProfilePhoto = () => ({
         const formData = new FormData();
         formData.append('formFile', file);
         return ApiService('protected').fetchData<UploadProfilePhoto_Response>({
-            url: '/users/photo',
+            url: '/v2/users/photo',
             method: 'post',
             data: formData,
             headers: {


### PR DESCRIPTION
## Summary
- Migrates 8 React service files from v1 to v2 API URL paths as part of Project 24 (API v2 Modernization) Phase 3a
- Updates ~70 endpoints across events, attendees, summaries, routes, photos, metrics, dependents, and users
- Restructures nested resource routes (e.g., `/eventattendees/{id}` → `/v2/events/{id}/attendees`)
- Consolidates lookup endpoints under `/v2/lookups/` (e.g., `/eventtypes` → `/v2/lookups/event-types`)
- Endpoints without v2 equivalents remain on v1 (GetAllActiveEvents, GetAllCompletedEvents, VerifyUniqueUserName, etc.)

### Files changed
| Service file | Endpoints migrated | Key changes |
|---|---|---|
| `dependent-invitations.ts` | 5 | Simple `/v2` prefix |
| `dependents.ts` | 9 | 3 controller groups (profile, waiver, event) |
| `event-litter-reports.ts` | 3 | Path rename `byeventid` → `by-event` |
| `event-attendee-metrics.ts` | 12 | Simple `/v2` prefix |
| `event-photos.ts` | 6 | Simple `/v2` prefix |
| `event-routes.ts` | 9 | Split across EventRoutes + EventAttendeeRoutes v2 controllers |
| `events.ts` | 20/26 | Nested resources for attendees/summaries/leads; 6 stay v1 |
| `users.ts` | 6/9 | 3 stay v1 (verify unique, export, delete) |

## Test plan
- [ ] Verify `npm run build` passes (confirmed locally — no type errors)
- [ ] Verify `npm run check` passes (confirmed locally — lint + prettier clean)
- [ ] Smoke test event CRUD flow against dev API
- [ ] Smoke test event summary creation/update
- [ ] Smoke test attendee registration/unregistration
- [ ] Smoke test route tracking and trim/restore
- [ ] Smoke test user profile update and photo upload
- [ ] Verify endpoints left on v1 still function (active/completed events lists, username verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)