### PR TITLE
Align frontend TypeScript models with v2 DTO shapes (Phase 3g)

### DIFF
--- a/Planning/Projects/Project_24_API_v2_Modernization.md
+++ b/Planning/Projects/Project_24_API_v2_Modernization.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 1, 2a–2i complete — 72+ v2 controllers, 100+ DTOs, 72+ test suites; Phases 3, 4 remaining) |
+| **Status** | In Progress (Phases 1, 2a–2i, 3a–3f complete — 85+ v2 controllers, 110+ DTOs, 993 tests; Phase 3g–3h, 4 remaining) |
 | **Priority** | High |
 | **Risk** | Medium |
 | **Size** | Very Large |
@@ -274,146 +274,40 @@ Migrate web and mobile clients to use v2 endpoints. V1 endpoints remain running 
 - **Date type changes**: Some `DateTimeOffset?` → `DateTimeOffset` (with `MinValue` default) or `DateOnly`
 - **Error responses**: Problem Details format — error message in `.detail` field, not `.message`. Includes `correlationId` for debugging.
 
-#### Phase 3-prereq - Error Handling & Shared Infrastructure
+#### Phase 3-prereq - Error Handling & Shared Infrastructure ✅ COMPLETE
 
-Must be completed before any service file migration. Sets up shared utilities that all sub-phases depend on.
+- [x] **`ProblemDetails` TypeScript type** — in `lib/api-errors.ts`
+- [x] **`getErrorMessage()` utility** — in `lib/api-errors.ts`
+- [x] **Axios response error interceptor** — in `services/index.ts` (normalizes v2 Problem Details + v1 formats)
+- [x] **`PagedResponse<T>` TypeScript type** — in `lib/api-errors.ts`
+- [x] **Update existing `onError` callbacks** — existing callbacks use `error.message` which the interceptor now populates from Problem Details
+- [x] Run `npm run lint` and `npm run build` — verified clean
 
-- [ ] **`ProblemDetails` TypeScript type** — add to `components/Models/` or `lib/`: `{ type?, status?, title?, detail?, instance?, traceId?, correlationId? }`
-- [ ] **`getErrorMessage()` utility** — add to `lib/`: extracts error message from both v2 Problem Details (`.response.data.detail`) and v1 formats (`.response.data.message`, `.message`), with fallback
-- [ ] **Axios response error interceptor** — add to `services/index.ts`: normalize error objects so `error.message` contains the Problem Details `detail` field when present (backward-compatible — v1 errors still work)
-- [ ] **`PagedResponse<T>` TypeScript type** — add to `components/Models/` or `lib/`: `{ items: T[], pagination: { page, pageSize, totalCount, totalPages, hasNext, hasPrevious } }`
-- [ ] **Update existing `onError` callbacks** — replace direct `error.message` / `error.response?.data?.message` access with `getErrorMessage()` in: `InviteFriendsCard.tsx`, `useEditEventPageMutations.ts`, `event-attendee-table.tsx`, `EventRouteTimeTrimDialog.tsx`, `eventsummary/$eventId/index.tsx`, `MyDependentsCard.tsx`
-- [ ] Run `npm run lint` and `npm run build` to verify no regressions
+#### Phase 3a–3f — URL Migrations ✅ COMPLETE (PRs #3093–#3097)
 
-**Phase 3-prereq totals:** 0 service files migrated, ~6 utility/component changes. **Critical prerequisite** — without this, every sub-phase would need ad-hoc error handling.
+All 48 frontend service files migrated to v2 API endpoints. Zero v1 URLs remaining. Completed across 4 PRs:
 
-#### Phase 3a - Core User Experience (highest traffic)
+- **PR #3093** (Phase 3a): 8 core service files (events, users, event-routes, event-photos, etc.)
+- **PR #3094** (Phase 3b): 6 service files (teams, communities, stats, leaderboards, achievements, community-prospects)
+- **PR #3096** (Phase 3c–3d): 25+ service files (partners, locations, waivers, CRM, admin, etc.) + created 13 missing v2 backend endpoints + TeamPhotosV2/TeamLogosV2 controllers
+- **PR #3097** (Phase 3e–3f): 16 remaining service files (adoptable-areas, sponsors, cms, maps, etc.) + created 20+ missing v2 backend endpoints + CommunityPhotosV2/PartnerLocationEventServicesV2 controllers + DTO audit field fixes
 
-Service files for the main user-facing flows. Must be correct before flipping the base URL.
+**Key changes made during migration:**
+- Paginated responses (`PagedResponse<T>`) properly typed and consumers updated to extract `.items`
+- Route changes handled (hyphenated paths, consolidated lookups under `/v2/lookups/`, pluralized endpoints)
+- 4 siteadmin pages updated for paginated response wrapper (events, users, partners, litter-reports)
+- `AdoptableAreaDto` and `SponsorDto` audit fields fixed for frontend compatibility
 
-- [ ] `users.ts` — 9 endpoints → `UsersV2Controller` routes
-  - **Model changes:** `UserData` → split into `UserDto` (reads, no Email/DateOfBirth/IsSiteAdmin) + `UserWriteDto` (writes, includes PII). Frontend `UserData` class needs refactoring or adapter layer. Pages displaying email/admin status must use auth context or separate endpoint.
-- [ ] `events.ts` — 23 endpoints → `EventsV2Controller`, `EventAttendeesV2Controller`, `EventSummaryV2Controller`, `LookupsV2Controller` routes
-  - **Model changes:** `EventData.eventVisibilityId` (int) → `EventDto.isEventPublic` (bool). `EventData.teamId` removed from DTO. `EventAttendeeData` gains `userName`, `givenName`, `profilePhotoUrl` (flattened from User nav). `EventSummaryData` loses navigation properties. Collection endpoints return `PagedResponse<EventDto>` instead of arrays.
-- [ ] `event-routes.ts` — 9 endpoints → `EventRoutesV2Controller`, `EventAttendeeRoutesV2Controller` routes
-  - **Model changes:** Route DTOs are structurally similar but use `DateTimeOffset` (not nullable). Nested under `/events/{eventId}/routes` and `/events/{eventId}/attendees/{userId}/routes`.
-- [ ] `event-attendee-metrics.ts` — 11 endpoints → `EventAttendeeMetricsV2Controller` routes
-  - **Model changes:** Metrics DTOs structurally similar. Nested under `/events/{eventId}/attendees/{userId}/metrics`.
-- [ ] `event-photos.ts` — photo upload/delete → `EventPhotosV2Controller` routes
-  - **Model changes:** Photo DTOs gain moderation status fields. Nested under `/events/{eventId}/photos`.
-- [ ] `event-litter-reports.ts` — event-linked litter reports → `EventLitterReportsV2Controller` routes
-  - **Model changes:** Uses `LitterReportDto` with `Images` array (not `LitterImages`). Nested under `/events/{eventId}/litterreports`.
-- [ ] `dependents.ts` — 9 endpoints → `DependentsV2Controller`, `EventDependentsV2Controller`, `DependentWaiversV2Controller` routes
-  - **Model changes:** `DependentDto.DateOfBirth` is `DateOnly` (not `DateTimeOffset`). Waiver DTOs are flat.
-- [ ] `dependent-invitations.ts` — 5 endpoints → `DependentInvitationsV2Controller` routes
-  - **Model changes:** Invitation DTOs are structurally similar with status enum changes.
+#### Phase 3g - Base URL Switch & TypeScript Model Alignment
 
