### PR TITLE
Fix v2 DTOs to match frontend TypeScript models

### DIFF
--- a/TrashMob.Models/Extensions/V2/EventMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventMappingsV2.cs
@@ -36,9 +36,13 @@ namespace TrashMob.Models.Extensions.V2
                 Longitude = entity.Longitude,
                 MaxNumberOfParticipants = entity.MaxNumberOfParticipants,
                 IsEventPublic = entity.EventVisibilityId == (int)EventVisibilityEnum.Public,
+                EventVisibilityId = entity.EventVisibilityId,
                 CreatedByUserId = entity.CreatedByUserId,
                 CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedByUserId = entity.LastUpdatedByUserId,
                 LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
+                TeamId = entity.TeamId,
+                CreatedByUserName = entity.CreatedByUser?.UserName ?? string.Empty,
             };
         }
         /// <summary>
@@ -64,8 +68,9 @@ namespace TrashMob.Models.Extensions.V2
                 Latitude = dto.Latitude,
                 Longitude = dto.Longitude,
                 MaxNumberOfParticipants = dto.MaxNumberOfParticipants,
-                EventVisibilityId = dto.IsEventPublic ? (int)EventVisibilityEnum.Public : (int)EventVisibilityEnum.Private,
+                EventVisibilityId = dto.EventVisibilityId != 0 ? dto.EventVisibilityId : (dto.IsEventPublic ? (int)EventVisibilityEnum.Public : (int)EventVisibilityEnum.Private),
                 CreatedByUserId = dto.CreatedByUserId,
+                TeamId = dto.TeamId,
             };
         }
 

--- a/TrashMob.Models/Extensions/V2/EventSummaryMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventSummaryMappingsV2.cs
@@ -25,7 +25,9 @@ namespace TrashMob.Models.Extensions.V2
                 PickedWeightUnitId = entity.PickedWeightUnitId,
                 IsFromRouteData = entity.IsFromRouteData,
                 Notes = entity.Notes ?? string.Empty,
+                CreatedByUserId = entity.CreatedByUserId,
                 CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedByUserId = entity.LastUpdatedByUserId,
                 LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
             };
         }
@@ -45,6 +47,8 @@ namespace TrashMob.Models.Extensions.V2
                 PickedWeightUnitId = dto.PickedWeightUnitId,
                 IsFromRouteData = dto.IsFromRouteData,
                 Notes = dto.Notes,
+                CreatedByUserId = dto.CreatedByUserId,
+                LastUpdatedByUserId = dto.LastUpdatedByUserId,
             };
         }
     }

--- a/TrashMob.Models/Extensions/V2/LookupMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/LookupMappingsV2.cs
@@ -18,6 +18,7 @@ namespace TrashMob.Models.Extensions.V2
                 Name = entity.Name ?? string.Empty,
                 Description = entity.Description ?? string.Empty,
                 DisplayOrder = entity.DisplayOrder ?? 0,
+                IsActive = entity.IsActive ?? true,
             };
         }
 
@@ -33,7 +34,7 @@ namespace TrashMob.Models.Extensions.V2
                 Name = dto.Name,
                 Description = dto.Description,
                 DisplayOrder = dto.DisplayOrder,
-                IsActive = true,
+                IsActive = dto.IsActive,
             };
         }
 
@@ -49,7 +50,7 @@ namespace TrashMob.Models.Extensions.V2
                 Name = dto.Name,
                 Description = dto.Description,
                 DisplayOrder = dto.DisplayOrder,
-                IsActive = true,
+                IsActive = dto.IsActive,
             };
         }
 
@@ -65,7 +66,7 @@ namespace TrashMob.Models.Extensions.V2
                 Name = dto.Name,
                 Description = dto.Description,
                 DisplayOrder = dto.DisplayOrder,
-                IsActive = true,
+                IsActive = dto.IsActive,
             };
         }
     }

