### PR TITLE
Seed default CMS content and fix error handling

### DIFF
--- a/Strapi/src/index.ts
+++ b/Strapi/src/index.ts
@@ -80,5 +80,82 @@ export default {
     }
 
     strapi.log.info("Default news categories seeded");
+
+    // Seed default home page single-type content if it doesn't exist.
+    // This prevents 404 errors from the CMS controller when content
+    // has not yet been created via the Strapi admin panel.
+
+    const heroSection = await strapi
+      .documents("api::hero-section.hero-section")
+      .findFirst();
+
+    if (!heroSection) {
+      await strapi
+        .documents("api::hero-section.hero-section")
+        .create({
+          data: {
+            tagline: "Meet up. Clean up. Feel good!",
+            primaryButtonText: "Join us today",
+            primaryButtonLink: "/gettingstarted",
+            secondaryButtonText: "Report Litter",
+            secondaryButtonLink: "/litterreports/create",
+            googlePlayUrl:
+              "https://play.google.com/store/apps/details?id=eco.trashmob.trashmobmobileapp",
+            appStoreUrl:
+              "https://apps.apple.com/us/app/trashmob/id1599996743?itscg=30200&itsct=apps_box_badge&mttnsubad=1599996743",
+          },
+          status: "published",
+        });
+      strapi.log.info("Default hero section content seeded");
+    }
+
+    const whatIsTrashmob = await strapi
+      .documents("api::what-is-trashmob.what-is-trashmob")
+      .findFirst();
+
+    if (!whatIsTrashmob) {
+      await strapi
+        .documents("api::what-is-trashmob.what-is-trashmob")
+        .create({
+          data: {
+            heading: "What is a TrashMob?",
+            description:
+              "A TrashMob is a group of citizens who are willing to take an hour or two out of their lives to get together and clean up their communities. Start your impact today.",
+            youtubeVideoUrl:
+              "https://www.youtube.com/embed/ylOBeVHRtuM?si=5oYDCAMdywNBmp_A",
+            primaryButtonText: "Learn more",
+            primaryButtonLink: "/aboutus",
+            secondaryButtonText: "View Upcoming Events",
+            secondaryButtonLink: "/#events",
+          },
+          status: "published",
+        });
+      strapi.log.info("Default 'What is TrashMob' content seeded");
+    }
+
+    const gettingStarted = await strapi
+      .documents("api::getting-started.getting-started")
+      .findFirst();
+
+    if (!gettingStarted) {
+      await strapi
+        .documents("api::getting-started.getting-started")
+        .create({
+          data: {
+            heading: "Getting Started",
+            subheading:
+              "All you really need to start or join a trash mob are:",
+            requirements: [
+              { icon: "gloves", label: "Work gloves" },
+              { icon: "bucket", label: "A bucket" },
+              { icon: "attitude", label: "A good attitude" },
+            ],
+            ctaButtonText: "Learn more",
+            ctaButtonLink: "/gettingstarted",
+          },
+          status: "published",
+        });
+      strapi.log.info("Default 'Getting Started' content seeded");
+    }
   },
 };

--- a/TrashMob/Controllers/V2/CmsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CmsV2Controller.cs
@@ -57,9 +57,14 @@ namespace TrashMob.Controllers.V2
 
                 return Content(rewritten, "application/json");
             }
+            catch (OperationCanceledException)
+            {
+                // Client disconnected — not an error worth logging
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Request canceled.");
+            }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to fetch hero section from CMS");
+                logger.LogWarning(ex, "Failed to fetch hero section from CMS");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
             }
         }
@@ -94,9 +99,13 @@ namespace TrashMob.Controllers.V2
 
                 return Content(rewritten, "application/json");
             }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Request canceled.");
+            }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to fetch what-is-trashmob from CMS");
+                logger.LogWarning(ex, "Failed to fetch what-is-trashmob from CMS");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
             }
         }
@@ -131,9 +140,13 @@ namespace TrashMob.Controllers.V2
 
                 return Content(rewritten, "application/json");
             }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Request canceled.");
+            }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to fetch getting-started from CMS");
+                logger.LogWarning(ex, "Failed to fetch getting-started from CMS");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
             }
         }
@@ -189,9 +202,13 @@ namespace TrashMob.Controllers.V2
 
                 return Content(rewritten, "application/json");
             }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Request canceled.");
+            }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to fetch news posts from CMS");
+                logger.LogWarning(ex, "Failed to fetch news posts from CMS");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
             }
         }
@@ -240,9 +257,13 @@ namespace TrashMob.Controllers.V2
 
                 return Content(rewritten, "application/json");
             }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Request canceled.");
+            }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to fetch news post by slug from CMS");
+                logger.LogWarning(ex, "Failed to fetch news post by slug from CMS");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
             }
         }
@@ -276,9 +297,13 @@ namespace TrashMob.Controllers.V2
 
                 return Content(response, "application/json");
             }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Request canceled.");
+            }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to fetch news categories from CMS");
+                logger.LogWarning(ex, "Failed to fetch news categories from CMS");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
             }
         }
@@ -346,9 +371,13 @@ namespace TrashMob.Controllers.V2
 
                 return Content(rss.ToString(), "application/rss+xml");
             }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Request canceled.");
+            }
             catch (HttpRequestException ex)
             {
-                logger.LogError(ex, "Failed to generate news feed from CMS");
+                logger.LogWarning(ex, "Failed to generate news feed from CMS");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "CMS unavailable.");
             }
         }


### PR DESCRIPTION
## Summary
- Seed default home page content in Strapi bootstrap so CMS endpoints stop returning 404
- Fix CMS controller error handling to suppress client-disconnect noise and reduce log severity

## Changes

**Strapi/src/index.ts** — Add idempotent seed logic for three single-type content entries:
- Hero Section: tagline, buttons, app store URLs (matches frontend defaults)
- What Is TrashMob: heading, description, YouTube URL, buttons
- Getting Started: heading, subheading, 3 requirement items, CTA button

**CmsV2Controller.cs** — All 7 endpoints updated:
- Add `catch (OperationCanceledException)` to silently handle client disconnects
- Downgrade `LogError` → `LogWarning` for CMS fetch failures

## Issues Addressed
- **#3104** — 1,316 daily 404s from `GetWhatIsTrashmob` (missing Strapi content)
- **#3108** — ObjectDisposedException in `GetHeroSection` (client disconnect)
- **#3105** — HttpRequestException (canceled) in CMS (client disconnect)
- **#3058** — SocketException (canceled) in CMS (client disconnect)

## Test plan
- [ ] After deploy, verify Strapi logs show "Default hero section content seeded" etc. on first startup
- [ ] Verify `GET /api/v2/cms/hero-section` returns 200 with seeded content (not 404)
- [ ] Verify `GET /api/v2/cms/what-is-trashmob` returns 200
- [ ] Verify `GET /api/v2/cms/getting-started` returns 200
- [ ] Verify home page renders correctly with seeded CMS content
- [ ] Verify seeding is idempotent — restarting Strapi doesn't duplicate content
- [ ] Confirm auto-exception issues stop recurring after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)