### PR TITLE
Fix home page crash: unwrap PagedResponse.items for filtered events

### DIFF
--- a/TrashMob/client-app/src/pages/_home/event-section.tsx
+++ b/TrashMob/client-app/src/pages/_home/event-section.tsx
@@ -45,7 +45,7 @@ const useGetFilteredEvents = (params: GetFilteredEvents_Params) => {
     return useQuery({
         queryKey: GetFilteredEvents(params).key,
         queryFn: GetFilteredEvents(params).service,
-        select: (res) => res.data || [],
+        select: (res) => res.data?.items || [],
     });
 };
 

--- a/TrashMob/client-app/src/services/events.ts
+++ b/TrashMob/client-app/src/services/events.ts
@@ -31,7 +31,7 @@ export type GetFilteredEvents_Params = {
     endDate?: string;
     createdByUserId?: string;
 };
-export type GetFilteredEvents_Response = EventData[];
+export type GetFilteredEvents_Response = PagedResponse<EventData>;
 
 export const GetFilteredEvents = (params: GetFilteredEvents_Params) => ({
     key: ['/events/filteredevents', params],


### PR DESCRIPTION
## Summary
- Fixes critical bug where the home page crashes with `TypeError: .map is not a function` because `GetFilteredEvents` returned a `PagedResponse<EventDto>` wrapper object but the consumer expected a raw array
- The v2 `/events/pagedfilteredevents` endpoint returns `{ items: [...], pageIndex, totalPages, ... }` but the frontend was calling `.map()` on the wrapper object

## Changes
- `services/events.ts`: Change `GetFilteredEvents_Response` from `EventData[]` to `PagedResponse<EventData>`
- `pages/_home/event-section.tsx`: Change `select: (res) => res.data || []` to `select: (res) => res.data?.items || []`

## Test plan
- [x] 55/55 E2E Playwright tests pass against dev API (4 skipped)
- [x] TypeScript compiles with 0 errors
- [x] Frontend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)