--- a/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
@@ -25,6 +25,10 @@ namespace TrashMob.Models.Extensions.V2
                 ProfilePhotoUrl = entity.User?.ProfilePhotoUrl ?? string.Empty,
                 IsTeamLead = entity.IsTeamLead,
                 JoinedDate = entity.JoinedDate,
+                CreatedByUserId = entity.CreatedByUserId,
+                CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedByUserId = entity.LastUpdatedByUserId,
+                LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
             };
         }
 
@@ -40,6 +44,8 @@ namespace TrashMob.Models.Extensions.V2
                 UserId = dto.UserId,
                 IsTeamLead = dto.IsTeamLead,
                 JoinedDate = dto.JoinedDate,
+                CreatedByUserId = dto.CreatedByUserId,
+                LastUpdatedByUserId = dto.LastUpdatedByUserId,
                 User = new User
                 {
                     Id = dto.UserId,

--- a/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/UserMappingsV2.cs
@@ -8,10 +8,10 @@ namespace TrashMob.Models.Extensions.V2
     public static class UserMappingsV2
     {
         /// <summary>
-        /// Maps a User entity to a V2 UserDto, excluding PII fields.
+        /// Maps a User entity to a V2 UserDto including all fields needed by the frontend.
         /// </summary>
         /// <param name="entity">The User entity to map.</param>
-        /// <returns>A UserDto containing only public-safe properties.</returns>
+        /// <returns>A UserDto containing user properties.</returns>
         public static UserDto ToV2Dto(this User entity)
         {
             return new UserDto
@@ -31,13 +31,16 @@ namespace TrashMob.Models.Extensions.V2
                 MemberSince = entity.MemberSince,
                 IsMinor = entity.IsMinor,
                 TravelLimitForLocalEvents = entity.TravelLimitForLocalEvents,
+                Email = entity.Email,
+                IsSiteAdmin = entity.IsSiteAdmin,
+                DateAgreedToTrashMobWaiver = entity.DateAgreedToTrashMobWaiver,
+                TrashMobWaiverVersion = entity.TrashMobWaiverVersion,
+                DateOfBirth = entity.DateOfBirth,
             };
         }
 
         /// <summary>
         /// Maps a V2 <see cref="UserDto"/> back to a <see cref="User"/> entity.
-        /// PII fields (Email, DateOfBirth) are not available in UserDto
-        /// and will not be populated on the returned entity.
         /// </summary>
         public static User ToEntity(this UserDto dto)
         {
@@ -58,6 +61,11 @@ namespace TrashMob.Models.Extensions.V2
                 MemberSince = dto.MemberSince,
                 IsMinor = dto.IsMinor,
                 TravelLimitForLocalEvents = dto.TravelLimitForLocalEvents,
+                Email = dto.Email,
+                IsSiteAdmin = dto.IsSiteAdmin,
+                DateAgreedToTrashMobWaiver = dto.DateAgreedToTrashMobWaiver,
+                TrashMobWaiverVersion = dto.TrashMobWaiverVersion,
+                DateOfBirth = dto.DateOfBirth,
             };
         }
 

--- a/TrashMob.Models/Poco/V2/EventDto.cs
+++ b/TrashMob.Models/Poco/V2/EventDto.cs
@@ -95,6 +95,11 @@ namespace TrashMob.Models.Poco.V2
         public bool IsEventPublic { get; set; }
 
         /// <summary>
+        /// Gets or sets the event visibility identifier (maps to EventVisibilityEnum).
+        /// </summary>
+        public int EventVisibilityId { get; set; }
+
+        /// <summary>
         /// Gets or sets the identifier of the user who created the event.
         /// </summary>
         public Guid CreatedByUserId { get; set; }
@@ -105,8 +110,28 @@ namespace TrashMob.Models.Poco.V2
         public DateTimeOffset CreatedDate { get; set; }
 
         /// <summary>
+        /// Gets or sets the identifier of the user who last updated the event.
+        /// </summary>
+        public Guid LastUpdatedByUserId { get; set; }
+
+        /// <summary>
         /// Gets or sets when the event was last updated.
         /// </summary>
         public DateTimeOffset LastUpdatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional team identifier associated with this event.