-**Phase 3a totals:** 8 service files, ~66 endpoints. **High model impact** — `UserData` and `EventData` are the most widely referenced frontend models.
-
-#### Phase 3b - Teams & Community (public-facing)
-
-- [ ] `teams.ts` — 29 endpoints → `TeamsV2Controller`, `TeamMembersV2Controller`, `TeamEventsV2Controller` routes
-  - **Model changes:** `TeamData` loses all nav collections (Members, JoinRequests, Photos, Adoptions). `TeamMemberData` gains flattened `UserName`, `GivenName`, `ProfilePhotoUrl`. Member/event endpoints nested under `/teams/{teamId}/members` and `/teams/{teamId}/events`.
-- [ ] `communities.ts` — 15 endpoints → `CommunitiesV2Controller` routes
-  - **Model changes:** Community DTOs are flat — no nested Partner/Contact objects. Dashboard and stats have dedicated DTO shapes.
-- [ ] `community-photos.ts` — community photo management → `CommunitiesV2Controller` photo routes
-  - **Model changes:** Photo DTOs gain moderation fields, nested under community routes.
-- [ ] `community-prospects.ts` — community prospect management → `CommunityProspectsV2Controller` routes
-  - **Model changes:** New `CommunityProspectDto` + `ProspectActivityDto` — these are new DTOs not present in v1.
-- [ ] `stats.ts` — 2 endpoints → `StatsV2Controller` routes
-  - **Model changes:** Minimal — stats DTOs are structurally similar to v1 `Stats` model.
-- [ ] `leaderboards.ts` — 5 endpoints → `LeaderboardsV2Controller` routes
-  - **Model changes:** Leaderboard DTOs may include rank position fields not in v1.
-- [ ] `achievements.ts` — 5 endpoints → `AchievementsV2Controller` routes
-  - **Model changes:** Achievement DTOs structurally similar.
-
-**Phase 3b totals:** 7 service files, ~56 endpoints. **Medium model impact** — `TeamData` nav property removal affects team detail pages.
-
-#### Phase 3c - Litter Reports, Waivers & Locations
-
-- [ ] `litter-report.ts` — 10 endpoints → `LitterReportsV2Controller` routes
-  - **Model changes:** `LitterReportData` → `LitterReportDto`: `LitterImages` → `Images` (field rename), image objects use `ImageUrl` instead of `AzureBlobURL`. Only non-cancelled images included. JSON property names use camelCase via `[JsonPropertyName]`.
-- [ ] `locations.ts` — 26 endpoints → `PickupLocationsV2Controller`, `PartnerLocationsV2Controller`, `PartnerLocationServicesV2Controller`, `EventPartnerLocationServicesV2Controller` routes
-  - **Model changes:** Location DTOs are flat — no nested Partner/Service navigation. Partner location endpoints split across multiple v2 controllers.
-- [ ] `waivers.ts` — waiver lookup → `WaiversV2Controller` routes
-  - **Model changes:** Waiver DTOs are flat with version tracking fields.
-- [ ] `user-waivers.ts` — 9 endpoints → `WaiversV2Controller` user waiver routes
-  - **Model changes:** User waiver DTOs include waiver metadata inline (no separate lookup needed).
-- [ ] `maps.ts` — address geocoding → `MapsV2Controller` routes
-  - **Model changes:** Minimal — geocoding response is structurally similar.
-
-**Phase 3c totals:** 5 service files, ~45 endpoints. **Medium model impact** — litter report image field rename affects image display components.
-
-#### Phase 3d - Partners & Invitations
-
-- [ ] `partners.ts` — 14 endpoints → `PartnersV2Controller`, `PartnerRequestsV2Controller` routes
-  - **Model changes:** Partner DTOs are flat — no nested PartnerType, PartnerStatus nav objects. Status/type resolved to name strings. Paginated responses.
-- [ ] `invitations.ts` — 9 endpoints → `PartnerAdminInvitationsV2Controller` routes
-  - **Model changes:** Invitation DTOs include flattened inviter/invitee info.
-- [ ] `admin.ts` — 4 endpoints → `AdminV2Controller`, `PartnerAdminsV2Controller` routes
-  - **Model changes:** Admin DTOs are flat with user info flattened.
-- [ ] `email-invites.ts` — 13 endpoints → `EmailInvitesV2Controller`, `CommunityInvitesV2Controller`, `TeamInvitesV2Controller` routes
-  - **Model changes:** Invite DTOs include rate limit metadata (quota remaining, batch limits).
-- [ ] `social-media.ts` — partner social media → `PartnerSocialMediaAccountsV2Controller` routes
-  - **Model changes:** Minimal structural changes.
-- [ ] `documents.ts` — partner documents → `PartnerDocumentsV2Controller` routes
-  - **Model changes:** Document DTOs combine admin and partner views into single DTO with role-based field visibility.
-
-**Phase 3d totals:** 6 service files, ~40 endpoints. **Low-medium model impact** — mostly admin pages with limited component reuse.
-
-#### Phase 3e - Adoptions & Sponsorships
-
-- [ ] `adoptable-areas.ts` — 24 endpoints → `AdoptableAreasV2Controller`, `AreaGenerationV2Controller`, `StagedAreasV2Controller` routes
-  - **Model changes:** `AdoptableAreaDto`, `AreaGenerationBatchDto`, `StagedAdoptableAreaDto` — new v2 DTOs. GeoJSON geometry fields may differ from v1 entity.
-- [ ] `team-adoptions.ts` — 9 endpoints → `TeamAdoptionsV2Controller`, `CommunityAdoptionsV2Controller` routes
-  - **Model changes:** `TeamAdoptionDto` — flat, no nested Team/Area nav properties.
-- [ ] `sponsored-adoptions.ts` — 6 endpoints → `CommunitySponsoredAdoptionsV2Controller`, `SponsorReportsV2Controller` routes
-  - **Model changes:** `SponsoredAdoptionDto` — flat, sponsor info inline.
-- [ ] `sponsors.ts` — 6 endpoints → `CommunitySponsorsV2Controller` routes
-  - **Model changes:** `SponsorDto` — flat, no nested Company nav.
-- [ ] `professional-companies.ts` — 7 endpoints → `CommunityProfessionalCompaniesV2Controller` routes
-  - **Model changes:** `ProfessionalCompanyDto` + `ProfessionalCompanyUserDto` — new DTOs.
-- [ ] `professional-company-portal.ts` — professional portal → `ProfessionalCompanyPortalV2Controller`, `ProfessionalCleanupLogsV2Controller` routes
-  - **Model changes:** Cleanup log DTOs are new v2 shapes.
-- [ ] `sponsor-portal.ts` — sponsor portal → `SponsorPortalV2Controller` routes
-  - **Model changes:** CSV export endpoint returns file download (same as v1).
-
-**Phase 3e totals:** 7 service files, ~52 endpoints. **Medium model impact** — adoption/sponsor DTOs are mostly new, limited existing frontend model overlap.
-
-#### Phase 3f - CRM, Fundraising & Admin
-
-- [ ] `contacts.ts` — 16 endpoints → `ContactsV2Controller`, `ContactNotesV2Controller`, `ContactTagsV2Controller`, `DonationsV2Controller`, `FundraisingAppealsV2Controller`, `FundraisingAnalyticsV2Controller` routes
-  - **Model changes:** CRM DTOs are largely new (added in Phase 2h). Frontend models may already align if CRM UI was built against v2-era DTOs.
-- [ ] `grants.ts` — 10 endpoints → `GrantsV2Controller`, `GrantTasksV2Controller` routes
-  - **Model changes:** Grant DTOs include status filter support. Task DTOs nested under `/grants/{grantId}/tasks`.
-- [ ] `waiver-admin.ts` — 14 endpoints → `WaiverAdminV2Controller`, `CommunityWaiverAdminV2Controller`, `WaiverComplianceV2Controller` routes
-  - **Model changes:** Compliance DTOs are new (summary, filtered list, expiring, CSV export). Admin waiver DTOs are flat.
-- [ ] `photo-moderation.ts` — 7 endpoints → `PhotoModerationV2Controller`, `PhotoFlagV2Controller` routes
-  - **Model changes:** Moderation queue DTOs include photo metadata + flag reason inline.
-- [ ] `newsletters.ts` — newsletter admin → `NewslettersAdminV2Controller` routes
-  - **Model changes:** `NewsletterDto` includes flattened `CategoryName` and 7 stat counters (TotalRecipients, Delivered, Opens, Clicks, Bounces, SpamReports, Unsubscribes). Separate `CreateNewsletterDto`/`UpdateNewsletterDto`/`ScheduleNewsletterDto` for writes.
-- [ ] `cms.ts` — 7 endpoints → `CmsV2Controller` routes
-  - **Model changes:** CMS proxy responses pass through from Strapi — minimal DTO changes.
-- [ ] `opportunities.ts` — 5 endpoints → `JobOpportunitiesV2Controller` routes
-  - **Model changes:** `JobOpportunityDto` — flat, structurally similar to v1 but with explicit `IsActive` field.
-- [ ] `job-opportunities.ts` — (if separate from opportunities.ts) → `JobOpportunitiesV2Controller` routes
-
-**Phase 3f totals:** 7–8 service files, ~59 endpoints. **Low model impact** — mostly admin-only pages with newer DTOs.
-
-#### Phase 3g - Infrastructure & Base URL Switch
-
-- [ ] `config.ts` — client config → `ConfigV2Controller` routes
-  - **Model changes:** Config response shape unchanged (App Insights key + Entra settings).
-- [ ] `services.ts` — service type lookup → `LookupsV2Controller` routes
-  - **Model changes:** Lookup responses now from consolidated `LookupsV2Controller` with 24h cache headers.
-- [ ] `contact.ts` — contact request → `ContactRequestV2Controller` routes
-  - **Model changes:** Contact request DTO structurally similar.
-- [ ] `feedback.ts` — user feedback → `UserFeedbackV2Controller` routes
-  - **Model changes:** Feedback DTOs include status management fields for admin.
-- [ ] `message.ts` — message request → `MessageRequestV2Controller` routes
-  - **Model changes:** Broadcast message DTO structurally similar.
-- [ ] `index.ts` — **Switch `BASE_URL` from `/api` to `/api/v2.0`** (final step after all service files updated)
+- [x] `config.ts` — migrated to `/v2/config`
+- [x] `services.ts` — migrated to `/v2/lookups/service-types`
+- [x] `contact.ts` — migrated to `/v2/contactrequest`, `/v2/partner-location-contacts/...`, `/v2/partner-contacts/...`
+- [x] `feedback.ts` — migrated to `/v2/feedback`
+- [x] `message.ts` — migrated to `/v2/messagerequest/`
+- [ ] `index.ts` — **Switch `BASE_URL` from `/api` to `/api/v2.0`** (final step after model alignment)
 - [ ] Update `vite.config.ts` proxy to forward `/api/v2.0` requests
