### PR TITLE
Add Google Analytics 4 with cookie consent

### DIFF
--- a/TrashMob/client-app/src/components/CookieConsent/CookieConsent.tsx
+++ b/TrashMob/client-app/src/components/CookieConsent/CookieConsent.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { getConsent, setConsent, loadClarity, loadAppInsights } from '@/lib/analytics';
+import { getConsent, setConsent, loadClarity, loadAppInsights, loadGoogleAnalytics } from '@/lib/analytics';
 
 export function CookieConsent() {
     const [visible, setVisible] = useState(() => getConsent() === null);
@@ -11,6 +11,7 @@ export function CookieConsent() {
         setConsent(true);
         loadClarity();
         loadAppInsights();
+        loadGoogleAnalytics();
         setVisible(false);
     }
 

--- a/TrashMob/client-app/src/lib/analytics.ts
+++ b/TrashMob/client-app/src/lib/analytics.ts
@@ -20,11 +20,14 @@ export function setConsent(analytics: boolean): void {
     localStorage.setItem(CONSENT_KEY, JSON.stringify(consent));
 }
 
+const GA4_MEASUREMENT_ID = 'G-T9F2NDS042';
+
 let clarityLoaded = false;
 let appInsightsLoaded = false;
+let ga4Loaded = false;
 
 export function loadClarity(): void {
-    if (clarityLoaded) return;
+    if (clarityLoaded || !import.meta.env.PROD) return;
     clarityLoaded = true;
 
     (function (c: Window, l: Document, a: string, r: string, i: string) {
@@ -40,6 +43,25 @@ export function loadClarity(): void {
         const y = l.getElementsByTagName(r)[0];
         y?.parentNode?.insertBefore(t, y);
     })(window, document, 'clarity', 'script', 'az7h8gs917');
+}
+
+export function loadGoogleAnalytics(): void {
+    if (ga4Loaded || !import.meta.env.PROD) return;
+    ga4Loaded = true;
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`;
+    document.head.appendChild(script);
+
+    const w = window as unknown as Record<string, unknown>;
+    if (!w.dataLayer) w.dataLayer = [];
+    const dataLayer = w.dataLayer as unknown[];
+    function gtag(...args: unknown[]) {
+        dataLayer.push(args);
+    }
+    gtag('js', new Date());
+    gtag('config', GA4_MEASUREMENT_ID);
 }
 
 export function loadAppInsights(): void {
@@ -124,5 +146,6 @@ export function initAnalytics(): void {
     if (consent?.analytics) {
         loadClarity();
         loadAppInsights();
+        loadGoogleAnalytics();
     }
 }

--- a/TrashMob/client-app/src/pages/privacypolicy/index.tsx
+++ b/TrashMob/client-app/src/pages/privacypolicy/index.tsx
@@ -3,8 +3,8 @@ import { HeroSection } from '@/components/Customization/HeroSection';
 import { Logo } from '@/components/Logo';
 
 export const CurrentPrivacyPolicyVersion: PrivacyPolicyVersion = {
-    versionId: '1.0',
-    versionDate: new Date(2026, 1, 23, 0, 0, 0, 0),
+    versionId: '1.1',
+    versionDate: new Date(2026, 2, 15, 0, 0, 0, 0),
 };
 
 export class PrivacyPolicyVersion {
@@ -136,6 +136,24 @@ export const PrivacyPolicy: React.FC = () => {
                             Privacy Policy
                         </a>
                     </li>
+                    <li>
+                        <strong>Google Analytics</strong> — Website traffic analysis and conversion tracking (with your
+                        consent).{' '}
+                        <a href='https://policies.google.com/privacy' target='_blank' rel='noopener noreferrer'>
+                            Privacy Policy
+                        </a>
+                    </li>
+                    <li>
+                        <strong>Microsoft Clarity</strong> — Anonymized session recordings and heatmaps to improve
+                        usability (with your consent).{' '}
+                        <a
+                            href='https://privacy.microsoft.com/privacystatement'
+                            target='_blank'
+                            rel='noopener noreferrer'
+                        >
+                            Privacy Policy
+                        </a>
+                    </li>
                 </ul>
 
                 <h2 className='font-medium text-3xl'>Data Sharing</h2>
@@ -250,10 +268,26 @@ export const PrivacyPolicy: React.FC = () => {
                 <h2 className='font-medium text-3xl'>Cookies and Tracking</h2>
 
                 <p className='text-lg'>
-                    TrashMob uses minimal cookies, limited to authentication session management. We do not use
-                    third-party advertising cookies, cross-site tracking pixels, or behavioral analytics that follow you
-                    across other websites. Application performance monitoring is handled through Azure Application
-                    Insights, which does not perform cross-site tracking.
+                    TrashMob uses cookies for authentication session management. With your consent, we also use the
+                    following analytics services to understand how the platform is used and to improve the experience:
+                </p>
+
+                <ul>
+                    <li>
+                        <strong>Azure Application Insights</strong> — Performance monitoring and feature usage tracking
+                    </li>
+                    <li>
+                        <strong>Google Analytics (GA4)</strong> — Traffic sources, page views, and conversion tracking
+                    </li>
+                    <li>
+                        <strong>Microsoft Clarity</strong> — Anonymized session recordings and heatmaps
+                    </li>
+                </ul>
+
+                <p className='text-lg'>
+                    These analytics tools are only loaded after you accept cookies via the consent banner. You can
+                    reject non-essential cookies and still use TrashMob with full functionality. We do not use
+                    third-party advertising cookies or cross-site tracking pixels.
                 </p>
 
                 <h2 className='font-medium text-3xl'>Data Security</h2>


### PR DESCRIPTION
## Summary
- Adds GA4 tracking (G-T9F2NDS042) to the site, integrated with existing cookie consent system
- GA4 and Clarity only load in production builds — no dev traffic pollution
- Updates privacy policy to v1.1, documenting all three analytics services (App Insights, GA4, Clarity)

## Changes
- **analytics.ts** — New `loadGoogleAnalytics()` function, production-only guard on GA4 and Clarity
- **CookieConsent.tsx** — Calls `loadGoogleAnalytics()` on accept
- **privacypolicy/index.tsx** — Version bump to 1.1, added GA4 and Clarity to third-party services, rewrote cookies section

## Test plan
- [ ] Verify GA4 does NOT load on `npm start` (dev mode) — check Network tab for no gtag.js requests
- [ ] Verify GA4 loads after cookie accept on production build (`npm run build && npm run preview`)
- [ ] Verify rejecting cookies does not load GA4
- [ ] Check GA4 realtime dashboard shows page views after accepting cookies on prod
- [ ] Review updated privacy policy at `/privacypolicy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)