+        /// </summary>
+        public Guid? TeamId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username of the event creator.
+        /// </summary>
+        public string CreatedByUserName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets whether the current user is attending this event (contextual, may be null).
+        /// </summary>
+        public bool? IsAttending { get; set; }
     }
 }

--- a/TrashMob.Models/Poco/V2/EventSummaryDto.cs
+++ b/TrashMob.Models/Poco/V2/EventSummaryDto.cs
@@ -55,9 +55,19 @@ namespace TrashMob.Models.Poco.V2
         public string Notes { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the identifier of the user who created the summary.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
         /// Gets or sets when the summary was created.
         /// </summary>
         public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who last updated the summary.
+        /// </summary>
+        public Guid LastUpdatedByUserId { get; set; }
 
         /// <summary>
         /// Gets or sets when the summary was last updated.

--- a/TrashMob.Models/Poco/V2/LookupItemDto.cs
+++ b/TrashMob.Models/Poco/V2/LookupItemDto.cs
@@ -26,4 +26,9 @@ public class LookupItemDto
     /// Gets or sets the display order for sorting.
     /// </summary>
     public int DisplayOrder { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this lookup item is active.
+    /// </summary>
+    public bool IsActive { get; set; } = true;
 }

--- a/TrashMob.Models/Poco/V2/TeamMemberDto.cs
+++ b/TrashMob.Models/Poco/V2/TeamMemberDto.cs
@@ -48,5 +48,25 @@ namespace TrashMob.Models.Poco.V2
         /// Gets or sets the date the member joined the team.
         /// </summary>
         public DateTimeOffset JoinedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who created this membership.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when this membership was created.
+        /// </summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who last updated this membership.
+        /// </summary>
+        public Guid LastUpdatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when this membership was last updated.
+        /// </summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
     }
 }

--- a/TrashMob.Models/Poco/V2/UserDto.cs
+++ b/TrashMob.Models/Poco/V2/UserDto.cs
@@ -5,7 +5,7 @@ namespace TrashMob.Models.Poco.V2
     using System;
 
     /// <summary>
