### PR TITLE
Prevent deletion of last image from litter reports

### DIFF
--- a/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
+++ b/TrashMob.Shared/Managers/LitterReport/LitterReportManager.cs
@@ -373,6 +373,16 @@ namespace TrashMob.Shared.Managers.LitterReport
                 return null;
             }
 
+            // Ensure at least one image remains after the update
+            var incomingImageCount = instance.LitterImages?.Count ?? 0;
+            var newImageCount = instance.LitterImages?.Count(x => x.Id == Guid.Empty) ?? 0;
+            var retainedExistingCount = incomingImageCount - newImageCount;
+            if (incomingImageCount == 0 || (retainedExistingCount == 0 && newImageCount == 0))
+            {
+                logger.LogWarning("UpdateAsync(FullLitterReport) rejected: no images for report {Id}", instance.Id);
+                return null;
+            }
+
             existingInstance.Name = instance.Name;
             existingInstance.Description = instance.Description;
             existingInstance.LitterReportStatusId = instance.LitterReportStatusId;

--- a/TrashMobMobile/ViewModels/EditLitterReportViewModel.cs
+++ b/TrashMobMobile/ViewModels/EditLitterReportViewModel.cs
@@ -183,13 +183,33 @@ public partial class EditLitterReportViewModel(ILitterReportManager litterReport
     }
 
     [RelayCommand]
-    private void DeleteLitterImage(LitterImageViewModel? litterImageViewModel)
+    private async Task DeleteLitterImage(LitterImageViewModel? litterImageViewModel)
     {
-        if (litterImageViewModel != null)
+        if (litterImageViewModel == null) return;
+
+        if (LitterImageViewModels.Count <= 1)
         {
-            LitterImageViewModels.Remove(litterImageViewModel);
+            var action = await Shell.Current.DisplayActionSheet(
+                "A litter report must have at least one image.",
+                "Cancel",
+                null,
+                "Add another image first",
+                "Delete entire report");
+
+            if (action == "Delete entire report")
+            {
+                await ExecuteAsync(async () =>
+                {
+                    await litterReportManager.DeleteLitterReportAsync(litterReport.Id);
+                    await NotificationService.Notify("Litter report has been deleted.");
+                    await Navigation.PopAsync();
+                }, "Failed to delete the litter report. Please try again.");
+            }
+
+            return;
         }
 
+        LitterImageViewModels.Remove(litterImageViewModel);
         ValidateReport();
     }
 


### PR DESCRIPTION
## Summary
- On mobile, show a dialog when user tries to delete the last image from a litter report
- Add backend validation preventing litter report updates with 0 images

## Changes

**Mobile — EditLitterReportViewModel.cs:**
- When deleting the last image, show action sheet with two options:
  - "Add another image first" — dismisses dialog, no action
  - "Delete entire report" — deletes the report and navigates back
- Images beyond the last one can still be deleted normally

**Backend — LitterReportManager.cs:**
- Add validation to `UpdateAsync(FullLitterReport)` rejecting updates with 0 images
- Server-side enforcement regardless of client

## Known Gap
The web litter report edit page (`/litterreports/:id/edit`) does not currently support image management — it's metadata-only (name, description, status). Adding image editing to the web is a separate feature.

## Test plan
- [ ] On mobile: edit a litter report with 1 image → tap delete → verify action sheet appears
- [ ] Choose "Add another image first" → verify dialog dismisses, image still present
- [ ] Choose "Delete entire report" → verify report is deleted and navigates back
- [ ] Edit report with 2+ images → delete one → verify it deletes normally (no dialog)
- [ ] `dotnet test` passes (996 tests)

Fixes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)