### PR TITLE
Complete v2 API migration: zero v1 frontend URLs remaining (Phase 3d)

### DIFF
--- a/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
@@ -32,7 +32,10 @@ namespace TrashMob.Models.Extensions.V2
                 SafetyRequirements = entity.SafetyRequirements,
                 AllowCoAdoption = entity.AllowCoAdoption,
                 IsActive = entity.IsActive,
+                CreatedByUserId = entity.CreatedByUserId,
                 CreatedDate = entity.CreatedDate,
+                LastUpdatedByUserId = entity.LastUpdatedByUserId,
+                LastUpdatedDate = entity.LastUpdatedDate,
             };
         }
 
@@ -59,6 +62,10 @@ namespace TrashMob.Models.Extensions.V2
                 SafetyRequirements = dto.SafetyRequirements,
                 AllowCoAdoption = dto.AllowCoAdoption,
                 IsActive = dto.IsActive,
+                CreatedByUserId = dto.CreatedByUserId,
+                CreatedDate = dto.CreatedDate,
+                LastUpdatedByUserId = dto.LastUpdatedByUserId,
+                LastUpdatedDate = dto.LastUpdatedDate,
             };
         }
 
@@ -322,7 +329,10 @@ namespace TrashMob.Models.Extensions.V2
                 PartnerId = entity.PartnerId,
                 IsActive = entity.IsActive,
                 ShowOnPublicMap = entity.ShowOnPublicMap,
+                CreatedByUserId = entity.CreatedByUserId,
                 CreatedDate = entity.CreatedDate,
+                LastUpdatedByUserId = entity.LastUpdatedByUserId,
+                LastUpdatedDate = entity.LastUpdatedDate,
             };
         }
 
@@ -341,6 +351,10 @@ namespace TrashMob.Models.Extensions.V2
                 PartnerId = dto.PartnerId,
                 IsActive = dto.IsActive,
                 ShowOnPublicMap = dto.ShowOnPublicMap,
+                CreatedByUserId = dto.CreatedByUserId,
+                CreatedDate = dto.CreatedDate,
+                LastUpdatedByUserId = dto.LastUpdatedByUserId,
+                LastUpdatedDate = dto.LastUpdatedDate,
             };
         }
 

--- a/TrashMob.Models/Extensions/V2/PartnerPhotoMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/PartnerPhotoMappingsV2.cs
@@ -1,0 +1,31 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Extension methods for mapping PartnerPhoto entities to V2 DTOs.
+    /// </summary>
+    public static class PartnerPhotoMappingsV2
+    {
+        /// <summary>
+        /// Maps a PartnerPhoto entity to a V2 PartnerPhotoDto.
+        /// </summary>
+        /// <param name="entity">The PartnerPhoto entity to map.</param>
+        /// <returns>A PartnerPhotoDto with all public-safe properties.</returns>
+        public static PartnerPhotoDto ToV2Dto(this PartnerPhoto entity)
+        {
+            return new PartnerPhotoDto
+            {
+                Id = entity.Id,
+                PartnerId = entity.PartnerId,
+                ImageUrl = entity.ImageUrl ?? string.Empty,
+                Caption = entity.Caption ?? string.Empty,
+                UploadedByUserId = entity.UploadedByUserId,
+                UploadedDate = entity.UploadedDate,
+                CreatedByUserId = entity.CreatedByUserId,
+                CreatedDate = entity.CreatedDate.GetValueOrDefault(),
+                LastUpdatedDate = entity.LastUpdatedDate.GetValueOrDefault(),
+            };
+        }
+    }
+}

--- a/TrashMob.Models/Poco/V2/AdoptableAreaDto.cs
+++ b/TrashMob.Models/Poco/V2/AdoptableAreaDto.cs
@@ -90,8 +90,23 @@ namespace TrashMob.Models.Poco.V2
         public bool IsActive { get; set; }
 
         /// <summary>
+        /// Gets or sets the identifier of the user who created this area.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
         /// Gets or sets when the area was created.
         /// </summary>
         public DateTimeOffset? CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who last updated this area.
+        /// </summary>
+        public Guid LastUpdatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the area was last updated.
+        /// </summary>
+        public DateTimeOffset? LastUpdatedDate { get; set; }
     }
 }

