### PR TITLE
Unskip 4 E2E tests: fix Radix nav hover + enable contact form tests

### DIFF
--- a/TrashMob/client-app/e2e/pages/home.page.ts
+++ b/TrashMob/client-app/e2e/pages/home.page.ts
@@ -66,21 +66,27 @@ export class HomePage {
         await this.heroTitle.waitFor({ state: 'visible' });
     }
 
-    // Navigation helpers - radix navigation menu opens on hover
+    // Navigation helpers - Radix NavigationMenu requires real mouse events to open.
+    // Playwright's .hover() doesn't always trigger the pointer events Radix listens for,
+    // but mouse.move to the element center does.
+    private async hoverNavTrigger(trigger: Locator) {
+        const box = await trigger.boundingBox();
+        if (box) {
+            await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        }
+        await this.page.waitForTimeout(400); // Allow animation
+    }
+
     async openExploreMenu() {
-        await this.exploreMenu.hover();
-        // Wait for menu content to be visible
-        await this.page.waitForTimeout(300); // Allow animation
+        await this.hoverNavTrigger(this.exploreMenu);
     }
 
     async openTakeActionMenu() {
-        await this.takeActionMenu.hover();
-        await this.page.waitForTimeout(300);
+        await this.hoverNavTrigger(this.takeActionMenu);
     }
 
     async openAboutMenu() {
-        await this.aboutMenu.hover();
-        await this.page.waitForTimeout(300);
+        await this.hoverNavTrigger(this.aboutMenu);
     }
 
     async navigateToEvents() {
@@ -90,12 +96,13 @@ export class HomePage {
 
     async navigateToTeams() {
         await this.openExploreMenu();
-        await this.page.getByRole('link', { name: 'Teams' }).click();
+        // Use the nav menu link specifically (contains description text)
+        await this.page.getByRole('link', { name: /Teams.*join.*team/i }).click();
     }
 
     async navigateToCommunities() {
         await this.openExploreMenu();
-        await this.page.getByRole('link', { name: 'Communities' }).click();
+        await this.page.getByRole('link', { name: /Communities.*community programs/i }).click();
     }
 
     async navigateToCreateEvent() {

--- a/TrashMob/client-app/e2e/tests/contact.spec.ts
+++ b/TrashMob/client-app/e2e/tests/contact.spec.ts
@@ -15,13 +15,11 @@ test.describe('Contact Us Form', () => {
             await expect(contactPage.submitButton).toBeVisible();
         });
 
-        // TODO: Enable after contact form changes are deployed to dev
-        test.skip('should have required field indicators', async ({ page }) => {
+        test('should have required field indicators', async ({ page }) => {
             const contactPage = new ContactPage(page);
             await contactPage.goto();
 
-            // Check that required fields have appropriate indicators
-            // This could be aria-required, required attribute, or visual indicator
+            // Check that required fields have the required attribute
             await expect(contactPage.nameInput).toHaveAttribute('required', '');
             await expect(contactPage.emailInput).toHaveAttribute('required', '');
             await expect(contactPage.messageInput).toHaveAttribute('required', '');
@@ -71,8 +69,7 @@ test.describe('Contact Us Form', () => {
     });
 
     test.describe('Form Submission', () => {
-        // Note: This test may need reCAPTCHA handling in CI
-        test.skip('should submit form with valid data', async ({ page }) => {
+        test('should submit form with valid data', async ({ page }) => {
             const contactPage = new ContactPage(page);
             await contactPage.goto();
 

--- a/TrashMob/client-app/e2e/tests/public-pages.spec.ts
+++ b/TrashMob/client-app/e2e/tests/public-pages.spec.ts
@@ -41,8 +41,7 @@ test.describe('Public Pages', () => {
     });
 
     test.describe('Navigation', () => {
-        // TODO: Navigation menu tests need refinement for radix UI hover behavior
-        test.skip('should navigate to Teams page from Explore menu', async ({ page }) => {
+        test('should navigate to Teams page from Explore menu', async ({ page }) => {
             const homePage = new HomePage(page);
             await homePage.goto();
 
@@ -50,7 +49,7 @@ test.describe('Public Pages', () => {
             await expect(page).toHaveURL('/teams');
         });
 
-        test.skip('should navigate to Communities page from Explore menu', async ({ page }) => {
+        test('should navigate to Communities page from Explore menu', async ({ page }) => {
             const homePage = new HomePage(page);
             await homePage.goto();
 


### PR DESCRIPTION
## Summary
Enables all 4 previously-skipped E2E tests by fixing the underlying issues.

## Fixes

### Radix NavigationMenu hover (2 tests)
- **Problem**: Playwright's `.hover()` doesn't trigger the pointer events that Radix NavigationMenu listens for in headless mode
- **Fix**: Use `page.mouse.move()` to the element center, which triggers real pointer events and opens the Radix dropdown
- **Also**: Use description text in link selectors (e.g. `/Teams.*join.*team/i`) to disambiguate nav menu links from footer links

### Contact form tests (2 tests)
- **"should have required field indicators"**: Contact form now has `required` attributes — enabled
- **"should submit form with valid data"**: No reCAPTCHA on the site — enabled

## Test Results
- 99 passed, 1 intermittent failure (event details page), 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)