### PR TITLE
Fix Android black screen after sign-out and re-sign-in

### DIFF
--- a/TrashMobMobile/ViewModels/HomeFeedViewModel.cs
+++ b/TrashMobMobile/ViewModels/HomeFeedViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using TrashMob.Models;
 using TrashMob.Models.Poco;
 using TrashMobMobile.Extensions;
+using TrashMobMobile.Pages;
 using TrashMobMobile.Services;
 
 public partial class HomeFeedViewModel(
@@ -56,6 +57,13 @@ public partial class HomeFeedViewModel(
         await ExecuteAsync(async () =>
         {
             var user = userManager.CurrentUser;
+            if (user == null)
+            {
+                // User not loaded yet — navigate back to welcome
+                await Shell.Current.GoToAsync($"//{nameof(WelcomePage)}");
+                return;
+            }
+
             WelcomeMessage = $"Hi, {user.UserName}";
             UserInitials = GetInitials(user.UserName);
             LocationSummary = BuildLocationSummary(user);

--- a/TrashMobMobile/ViewModels/WelcomeViewModel.cs
+++ b/TrashMobMobile/ViewModels/WelcomeViewModel.cs
@@ -47,16 +47,22 @@ public partial class WelcomeViewModel(IAuthService authService, IStatsRestServic
 
             IsBusy = false;
 
-            if (signedIn.Succeeded)
+            if (signedIn.Succeeded && App.CurrentUser != null)
             {
                 // Yield to allow the Android activity to fully resume after
                 // returning from the MSAL browser/webview, preventing a black
                 // screen when navigating immediately after interactive auth.
-                await Task.Delay(100);
+                // 500ms is needed on some Android devices; 100ms was insufficient.
+                await Task.Delay(500);
                 await MainThread.InvokeOnMainThreadAsync(async () =>
                 {
                     await Shell.Current.GoToAsync($"//{nameof(MainTabsPage)}");
                 });
+            }
+            else if (signedIn.Succeeded)
+            {
+                // Auth succeeded but user lookup failed — treat as error
+                await NotificationService.NotifyError("Sign in succeeded but your account could not be loaded. Please try again.");
             }
             else
             {


### PR DESCRIPTION
## Summary
- Fix black screen that occurs on Android when signing out and signing back in
- Add defensive null checks to prevent crash if user lookup fails during auth

## Root Cause
After sign-out, MSAL token cache is cleared. Re-sign-in requires interactive auth (browser). When the MSAL browser closes and the Android activity resumes, the MAUI Shell isn't fully restored. The previous 100ms delay was insufficient, and `HomeFeedViewModel.Init()` crashed accessing `userManager.CurrentUser` (null) → unhandled exception → black screen.

## Changes
- **WelcomeViewModel** — Increase post-auth delay to 500ms, check `App.CurrentUser != null` before navigating, show error if user lookup failed
- **HomeFeedViewModel** — Null guard on `userManager.CurrentUser` in `Init()`, navigate back to WelcomePage as fallback

## Test plan
- [ ] On Android: sign in → sign out → sign in again → should navigate to home feed (not black screen)
- [ ] On Android: verify first-time sign in still works normally
- [ ] On iOS: verify sign in/out/in cycle still works (no regression)
- [ ] Kill app and reopen after sign-in → should still work (silent auth path)

Fixes #3077

🤖 Generated with [Claude Code](https://claude.com/claude-code)