--- a/TrashMob.Models/Poco/V2/PartnerPhotoDto.cs
+++ b/TrashMob.Models/Poco/V2/PartnerPhotoDto.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a partner/community photo. Flat DTO excluding navigation and moderation properties.
+    /// </summary>
+    public class PartnerPhotoDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the photo.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the partner identifier this photo belongs to.
+        /// </summary>
+        public Guid PartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL where the image is stored.
+        /// </summary>
+        public string ImageUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the caption for the photo.
+        /// </summary>
+        public string Caption { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who uploaded the photo.
+        /// </summary>
+        public Guid UploadedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date when the photo was uploaded.
+        /// </summary>
+        public DateTimeOffset UploadedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who created this record.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when this record was created.
+        /// </summary>
+        public DateTimeOffset CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets when this record was last updated.
+        /// </summary>
+        public DateTimeOffset LastUpdatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/Poco/V2/SponsorDto.cs
+++ b/TrashMob.Models/Poco/V2/SponsorDto.cs
@@ -50,8 +50,23 @@ namespace TrashMob.Models.Poco.V2
         public bool ShowOnPublicMap { get; set; }
 
         /// <summary>
+        /// Gets or sets the identifier of the user who created this sponsor.
+        /// </summary>
+        public Guid CreatedByUserId { get; set; }
+
+        /// <summary>
         /// Gets or sets when the sponsor was created.
         /// </summary>
         public DateTimeOffset? CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who last updated this sponsor.
+        /// </summary>
+        public Guid LastUpdatedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the sponsor was last updated.
+        /// </summary>
+        public DateTimeOffset? LastUpdatedDate { get; set; }
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunitiesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunitiesV2ControllerTests.cs
@@ -4,6 +4,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
@@ -12,18 +13,27 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using TrashMob.Models;
     using TrashMob.Models.Poco;
     using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Areas;
     using TrashMob.Shared.Managers.Interfaces;
     using Xunit;
 
     public class CommunitiesV2ControllerTests
     {
         private readonly Mock<ICommunityManager> communityManager = new();
+        private readonly Mock<IImageManager> imageManager = new();
+        private readonly Mock<INominatimService> nominatimService = new();
+        private readonly Mock<IAuthorizationService> authorizationService = new();
         private readonly Mock<ILogger<CommunitiesV2Controller>> logger = new();
         private readonly CommunitiesV2Controller controller;
 
         public CommunitiesV2ControllerTests()
         {
-            controller = new CommunitiesV2Controller(communityManager.Object, logger.Object);
+            controller = new CommunitiesV2Controller(
+                communityManager.Object,
+                imageManager.Object,
+                nominatimService.Object,
+                authorizationService.Object,
+                logger.Object);
         }
 
         [Fact]

--- a/TrashMob.Shared.Tests/Controllers/V2/EventPartnerLocationServicesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventPartnerLocationServicesV2ControllerTests.cs
@@ -19,6 +19,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     {
         private readonly Mock<IEventPartnerLocationServiceManager> serviceManager = new();
         private readonly Mock<IKeyedManager<Event>> eventManager = new();
+        private readonly Mock<IPartnerLocationManager> partnerLocationManager = new();
         private readonly Mock<IAuthorizationService> authorizationService = new();
         private readonly Mock<ILogger<EventPartnerLocationServicesV2Controller>> logger = new();
         private readonly EventPartnerLocationServicesV2Controller controller;
@@ -26,7 +27,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         public EventPartnerLocationServicesV2ControllerTests()
         {
             controller = new EventPartnerLocationServicesV2Controller(
-                serviceManager.Object, eventManager.Object, authorizationService.Object, logger.Object);
+                serviceManager.Object, eventManager.Object, partnerLocationManager.Object, authorizationService.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),

--- a/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
@@ -21,13 +21,14 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     {
         private readonly Mock<IEventManager> eventManager = new();
         private readonly Mock<IEventAttendeeManager> eventAttendeeManager = new();
+        private readonly Mock<IEventSummaryManager> eventSummaryManager = new();
         private readonly Mock<IAuthorizationService> authorizationService = new();
         private readonly Mock<ILogger<EventsV2Controller>> logger = new();
         private readonly EventsV2Controller controller;
 
         public EventsV2ControllerTests()
         {
-            controller = new EventsV2Controller(eventManager.Object, eventAttendeeManager.Object, authorizationService.Object, logger.Object);
+            controller = new EventsV2Controller(eventManager.Object, eventAttendeeManager.Object, eventSummaryManager.Object, authorizationService.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),

--- a/TrashMob/Controllers/V2/CommunitiesV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunitiesV2Controller.cs
@@ -1,20 +1,29 @@
 namespace TrashMob.Controllers.V2
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Cors;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco;
     using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Areas;
     using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
 
     /// <summary>
-    /// V2 controller for community discovery and sub-resources.
+    /// V2 controller for community discovery, sub-resources, and admin operations.
     /// Communities are partners with enabled home pages.
     /// </summary>
     [ApiController]
@@ -23,8 +32,17 @@ namespace TrashMob.Controllers.V2
     [Route("api/v{version:apiVersion}/communities")]
     public class CommunitiesV2Controller(
         ICommunityManager communityManager,
+        IImageManager imageManager,
+        INominatimService nominatimService,
+        IAuthorizationService authorizationService,
         ILogger<CommunitiesV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        // ============================================================================
+        // Public Endpoints
+        // ============================================================================
+
         /// <summary>
         /// Gets enabled communities, optionally filtered by location.
         /// </summary>
@@ -81,6 +99,33 @@ namespace TrashMob.Controllers.V2
             }
 
             return Ok(community.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Checks if a community slug is available.
+        /// </summary>
+        /// <param name="slug">The slug to check.</param>
+        /// <param name="excludePartnerId">Optional partner ID to exclude (for updates).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>True if the slug is available, false otherwise.</returns>
+        /// <response code="200">Returns whether the slug is available.</response>
+        [HttpGet("check-slug")]
+        [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+        public async Task<IActionResult> CheckSlug(
+            [FromQuery] string slug,
+            [FromQuery] Guid? excludePartnerId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CheckSlug requested Slug={Slug}, ExcludePartnerId={ExcludePartnerId}",
+                slug, excludePartnerId);
+
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                return Ok(false);
+            }
+
+            var isAvailable = await communityManager.IsSlugAvailableAsync(slug, excludePartnerId, cancellationToken);
+            return Ok(isAvailable);
         }
 
         /// <summary>
@@ -158,6 +203,40 @@ namespace TrashMob.Controllers.V2
         }
 
         /// <summary>
+        /// Gets litter reports in a community.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of litter reports in the community.</returns>
+        /// <response code="200">Returns the litter report list.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet("{slug}/litterreports")]
+        [ProducesResponseType(typeof(IReadOnlyList<LitterReportDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetCommunityLitterReports(
+            string slug,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetCommunityLitterReports requested Slug={Slug}", slug);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+
+            if (community is null)
+            {
+                return Problem(
+                    detail: $"Community with slug '{slug}' not found.",
+                    statusCode: StatusCodes.Status404NotFound,
+                    title: "Not found");
+            }
+
+            var litterReports = await communityManager.GetCommunityLitterReportsAsync(slug, cancellationToken);
+            var dtos = litterReports.Select(lr => lr.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
         /// Gets aggregated impact stats for a community.
         /// </summary>
         /// <param name="slug">The community slug.</param>
@@ -188,6 +267,358 @@ namespace TrashMob.Controllers.V2
             var stats = await communityManager.GetCommunityStatsAsync(slug, cancellationToken);
 
             return Ok(stats.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets communities marked as featured for display on landing and home pages.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of featured communities.</returns>
+        /// <response code="200">Returns the featured community list.</response>
+        [HttpGet("featured")]
+        [ProducesResponseType(typeof(IReadOnlyList<PartnerDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetFeaturedCommunities(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetFeaturedCommunities requested");
+
+            var communities = await communityManager.GetFeaturedCommunitiesAsync(cancellationToken);
+            var dtos = communities.Select(c => c.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Gets aggregate public stats across all active communities.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Aggregate statistics for all communities.</returns>
+        /// <response code="200">Returns the public stats.</response>
+        [HttpGet("public-stats")]
+        [ProducesResponseType(typeof(CommunityPublicStats), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetPublicStats(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPublicStats requested");
+
+            var stats = await communityManager.GetPublicStatsAsync(cancellationToken);
+            return Ok(stats);
+        }
+
+        // ============================================================================
+        // Admin Endpoints (Require Authentication and Authorization)
+        // ============================================================================
+
+        /// <summary>
+        /// Gets community details for admin editing.
+        /// Requires the user to be a community admin or site admin.
+        /// </summary>
+        /// <param name="communityId">The community/partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The community details.</returns>
+        /// <response code="200">Returns the community.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet("admin/{communityId:guid}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(PartnerDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetCommunityForAdmin(
+            Guid communityId,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetCommunityForAdmin requested CommunityId={CommunityId}", communityId);
+
+            var community = await communityManager.GetByIdAsync(communityId, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            return Ok(community.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Gets admin dashboard data for a community.
+        /// Requires the user to be a community admin or site admin.
+        /// </summary>
+        /// <param name="communityId">The community/partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Dashboard data including stats, recent events, and activity.</returns>
+        /// <response code="200">Returns the dashboard data.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet("admin/{communityId:guid}/dashboard")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(CommunityDashboard), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetCommunityDashboard(
+            Guid communityId,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetCommunityDashboard requested CommunityId={CommunityId}", communityId);
+
+            var community = await communityManager.GetByIdAsync(communityId, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var dashboard = await communityManager.GetCommunityDashboardAsync(communityId, cancellationToken);
+            return Ok(dashboard);
+        }
+
+        /// <summary>
+        /// Updates community content (branding, about, contact info).
+        /// Requires the user to be a community admin or site admin.
+        /// </summary>
+        /// <param name="communityId">The community/partner ID.</param>
+        /// <param name="communityDto">The updated community data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated community.</returns>
+        /// <response code="200">Returns the updated community.</response>
+        /// <response code="400">Community ID mismatch or invalid data.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpPut("admin/{communityId:guid}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateCommunityContent(
+            Guid communityId,
+            [FromBody] PartnerDto communityDto,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 UpdateCommunityContent requested CommunityId={CommunityId}", communityId);
+
+            if (communityDto is null || communityDto.Id != communityId)
+            {
+                return BadRequest("Community ID in URL must match the body.");
+            }
+
+            var existing = await communityManager.GetByIdAsync(communityId, cancellationToken);
+            if (existing is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(existing, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var entity = communityDto.ToEntity();
+            var updated = await communityManager.UpdateCommunityContentAsync(entity, UserId, cancellationToken);
+
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Suggests geographic bounds for a community based on its location fields.
+        /// Queries the Nominatim geocoding service to derive a bounding box.
+        /// </summary>
+        /// <param name="communityId">The community/partner ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Suggested geographic bounds with optional GeoJSON polygon.</returns>
+        /// <response code="200">Returns the suggested bounds.</response>
+        /// <response code="400">Community has no location info or bounds could not be found.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet("admin/{communityId:guid}/suggest-bounds")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(SuggestedBounds), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SuggestBounds(
+            Guid communityId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SuggestBounds requested CommunityId={CommunityId}", communityId);
+
+            var community = await communityManager.GetByIdAsync(communityId, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            // Build query from community location fields
+            var queryParts = new List<string>();
+
+            if (community.RegionType.HasValue
+                && community.RegionType.Value == (int)RegionTypeEnum.County
+                && !string.IsNullOrWhiteSpace(community.CountyName))
+            {
+                queryParts.Add(community.CountyName);
+            }
+            else if (!string.IsNullOrWhiteSpace(community.City))
+            {
+                queryParts.Add(community.City);
+            }
+
+            if (!string.IsNullOrWhiteSpace(community.Region))
+            {
+                queryParts.Add(community.Region);
+            }
+
+            if (!string.IsNullOrWhiteSpace(community.Country))
+            {
+                queryParts.Add(community.Country);
+            }
+
+            if (queryParts.Count == 0)
+            {
+                return BadRequest("Community has no location information (city, region, or country) to look up bounds.");
+            }
+
+            var query = string.Join(", ", queryParts);
+            var bounds = await nominatimService.LookupBoundsWithGeometryAsync(query, cancellationToken);
+
+            if (bounds is null)
+            {
+                return BadRequest($"Could not find geographic bounds for \"{query}\". Try adjusting the community's location fields.");
+            }
+
+            var result = new SuggestedBounds
+            {
+                North = bounds.North,
+                South = bounds.South,
+                East = bounds.East,
+                West = bounds.West,
+                CenterLatitude = (bounds.North + bounds.South) / 2.0,
+                CenterLongitude = (bounds.East + bounds.West) / 2.0,
+                Query = query,
+                BoundaryGeoJson = bounds.GeoJson,
+            };
+
+            return Ok(result);
+        }
+
+        // ============================================================================
+        // Community Branding Image Endpoints
+        // ============================================================================
+
+        /// <summary>
+        /// Uploads a community logo image (resized to 200x200).
+        /// </summary>
+        /// <param name="communityId">The community/partner ID.</param>
+        /// <param name="imageUpload">The image file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The URL of the uploaded logo.</returns>
+        /// <response code="200">Returns the logo URL.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpPost("admin/{communityId:guid}/logo")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadCommunityLogo(
+            Guid communityId,
+            [FromForm] ImageUpload imageUpload,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadCommunityLogo requested CommunityId={CommunityId}", communityId);
+
+            var community = await communityManager.GetByIdAsync(communityId, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            imageUpload.ParentId = communityId;
+            imageUpload.ImageType = ImageTypeEnum.CommunityLogo;
+            var url = await imageManager.UploadImageWithSizeAsync(imageUpload, 200, 200);
+
+            community.LogoUrl = url;
+            await communityManager.UpdateCommunityContentAsync(community, UserId, cancellationToken);
+
+            return Ok(new { url });
+        }
+
+        /// <summary>
+        /// Uploads a community banner image (resized to 1200x300).
+        /// </summary>
+        /// <param name="communityId">The community/partner ID.</param>
+        /// <param name="imageUpload">The image file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The URL of the uploaded banner.</returns>
+        /// <response code="200">Returns the banner URL.</response>
+        /// <response code="403">User is not authorized.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpPost("admin/{communityId:guid}/banner")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadCommunityBanner(
+            Guid communityId,
+            [FromForm] ImageUpload imageUpload,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadCommunityBanner requested CommunityId={CommunityId}", communityId);
+
+            var community = await communityManager.GetByIdAsync(communityId, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            imageUpload.ParentId = communityId;
+            imageUpload.ImageType = ImageTypeEnum.CommunityBanner;
+            var url = await imageManager.UploadImageWithSizeAsync(imageUpload, 1200, 300);
+
+            community.BannerImageUrl = url;
+            await communityManager.UpdateCommunityContentAsync(community, UserId, cancellationToken);
+
+            return Ok(new { url });
+        }
+
+        // ============================================================================
+        // Private Helpers
+        // ============================================================================
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
         }
     }
 }

--- a/TrashMob/Controllers/V2/CommunityPhotosV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunityPhotosV2Controller.cs
@@ -1,0 +1,231 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// V2 controller for community photo gallery operations as a nested resource under communities.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/communities/{slug}/photos")]
+    public class CommunityPhotosV2Controller(
+        ICommunityManager communityManager,
+        IPartnerPhotoManager partnerPhotoManager,
+        IImageManager imageManager,
+        IAuthorizationService authorizationService,
+        ILogger<CommunityPhotosV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all photos for a community.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of community photos.</returns>
+        /// <response code="200">Returns the community photos.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<PartnerPhotoDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetCommunityPhotos(string slug, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetCommunityPhotos requested Slug={Slug}", slug);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            var photos = await partnerPhotoManager.GetByPartnerIdAsync(community.Id, cancellationToken);
+            return Ok(photos.Select(p => p.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Uploads a photo for a community. Only community admins can upload photos.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="imageUpload">The image upload data (multipart/form-data).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The created photo.</returns>
+        /// <response code="201">Photo uploaded successfully.</response>
+        /// <response code="400">Invalid upload data.</response>
+        /// <response code="403">User is not a community admin.</response>
+        /// <response code="404">Community not found.</response>
+        [HttpPost]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerPhotoDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadCommunityPhoto(
+            string slug,
+            [FromForm] ImageUpload imageUpload,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UploadCommunityPhoto requested Slug={Slug}", slug);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            // Create the partner photo record
+            var photoId = Guid.NewGuid();
+            var partnerPhoto = new PartnerPhoto
+            {
+                Id = photoId,
+                PartnerId = community.Id,
+                Caption = string.Empty,
+            };
+
+            // Upload to blob storage
+            imageUpload.ParentId = photoId;
+            imageUpload.ImageType = ImageTypeEnum.PartnerPhoto;
+            await imageManager.UploadImageAsync(imageUpload);
+
+            // Get the image URL and save photo record
+            var imageUrl = await imageManager.GetImageUrlAsync(photoId, ImageTypeEnum.PartnerPhoto, ImageSizeEnum.Reduced, cancellationToken);
+            partnerPhoto.ImageUrl = imageUrl;
+            var createdPhoto = await partnerPhotoManager.AddAsync(partnerPhoto, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetCommunityPhotos), new { slug }, createdPhoto.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a community photo caption. Only community admins can update photos.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="photoId">The photo ID.</param>
+        /// <param name="caption">The new caption text.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated photo.</returns>
+        /// <response code="200">Returns the updated photo.</response>
+        /// <response code="403">User is not a community admin.</response>
+        /// <response code="404">Community or photo not found.</response>
+        [HttpPut("{photoId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(PartnerPhotoDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateCommunityPhotoCaption(
+            string slug,
+            Guid photoId,
+            [FromBody] string caption,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 UpdateCommunityPhotoCaption requested Slug={Slug}, PhotoId={PhotoId}", slug, photoId);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var photo = await partnerPhotoManager.GetAsync(photoId, cancellationToken);
+            if (photo is null || photo.PartnerId != community.Id)
+            {
+                return NotFound();
+            }
+
+            photo.Caption = caption ?? string.Empty;
+            photo.LastUpdatedByUserId = UserId;
+            photo.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var updatedPhoto = await partnerPhotoManager.UpdateAsync(photo, UserId, cancellationToken);
+            return Ok(updatedPhoto.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a community photo. Only community admins can delete photos.
+        /// </summary>
+        /// <param name="slug">The community slug.</param>
+        /// <param name="photoId">The photo ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Photo deleted.</response>
+        /// <response code="403">User is not a community admin.</response>
+        /// <response code="404">Community or photo not found.</response>
+        [HttpDelete("{photoId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteCommunityPhoto(
+            string slug,
+            Guid photoId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteCommunityPhoto requested Slug={Slug}, PhotoId={PhotoId}", slug, photoId);
+
+            var community = await communityManager.GetBySlugAsync(slug, cancellationToken);
+            if (community is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(community, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var photo = await partnerPhotoManager.GetAsync(photoId, cancellationToken);
+            if (photo is null || photo.PartnerId != community.Id)
+            {
+                return NotFound();
+            }
+
+            // HardDelete removes from blob storage and database
+            await partnerPhotoManager.HardDeleteAsync(photoId, cancellationToken);
+            return NoContent();
+        }
+
+        // ============================================================================
+        // Private Helpers
+        // ============================================================================
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/EventPartnerLocationServicesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventPartnerLocationServicesV2Controller.cs
@@ -11,6 +11,7 @@ namespace TrashMob.Controllers.V2
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
+    using System.Linq;
     using TrashMob.Models;
     using TrashMob.Models.Extensions.V2;
     using TrashMob.Models.Poco;
@@ -29,6 +30,7 @@ namespace TrashMob.Controllers.V2
     public class EventPartnerLocationServicesV2Controller(
         IEventPartnerLocationServiceManager eventPartnerLocationServiceManager,
         IKeyedManager<Event> eventManager,
+        IPartnerLocationManager partnerLocationManager,
         IAuthorizationService authorizationService,
         ILogger<EventPartnerLocationServicesV2Controller> logger) : ControllerBase
     {
@@ -157,6 +159,69 @@ namespace TrashMob.Controllers.V2
             await eventPartnerLocationServiceManager.UpdateAsync(entity, UserId, cancellationToken);
 
             return Ok();
+        }
+
+        /// <summary>
+        /// Accepts or declines an event partner location service.
+        /// </summary>
+        /// <param name="acceptDecline">Either "accept" or "decline".</param>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="partnerLocationId">The partner location ID.</param>
+        /// <param name="serviceTypeId">The service type ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated service.</response>
+        /// <response code="403">Not authorized.</response>
+        /// <response code="404">Service or partner not found.</response>
+        [HttpPut("{acceptDecline}/{eventId}/{partnerLocationId}/{serviceTypeId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventPartnerLocationService), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> AcceptOrDecline(
+            string acceptDecline, Guid eventId, Guid partnerLocationId, int serviceTypeId,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 {Action}EventPartnerLocationService Event={EventId}, PartnerLocation={PartnerLocationId}, ServiceType={ServiceTypeId}",
+                acceptDecline, eventId, partnerLocationId, serviceTypeId);
+
+            if (acceptDecline != "accept" && acceptDecline != "decline")
+            {
+                return Problem(detail: "Action must be 'accept' or 'decline'.", statusCode: StatusCodes.Status400BadRequest, title: "Invalid action");
+            }
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(partnerLocationId, cancellationToken);
+            if (partner is null)
+            {
+                return NotFound();
+            }
+
+            var eventPartnerLocationServices =
+                await eventPartnerLocationServiceManager.GetCurrentPartnersAsync(eventId, cancellationToken);
+
+            if (eventPartnerLocationServices is null || !eventPartnerLocationServices.Any(epls =>
+                    epls.ServiceTypeId == serviceTypeId && epls.PartnerLocationId == partnerLocationId))
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var eventPartnerLocationService =
+                eventPartnerLocationServices.FirstOrDefault(epls => epls.ServiceTypeId == serviceTypeId);
+
+            eventPartnerLocationService.EventPartnerLocationServiceStatusId = acceptDecline == "accept"
+                ? (int)EventPartnerLocationServiceStatusEnum.Accepted
+                : (int)EventPartnerLocationServiceStatusEnum.Declined;
+
+            var updatedService = await eventPartnerLocationServiceManager
+                .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken);
+
+            return Ok(updatedService);
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/EventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventsV2Controller.cs
@@ -33,6 +33,7 @@ namespace TrashMob.Controllers.V2
     public class EventsV2Controller(
         IEventManager eventManager,
         IEventAttendeeManager eventAttendeeManager,
+        IEventSummaryManager eventSummaryManager,
         IAuthorizationService authorizationService,
         ILogger<EventsV2Controller> logger) : ControllerBase
     {
@@ -219,6 +220,90 @@ namespace TrashMob.Controllers.V2
                 PageIndex = pageIndex,
                 TotalPages = pageSize > 0 ? (int)Math.Ceiling(ordered.Count / (double)pageSize) : 1,
             });
+        }
+
+        /// <summary>
+        /// Gets a list of all active events.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the active events.</response>
+        [HttpGet("active")]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetActiveEvents(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetActiveEvents");
+
+            Guid? userId = User.Identity?.IsAuthenticated == true ? UserId : (Guid?)null;
+            var results = await eventManager.GetActiveEventsAsync(userId, cancellationToken);
+
+            return Ok(results.Select(e => e.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a list of all completed events.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the completed events.</response>
+        [HttpGet("completed")]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetCompletedEvents(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetCompletedEvents");
+
+            var results = await eventManager.GetCompletedEventsAsync(cancellationToken);
+
+            return Ok(results.Select(e => e.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets a list of all events that are not canceled.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the not-canceled events.</response>
+        [HttpGet("notcanceled")]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetNotCanceledEvents(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetNotCanceledEvents");
+
+            Guid? userId = User.Identity?.IsAuthenticated == true ? UserId : (Guid?)null;
+            var results = await eventManager.GetFilteredEventsAsync(new EventFilter(), userId, cancellationToken);
+
+            return Ok(results.Select(e => e.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets event summaries filtered by location.
+        /// </summary>
+        /// <param name="country">The country filter.</param>
+        /// <param name="region">The region filter.</param>
+        /// <param name="city">The city filter.</param>
+        /// <param name="postalCode">The postal code filter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the filtered event summaries.</response>
+        [HttpGet("summaries")]
+        [ProducesResponseType(typeof(IEnumerable<DisplayEventSummary>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEventSummaries(
+            [FromQuery] string country = "",
+            [FromQuery] string region = "",
+            [FromQuery] string city = "",
+            [FromQuery] string postalCode = "",
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation("V2 GetEventSummaries Country={Country}, Region={Region}, City={City}, PostalCode={PostalCode}",
+                country, region, city, postalCode);
+
+            var locationFilter = new LocationFilter
+            {
+                City = city,
+                Region = region,
+                Country = country,
+                PostalCode = postalCode,
+            };
+
+            var eventSummaries = await eventSummaryManager.GetFilteredAsync(locationFilter, cancellationToken);
+
+            return Ok(eventSummaries);
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/JobOpportunitiesV2Controller.cs
+++ b/TrashMob/Controllers/V2/JobOpportunitiesV2Controller.cs
@@ -1,6 +1,8 @@
 namespace TrashMob.Controllers.V2
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
@@ -29,6 +31,22 @@ namespace TrashMob.Controllers.V2
         ILogger<JobOpportunitiesV2Controller> logger) : ControllerBase
     {
         private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all job opportunities.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of all job opportunities.</returns>
+        /// <response code="200">Returns all job opportunities.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<JobOpportunityDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAllJobOpportunities");
+
+            var results = await jobOpportunityManager.GetAsync(cancellationToken);
+            return Ok(results.Select(j => j.ToV2Dto()));
+        }
 
         /// <summary>
         /// Gets a job opportunity by its identifier.

--- a/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/LitterReportsV2Controller.cs
@@ -89,6 +89,36 @@ namespace TrashMob.Controllers.V2
         }
 
         /// <summary>
+        /// Gets all new litter reports (status = new).
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the new litter reports.</response>
+        [HttpGet("new")]
+        [ProducesResponseType(typeof(IEnumerable<LitterReportDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetNewLitterReports(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetNewLitterReports");
+
+            var result = await litterReportManager.GetNewLitterReportsAsync(cancellationToken);
+            return Ok(result.Select(r => r.ToV2Dto()));
+        }
+
+        /// <summary>
+        /// Gets all non-cancelled litter reports.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the non-cancelled litter reports.</response>
+        [HttpGet("notcancelled")]
+        [ProducesResponseType(typeof(IEnumerable<LitterReportDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetNotCancelledLitterReports(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetNotCancelledLitterReports");
+
+            var result = await litterReportManager.GetNotCancelledLitterReportsAsync(cancellationToken);
+            return Ok(result.Select(r => r.ToV2Dto()));
+        }
+
+        /// <summary>
         /// Adds a new litter report.
         /// </summary>
         /// <param name="litterReport">The litter report to add.</param>

--- a/TrashMob/Controllers/V2/NewsletterPreferencesV2Controller.cs
+++ b/TrashMob/Controllers/V2/NewsletterPreferencesV2Controller.cs
@@ -145,5 +145,57 @@ namespace TrashMob.Controllers.V2
 
             return NoContent();
         }
+
+        /// <summary>
+        /// Processes an unsubscribe request using a token (no authentication required).
+        /// Used for one-click unsubscribe from email links.
+        /// </summary>
+        /// <param name="request">The unsubscribe request containing the token.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Unsubscribe successful.</response>
+        /// <response code="400">Token is missing or invalid.</response>
+        [AllowAnonymous]
+        [HttpPost("unsubscribe")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> ProcessUnsubscribe(
+            [FromBody] UnsubscribeRequestDto request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 ProcessUnsubscribe");
+
+            if (string.IsNullOrWhiteSpace(request?.Token))
+            {
+                return Problem(detail: "Token is required.", statusCode: StatusCodes.Status400BadRequest, title: "Invalid request");
+            }
+
+            var result = await preferenceManager.ProcessUnsubscribeTokenAsync(request.Token, cancellationToken);
+
+            if (!result.Success)
+            {
+                return Problem(detail: result.ErrorMessage, statusCode: StatusCodes.Status400BadRequest, title: "Unsubscribe failed");
+            }
+
+            return Ok(new
+            {
+                success = true,
+                email = result.Email,
+                allCategories = result.AllCategories,
+                categoryName = result.CategoryName,
+                message = result.AllCategories
+                    ? "You have been unsubscribed from all newsletters."
+                    : $"You have been unsubscribed from {result.CategoryName} newsletters."
+            });
+        }
+    }
+
+    /// <summary>
+    /// Request model for token-based unsubscribe in V2 API.
+    /// </summary>
+    public class UnsubscribeRequestDto
+    {
+        /// <summary>
+        /// Gets or sets the unsubscribe token.
+        /// </summary>
+        public string Token { get; set; } = string.Empty;
     }
 }

--- a/TrashMob/Controllers/V2/PartnerLocationEventServicesV2Controller.cs
+++ b/TrashMob/Controllers/V2/PartnerLocationEventServicesV2Controller.cs
@@ -1,0 +1,88 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models.Poco;
+    using TrashMob.Security;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for managing partner location event services.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/partnerlocationeventservices")]
+    public class PartnerLocationEventServicesV2Controller(
+        IEventPartnerLocationServiceManager eventPartnerLocationServiceManager,
+        IPartnerLocationManager partnerLocationManager,
+        IAuthorizationService authorizationService,
+        ILogger<PartnerLocationEventServicesV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => new(HttpContext.Items["UserId"]?.ToString() ?? string.Empty);
+
+        /// <summary>
+        /// Gets all event services for a given partner location.
+        /// </summary>
+        /// <param name="locationId">The partner location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the event services for the partner location.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpGet("{locationId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayPartnerLocationServiceEvent>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> GetByPartnerLocation(Guid locationId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocationEventServices PartnerLocation={PartnerLocationId}", locationId);
+
+            var partner = await partnerLocationManager.GetPartnerForLocationAsync(locationId, cancellationToken);
+            if (!await IsAuthorizedAsync(partner, AuthorizationPolicyConstants.UserIsPartnerUserOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var events = await eventPartnerLocationServiceManager
+                .GetByPartnerLocationAsync(locationId, cancellationToken);
+
+            return Ok(events);
+        }
+
+        /// <summary>
+        /// Gets all event services for a given user.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the event services for the user.</response>
+        [HttpGet("by-user/{userId}")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [ProducesResponseType(typeof(IReadOnlyList<DisplayPartnerLocationServiceEvent>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByUser(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPartnerLocationEventServicesByUser User={UserId}", userId);
+
+            var events = await eventPartnerLocationServiceManager.GetByUserAsync(userId, cancellationToken);
+
+            return Ok(events);
+        }
+
+        private async Task<bool> IsAuthorizedAsync(object resource, string policy)
+        {
+            if (User.Identity?.IsAuthenticated != true)
+            {
+                return false;
+            }
+
+            var authResult = await authorizationService.AuthorizeAsync(User, resource, policy);
+            return authResult.Succeeded;
+        }
+    }
+}

--- a/TrashMob/Controllers/V2/PickupLocationsV2Controller.cs
+++ b/TrashMob/Controllers/V2/PickupLocationsV2Controller.cs
@@ -77,6 +77,61 @@ namespace TrashMob.Controllers.V2
         }
 
         /// <summary>
+        /// Gets pickup locations by user ID.
+        /// </summary>
+        /// <param name="userId">The user ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the pickup locations for the user.</response>
+        [HttpGet("by-user/{userId}")]
+        [ProducesResponseType(typeof(IReadOnlyList<PickupLocationDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetByUser(Guid userId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetPickupLocationsByUser User={UserId}", userId);
+
+            var entities = await pickupLocationManager.GetByUserAsync(userId, cancellationToken);
+            var dtos = entities.Select(e => e.ToV2Dto()).ToList();
+
+            return Ok(dtos);
+        }
+
+        /// <summary>
+        /// Marks a pickup location as picked up.
+        /// </summary>
+        /// <param name="id">The pickup location ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Pickup location marked as picked up.</response>
+        /// <response code="403">Not authorized.</response>
+        [HttpPost("{id}/mark-picked-up")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> MarkAsPickedUp(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 MarkAsPickedUp Id={Id}", id);
+
+            var pickupLocation = await pickupLocationManager.GetAsync(id, cancellationToken);
+            if (pickupLocation is null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(pickupLocation, AuthorizationPolicyConstants.UserIsEventLead))
+            {
+                var mobEvent = await eventManager.GetAsync(pickupLocation.EventId, cancellationToken);
+                if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLead))
+                {
+                    return Forbid();
+                }
+            }
+
+            await pickupLocationManager.MarkAsPickedUpAsync(id, UserId, cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
         /// Adds a new pickup location.
         /// </summary>
         /// <param name="dto">The pickup location data.</param>

--- a/TrashMob/client-app/src/pages/siteadmin/litter-reports/page.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/litter-reports/page.tsx
@@ -8,7 +8,7 @@ export const SiteAdminLitterReports = () => {
     const { data: litterReports, isLoading } = useQuery({
         queryKey: GetLitterReports().key,
         queryFn: GetLitterReports().service,
-        select: (res) => res.data,
+        select: (res) => res.data.items,
     });
 
     const len = litterReports?.length ?? 0;

--- a/TrashMob/client-app/src/services/adoptable-areas.ts
+++ b/TrashMob/client-app/src/services/adoptable-areas.ts
@@ -15,7 +15,7 @@ export const GetAdoptableAreas = (params: GetAdoptableAreas_Params) => ({
     key: ['/communities/', params.partnerId, '/areas'],
     service: async () =>
         ApiService('public').fetchData<GetAdoptableAreas_Response>({
-            url: `/communities/${params.partnerId}/areas`,
+            url: `/v2/communities/${params.partnerId}/areas`,
             method: 'get',
         }),
 });
@@ -26,7 +26,7 @@ export const GetAvailableAreas = (params: GetAvailableAreas_Params) => ({
     key: ['/communities/', params.partnerId, '/areas/available'],
     service: async () =>
         ApiService('public').fetchData<GetAvailableAreas_Response>({
-            url: `/communities/${params.partnerId}/areas/available`,
+            url: `/v2/communities/${params.partnerId}/areas/available`,
             method: 'get',
         }),
 });
@@ -37,7 +37,7 @@ export const GetAdoptableArea = (params: GetAdoptableArea_Params) => ({
     key: ['/communities/', params.partnerId, '/areas/', params.areaId],
     service: async () =>
         ApiService('public').fetchData<GetAdoptableArea_Response>({
-            url: `/communities/${params.partnerId}/areas/${params.areaId}`,
+            url: `/v2/communities/${params.partnerId}/areas/${params.areaId}`,
             method: 'get',
         }),
 });
@@ -50,7 +50,7 @@ export const CheckAreaName = (params: CheckAreaName_Params) => ({
         const queryParams = new URLSearchParams({ name: params.name });
         if (params.excludeAreaId) queryParams.append('excludeAreaId', params.excludeAreaId);
         return ApiService('public').fetchData<CheckAreaName_Response>({
-            url: `/communities/${params.partnerId}/areas/check-name?${queryParams.toString()}`,
+            url: `/v2/communities/${params.partnerId}/areas/check-name?${queryParams.toString()}`,
             method: 'get',
         });
     },
@@ -63,7 +63,7 @@ export const CreateAdoptableArea = () => ({
     key: ['/communities/areas', 'create'],
     service: async (params: CreateAdoptableArea_Params, body: CreateAdoptableArea_Body) =>
         ApiService('protected').fetchData<CreateAdoptableArea_Response, CreateAdoptableArea_Body>({
-            url: `/communities/${params.partnerId}/areas`,
+            url: `/v2/communities/${params.partnerId}/areas`,
             method: 'post',
             data: body,
         }),
@@ -76,7 +76,7 @@ export const UpdateAdoptableArea = () => ({
     key: ['/communities/areas', 'update'],
     service: async (params: UpdateAdoptableArea_Params, body: UpdateAdoptableArea_Body) =>
         ApiService('protected').fetchData<UpdateAdoptableArea_Response, UpdateAdoptableArea_Body>({
-            url: `/communities/${params.partnerId}/areas/${params.areaId}`,
+            url: `/v2/communities/${params.partnerId}/areas/${params.areaId}`,
             method: 'put',
             data: body,
         }),
@@ -88,7 +88,7 @@ export const DeleteAdoptableArea = () => ({
     key: ['/communities/areas', 'delete'],
     service: async (params: DeleteAdoptableArea_Params) =>
         ApiService('protected').fetchData<DeleteAdoptableArea_Response>({
-            url: `/communities/${params.partnerId}/areas/${params.areaId}`,
+            url: `/v2/communities/${params.partnerId}/areas/${params.areaId}`,
             method: 'delete',
         }),
 });
@@ -99,7 +99,7 @@ export const ClearAllAreas = () => ({
     key: ['/communities/areas', 'clear-all'],
     service: async (params: ClearAllAreas_Params) =>
         ApiService('protected').fetchData<ClearAllAreas_Response>({
-            url: `/communities/${params.partnerId}/areas/clear-all`,
+            url: `/v2/communities/${params.partnerId}/areas/clear-all`,
             method: 'delete',
         }),
 });
@@ -113,7 +113,7 @@ export const ExportAreas = (params: ExportAreas_Params) => ({
     key: ['/communities/', params.partnerId, '/areas/export', params.format],
     service: async () =>
         ApiService('protected').fetchData<Blob>({
-            url: `/communities/${params.partnerId}/areas/export?format=${params.format}`,
+            url: `/v2/communities/${params.partnerId}/areas/export?format=${params.format}`,
             method: 'get',
             responseType: 'blob',
         }),
@@ -145,7 +145,7 @@ export const SuggestArea = () => ({
     key: ['/communities/areas', 'suggest'],
     service: async (params: SuggestArea_Params, body: SuggestArea_Body) =>
         ApiService('protected').fetchData<SuggestArea_Response>({
-            url: `/communities/${params.partnerId}/areas/suggest`,
+            url: `/v2/communities/${params.partnerId}/areas/suggest`,
             method: 'post',
             data: body,
         }),
@@ -174,7 +174,7 @@ export const ParseImportFile = () => ({
     key: ['/communities/areas', 'import-parse'],
     service: async (params: ParseImportFile_Params, formData: FormData) =>
         ApiService('protected').fetchData<ParseImportFile_Response>({
-            url: `/communities/${params.partnerId}/areas/import/parse`,
+            url: `/v2/communities/${params.partnerId}/areas/import/parse`,
             method: 'post',
             data: formData,
             headers: { 'Content-Type': 'multipart/form-data' },
@@ -194,7 +194,7 @@ export const BulkImportAreas = () => ({
     key: ['/communities/areas', 'bulk-import'],
     service: async (params: BulkImportAreas_Params, body: BulkImportAreas_Body) =>
         ApiService('protected').fetchData<BulkImportAreas_Response>({
-            url: `/communities/${params.partnerId}/areas/import`,
+            url: `/v2/communities/${params.partnerId}/areas/import`,
             method: 'post',
             data: body,
         }),
@@ -217,7 +217,7 @@ export const StartAreaGeneration = () => ({
     key: ['/communities/areas', 'generate'],
     service: async (params: StartAreaGeneration_Params, body: StartAreaGeneration_Body) =>
         ApiService('protected').fetchData<StartAreaGeneration_Response, StartAreaGeneration_Body>({
-            url: `/communities/${params.partnerId}/areas/generate`,
+            url: `/v2/communities/${params.partnerId}/areas/generate`,
             method: 'post',
             data: body,
         }),
@@ -229,7 +229,7 @@ export const GetGenerationStatus = (params: GetGenerationStatus_Params) => ({
     key: ['/communities/', params.partnerId, '/areas/generate/status'],
     service: async () =>
         ApiService('public').fetchData<GetGenerationStatus_Response>({
-            url: `/communities/${params.partnerId}/areas/generate/status`,
+            url: `/v2/communities/${params.partnerId}/areas/generate/status`,
             method: 'get',
         }),
 });
@@ -240,7 +240,7 @@ export const GetGenerationBatches = (params: GetGenerationBatches_Params) => ({
     key: ['/communities/', params.partnerId, '/areas/generate/batches'],
     service: async () =>
         ApiService('public').fetchData<GetGenerationBatches_Response>({
-            url: `/communities/${params.partnerId}/areas/generate/batches`,
+            url: `/v2/communities/${params.partnerId}/areas/generate/batches`,
             method: 'get',
         }),
 });
@@ -251,7 +251,7 @@ export const GetGenerationBatch = (params: GetGenerationBatch_Params) => ({
     key: ['/communities/', params.partnerId, '/areas/generate/batches/', params.batchId],
     service: async () =>
         ApiService('public').fetchData<GetGenerationBatch_Response>({
-            url: `/communities/${params.partnerId}/areas/generate/batches/${params.batchId}`,
+            url: `/v2/communities/${params.partnerId}/areas/generate/batches/${params.batchId}`,
             method: 'get',
         }),
 });
@@ -262,7 +262,7 @@ export const CancelGeneration = () => ({
     key: ['/communities/areas', 'cancel-generation'],
     service: async (params: CancelGeneration_Params) =>
         ApiService('protected').fetchData<CancelGeneration_Response>({
-            url: `/communities/${params.partnerId}/areas/generate/batches/${params.batchId}`,
+            url: `/v2/communities/${params.partnerId}/areas/generate/batches/${params.batchId}`,
             method: 'delete',
         }),
 });
@@ -277,7 +277,7 @@ export const GetStagedAreas = (params: GetStagedAreas_Params) => ({
     key: ['/communities/', params.partnerId, '/areas/staged', params.batchId],
     service: async () =>
         ApiService('public').fetchData<GetStagedAreas_Response>({
-            url: `/communities/${params.partnerId}/areas/staged?batchId=${params.batchId}`,
+            url: `/v2/communities/${params.partnerId}/areas/staged?batchId=${params.batchId}`,
             method: 'get',
         }),
 });
@@ -288,7 +288,7 @@ export const ApproveStagedArea = () => ({
     key: ['/communities/areas/staged', 'approve'],
     service: async (params: ApproveStagedArea_Params) =>
         ApiService('protected').fetchData<ApproveStagedArea_Response>({
-            url: `/communities/${params.partnerId}/areas/staged/${params.id}/approve`,
+            url: `/v2/communities/${params.partnerId}/areas/staged/${params.id}/approve`,
             method: 'put',
         }),
 });
@@ -299,7 +299,7 @@ export const RejectStagedArea = () => ({
     key: ['/communities/areas/staged', 'reject'],
     service: async (params: RejectStagedArea_Params) =>
         ApiService('protected').fetchData<RejectStagedArea_Response>({
-            url: `/communities/${params.partnerId}/areas/staged/${params.id}/reject`,
+            url: `/v2/communities/${params.partnerId}/areas/staged/${params.id}/reject`,
             method: 'put',
         }),
 });
@@ -311,7 +311,7 @@ export const BulkApproveStagedAreas = () => ({
     key: ['/communities/areas/staged', 'approve-batch'],
     service: async (params: BulkApproveStagedAreas_Params, body: BulkApproveStagedAreas_Body) =>
         ApiService('protected').fetchData<BulkApproveStagedAreas_Response, BulkApproveStagedAreas_Body>({
-            url: `/communities/${params.partnerId}/areas/staged/approve-batch`,
+            url: `/v2/communities/${params.partnerId}/areas/staged/approve-batch`,
             method: 'post',
             data: body,
         }),
@@ -324,7 +324,7 @@ export const BulkRejectStagedAreas = () => ({
     key: ['/communities/areas/staged', 'reject-batch'],
     service: async (params: BulkRejectStagedAreas_Params, body: BulkRejectStagedAreas_Body) =>
         ApiService('protected').fetchData<BulkRejectStagedAreas_Response, BulkRejectStagedAreas_Body>({
-            url: `/communities/${params.partnerId}/areas/staged/reject-batch`,
+            url: `/v2/communities/${params.partnerId}/areas/staged/reject-batch`,
             method: 'post',
             data: body,
         }),
@@ -337,7 +337,7 @@ export const UpdateStagedAreaName = () => ({
     key: ['/communities/areas/staged', 'update-name'],
     service: async (params: UpdateStagedAreaName_Params, body: UpdateStagedAreaName_Body) =>
         ApiService('protected').fetchData<UpdateStagedAreaName_Response, UpdateStagedAreaName_Body>({
-            url: `/communities/${params.partnerId}/areas/staged/${params.id}/name`,
+            url: `/v2/communities/${params.partnerId}/areas/staged/${params.id}/name`,
             method: 'put',
             data: body,
         }),
@@ -350,7 +350,7 @@ export const CreateApprovedAreas = () => ({
     key: ['/communities/areas/staged', 'create-approved'],
     service: async (params: CreateApprovedAreas_Params, body: CreateApprovedAreas_Body) =>
         ApiService('protected').fetchData<CreateApprovedAreas_Response, CreateApprovedAreas_Body>({
-            url: `/communities/${params.partnerId}/areas/staged/create-approved`,
+            url: `/v2/communities/${params.partnerId}/areas/staged/create-approved`,
             method: 'post',
             data: body,
         }),

--- a/TrashMob/client-app/src/services/cms.ts
+++ b/TrashMob/client-app/src/services/cms.ts
@@ -54,7 +54,7 @@ export const GetHeroSection = () => ({
     key: ['/cms/hero-section'],
     service: async () =>
         ApiService('public')
-            .fetchData<GetHeroSection_Response>({ url: '/cms/hero-section', method: 'get' })
+            .fetchData<GetHeroSection_Response>({ url: '/v2/cms/hero-section', method: 'get' })
             .then((res) => res.data?.data ?? null)
             .catch(() => null),
 });
@@ -64,7 +64,7 @@ export const GetWhatIsTrashmob = () => ({
     key: ['/cms/what-is-trashmob'],
     service: async () =>
         ApiService('public')
-            .fetchData<GetWhatIsTrashmob_Response>({ url: '/cms/what-is-trashmob', method: 'get' })
+            .fetchData<GetWhatIsTrashmob_Response>({ url: '/v2/cms/what-is-trashmob', method: 'get' })
             .then((res) => res.data?.data ?? null)
             .catch(() => null),
 });
@@ -74,7 +74,7 @@ export const GetGettingStarted = () => ({
     key: ['/cms/getting-started'],
     service: async () =>
         ApiService('public')
-            .fetchData<GetGettingStarted_Response>({ url: '/cms/getting-started', method: 'get' })
+            .fetchData<GetGettingStarted_Response>({ url: '/v2/cms/getting-started', method: 'get' })
             .then((res) => res.data?.data ?? null)
             .catch(() => null),
 });
@@ -132,7 +132,7 @@ export const GetNewsPosts = (params: NewsPostsParams = {}) => ({
         if (params.category) searchParams.set('category', params.category);
         const qs = searchParams.toString();
         return ApiService('public')
-            .fetchData<GetNewsPosts_Response>({ url: `/cms/news-posts${qs ? `?${qs}` : ''}`, method: 'get' })
+            .fetchData<GetNewsPosts_Response>({ url: `/v2/cms/news-posts${qs ? `?${qs}` : ''}`, method: 'get' })
             .then((res) => res.data)
             .catch(() => ({ data: [], meta: { pagination: { page: 1, pageSize: 10, pageCount: 0, total: 0 } } }));
     },
@@ -143,7 +143,7 @@ export const GetNewsPostBySlug = (slug: string) => ({
     key: ['/cms/news-posts', slug],
     service: async () =>
         ApiService('public')
-            .fetchData<GetNewsPostBySlug_Response>({ url: `/cms/news-posts/${slug}`, method: 'get' })
+            .fetchData<GetNewsPostBySlug_Response>({ url: `/v2/cms/news-posts/${slug}`, method: 'get' })
             .then((res) => res.data?.data?.[0] ?? null)
             .catch(() => null),
 });
@@ -153,7 +153,7 @@ export const GetNewsCategories = () => ({
     key: ['/cms/news-categories'],
     service: async () =>
         ApiService('public')
-            .fetchData<GetNewsCategories_Response>({ url: '/cms/news-categories', method: 'get' })
+            .fetchData<GetNewsCategories_Response>({ url: '/v2/cms/news-categories', method: 'get' })
             .then((res) => res.data?.data ?? [])
             .catch(() => []),
 });
@@ -164,6 +164,6 @@ export const GetCmsAdminUrl = () => ({
     key: ['/cms/admin-url'],
     service: async () =>
         ApiService('protected')
-            .fetchData<GetCmsAdminUrl_Response>({ url: '/cms/admin-url', method: 'get' })
+            .fetchData<GetCmsAdminUrl_Response>({ url: '/v2/cms/admin-url', method: 'get' })
             .then((res) => res.data),
 });

--- a/TrashMob/client-app/src/services/communities.ts
+++ b/TrashMob/client-app/src/services/communities.ts
@@ -51,7 +51,7 @@ export const CheckCommunitySlug = (params: CheckCommunitySlug_Params) => ({
         const queryParams = new URLSearchParams({ slug: params.slug });
         if (params.excludePartnerId) queryParams.append('excludePartnerId', params.excludePartnerId);
         return ApiService('public').fetchData<CheckCommunitySlug_Response>({
-            url: `/communities/check-slug?${queryParams.toString()}`,
+            url: `/v2/communities/check-slug?${queryParams.toString()}`,
             method: 'get',
         });
     },
@@ -93,7 +93,7 @@ export const GetCommunityLitterReports = (params: GetCommunityLitterReports_Para
     key: ['/communities/', params.slug, '/litterreports'],
     service: async () =>
         ApiService('public').fetchData<GetCommunityLitterReports_Response>({
-            url: `/communities/${params.slug}/litterreports`,
+            url: `/v2/communities/${params.slug}/litterreports`,
             method: 'get',
         }),
 });
@@ -118,7 +118,7 @@ export const GetFeaturedCommunities = () => ({
     key: ['/communities/featured'],
     service: async () =>
         ApiService('public').fetchData<GetFeaturedCommunities_Response>({
-            url: '/communities/featured',
+            url: '/v2/communities/featured',
             method: 'get',
         }),
 });
@@ -134,7 +134,7 @@ export const GetCommunityPublicStats = () => ({
     key: ['/communities/public-stats'],
     service: async () =>
         ApiService('public').fetchData<GetCommunityPublicStats_Response>({
-            url: '/communities/public-stats',
+            url: '/v2/communities/public-stats',
             method: 'get',
         }),
 });
@@ -166,7 +166,7 @@ export const GetCommunityDashboard = (params: GetCommunityDashboard_Params) => (
     key: ['/communities/admin/', params.communityId, '/dashboard'],
     service: async () =>
         ApiService('protected').fetchData<GetCommunityDashboard_Response>({
-            url: `/communities/admin/${params.communityId}/dashboard`,
+            url: `/v2/communities/admin/${params.communityId}/dashboard`,
             method: 'get',
         }),
 });
@@ -177,7 +177,7 @@ export const GetCommunityForAdmin = (params: GetCommunityForAdmin_Params) => ({
     key: ['/communities/admin/', params.communityId],
     service: async () =>
         ApiService('protected').fetchData<GetCommunityForAdmin_Response>({
-            url: `/communities/admin/${params.communityId}`,
+            url: `/v2/communities/admin/${params.communityId}`,
             method: 'get',
         }),
 });
@@ -188,7 +188,7 @@ export const UpdateCommunityContent = () => ({
     key: ['/communities/admin/', 'update'],
     service: async (params: UpdateCommunityContent_Params) =>
         ApiService('protected').fetchData<UpdateCommunityContent_Response>({
-            url: `/communities/admin/${params.id}`,
+            url: `/v2/communities/admin/${params.id}`,
             method: 'put',
             data: params,
         }),
@@ -215,7 +215,7 @@ export const SuggestCommunityBounds = (params: SuggestCommunityBounds_Params) =>
     key: ['/communities/admin/', params.communityId, '/suggest-bounds'],
     service: async () =>
         ApiService('protected').fetchData<SuggestCommunityBounds_Response>({
-            url: `/communities/admin/${params.communityId}/suggest-bounds`,
+            url: `/v2/communities/admin/${params.communityId}/suggest-bounds`,
             method: 'get',
         }),
 });
@@ -232,7 +232,7 @@ export const UploadCommunityLogo = () => ({
         const formData = new FormData();
         formData.append('formFile', file);
         return ApiService('protected').fetchData<UploadCommunityLogo_Response>({
-            url: `/communities/admin/${params.communityId}/logo`,
+            url: `/v2/communities/admin/${params.communityId}/logo`,
             method: 'post',
             data: formData,
             headers: { 'Content-Type': 'multipart/form-data' },
@@ -248,7 +248,7 @@ export const UploadCommunityBanner = () => ({
         const formData = new FormData();
         formData.append('formFile', file);
         return ApiService('protected').fetchData<UploadCommunityBanner_Response>({
-            url: `/communities/admin/${params.communityId}/banner`,
+            url: `/v2/communities/admin/${params.communityId}/banner`,
             method: 'post',
             data: formData,
             headers: { 'Content-Type': 'multipart/form-data' },

--- a/TrashMob/client-app/src/services/community-photos.ts
+++ b/TrashMob/client-app/src/services/community-photos.ts
@@ -15,7 +15,7 @@ export const GetCommunityPhotos = (params: GetCommunityPhotos_Params) => ({
     key: ['/communities', params.slug, 'photos'],
     service: async () =>
         ApiService('public').fetchData<GetCommunityPhotos_Response>({
-            url: `/communities/${params.slug}/photos`,
+            url: `/v2/communities/${params.slug}/photos`,
             method: 'get',
         }),
 });
@@ -32,7 +32,7 @@ export const UploadCommunityPhoto = () => ({
         const formData = new FormData();
         formData.append('formFile', file);
         return ApiService('protected').fetchData<UploadCommunityPhoto_Response>({
-            url: `/communities/${params.slug}/photos`,
+            url: `/v2/communities/${params.slug}/photos`,
             method: 'post',
             data: formData,
             headers: {
@@ -52,7 +52,7 @@ export const UpdateCommunityPhotoCaption = () => ({
     key: ['/communities/photos', 'update'],
     service: async (params: UpdateCommunityPhoto_Params, caption: string) =>
         ApiService('protected').fetchData<UpdateCommunityPhoto_Response, string>({
-            url: `/communities/${params.slug}/photos/${params.photoId}`,
+            url: `/v2/communities/${params.slug}/photos/${params.photoId}`,
             method: 'put',
             data: caption,
         }),
@@ -68,7 +68,7 @@ export const DeleteCommunityPhoto = () => ({
     key: ['/communities/photos', 'delete'],
     service: async (params: DeleteCommunityPhoto_Params) =>
         ApiService('protected').fetchData<DeleteCommunityPhoto_Response>({
-            url: `/communities/${params.slug}/photos/${params.photoId}`,
+            url: `/v2/communities/${params.slug}/photos/${params.photoId}`,
             method: 'delete',
         }),
 });

--- a/TrashMob/client-app/src/services/events.ts
+++ b/TrashMob/client-app/src/services/events.ts
@@ -59,7 +59,7 @@ export const GetAllActiveEvents = () => ({
     key: ['/Events/active'],
     service: async () =>
         ApiService('public').fetchData<GetAllActiveEvents_Response>({
-            url: '/Events/active',
+            url: '/v2/events/active',
             method: 'get',
         }),
 });
@@ -69,7 +69,7 @@ export const GetAllCompletedEvents = () => ({
     key: ['/Events/completed'],
     service: async () =>
         ApiService('public').fetchData<GetAllCompletedEvents_Response>({
-            url: '/Events/completed',
+            url: '/v2/events/completed',
             method: 'get',
         }),
 });
@@ -79,7 +79,7 @@ export const GetAllNotCancelledEvents = () => ({
     key: ['/Events/notcanceled'],
     service: async () =>
         ApiService('public').fetchData<GetAllNotCancelledEvents_Response>({
-            url: '/Events/notcanceled',
+            url: '/v2/events/notcanceled',
             method: 'get',
         }),
 });
@@ -106,7 +106,7 @@ export const GetEventsSummaries = (params: GetEventsSummaries_Params) => ({
     key: ['/eventsummaries', params],
     service: async () =>
         ApiService('public').fetchData<GetEventsSummaries_Response>({
-            url: `/eventsummaries?country=${params.country}&region=${params.region}&city=${params.city}&postalCode=${params.postalCode}`,
+            url: `/v2/events/summaries?country=${params.country}&region=${params.region}&city=${params.city}&postalCode=${params.postalCode}`,
             method: 'get',
         }),
 });

--- a/TrashMob/client-app/src/services/job-opportunities.ts
+++ b/TrashMob/client-app/src/services/job-opportunities.ts
@@ -6,7 +6,7 @@ export const GetAllJobOpportunities = () => ({
     key: ['/jobopportunities'],
     service: async () => {
         return ApiService('public').fetchData<GetAllJobOpportunities_Response>({
-            url: '/jobopportunities',
+            url: '/v2/jobopportunities',
             method: 'get',
         });
     },

--- a/TrashMob/client-app/src/services/leaderboards.ts
+++ b/TrashMob/client-app/src/services/leaderboards.ts
@@ -61,7 +61,7 @@ export const GetLeaderboardOptions = () => ({
     key: ['/leaderboards/options'],
     service: async () =>
         ApiService('public').fetchData<GetLeaderboardOptions_Response>({
-            url: '/leaderboards/options',
+            url: '/v2/leaderboards/options',
             method: 'get',
         }),
 });

--- a/TrashMob/client-app/src/services/litter-report.ts
+++ b/TrashMob/client-app/src/services/litter-report.ts
@@ -1,13 +1,13 @@
 import LitterReportData from '@/components/Models/LitterReportData';
+import { PagedResponse } from '@/lib/api-errors';
 import { ApiService } from '.';
 
-// No v2 equivalent for filtered list (new/notcancelled) — stays on v1
-export type GetLitterReports_Response = LitterReportData[];
+export type GetLitterReports_Response = PagedResponse<LitterReportData>;
 export const GetLitterReports = () => ({
     key: ['/litterreport', 'list'],
     service: async () =>
         ApiService('public').fetchData<GetLitterReports_Response>({
-            url: '/litterreport',
+            url: '/v2/litterreports?pageSize=100',
             method: 'get',
         }),
 });
@@ -23,24 +23,22 @@ export const GetLitterReport = (params: GetLitterReport_Params) => ({
         }),
 });
 
-// No v2 equivalent for status-filtered endpoints — stays on v1
 export type GetNewLitterReports_Response = LitterReportData[];
 export const GetNewLitterReports = () => ({
     key: ['/litterreport', 'new'],
     service: async () =>
         ApiService('public').fetchData<GetNewLitterReports_Response>({
-            url: '/litterreport/new',
+            url: '/v2/litterreports/new',
             method: 'get',
         }),
 });
 
-// No v2 equivalent for status-filtered endpoints — stays on v1
 export type GetNotCancelledLitterReports_Response = LitterReportData[];
 export const GetNotCancelledLitterReports = () => ({
     key: ['/litterreport', 'notcancelled'],
     service: async () =>
         ApiService('public').fetchData<GetNotCancelledLitterReports_Response>({
-            url: '/litterreport/notcancelled',
+            url: '/v2/litterreports/notcancelled',
             method: 'get',
         }),
 });

--- a/TrashMob/client-app/src/services/locations.ts
+++ b/TrashMob/client-app/src/services/locations.ts
@@ -100,14 +100,13 @@ export const GetEventPickupLocations = (params: GetEventPickupLocations_Params) 
         }),
 });
 
-// No v2 equivalent — stays on v1
 export type GetEventPickupLocationsByUser_Params = { userId: string };
 export type GetEventPickupLocationsByUser_Response = PickupLocationData[];
 export const GetEventPickupLocationsByUser = (params: GetEventPickupLocationsByUser_Params) => ({
     key: ['/pickupLocations/getbyuser/', params],
     service: async () =>
         ApiService('protected').fetchData<GetEventPickupLocationsByUser_Response>({
-            url: `/pickupLocations/getbyuser/${params.userId}`,
+            url: `/v2/pickuplocations/by-user/${params.userId}`,
             method: 'get',
         }),
 });
@@ -293,7 +292,6 @@ export const UpdateLocationService = () => ({
         }),
 });
 
-// No v2 equivalent — stays on v1
 export type GetPartnerLocationEventServicesByLocationId_Params = {
     locationId: string;
 };
@@ -304,24 +302,22 @@ export const GetPartnerLocationEventServicesByLocationId = (
     key: ['/partnerlocationeventservices/', params],
     service: async () =>
         ApiService('protected').fetchData<GetPartnerLocationEventServicesByLocationId_Response>({
-            url: `/partnerlocationeventservices/${params.locationId}`,
+            url: `/v2/partnerlocationeventservices/${params.locationId}`,
             method: 'get',
         }),
 });
 
-// No v2 equivalent — stays on v1
 export type GetPartnerLocationEventServicesByUserId_Params = { userId: string };
 export type GetPartnerLocationEventServicesByUserId_Response = DisplayPartnerLocationEventData[];
 export const GetPartnerLocationEventServicesByUserId = (params: GetPartnerLocationEventServicesByUserId_Params) => ({
     key: ['/partnerlocationeventservices/getbyuser/', params],
     service: async () =>
         ApiService('protected').fetchData<GetPartnerLocationEventServicesByUserId_Response>({
-            url: `/partnerlocationeventservices/getbyuser/${params.userId}`,
+            url: `/v2/partnerlocationeventservices/by-user/${params.userId}`,
             method: 'get',
         }),
 });
 
-// No v2 equivalent for accept/decline route pattern — stays on v1
 export type UpdateEventPartnerLocationServices_Params = {
     acceptDecline: 'accept' | 'decline';
     eventId: string;
@@ -333,19 +329,18 @@ export const UpdateEventPartnerLocationServices = () => ({
     key: ['/eventpartnerlocationservices/', 'update'],
     service: async (params: UpdateEventPartnerLocationServices_Params) =>
         ApiService('protected').fetchData<UpdateEventPartnerLocationServices_Response>({
-            url: `/eventpartnerlocationservices/${params.acceptDecline}/${params.eventId}/${params.partnerLocationId}/${params.serviceTypeId}`,
+            url: `/v2/eventpartnerlocationservices/${params.acceptDecline}/${params.eventId}/${params.partnerLocationId}/${params.serviceTypeId}`,
             method: 'put',
         }),
 });
 
-// No v2 equivalent — stays on v1
 export type PickupLocationMarkAsPickedUp_Params = { locationId: string };
 export type PickupLocationMarkAsPickedUp_Response = unknown;
 export const PickupLocationMarkAsPickedUp = () => ({
     key: ['/pickuplocations/markpickedup/'],
     service: async (params: PickupLocationMarkAsPickedUp_Params) =>
         ApiService('protected').fetchData<PickupLocationMarkAsPickedUp_Response>({
-            url: `/pickuplocations/markpickedup/${params.locationId}`,
+            url: `/v2/pickuplocations/${params.locationId}/mark-picked-up`,
             method: 'post',
         }),
 });

--- a/TrashMob/client-app/src/services/maps.ts
+++ b/TrashMob/client-app/src/services/maps.ts
@@ -11,13 +11,14 @@ import { ApiService } from '.';
 export type GetMaps_Response = string;
 export const GetMaps = () => ({
     key: ['/maps'],
-    service: async () => ApiService('public').fetchData<GetMaps_Response>({ url: `/maps`, method: 'get' }),
+    service: async () => ApiService('public').fetchData<GetMaps_Response>({ url: `/v2/maps`, method: 'get' }),
 });
 
 export type GetGoogleMapApiKey_Response = string;
 export const GetGoogleMapApiKey = () => ({
     key: ['/maps/googlemapkey'],
-    service: async () => ApiService('public').fetchData<GetMaps_Response>({ url: `/maps/googlemapkey`, method: 'get' }),
+    service: async () =>
+        ApiService('public').fetchData<GetMaps_Response>({ url: `/v2/maps/googlemapkey`, method: 'get' }),
 });
 
 export type GeographicEntityType =
@@ -39,7 +40,7 @@ export const SearchAddress = () => ({
     service: async (params: SearchAddress_Params) => {
         const entityTypeParam = params.entityType ? `&entityType=${params.entityType.join(',')}` : '';
         return ApiService('public').fetchData<SearchAddress_Response>({
-            url: `/maps/search?query=${encodeURIComponent(params.query)}${entityTypeParam}`,
+            url: `/v2/maps/search?query=${encodeURIComponent(params.query)}${entityTypeParam}`,
             method: 'get',
         });
     },
@@ -51,7 +52,7 @@ export const ReverseGeocode = () => ({
     key: ['ReverseGeocode'],
     service: async (params: ReverseGeocode_Params) =>
         ApiService('public').fetchData<ReverseGeocode_Response>({
-            url: `/maps/reversegeocode?latitude=${params.lat}&longitude=${params.long}`,
+            url: `/v2/maps/reversegeocode?latitude=${params.lat}&longitude=${params.long}`,
             method: 'get',
         }),
 });
@@ -70,7 +71,7 @@ export const AzureMapSearchAddress = () => ({
         // Redirect to the secure proxy endpoint (ignoring azureKey)
         const entityTypeParam = params.entityType ? `&entityType=${params.entityType.join(',')}` : '';
         return ApiService('public').fetchData<AzureMapSearchAddress_Response>({
-            url: `/maps/search?query=${encodeURIComponent(params.query)}${entityTypeParam}`,
+            url: `/v2/maps/search?query=${encodeURIComponent(params.query)}${entityTypeParam}`,
             method: 'get',
         });
     },
@@ -86,7 +87,7 @@ export const AzureMapSearchAddressReverse = () => ({
     service: async (params: AzureMapSearchAddressReverse_Params) => {
         // Redirect to the secure proxy endpoint (ignoring azureKey)
         return ApiService('public').fetchData<AzureMapSearchAddressReverse_Response>({
-            url: `/maps/reversegeocode?latitude=${params.lat}&longitude=${params.long}`,
+            url: `/v2/maps/reversegeocode?latitude=${params.lat}&longitude=${params.long}`,
             method: 'get',
         });
     },

--- a/TrashMob/client-app/src/services/newsletters.ts
+++ b/TrashMob/client-app/src/services/newsletters.ts
@@ -124,7 +124,7 @@ export const ProcessUnsubscribe = () => ({
     key: ['/newsletter-preferences', 'unsubscribe'],
     service: async (body: ProcessUnsubscribe_Body) =>
         ApiService('public').fetchData<ProcessUnsubscribe_Response, ProcessUnsubscribe_Body>({
-            url: '/newsletter-preferences/unsubscribe',
+            url: '/v2/newsletter-preferences/unsubscribe',
             method: 'post',
             data: body,
         }),

--- a/TrashMob/client-app/src/services/opportunities.ts
+++ b/TrashMob/client-app/src/services/opportunities.ts
@@ -6,7 +6,7 @@ export const GetAllJobOpportunities = () => ({
     key: ['/jobopportunities'],
     service: async () =>
         ApiService('protected').fetchData<GetAllJobOpportunities_Response>({
-            url: '/jobopportunities',
+            url: '/v2/jobopportunities',
             method: 'get',
         }),
 });

--- a/TrashMob/client-app/src/services/professional-companies.ts
+++ b/TrashMob/client-app/src/services/professional-companies.ts
@@ -13,7 +13,7 @@ export const GetProfessionalCompanies = (params: GetProfessionalCompanies_Params
     key: ['/communities/', params.partnerId, '/professional-companies'],
     service: async () =>
         ApiService('protected').fetchData<GetProfessionalCompanies_Response>({
-            url: `/communities/${params.partnerId}/professional-companies`,
+            url: `/v2/communities/${params.partnerId}/professional-companies`,
             method: 'get',
         }),
 });
@@ -24,7 +24,7 @@ export const GetProfessionalCompany = (params: GetProfessionalCompany_Params) =>
     key: ['/communities/', params.partnerId, '/professional-companies/', params.companyId],
     service: async () =>
         ApiService('protected').fetchData<GetProfessionalCompany_Response>({
-            url: `/communities/${params.partnerId}/professional-companies/${params.companyId}`,
+            url: `/v2/communities/${params.partnerId}/professional-companies/${params.companyId}`,
             method: 'get',
         }),
 });
@@ -36,7 +36,7 @@ export const CreateProfessionalCompany = () => ({
     key: ['/communities/professional-companies', 'create'],
     service: async (params: CreateProfessionalCompany_Params, body: CreateProfessionalCompany_Body) =>
         ApiService('protected').fetchData<CreateProfessionalCompany_Response, CreateProfessionalCompany_Body>({
-            url: `/communities/${params.partnerId}/professional-companies`,
+            url: `/v2/communities/${params.partnerId}/professional-companies`,
             method: 'post',
             data: body,
         }),
@@ -49,7 +49,7 @@ export const UpdateProfessionalCompany = () => ({
     key: ['/communities/professional-companies', 'update'],
     service: async (params: UpdateProfessionalCompany_Params, body: UpdateProfessionalCompany_Body) =>
         ApiService('protected').fetchData<UpdateProfessionalCompany_Response, UpdateProfessionalCompany_Body>({
-            url: `/communities/${params.partnerId}/professional-companies/${params.companyId}`,
+            url: `/v2/communities/${params.partnerId}/professional-companies/${params.companyId}`,
             method: 'put',
             data: body,
         }),
@@ -71,7 +71,7 @@ export const GetCompanyUsers = (params: GetCompanyUsers_Params) => ({
     key: ['/communities/', params.partnerId, '/professional-companies/', params.companyId, '/users'],
     service: async () =>
         ApiService('protected').fetchData<GetCompanyUsers_Response>({
-            url: `/communities/${params.partnerId}/professional-companies/${params.companyId}/users`,
+            url: `/v2/communities/${params.partnerId}/professional-companies/${params.companyId}/users`,
             method: 'get',
         }),
 });
@@ -87,7 +87,7 @@ export const AssignCompanyUser = () => ({
     key: ['/communities/professional-companies/users', 'assign'],
     service: async (params: AssignCompanyUser_Params, body: AssignCompanyUser_Body) =>
         ApiService('protected').fetchData<AssignCompanyUser_Response, AssignCompanyUser_Body>({
-            url: `/communities/${params.partnerId}/professional-companies/${params.companyId}/users`,
+            url: `/v2/communities/${params.partnerId}/professional-companies/${params.companyId}/users`,
             method: 'post',
             data: body,
         }),
@@ -99,7 +99,7 @@ export const RemoveCompanyUser = () => ({
     key: ['/communities/professional-companies/users', 'remove'],
     service: async (params: RemoveCompanyUser_Params) =>
         ApiService('protected').fetchData<RemoveCompanyUser_Response>({
-            url: `/communities/${params.partnerId}/professional-companies/${params.companyId}/users/${params.userId}`,
+            url: `/v2/communities/${params.partnerId}/professional-companies/${params.companyId}/users/${params.userId}`,
             method: 'delete',
         }),
 });

--- a/TrashMob/client-app/src/services/professional-company-portal.ts
+++ b/TrashMob/client-app/src/services/professional-company-portal.ts
@@ -14,7 +14,7 @@ export const GetMyCompanies = () => ({
     key: ['/professional-companies/mine'],
     service: async () =>
         ApiService('protected').fetchData<GetMyCompanies_Response>({
-            url: `/professional-companies/mine`,
+            url: `/v2/professional-companies/mine`,
             method: 'get',
         }),
 });
@@ -29,7 +29,7 @@ export const GetCompanyAssignments = (params: GetCompanyAssignments_Params) => (
     key: ['/professional-companies/', params.companyId, '/assignments'],
     service: async () =>
         ApiService('protected').fetchData<GetCompanyAssignments_Response>({
-            url: `/professional-companies/${params.companyId}/cleanup-logs/assignments`,
+            url: `/v2/professional-companies/${params.companyId}/cleanup-logs/assignments`,
             method: 'get',
         }),
 });
@@ -44,7 +44,7 @@ export const GetCompanyCleanupLogs = (params: GetCompanyCleanupLogs_Params) => (
     key: ['/professional-companies/', params.companyId, '/cleanup-logs'],
     service: async () =>
         ApiService('protected').fetchData<GetCompanyCleanupLogs_Response>({
-            url: `/professional-companies/${params.companyId}/cleanup-logs`,
+            url: `/v2/professional-companies/${params.companyId}/cleanup-logs`,
             method: 'get',
         }),
 });
@@ -56,7 +56,7 @@ export const LogCleanup = () => ({
     key: ['/professional-companies/cleanup-logs', 'create'],
     service: async (params: LogCleanup_Params, body: LogCleanup_Body) =>
         ApiService('protected').fetchData<LogCleanup_Response, LogCleanup_Body>({
-            url: `/professional-companies/${params.companyId}/cleanup-logs`,
+            url: `/v2/professional-companies/${params.companyId}/cleanup-logs`,
             method: 'post',
             data: body,
         }),

--- a/TrashMob/client-app/src/services/sponsor-portal.ts
+++ b/TrashMob/client-app/src/services/sponsor-portal.ts
@@ -14,7 +14,7 @@ export const GetMySponsors = () => ({
     key: ['/sponsors/mine'],
     service: async () =>
         ApiService('protected').fetchData<GetMySponsors_Response>({
-            url: `/sponsors/mine`,
+            url: `/v2/sponsors/mine`,
             method: 'get',
         }),
 });
@@ -29,7 +29,7 @@ export const GetSponsorAdoptions = (params: GetSponsorAdoptions_Params) => ({
     key: ['/sponsors/', params.sponsorId, '/adoptions'],
     service: async () =>
         ApiService('protected').fetchData<GetSponsorAdoptions_Response>({
-            url: `/sponsors/${params.sponsorId}/adoptions`,
+            url: `/v2/sponsors/${params.sponsorId}/adoptions`,
             method: 'get',
         }),
 });
@@ -44,7 +44,7 @@ export const GetSponsorCleanupLogs = (params: GetSponsorCleanupLogs_Params) => (
     key: ['/sponsors/', params.sponsorId, '/cleanup-logs'],
     service: async () =>
         ApiService('protected').fetchData<GetSponsorCleanupLogs_Response>({
-            url: `/sponsors/${params.sponsorId}/cleanup-logs`,
+            url: `/v2/sponsors/${params.sponsorId}/cleanup-logs`,
             method: 'get',
         }),
 });
@@ -58,7 +58,7 @@ export const ExportSponsorCleanupLogs = (params: ExportSponsorCleanupLogs_Params
     key: ['/sponsors/', params.sponsorId, '/cleanup-logs/export'],
     service: async () =>
         ApiService('protected').fetchData<Blob>({
-            url: `/sponsors/${params.sponsorId}/cleanup-logs/export`,
+            url: `/v2/sponsors/${params.sponsorId}/cleanup-logs/export`,
             method: 'get',
             responseType: 'blob',
         }),

--- a/TrashMob/client-app/src/services/sponsored-adoptions.ts
+++ b/TrashMob/client-app/src/services/sponsored-adoptions.ts
@@ -15,7 +15,7 @@ export const GetSponsoredAdoptions = (params: GetSponsoredAdoptions_Params) => (
     key: ['/communities/', params.partnerId, '/sponsored-adoptions'],
     service: async () =>
         ApiService('protected').fetchData<GetSponsoredAdoptions_Response>({
-            url: `/communities/${params.partnerId}/sponsored-adoptions`,
+            url: `/v2/communities/${params.partnerId}/sponsored-adoptions`,
             method: 'get',
         }),
 });
@@ -26,7 +26,7 @@ export const GetSponsoredAdoption = (params: GetSponsoredAdoption_Params) => ({
     key: ['/communities/', params.partnerId, '/sponsored-adoptions/', params.id],
     service: async () =>
         ApiService('protected').fetchData<GetSponsoredAdoption_Response>({
-            url: `/communities/${params.partnerId}/sponsored-adoptions/${params.id}`,
+            url: `/v2/communities/${params.partnerId}/sponsored-adoptions/${params.id}`,
             method: 'get',
         }),
 });
@@ -38,7 +38,7 @@ export const CreateSponsoredAdoption = () => ({
     key: ['/communities/sponsored-adoptions', 'create'],
     service: async (params: CreateSponsoredAdoption_Params, body: CreateSponsoredAdoption_Body) =>
         ApiService('protected').fetchData<CreateSponsoredAdoption_Response, CreateSponsoredAdoption_Body>({
-            url: `/communities/${params.partnerId}/sponsored-adoptions`,
+            url: `/v2/communities/${params.partnerId}/sponsored-adoptions`,
             method: 'post',
             data: body,
         }),
@@ -51,7 +51,7 @@ export const UpdateSponsoredAdoption = () => ({
     key: ['/communities/sponsored-adoptions', 'update'],
     service: async (params: UpdateSponsoredAdoption_Params, body: UpdateSponsoredAdoption_Body) =>
         ApiService('protected').fetchData<UpdateSponsoredAdoption_Response, UpdateSponsoredAdoption_Body>({
-            url: `/communities/${params.partnerId}/sponsored-adoptions/${params.id}`,
+            url: `/v2/communities/${params.partnerId}/sponsored-adoptions/${params.id}`,
             method: 'put',
             data: body,
         }),
@@ -67,7 +67,7 @@ export const GetSponsoredAdoptionCompliance = (params: GetSponsoredAdoptionCompl
     key: ['/communities/', params.partnerId, '/sponsored-adoptions/compliance'],
     service: async () =>
         ApiService('protected').fetchData<GetSponsoredAdoptionCompliance_Response>({
-            url: `/communities/${params.partnerId}/sponsored-adoptions/compliance`,
+            url: `/v2/communities/${params.partnerId}/sponsored-adoptions/compliance`,
             method: 'get',
         }),
 });
@@ -82,7 +82,7 @@ export const GetAdoptionCleanupLogs = (params: GetAdoptionCleanupLogs_Params) =>
     key: ['/sponsors/', params.sponsorId, '/adoptions/', params.adoptionId, '/reports'],
     service: async () =>
         ApiService('protected').fetchData<GetAdoptionCleanupLogs_Response>({
-            url: `/sponsors/${params.sponsorId}/adoptions/${params.adoptionId}/reports`,
+            url: `/v2/sponsors/${params.sponsorId}/adoptions/${params.adoptionId}/reports`,
             method: 'get',
         }),
 });

--- a/TrashMob/client-app/src/services/sponsors.ts
+++ b/TrashMob/client-app/src/services/sponsors.ts
@@ -13,7 +13,7 @@ export const GetSponsors = (params: GetSponsors_Params) => ({
     key: ['/communities/', params.partnerId, '/sponsors'],
     service: async () =>
         ApiService('protected').fetchData<GetSponsors_Response>({
-            url: `/communities/${params.partnerId}/sponsors`,
+            url: `/v2/communities/${params.partnerId}/sponsors`,
             method: 'get',
         }),
 });
@@ -24,7 +24,7 @@ export const GetSponsor = (params: GetSponsor_Params) => ({
     key: ['/communities/', params.partnerId, '/sponsors/', params.sponsorId],
     service: async () =>
         ApiService('protected').fetchData<GetSponsor_Response>({
-            url: `/communities/${params.partnerId}/sponsors/${params.sponsorId}`,
+            url: `/v2/communities/${params.partnerId}/sponsors/${params.sponsorId}`,
             method: 'get',
         }),
 });
@@ -36,7 +36,7 @@ export const CreateSponsor = () => ({
     key: ['/communities/sponsors', 'create'],
     service: async (params: CreateSponsor_Params, body: CreateSponsor_Body) =>
         ApiService('protected').fetchData<CreateSponsor_Response, CreateSponsor_Body>({
-            url: `/communities/${params.partnerId}/sponsors`,
+            url: `/v2/communities/${params.partnerId}/sponsors`,
             method: 'post',
             data: body,
         }),
@@ -49,7 +49,7 @@ export const UpdateSponsor = () => ({
     key: ['/communities/sponsors', 'update'],
     service: async (params: UpdateSponsor_Params, body: UpdateSponsor_Body) =>
         ApiService('protected').fetchData<UpdateSponsor_Response, UpdateSponsor_Body>({
-            url: `/communities/${params.partnerId}/sponsors/${params.sponsorId}`,
+            url: `/v2/communities/${params.partnerId}/sponsors/${params.sponsorId}`,
             method: 'put',
             data: body,
         }),
@@ -61,7 +61,7 @@ export const DeactivateSponsor = () => ({
     key: ['/communities/sponsors', 'deactivate'],
     service: async (params: DeactivateSponsor_Params) =>
         ApiService('protected').fetchData<DeactivateSponsor_Response>({
-            url: `/communities/${params.partnerId}/sponsors/${params.sponsorId}`,
+            url: `/v2/communities/${params.partnerId}/sponsors/${params.sponsorId}`,
             method: 'delete',
         }),
 });
@@ -78,7 +78,7 @@ export const UploadSponsorLogo = () => ({
         const formData = new FormData();
         formData.append('formFile', file);
         return ApiService('protected').fetchData<UploadSponsorLogo_Response>({
-            url: `/communities/${params.partnerId}/sponsors/${params.sponsorId}/logo`,
+            url: `/v2/communities/${params.partnerId}/sponsors/${params.sponsorId}/logo`,
             method: 'post',
             data: formData,
             headers: { 'Content-Type': 'multipart/form-data' },

--- a/TrashMob/client-app/src/services/team-adoptions.ts
+++ b/TrashMob/client-app/src/services/team-adoptions.ts
@@ -14,7 +14,7 @@ export const GetTeamAdoptions = (params: GetTeamAdoptions_Params) => ({
     key: ['/teams/', params.teamId, '/adoptions'],
     service: async () =>
         ApiService('protected').fetchData<GetTeamAdoptions_Response>({
-            url: `/teams/${params.teamId}/adoptions`,
+            url: `/v2/teams/${params.teamId}/adoptions`,
             method: 'get',
         }),
 });
@@ -29,7 +29,7 @@ export const SubmitAdoption = () => ({
     key: ['/teams/adoptions', 'submit'],
     service: async (params: SubmitAdoption_Params, body: SubmitAdoption_Body) =>
         ApiService('protected').fetchData<SubmitAdoption_Response, SubmitAdoption_Body>({
-            url: `/teams/${params.teamId}/adoptions`,
+            url: `/v2/teams/${params.teamId}/adoptions`,
             method: 'post',
             data: body,
         }),
@@ -45,7 +45,7 @@ export const GetPendingApplications = (params: GetPendingApplications_Params) =>
     key: ['/communities/', params.partnerId, '/adoptions/pending'],
     service: async () =>
         ApiService('protected').fetchData<GetPendingApplications_Response>({
-            url: `/communities/${params.partnerId}/adoptions/pending`,
+            url: `/v2/communities/${params.partnerId}/adoptions/pending`,
             method: 'get',
         }),
 });
@@ -56,7 +56,7 @@ export const GetApprovedAdoptions = (params: GetApprovedAdoptions_Params) => ({
     key: ['/communities/', params.partnerId, '/adoptions/approved'],
     service: async () =>
         ApiService('protected').fetchData<GetApprovedAdoptions_Response>({
-            url: `/communities/${params.partnerId}/adoptions/approved`,
+            url: `/v2/communities/${params.partnerId}/adoptions/approved`,
             method: 'get',
         }),
 });
@@ -67,7 +67,7 @@ export const ApproveAdoption = () => ({
     key: ['/communities/adoptions', 'approve'],
     service: async (params: ApproveAdoption_Params) =>
         ApiService('protected').fetchData<ApproveAdoption_Response>({
-            url: `/communities/${params.partnerId}/adoptions/${params.adoptionId}/approve`,
+            url: `/v2/communities/${params.partnerId}/adoptions/${params.adoptionId}/approve`,
             method: 'post',
         }),
 });
@@ -79,7 +79,7 @@ export const RejectAdoption = () => ({
     key: ['/communities/adoptions', 'reject'],
     service: async (params: RejectAdoption_Params, body: RejectAdoption_Body) =>
         ApiService('protected').fetchData<RejectAdoption_Response, RejectAdoption_Body>({
-            url: `/communities/${params.partnerId}/adoptions/${params.adoptionId}/reject`,
+            url: `/v2/communities/${params.partnerId}/adoptions/${params.adoptionId}/reject`,
             method: 'post',
             data: body,
         }),
@@ -95,7 +95,7 @@ export const GetDelinquentAdoptions = (params: GetDelinquentAdoptions_Params) =>
     key: ['/communities/', params.partnerId, '/adoptions/delinquent'],
     service: async () =>
         ApiService('protected').fetchData<GetDelinquentAdoptions_Response>({
-            url: `/communities/${params.partnerId}/adoptions/delinquent`,
+            url: `/v2/communities/${params.partnerId}/adoptions/delinquent`,
             method: 'get',
         }),
 });
@@ -106,7 +106,7 @@ export const GetComplianceStats = (params: GetComplianceStats_Params) => ({
     key: ['/communities/', params.partnerId, '/adoptions/stats'],
     service: async () =>
         ApiService('protected').fetchData<GetComplianceStats_Response>({
-            url: `/communities/${params.partnerId}/adoptions/stats`,
+            url: `/v2/communities/${params.partnerId}/adoptions/stats`,
             method: 'get',
         }),
 });
@@ -116,7 +116,7 @@ export const ExportAdoptions = (params: ExportAdoptions_Params) => ({
     key: ['/communities/', params.partnerId, '/adoptions/export'],
     service: async () =>
         ApiService('protected').fetchData<Blob>({
-            url: `/communities/${params.partnerId}/adoptions/export`,
+            url: `/v2/communities/${params.partnerId}/adoptions/export`,
             method: 'get',
             responseType: 'blob',
         }),


### PR DESCRIPTION
## Summary
- Migrates ALL remaining frontend service files to v2 API endpoints — **zero v1 URLs remain** in any frontend service file
- Creates 20+ new v2 backend endpoints to fill gaps
- Adds 2 new v2 controllers and fixes 2 DTOs with missing audit fields

## Details

### Frontend migrations (16 service files, ~90 URLs migrated)
| File | URLs |
|---|---|
| adoptable-areas | 24 |
| cms, maps, community-photos | 17 |
| professional-companies, portal | 11 |
| sponsors, sponsor-portal, sponsored-adoptions | 16 |
| team-adoptions, leaderboards | 10 |
| communities admin | 10 |
| events, litter-report, locations, job-opportunities, newsletters | 15 |

### New v2 backend endpoints
| Controller | Endpoints |
|---|---|
| CommunitiesV2 | check-slug, featured, public-stats, admin/{id}, admin dashboard, update, suggest-bounds, logo, banner, litter reports |
| **CommunityPhotosV2** (new) | GET, POST, PUT, DELETE |
| EventsV2 | active, completed, notcanceled, summaries |
| LitterReportsV2 | new, notcancelled |
| PickupLocationsV2 | by-user, mark-picked-up |
| EventPartnerLocationServicesV2 | accept/decline |
| **PartnerLocationEventServicesV2** (new) | by location, by user |
| JobOpportunitiesV2 | list all |
| NewsletterPreferencesV2 | unsubscribe |

### DTO fixes
- `AdoptableAreaDto` + `SponsorDto`: added missing `CreatedByUserId`, `LastUpdatedByUserId`, `LastUpdatedDate` audit fields + updated mappings

## Test plan
- [ ] Backend builds with 0 errors, 993 tests pass
- [ ] Frontend lint clean, build clean, zero v1 URLs (`grep` for `url: '/[^v]` returns empty)
- [ ] Verify siteadmin litter reports page works with paginated response
- [ ] Verify community admin dashboard, logo/banner upload work via v2
- [ ] Verify event status filters (active/completed/notcanceled) work via v2
- [ ] Verify adoptable areas CRUD works via v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)