### PR TITLE
Prevent registration to full events

### DIFF
--- a/TrashMob.Shared.Tests/Managers/Events/EventAttendeeManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventAttendeeManagerTests.cs
@@ -52,6 +52,113 @@ namespace TrashMob.Shared.Tests.Managers.Events
                 _emailManager.Object);
         }
 
+        #region AddAsync Capacity Tests
+
+        [Fact]
+        public async Task AddAsync_WhenEventIsFull_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .WithMaxParticipants(2)
+                .Build();
+
+            var existingAttendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId).Build(),
+                new EventAttendeeBuilder().ForEvent(eventId).Build()
+            };
+
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            _attendeeRepository.SetupGet(existingAttendees);
+
+            var newAttendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .Build();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.AddAsync(newAttendee, userId));
+
+            Assert.Contains("full", ex.Message);
+        }
+
+        [Fact]
+        public async Task AddAsync_WhenEventHasCapacity_Succeeds()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .WithMaxParticipants(5)
+                .Build();
+
+            var existingAttendees = new List<EventAttendee>
+            {
+                new EventAttendeeBuilder().ForEvent(eventId).Build(),
+                new EventAttendeeBuilder().ForEvent(eventId).Build()
+            };
+
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            _attendeeRepository.SetupGet(existingAttendees);
+            _attendeeRepository.Setup(r => r.AddAsync(It.IsAny<EventAttendee>()))
+                .ReturnsAsync((EventAttendee ea) => ea);
+
+            var newAttendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .Build();
+
+            // Act
+            var result = await _sut.AddAsync(newAttendee, userId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(eventId, result.EventId);
+        }
+
+        [Fact]
+        public async Task AddAsync_WhenNoCapacityLimit_Succeeds()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            var evt = new EventBuilder()
+                .WithId(eventId)
+                .WithMaxParticipants(0)
+                .Build();
+
+            _eventRepository.Setup(r => r.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evt);
+
+            _attendeeRepository.Setup(r => r.AddAsync(It.IsAny<EventAttendee>()))
+                .ReturnsAsync((EventAttendee ea) => ea);
+
+            var newAttendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .Build();
+
+            // Act
+            var result = await _sut.AddAsync(newAttendee, userId);
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        #endregion
+
         #region GetEventsUserIsAttendingAsync Tests
 
         [Fact]

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -25,6 +25,25 @@ namespace TrashMob.Shared.Managers.Events
     {
 
         /// <inheritdoc />
+        public override async Task<EventAttendee> AddAsync(EventAttendee instance, Guid userId,
+            CancellationToken cancellationToken = default)
+        {
+            var evt = await eventRepository.GetAsync(instance.EventId, cancellationToken);
+
+            if (evt != null && evt.MaxNumberOfParticipants > 0)
+            {
+                var currentCount = await GetActiveAttendeeCountAsync(instance.EventId, cancellationToken);
+
+                if (currentCount >= evt.MaxNumberOfParticipants)
+                {
+                    throw new InvalidOperationException("This event is full. No more registrations are allowed.");
+                }
+            }
+
+            return await base.AddAsync(instance, userId, cancellationToken);
+        }
+
+        /// <inheritdoc />
         public override async Task<IEnumerable<EventAttendee>> GetByParentIdAsync(Guid parentId,
             CancellationToken cancellationToken)
         {

--- a/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
@@ -95,11 +95,13 @@ namespace TrashMob.Controllers.V2
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Attendee registered.</response>
         /// <response code="400">Waivers required.</response>
+        /// <response code="409">Event is full.</response>
         [HttpPost]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(WaiverRequiredResponse), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
         public async Task<IActionResult> AddEventAttendee(
             Guid eventId,
             EventAttendeeDto dto,
@@ -125,8 +127,18 @@ namespace TrashMob.Controllers.V2
                 });
             }
 
-            await eventAttendeeManager.AddAsync(eventAttendee, UserId, cancellationToken);
-            return Ok();
+            try
+            {
+                await eventAttendeeManager.AddAsync(eventAttendee, UserId, cancellationToken);
+                return Ok();
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("full"))
+            {
+                return Problem(
+                    detail: ex.Message,
+                    statusCode: StatusCodes.Status409Conflict,
+                    title: "Event Full");
+            }
         }
 
         /// <summary>