-    /// V2 API representation of a user. Excludes PII (email, date of birth, identity provider fields).
+    /// V2 API representation of a user. Includes fields needed by the frontend for auth and profile display.
     /// </summary>
     public class UserDto
     {
@@ -83,5 +83,30 @@ namespace TrashMob.Models.Poco.V2
         /// Gets or sets the travel distance limit for finding local events.
         /// </summary>
         public int TravelLimitForLocalEvents { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's email address.
+        /// </summary>
+        public string Email { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets whether the user is a site administrator.
+        /// </summary>
+        public bool IsSiteAdmin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the user agreed to the TrashMob waiver.
+        /// </summary>
+        public DateTimeOffset? DateAgreedToTrashMobWaiver { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the TrashMob waiver the user agreed to.
+        /// </summary>
+        public string TrashMobWaiverVersion { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the user's date of birth.
+        /// </summary>
+        public DateTimeOffset? DateOfBirth { get; set; }
     }
 }

--- a/TrashMob.Shared.Tests/Extensions/V2/EventMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventMappingsV2Tests.cs
@@ -10,6 +10,8 @@ namespace TrashMob.Shared.Tests.Extensions.V2
         [Fact]
         public void ToV2Dto_MapsAllProperties()
         {
+            var teamId = Guid.NewGuid();
+            var lastUpdatedByUserId = Guid.NewGuid();
             var entity = new Event
             {
                 Id = Guid.NewGuid(),
@@ -31,7 +33,10 @@ namespace TrashMob.Shared.Tests.Extensions.V2
                 EventVisibilityId = (int)EventVisibilityEnum.Public,
                 CreatedByUserId = Guid.NewGuid(),
                 CreatedDate = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                LastUpdatedByUserId = lastUpdatedByUserId,
                 LastUpdatedDate = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
+                TeamId = teamId,
+                CreatedByUser = new User { UserName = "creator" },
             };
 
             var dto = entity.ToV2Dto();
@@ -53,9 +58,13 @@ namespace TrashMob.Shared.Tests.Extensions.V2
             Assert.Equal(entity.Longitude, dto.Longitude);
             Assert.Equal(entity.MaxNumberOfParticipants, dto.MaxNumberOfParticipants);
             Assert.True(dto.IsEventPublic);
+            Assert.Equal((int)EventVisibilityEnum.Public, dto.EventVisibilityId);
             Assert.Equal(entity.CreatedByUserId, dto.CreatedByUserId);
             Assert.Equal(entity.CreatedDate, dto.CreatedDate);
+            Assert.Equal(lastUpdatedByUserId, dto.LastUpdatedByUserId);
             Assert.Equal(entity.LastUpdatedDate, dto.LastUpdatedDate);
+            Assert.Equal(teamId, dto.TeamId);
+            Assert.Equal("creator", dto.CreatedByUserName);
         }
 
         [Fact]

--- a/TrashMob.Shared.Tests/Extensions/V2/UserMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/UserMappingsV2Tests.cs
@@ -26,6 +26,11 @@ namespace TrashMob.Shared.Tests.Extensions.V2
                 ProfilePhotoUrl = "https://example.com/photo.jpg",
                 MemberSince = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
                 IsMinor = false,
+                Email = "test@example.com",
+                IsSiteAdmin = true,
+                DateAgreedToTrashMobWaiver = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+                TrashMobWaiverVersion = "1.0",
+                DateOfBirth = new DateTimeOffset(1990, 1, 1, 0, 0, 0, TimeSpan.Zero),
             };
 
             var dto = entity.ToV2Dto();
@@ -44,6 +49,11 @@ namespace TrashMob.Shared.Tests.Extensions.V2
             Assert.Equal(entity.ProfilePhotoUrl, dto.ProfilePhotoUrl);
             Assert.Equal(entity.MemberSince, dto.MemberSince);
             Assert.Equal(entity.IsMinor, dto.IsMinor);
+            Assert.Equal(entity.Email, dto.Email);
+            Assert.Equal(entity.IsSiteAdmin, dto.IsSiteAdmin);
+            Assert.Equal(entity.DateAgreedToTrashMobWaiver, dto.DateAgreedToTrashMobWaiver);
+            Assert.Equal(entity.TrashMobWaiverVersion, dto.TrashMobWaiverVersion);
+            Assert.Equal(entity.DateOfBirth, dto.DateOfBirth);
         }
 
         [Fact]
@@ -60,25 +70,31 @@ namespace TrashMob.Shared.Tests.Extensions.V2
         }
 
         [Fact]
-        public void ToV2Dto_DoesNotExposePiiFields()
+        public void ToV2Dto_MapsAuthAndProfileFields()
         {
             var entity = new User
             {
-                Email = "secret@example.com",
+                Email = "test@example.com",
                 ObjectId = Guid.NewGuid(),
                 NameIdentifier = "secret-identifier",
                 DateOfBirth = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
                 IsSiteAdmin = true,
+                DateAgreedToTrashMobWaiver = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+                TrashMobWaiverVersion = "1.0",
             };
 
             var dto = entity.ToV2Dto();
 
+            Assert.Equal("test@example.com", dto.Email);
+            Assert.True(dto.IsSiteAdmin);
+            Assert.Equal(entity.DateOfBirth, dto.DateOfBirth);
+            Assert.Equal(entity.DateAgreedToTrashMobWaiver, dto.DateAgreedToTrashMobWaiver);
+            Assert.Equal("1.0", dto.TrashMobWaiverVersion);
+
+            // Identity provider fields are still excluded from UserDto
             var dtoType = dto.GetType();
-            Assert.Null(dtoType.GetProperty("Email"));
             Assert.Null(dtoType.GetProperty("ObjectId"));
             Assert.Null(dtoType.GetProperty("NameIdentifier"));
-            Assert.Null(dtoType.GetProperty("DateOfBirth"));
-            Assert.Null(dtoType.GetProperty("IsSiteAdmin"));
         }
 
         [Fact]