+- [ ] **TypeScript model alignment** — update frontend model classes in `components/Models/` to match v2 DTO shapes
 - [ ] **Smoke test all pages** after base URL switch
 
 **Phase 3g totals:** 5 service files + base URL switch + smoke test. **Low model impact** — infrastructure endpoints with minimal shape changes.

--- a/TrashMob/client-app/src/components/Models/EventData.tsx
+++ b/TrashMob/client-app/src/components/Models/EventData.tsx
@@ -31,15 +31,17 @@ class EventData {
 
     createdDate: Date = new Date();
 
-    latitude: number = 0;
+    latitude: number | null = null;
 
-    longitude: number = 0;
+    longitude: number | null = null;
 
     maxNumberOfParticipants: number = 0;
 
     lastUpdatedByUserId: string = Guid.EMPTY;
 
     lastUpdatedDate: Date = new Date();
+
+    isEventPublic: boolean = true;
 
     eventVisibilityId: number = 1;
 

--- a/TrashMob/client-app/src/components/Models/LitterImageData.tsx
+++ b/TrashMob/client-app/src/components/Models/LitterImageData.tsx
@@ -5,6 +5,14 @@ class LitterImageData {
 
     litterReportId: string = '';
 
+    /**
+     * V2 API returns this as `imageUrl` (camelCase from C# `ImageUrl`).
+     */
+    imageUrl: string = '';
+
+    /**
+     * @deprecated Use `imageUrl` instead. V1 API used `imageURL` casing.
+     */
     imageURL: string = '';
 
     streetAddress: string = '';

--- a/TrashMob/client-app/src/components/Models/LitterReportData.tsx
+++ b/TrashMob/client-app/src/components/Models/LitterReportData.tsx
@@ -10,6 +10,16 @@ class LitterReportData {
 
     litterReportStatusId: number = 1;
 
+    /**
+     * V2 API returns the image collection as `images` (camelCase from C# `Images`).
+     * This is the canonical field that matches the v2 DTO JSON shape.
+     */
+    images: LitterImageData[] = [];
+
+    /**
+     * @deprecated Use `images` instead. Kept for backward compatibility with existing
+     * component code that references `litterImages`. Components should migrate to `images`.
+     */
     litterImages: LitterImageData[] = [];
 
     createdByUserId: string = '';

--- a/TrashMob/client-app/src/components/Models/PartnerData.tsx
+++ b/TrashMob/client-app/src/components/Models/PartnerData.tsx
@@ -42,6 +42,22 @@ class PartnerData {
 
     country: string = '';
 
+    isFeatured: boolean = false;
+
+    boundsNorth: number | null = null;
+
+    boundsSouth: number | null = null;
+
+    boundsEast: number | null = null;
+
+    boundsWest: number | null = null;
+
+    boundaryGeoJson: string = '';
+
+    regionType: number | null = null;
+
+    countyName: string = '';
+
     logoUrl: string = '';
 
     contactEmail: string = '';

--- a/TrashMob/client-app/src/components/Models/PickupLocationData.tsx
+++ b/TrashMob/client-app/src/components/Models/PickupLocationData.tsx
@@ -13,9 +13,11 @@ class PickupLocationData {
 
     country: string = '';
 
-    latitude: number = 0;
+    county: string = '';
 
-    longitude: number = 0;
+    latitude: number | null = null;
+
+    longitude: number | null = null;
 
     postalCode: string = '';
 

--- a/TrashMob/client-app/src/components/Models/TeamMemberData.tsx
+++ b/TrashMob/client-app/src/components/Models/TeamMemberData.tsx
@@ -19,8 +19,11 @@ class TeamMemberData {
 
     lastUpdatedDate: Date = new Date();
 
-    // Optional user info for display purposes
-    userName?: string;
+    userName: string = '';
+
+    givenName: string = '';
+
+    profilePhotoUrl: string = '';
 }
 
 export default TeamMemberData;

--- a/TrashMob/client-app/src/components/Models/UserData.tsx
+++ b/TrashMob/client-app/src/components/Models/UserData.tsx
@@ -19,11 +19,11 @@ class UserData {
 
     trashMobWaiverVersion: string = '';
 
-    memberSince: Date = new Date();
+    memberSince: Date | null = null;
 
-    latitude: number = 0;
+    latitude: number | null = null;
 
-    longitude: number = 0;
+    longitude: number | null = null;
 
     prefersMetric: boolean = false;
 

--- a/TrashMob/client-app/src/components/communities/community-detail-map.tsx
+++ b/TrashMob/client-app/src/components/communities/community-detail-map.tsx
@@ -151,7 +151,7 @@ export const CommunityDetailMap = (props: CommunityDetailMapProps) => {
     // Get litter reports with coordinates from their images
     const litterReportsWithLocation = litterReports
         .map((report) => {
-            const imageWithLocation = report.litterImages?.find((img) => img.latitude && img.longitude);
+            const imageWithLocation = report.images?.find((img) => img.latitude && img.longitude);
             if (!imageWithLocation) return null;
             return {
                 ...report,
@@ -325,7 +325,7 @@ export const CommunityDetailMap = (props: CommunityDetailMapProps) => {
                                       className={cn({
                                           'animate-[bounce_1s_both_3s]': isInViewPort,
                                       })}
-                                      position={{ lat: event.latitude, lng: event.longitude }}
+                                      position={{ lat: event.latitude!, lng: event.longitude! }}
                                       onMouseEnter={() => handleEventMarkerHover(event.id)}
                                       zIndex={10}
                                   >

--- a/TrashMob/client-app/src/components/events/event-attendee-table.tsx
+++ b/TrashMob/client-app/src/components/events/event-attendee-table.tsx
@@ -205,7 +205,9 @@ export const EventAttendeeTable = (props: EventAttendeeTableProps) => {
                                     </TableCell>
                                     <TableCell>{user.city}</TableCell>
                                     <TableCell>{user.country}</TableCell>
-                                    <TableCell>{new Date(user.memberSince).toLocaleDateString()}</TableCell>
+                                    <TableCell>
+                                        {user.memberSince ? new Date(user.memberSince).toLocaleDateString() : ''}
+                                    </TableCell>
                                     {isCurrentUserLead ? (
                                         <TableCell>
                                             {hasValidWaiver ? (

--- a/TrashMob/client-app/src/components/events/event-map.tsx
+++ b/TrashMob/client-app/src/components/events/event-map.tsx
@@ -100,7 +100,7 @@ export const EventsMap = (props: EventsMapProps) => {
     // Get first image with coordinates for each litter report (for pin placement)
     const litterReportsWithLocation = (litterReports || [])
         .map((report) => {
-            const imageWithLocation = report.litterImages?.find((img) => img.latitude && img.longitude);
+            const imageWithLocation = report.images?.find((img) => img.latitude && img.longitude);
             if (!imageWithLocation) return null;
             return {
                 ...report,
@@ -124,24 +124,26 @@ export const EventsMap = (props: EventsMapProps) => {
         <div ref={ref}>
             <GoogleMap id={id} gestureHandling={gestureHandling} {...rest}>
                 {/* Event Markers */}
-                {eventsWithAttendance.map((event) => {
-                    const isCompleted = isCompletedEvent(event);
-                    return (
-                        <AdvancedMarker
-                            key={event.id}
-                            ref={(el) => {
-                                eventMarkersRef.current[event.id] = el!;
-                            }}
-                            className={cn({
-                                'animate-[bounce_1s_both_3s]': isInViewPort,
-                            })}
-                            position={{ lat: event.latitude, lng: event.longitude }}
-                            onMouseEnter={() => handleEventMarkerHover(event.id)}
-                        >
-                            <EventPin color={isCompleted ? colors.completed : colors.upcoming} size={48} />
-                        </AdvancedMarker>
-                    );
-                })}
+                {eventsWithAttendance
+                    .filter((e) => e.latitude != null && e.longitude != null)
+                    .map((event) => {
+                        const isCompleted = isCompletedEvent(event);
+                        return (
+                            <AdvancedMarker
+                                key={event.id}
+                                ref={(el) => {
+                                    eventMarkersRef.current[event.id] = el!;
+                                }}
+                                className={cn({
+                                    'animate-[bounce_1s_both_3s]': isInViewPort,
+                                })}
+                                position={{ lat: event.latitude!, lng: event.longitude! }}
+                                onMouseEnter={() => handleEventMarkerHover(event.id)}
+                            >
+                                <EventPin color={isCompleted ? colors.completed : colors.upcoming} size={48} />
+                            </AdvancedMarker>
+                        );
+                    })}
 
                 {/* Litter Report Markers */}
                 {showLitterReports

--- a/TrashMob/client-app/src/components/eventsummary/add-litter-report-dialog.tsx
+++ b/TrashMob/client-app/src/components/eventsummary/add-litter-report-dialog.tsx
@@ -74,7 +74,7 @@ export const AddLitterReportDialog = ({
     };
 
     const getLocation = (report: LitterReportData) => {
-        const firstImage = report.litterImages?.[0];
+        const firstImage = report.images?.[0];
         if (!firstImage) return 'No location';
         const parts = [firstImage.city, firstImage.region].filter(Boolean);
         return parts.join(', ') || 'No location';
@@ -149,7 +149,7 @@ export const AddLitterReportDialog = ({
                                                             {LitterReportStatusLabels[statusId] || 'Unknown'}
                                                         </Badge>
                                                         <span className='text-xs text-muted-foreground'>
-                                                            {report.litterImages?.length || 0} photo(s)
+                                                            {report.images?.length || 0} photo(s)
                                                         </span>
                                                     </div>
                                                 </div>

--- a/TrashMob/client-app/src/components/eventsummary/associated-litter-reports.tsx
+++ b/TrashMob/client-app/src/components/eventsummary/associated-litter-reports.tsx
@@ -103,8 +103,8 @@ export const AssociatedLitterReports = ({ eventId, isOwner }: AssociatedLitterRe
         }
     };
 
-    const getLocation = (report: { litterImages?: Array<{ city?: string; region?: string }> }) => {
-        const firstImage = report.litterImages?.[0];
+    const getLocation = (report: { images?: Array<{ city?: string; region?: string }> }) => {
+        const firstImage = report.images?.[0];
         if (!firstImage) return '-';
         const parts = [firstImage.city, firstImage.region].filter(Boolean);
         return parts.join(', ') || '-';
@@ -163,7 +163,7 @@ export const AssociatedLitterReports = ({ eventId, isOwner }: AssociatedLitterRe
                                         {LitterReportStatusLabels[statusId] || 'Unknown'}
                                     </Badge>
                                 </TableCell>
-                                <TableCell>{report.litterImages?.length || 0}</TableCell>
+                                <TableCell>{report.images?.length || 0}</TableCell>
                                 {isOwner ? (
                                     <TableCell>
                                         <DropdownMenu>

--- a/TrashMob/client-app/src/components/litterreports/litter-report-info-window.tsx
+++ b/TrashMob/client-app/src/components/litterreports/litter-report-info-window.tsx
@@ -30,7 +30,7 @@ export const LitterReportInfoWindowContent = ({ report }: LitterReportInfoWindow
     const statusId = report.litterReportStatusId as LitterReportStatusEnum;
     const statusLabel = LitterReportStatusLabels[statusId] || 'Unknown';
     const statusColor = LitterReportStatusColors[statusId] || 'bg-gray-500';
-    const firstImage = report.litterImages?.[0];
+    const firstImage = report.images?.[0];
 
     const location = firstImage ? [firstImage.city, firstImage.region].filter(Boolean).join(', ') : null;
 
@@ -40,8 +40,8 @@ export const LitterReportInfoWindowContent = ({ report }: LitterReportInfoWindow
                 <Badge variant='outline' className={`${statusColor} text-white border-0 text-xs`}>
                     {statusLabel}
                 </Badge>
-                {report.litterImages?.length ? (
-                    <span className='text-xs text-muted-foreground'>{report.litterImages.length} photo(s)</span>
+                {report.images?.length ? (
+                    <span className='text-xs text-muted-foreground'>{report.images.length} photo(s)</span>
                 ) : null}
             </div>
 

--- a/TrashMob/client-app/src/pages/MyDashboard/LitterReportsMapView.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/LitterReportsMapView.tsx
@@ -27,7 +27,7 @@ export const LitterReportsMapView = ({ reports }: LitterReportsMapViewProps) => 
     const [selected, setSelected] = useState<LitterReportData | null>(null);
 
     const reportsWithLocation = reports.filter((r) => {
-        const img = r.litterImages?.[0];
+        const img = r.images?.[0];
         return img?.latitude && img?.longitude;
     });
 
@@ -38,13 +38,12 @@ export const LitterReportsMapView = ({ reports }: LitterReportsMapViewProps) => 
     }
 
     const avgLat =
-        reportsWithLocation.reduce((sum, r) => sum + (r.litterImages[0].latitude ?? 0), 0) / reportsWithLocation.length;
+        reportsWithLocation.reduce((sum, r) => sum + (r.images[0].latitude ?? 0), 0) / reportsWithLocation.length;
     const avgLng =
-        reportsWithLocation.reduce((sum, r) => sum + (r.litterImages[0].longitude ?? 0), 0) /
-        reportsWithLocation.length;
+        reportsWithLocation.reduce((sum, r) => sum + (r.images[0].longitude ?? 0), 0) / reportsWithLocation.length;
 
     const getLocation = (report: LitterReportData) => {
-        const firstImage = report.litterImages?.[0];
+        const firstImage = report.images?.[0];
         if (!firstImage) return '';
         const parts = [firstImage.city, firstImage.region].filter(Boolean);
         return parts.join(', ');
@@ -62,8 +61,8 @@ export const LitterReportsMapView = ({ reports }: LitterReportsMapViewProps) => 
                     <AdvancedMarker
                         key={report.id}
                         position={{
-                            lat: report.litterImages[0].latitude!,
-                            lng: report.litterImages[0].longitude!,
+                            lat: report.images[0].latitude!,
+                            lng: report.images[0].longitude!,
                         }}
                         onClick={() => setSelected(report)}
                     >
@@ -74,8 +73,8 @@ export const LitterReportsMapView = ({ reports }: LitterReportsMapViewProps) => 
                 {selected ? (
                     <InfoWindow
                         position={{
-                            lat: selected.litterImages[0].latitude!,
-                            lng: selected.litterImages[0].longitude!,
+                            lat: selected.images[0].latitude!,
+                            lng: selected.images[0].longitude!,
                         }}
                         onCloseClick={() => setSelected(null)}
                     >

--- a/TrashMob/client-app/src/pages/MyDashboard/MyLitterReportsTable.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyLitterReportsTable.tsx
@@ -22,7 +22,7 @@ const formatDate = (date: Date | null) => {
 };
 
 const getLocation = (report: LitterReportData) => {
-    const firstImage = report.litterImages?.[0];
+    const firstImage = report.images?.[0];
     if (!firstImage) return '-';
     const parts = [firstImage.city, firstImage.region].filter(Boolean);
     return parts.join(', ') || '-';

--- a/TrashMob/client-app/src/pages/MyDashboard/NearbyLitterReportsWidget.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/NearbyLitterReportsWidget.tsx
@@ -50,7 +50,7 @@ export const NearbyLitterReportsWidget = ({ viewMode, userLocation, radiusMiles 
 
         return litterReports
             .map((report) => {
-                const firstImage = report.litterImages?.[0];
+                const firstImage = report.images?.[0];
                 if (!firstImage?.latitude || !firstImage?.longitude) return null;
 
                 const distance = calculateDistanceMiles(
@@ -69,7 +69,7 @@ export const NearbyLitterReportsWidget = ({ viewMode, userLocation, radiusMiles 
     }, [litterReports, userLocation, radiusMiles]);
 
     const getLocation = (report: LitterReportData) => {
-        const firstImage = report.litterImages?.[0];
+        const firstImage = report.images?.[0];
         if (!firstImage) return '-';
         const parts = [firstImage.city, firstImage.region].filter(Boolean);
         return parts.join(', ') || '-';
@@ -106,7 +106,7 @@ export const NearbyLitterReportsWidget = ({ viewMode, userLocation, radiusMiles 
                     defaultZoom={11}
                 >
                     {nearbyReports.map(({ report }) => {
-                        const img = report.litterImages[0];
+                        const img = report.images[0];
                         return (
                             <AdvancedMarker
                                 key={report.id}
@@ -123,8 +123,8 @@ export const NearbyLitterReportsWidget = ({ viewMode, userLocation, radiusMiles 
                     {selected ? (
                         <InfoWindow
                             position={{
-                                lat: selected.report.litterImages[0].latitude!,
-                                lng: selected.report.litterImages[0].longitude!,
+                                lat: selected.report.images[0].latitude!,
+                                lng: selected.report.images[0].longitude!,
                             }}
                             onCloseClick={() => setSelected(null)}
                         >

--- a/TrashMob/client-app/src/pages/MyDashboard/PickupRequestsMapView.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/PickupRequestsMapView.tsx
@@ -20,7 +20,9 @@ interface PickupRequestsMapViewProps {
 export const PickupRequestsMapView = ({ pickups }: PickupRequestsMapViewProps) => {
     const [selected, setSelected] = useState<PickupLocationData | null>(null);
 
-    const pickupsWithLocation = pickups.filter((p) => p.latitude !== 0 && p.longitude !== 0);
+    const pickupsWithLocation = pickups.filter(
+        (p) => p.latitude != null && p.latitude !== 0 && p.longitude != null && p.longitude !== 0,
+    );
 
     if (pickupsWithLocation.length === 0) {
         return (
@@ -30,8 +32,8 @@ export const PickupRequestsMapView = ({ pickups }: PickupRequestsMapViewProps) =
         );
     }
 
-    const avgLat = pickupsWithLocation.reduce((sum, p) => sum + p.latitude, 0) / pickupsWithLocation.length;
-    const avgLng = pickupsWithLocation.reduce((sum, p) => sum + p.longitude, 0) / pickupsWithLocation.length;
+    const avgLat = pickupsWithLocation.reduce((sum, p) => sum + (p.latitude ?? 0), 0) / pickupsWithLocation.length;
+    const avgLng = pickupsWithLocation.reduce((sum, p) => sum + (p.longitude ?? 0), 0) / pickupsWithLocation.length;
 
     return (
         <div className='rounded-md overflow-hidden border'>
@@ -44,7 +46,7 @@ export const PickupRequestsMapView = ({ pickups }: PickupRequestsMapViewProps) =
                 {pickupsWithLocation.map((pickup) => (
                     <AdvancedMarker
                         key={pickup.id}
-                        position={{ lat: pickup.latitude, lng: pickup.longitude }}
+                        position={{ lat: pickup.latitude!, lng: pickup.longitude! }}
                         onClick={() => setSelected(pickup)}
                     >
                         <PickupMarkerPin />
@@ -53,7 +55,7 @@ export const PickupRequestsMapView = ({ pickups }: PickupRequestsMapViewProps) =
 
                 {selected ? (
                     <InfoWindow
-                        position={{ lat: selected.latitude, lng: selected.longitude }}
+                        position={{ lat: selected.latitude!, lng: selected.longitude! }}
                         onCloseClick={() => setSelected(null)}
                     >
                         <div className='text-sm space-y-1 max-w-[200px]'>

--- a/TrashMob/client-app/src/pages/MyDashboard/index.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/index.tsx
@@ -200,7 +200,7 @@ const MyDashboard: FC<MyDashboardProps> = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const userId = currentUser.id;
-    const userPreferredLocation = { lat: currentUser.latitude, lng: currentUser.longitude };
+    const userPreferredLocation = { lat: currentUser.latitude ?? 0, lng: currentUser.longitude ?? 0 };
 
     const [upcomingEventsView, setUpcomingEventsView] = useState<'table' | 'map'>('table');
     const [pastEventsView, setPastEventsView] = useState<'table' | 'map'>('table');

--- a/TrashMob/client-app/src/pages/events/create.tsx
+++ b/TrashMob/client-app/src/pages/events/create.tsx
@@ -192,7 +192,7 @@ export const CreateEventPage = () => {
     // Pre-populate form when creating from a litter report
     useEffect(() => {
         if (fromLitterReport) {
-            const firstImage = fromLitterReport.litterImages?.[0];
+            const firstImage = fromLitterReport.images?.[0];
             if (firstImage) {
                 form.setValue('latitude', firstImage.latitude || 0);
                 form.setValue('longitude', firstImage.longitude || 0);

--- a/TrashMob/client-app/src/pages/events/edit/index.tsx
+++ b/TrashMob/client-app/src/pages/events/edit/index.tsx
@@ -132,8 +132,8 @@ export const EditEventPage = () => {
             region: event.region,
             country: event.country,
             postalCode: event.postalCode,
-            latitude: event.latitude,
-            longitude: event.longitude,
+            latitude: event.latitude ?? undefined,
+            longitude: event.longitude ?? undefined,
             maxNumberOfParticipants: event.maxNumberOfParticipants,
             eventVisibilityId: `${event.eventVisibilityId}`,
             teamId: event.teamId,
@@ -574,13 +574,13 @@ export const EditEventPage = () => {
                                 <div className='col-span-12'>
                                     <GoogleMap
                                         id='locationPicker'
-                                        defaultCenter={{ lat: event.latitude, lng: event.longitude }}
+                                        defaultCenter={{ lat: event.latitude ?? 0, lng: event.longitude ?? 0 }}
                                         defaultZoom={16}
                                         style={{ width: '100%', height: '300px' }}
                                         onClick={handleClickMap}
                                     >
                                         <Marker
-                                            position={{ lat: event.latitude, lng: event.longitude }}
+                                            position={{ lat: event.latitude ?? 0, lng: event.longitude ?? 0 }}
                                             draggable
                                             onDragEnd={handleMarkerDragEnd}
                                         />
@@ -595,7 +595,7 @@ export const EditEventPage = () => {
                                             ]).join(', ')}
                                         </span>
                                         <span>
-                                            ({event.latitude}, {event.longitude})
+                                            ({event.latitude ?? 0}, {event.longitude ?? 0})
                                         </span>
                                     </FormDescription>
                                 </div>

--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.$locationId.edit.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.$locationId.edit.tsx
@@ -125,6 +125,8 @@ export const PickupLocationEditForm = (props: PickupLocationEditFormProps) => {
         if (pickupLocation) {
             form.reset({
                 ...pickupLocation,
+                latitude: pickupLocation.latitude ?? undefined,
+                longitude: pickupLocation.longitude ?? undefined,
             });
         }
     }, [pickupLocation]);

--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.create.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.create.tsx
@@ -104,8 +104,8 @@ export const PickupLocationCreateForm = (props: PickupLocationCreateFormProps) =
         if (event) {
             form.reset({
                 name: `Bags from ${event.name}`,
-                latitude: event.latitude,
-                longitude: event.longitude,
+                latitude: event.latitude ?? undefined,
+                longitude: event.longitude ?? undefined,
                 streetAddress: event.streetAddress,
                 city: event.city,
                 country: event.country,

--- a/TrashMob/client-app/src/pages/litterreports/$litterReportId/index.tsx
+++ b/TrashMob/client-app/src/pages/litterreports/$litterReportId/index.tsx
@@ -40,7 +40,7 @@ const formatDate = (date: Date | null) => {
     });
 };
 
-const getFullAddress = (image: LitterReportData['litterImages'][0]) => {
+const getFullAddress = (image: LitterReportData['images'][0]) => {
     if (!image) return '-';
     const parts = [image.streetAddress, image.city, image.region, image.postalCode, image.country].filter(Boolean);
     return parts.join(', ') || '-';
@@ -144,7 +144,7 @@ export const LitterReportDetailPage = () => {
     const statusId = litterReport.litterReportStatusId as LitterReportStatusEnum;
     const statusLabel = LitterReportStatusLabels[statusId] || 'Unknown';
     const statusColor = LitterReportStatusColors[statusId] || 'bg-gray-500';
-    const firstImage = litterReport.litterImages?.[0];
+    const firstImage = litterReport.images?.[0];
 
     return (
         <div>
@@ -210,13 +210,13 @@ export const LitterReportDetailPage = () => {
                         </Card>
 
                         {/* Photos */}
-                        {litterReport.litterImages && litterReport.litterImages.length > 0 ? (
+                        {litterReport.images && litterReport.images.length > 0 ? (
                             <Card>
                                 <CardHeader>
                                     <CardTitle className='flex items-center gap-2'>
                                         <ImageIcon className='h-5 w-5' /> Photos (
                                         {
-                                            litterReport.litterImages.filter(
+                                            litterReport.images.filter(
                                                 (img) => !img.inReview || currentUser.isSiteAdmin,
                                             ).length
                                         }
@@ -225,17 +225,17 @@ export const LitterReportDetailPage = () => {
                                 </CardHeader>
                                 <CardContent>
                                     <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-                                        {litterReport.litterImages
+                                        {litterReport.images
                                             .filter((img) => !img.inReview || currentUser.isSiteAdmin)
                                             .map((image) => (
                                                 <div
                                                     key={image.id}
                                                     className='aspect-square relative rounded-lg overflow-hidden bg-muted group'
                                                 >
-                                                    {image.imageURL ? (
+                                                    {image.imageUrl ? (
                                                         <>
                                                             <img
-                                                                src={image.imageURL}
+                                                                src={image.imageUrl}
                                                                 alt='Litter'
                                                                 className='object-cover w-full h-full'
                                                             />
@@ -326,15 +326,14 @@ export const LitterReportDetailPage = () => {
                         ) : null}
 
                         {/* Location details for each image */}
-                        {litterReport.litterImages &&
-                        litterReport.litterImages.filter((img) => !img.inReview || currentUser.isSiteAdmin).length >
-                            1 ? (
+                        {litterReport.images &&
+                        litterReport.images.filter((img) => !img.inReview || currentUser.isSiteAdmin).length > 1 ? (
                             <Card>
                                 <CardHeader>
                                     <CardTitle>Photo Locations</CardTitle>
                                 </CardHeader>
                                 <CardContent className='space-y-3'>
-                                    {litterReport.litterImages
+                                    {litterReport.images
                                         .filter((img) => !img.inReview || currentUser.isSiteAdmin)
                                         .map((image, index) => (
                                             <div key={image.id} className='text-sm'>

--- a/TrashMob/client-app/src/pages/litterreports/create.tsx
+++ b/TrashMob/client-app/src/pages/litterreports/create.tsx
@@ -128,7 +128,7 @@ const CreateLitterReportPageInner = () => {
             litterReport.lastUpdatedByUserId = currentUser.id;
 
             // Build litter image data array
-            litterReport.litterImages = images.map((img) => {
+            litterReport.images = images.map((img) => {
                 const litterImage = new LitterImageData();
                 litterImage.id = img.id;
                 litterImage.litterReportId = litterReport.id;
@@ -151,7 +151,7 @@ const CreateLitterReportPageInner = () => {
             // Step 2: Upload each image file
             for (const img of images) {
                 // Find the corresponding image ID from the created report
-                const createdImage = createdReport.litterImages.find(
+                const createdImage = createdReport.images.find(
                     (ci: LitterImageData) =>
                         ci.latitude === img.latitude &&
                         ci.longitude === img.longitude &&

--- a/TrashMob/client-app/src/pages/litterreports/index.tsx
+++ b/TrashMob/client-app/src/pages/litterreports/index.tsx
@@ -39,7 +39,7 @@ const formatDate = (date: Date | null) => {
 };
 
 const getLocation = (report: LitterReportData) => {
-    const firstImage = report.litterImages?.[0];
+    const firstImage = report.images?.[0];
     if (!firstImage) return '-';
     const parts = [firstImage.city, firstImage.region].filter(Boolean);
     return parts.join(', ') || '-';
@@ -123,7 +123,7 @@ const columns: ColumnDef<LitterReportData>[] = [
     {
         id: 'images',
         header: 'Photos',
-        cell: ({ row }) => <span>{row.original.litterImages?.length || 0}</span>,
+        cell: ({ row }) => <span>{row.original.images?.length || 0}</span>,
     },
     {
         id: 'actions',
@@ -176,7 +176,7 @@ export const LitterReportsPage = () => {
         () =>
             filteredReports
                 .map((report) => {
-                    const img = report.litterImages?.find((i) => i.latitude && i.longitude);
+                    const img = report.images?.find((i) => i.latitude && i.longitude);
                     if (!img) return null;
                     return { ...report, latitude: img.latitude!, longitude: img.longitude! };
                 })

--- a/TrashMob/client-app/src/pages/locationpreference/index.tsx
+++ b/TrashMob/client-app/src/pages/locationpreference/index.tsx
@@ -108,7 +108,7 @@ export const LocationPreference = () => {
             body.userName = currentUser.userName ?? '';
             body.email = currentUser.email ?? '';
             body.dateAgreedToTrashMobWaiver = new Date(currentUser.dateAgreedToTrashMobWaiver);
-            body.memberSince = new Date(currentUser.memberSince);
+            body.memberSince = currentUser.memberSince ? new Date(currentUser.memberSince) : new Date();
             body.trashMobWaiverVersion = currentUser.trashMobWaiverVersion;
 
             body.city = values.city ?? '';

--- a/TrashMob/client-app/src/pages/myprofile/index.tsx
+++ b/TrashMob/client-app/src/pages/myprofile/index.tsx
@@ -168,7 +168,7 @@ export const MyProfile = () => {
             body.id = currentUser.id;
             body.email = currentUser.email ?? '';
             body.dateAgreedToTrashMobWaiver = new Date(currentUser.dateAgreedToTrashMobWaiver);
-            body.memberSince = new Date(currentUser.memberSince);
+            body.memberSince = currentUser.memberSince ? new Date(currentUser.memberSince) : new Date();
             body.trashMobWaiverVersion = currentUser.trashMobWaiverVersion;
             body.latitude = currentUser.latitude;
             body.longitude = currentUser.longitude;
@@ -359,7 +359,14 @@ export const MyProfile = () => {
                                     <div className='col-span-12 sm:col-span-6'>
                                         <div className='space-y-2'>
                                             <FormLabel>Member Since</FormLabel>
-                                            <Input value={new Date(user.memberSince).toLocaleDateString()} disabled />
+                                            <Input
+                                                value={
+                                                    user.memberSince
+                                                        ? new Date(user.memberSince).toLocaleDateString()
+                                                        : ''
+                                                }
+                                                disabled
+                                            />
                                         </div>
                                     </div>
                                 </div>

--- a/TrashMob/client-app/src/pages/siteadmin/litter-reports/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/litter-reports/columns.tsx
@@ -45,10 +45,10 @@ export const columns: ColumnDef<LitterReportData>[] = [
         },
     },
     {
-        accessorKey: 'litterImages',
+        accessorKey: 'images',
         header: 'Images',
         cell: ({ row }) => {
-            const images = row.original.litterImages || [];
+            const images = row.original.images || [];
             return images.length;
         },
     },


### PR DESCRIPTION
## Summary
- Updates 7 frontend TypeScript model classes to match v2 API DTO field names, types, and nullability
- Renames `litterImages` → `images` and `imageURL` → `imageUrl` across 15 component files (37+ occurrences)
- Fixes all nullable type errors in 8 component files caused by the type alignment
- Updates Project 24 document to reflect Phase 3a-3f completion

## Model alignment details

| Model | Changes |
|---|---|
| EventData | Added `isEventPublic: boolean`, `latitude`/`longitude` now `number \| null` |
| UserData | `memberSince` now `Date \| null`, `latitude`/`longitude` now `number \| null` |
| TeamMemberData | Added `givenName`, `profilePhotoUrl`; `userName` now required |
| LitterReportData | Added `images[]` (v2 field name), kept `litterImages` deprecated |
| LitterImageData | Added `imageUrl` (v2 field name), kept `imageURL` deprecated |
| PartnerData | Added `isFeatured`, `boundsNorth/South/East/West`, `boundaryGeoJson`, `regionType`, `countyName` |
| PickupLocationData | Added `county`, `latitude`/`longitude` now `number \| null` |

## Component fixes (nullable type errors)
- Google Maps positions: `?? 0` fallback for nullable coords
- Date constructors: null checks for `memberSince`
- Form fields: `?? undefined` for null-to-undefined conversion
- Map markers: `.filter()` + `!` assertions after null exclusion

## Test plan
- [ ] TypeScript compiles with 0 errors
- [ ] ESLint + Prettier clean (`npm run check`)
- [ ] Frontend build succeeds
- [ ] 993 backend tests pass
- [ ] Litter report pages display images correctly (uses `images` not `litterImages`)
- [ ] Event map displays markers correctly with nullable coords
- [ ] User profile and location preference pages handle nullable memberSince

🤖 Generated with [Claude Code](https://claude.com/claude-code)