### PR TITLE
Fix route controller UserId crashes and LitterImage tracking conflict

### DIFF
--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -364,15 +364,22 @@ namespace TrashMob.Shared.Managers.LitterReport
         public async Task<LitterReport> UpdateAsync(FullLitterReport instance, Guid userId,
             CancellationToken cancellationToken)
         {
-            var existingInstance =
-                await Repo.GetWithNoTrackingAsync(instance.Id, cancellationToken);
+            var existingInstance = Repo.Get(l => l.Id == instance.Id, withNoTracking: false)
+                .Include(l => l.LitterImages)
+                .FirstOrDefault();
 
             if (existingInstance is null)
             {
                 return null;
             }
 
-            var updateInstance = await base.UpdateAsync(instance.ToLitterReport(), userId, cancellationToken);
+            existingInstance.Name = instance.Name;
+            existingInstance.Description = instance.Description;
+            existingInstance.LitterReportStatusId = instance.LitterReportStatusId;
+            existingInstance.LastUpdatedByUserId = userId;
+            existingInstance.LastUpdatedDate = DateTime.UtcNow;
+
+            var updateInstance = await base.UpdateAsync(existingInstance, userId, cancellationToken);
 
             // Delete images not in the updated report
             var ExistinglitterImages = await litterImageManager.GetByParentIdAsync(instance.Id, cancellationToken);

--- a/TrashMob/Controllers/EventAttendeeRoutesController.cs
+++ b/TrashMob/Controllers/EventAttendeeRoutesController.cs
@@ -46,7 +46,9 @@ namespace TrashMob.Controllers
         {
             var result = await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken);
 
-            var currentUserId = User.Identity?.IsAuthenticated == true ? UserId : Guid.Empty;
+            var currentUserId = User.Identity?.IsAuthenticated == true && HttpContext.Items["UserId"] != null
+                ? UserId
+                : Guid.Empty;
 
             var displayEventAttendeeRoutes = result
                 .Where(r => r.PrivacyLevel != "Private" || r.UserId == currentUserId)

--- a/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeeRoutesV2Controller.cs
@@ -67,7 +67,9 @@ namespace TrashMob.Controllers.V2
 
             var result = await eventAttendeeRouteManager.GetByParentIdAsync(eventId, cancellationToken);
 
-            var currentUserId = User.Identity?.IsAuthenticated == true ? UserId : Guid.Empty;
+            var currentUserId = User.Identity?.IsAuthenticated == true && HttpContext.Items["UserId"] != null
+                ? UserId
+                : Guid.Empty;
 
             var displayRoutes = result
                 .Where(r => r.PrivacyLevel != "Private" || r.UserId == currentUserId)


### PR DESCRIPTION
## Summary
- Fix crashes when unauthenticated users hit event attendee route endpoints
- Fix EF Core entity tracking conflict when updating litter reports with images

## Issues Fixed

**#3106** — `FormatException: Unrecognized Guid format` (2 occurrences)
- V2 `EventAttendeeRoutesV2Controller.GetByEvent` accesses `UserId` property which parses empty string as Guid
- Fix: check `HttpContext.Items["UserId"] != null` before accessing `UserId`

**#3057** — `NullReferenceException: Object reference not set` (11 occurrences)
- V1 `EventAttendeeRoutesController.GetEventAttendeeRoutesByEventId` accesses `SecureController.UserId` which calls `.ToString()` on null
- Fix: same null check pattern

**#3071** — `InvalidOperationException: LitterImage cannot be tracked` (1 occurrence)
- `LitterReportManager.UpdateAsync(FullLitterReport)` fetched with no-tracking then called `base.UpdateAsync()` which attached a new entity instance, conflicting with later operations
- Fix: fetch with tracking and update properties directly (matches the pattern used by the other `UpdateAsync(LitterReport)` overload)

## Test plan
- [ ] `dotnet test` passes (993 tests) ✅
- [ ] Visit event details page while logged out — routes should display without crash
- [ ] Update a litter report with images — should save without tracking conflict
- [ ] Verify auto-exception issues stop recurring after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)