--- a/TrashMob/client-app/src/components/Customization/RegisterBtn.tsx
+++ b/TrashMob/client-app/src/components/Customization/RegisterBtn.tsx
@@ -23,6 +23,7 @@ interface RegisterBtnProps {
     isAttending: string;
     isUserLoaded: boolean;
     isEventCompleted: boolean;
+    isEventFull?: boolean;
 }
 
 export const RegisterBtn: FC<RegisterBtnProps> = ({
@@ -31,6 +32,7 @@ export const RegisterBtn: FC<RegisterBtnProps> = ({
     isAttending,
     isUserLoaded,
     isEventCompleted,
+    isEventFull = false,
 }) => {
     const userId = currentUser.id;
     const navigate = useNavigate();
@@ -156,12 +158,15 @@ export const RegisterBtn: FC<RegisterBtnProps> = ({
         <>
             <Button
                 className={cn({
-                    hidden: !isUserLoaded || isAttending === 'Yes' || registered || isEventCompleted,
+                    hidden: !isUserLoaded || isAttending === 'Yes' || registered || isEventCompleted || isEventFull,
                 })}
                 onClick={() => handleAttend(eventId)}
             >
                 {registered ? 'Attended!' : 'Attend'}
             </Button>
+            {isEventFull && !isEventCompleted && isAttending !== 'Yes' && !registered ? (
+                <p className='text-sm font-medium text-destructive'>This event is full.</p>
+            ) : null}
 
             {requiredWaivers ? (
                 <WaiverSigningFlow

--- a/TrashMob/client-app/src/pages/eventdetails/$eventId/page.tsx
+++ b/TrashMob/client-app/src/pages/eventdetails/$eventId/page.tsx
@@ -101,6 +101,10 @@ export const EventDetails: FC<EventDetailsProps> = () => {
 
     const isEventCompleted = event ? isCompletedEvent(event) : true;
 
+    const totalHeadcount = (eventAttendees || []).length + (dependentCount || 0);
+    const isEventFull =
+        !!maxNumberOfParticipants && maxNumberOfParticipants > 0 && totalHeadcount >= maxNumberOfParticipants;
+
     const startDateTime = moment(eventDate);
     const endDateTime = moment(startDateTime).add(durationHours, 'hours').add(durationMinutes, 'minutes');
 
@@ -145,6 +149,7 @@ export const EventDetails: FC<EventDetailsProps> = () => {
                                         isEventCompleted={isEventCompleted}
                                         currentUser={currentUser}
                                         isUserLoaded={isUserLoaded}
+                                        isEventFull={isEventFull}
                                     />
                                 ) : null}
                                 <DropdownMenu>


### PR DESCRIPTION
## Summary
- Enforce event capacity limits server-side (backend) and hide the register button on the web when events are full
- Mobile app already had this check — no mobile changes needed

## Changes

**Backend — EventAttendeeManager.cs:**
- Override `AddAsync` to check `MaxNumberOfParticipants` before registration
- Throws `InvalidOperationException` when event is at capacity (0 = unlimited)

**Backend — EventAttendeesV2Controller.cs:**
- Catch capacity exception and return `409 Conflict` with ProblemDetails

**Web — RegisterBtn.tsx:**
- Accept new `isEventFull` prop
- Hide Attend button when full, show "This event is full" message

**Web — eventdetails page.tsx:**
- Compute `isEventFull` from attendee count (including dependents) vs `maxNumberOfParticipants`
- Pass to RegisterBtn

**Tests — EventAttendeeManagerTests.cs (3 new tests):**
- Full event rejects registration with InvalidOperationException
- Event with remaining capacity allows registration
- Event with no capacity limit (0) allows registration

## Test plan
- [ ] `dotnet test` passes (all 996 tests)
- [ ] Create event with MaxNumberOfParticipants=2, register 2 users, verify 3rd cannot register (web)
- [ ] Verify "This event is full" message appears on event details page
- [ ] Verify events with no capacity limit (0) still allow unlimited registration
- [ ] Verify mobile app behavior unchanged (already had capacity check)

Fixes #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)