@@ -114,6 +130,11 @@ namespace TrashMob.Shared.Tests.Extensions.V2
                 MemberSince = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
                 IsMinor = false,
                 TravelLimitForLocalEvents = 15,
+                Email = "test@example.com",
+                IsSiteAdmin = true,
+                DateAgreedToTrashMobWaiver = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+                TrashMobWaiverVersion = "1.0",
+                DateOfBirth = new DateTimeOffset(1990, 1, 1, 0, 0, 0, TimeSpan.Zero),
             };
 
             var entity = dto.ToEntity();
@@ -133,6 +154,11 @@ namespace TrashMob.Shared.Tests.Extensions.V2
             Assert.Equal(dto.MemberSince, entity.MemberSince);
             Assert.Equal(dto.IsMinor, entity.IsMinor);
             Assert.Equal(dto.TravelLimitForLocalEvents, entity.TravelLimitForLocalEvents);
+            Assert.Equal(dto.Email, entity.Email);
+            Assert.Equal(dto.IsSiteAdmin, entity.IsSiteAdmin);
+            Assert.Equal(dto.DateAgreedToTrashMobWaiver, entity.DateAgreedToTrashMobWaiver);
+            Assert.Equal(dto.TrashMobWaiverVersion, entity.TrashMobWaiverVersion);
+            Assert.Equal(dto.DateOfBirth, entity.DateOfBirth);
         }
 
         [Fact]
@@ -255,6 +281,11 @@ namespace TrashMob.Shared.Tests.Extensions.V2
                 MemberSince = new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
                 IsMinor = false,
                 TravelLimitForLocalEvents = 10,
+                Email = "roundtrip@example.com",
+                IsSiteAdmin = true,
+                DateAgreedToTrashMobWaiver = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero),
+                TrashMobWaiverVersion = "2.0",
+                DateOfBirth = new DateTimeOffset(1985, 5, 10, 0, 0, 0, TimeSpan.Zero),
             };
 
             var roundTripped = entity.ToV2Dto().ToEntity();
@@ -274,6 +305,11 @@ namespace TrashMob.Shared.Tests.Extensions.V2
             Assert.Equal(entity.MemberSince, roundTripped.MemberSince);
             Assert.Equal(entity.IsMinor, roundTripped.IsMinor);
             Assert.Equal(entity.TravelLimitForLocalEvents, roundTripped.TravelLimitForLocalEvents);
+            Assert.Equal(entity.Email, roundTripped.Email);
+            Assert.Equal(entity.IsSiteAdmin, roundTripped.IsSiteAdmin);
+            Assert.Equal(entity.DateAgreedToTrashMobWaiver, roundTripped.DateAgreedToTrashMobWaiver);
+            Assert.Equal(entity.TrashMobWaiverVersion, roundTripped.TrashMobWaiverVersion);
+            Assert.Equal(entity.DateOfBirth, roundTripped.DateOfBirth);
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Fixes breakage from PR #3093** — v2 API endpoints were returning lean DTOs missing fields the React frontend depends on (e.g., `eventVisibilityId`, `email`, `isSiteAdmin`, `isActive`)
- Adds missing fields to 5 v2 DTOs: `EventDto`, `UserDto`, `LookupItemDto`, `EventSummaryDto`, `TeamMemberDto`
- Updates all corresponding V2 mapping extensions and tests
- **Must merge before PR #3094** (Phase 3b) to prevent the same class of breakage for teams/lookups

## Test plan
- [x] All 993 backend tests pass (including updated V2 mapping tests)
- [x] Solution builds clean with 0 warnings
- [ ] Verify dev environment event pages load correctly after deploy
- [ ] Verify admin route guards work (isSiteAdmin now included in UserDto)
- [ ] Verify event creation form sends correct eventVisibilityId

🤖 Generated with [Claude Code](https://claude.com/claude-code)