### PR TITLE
Remove hardcoded What to Expect from mobile event view

### DIFF
--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -78,9 +78,6 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     private string spotsLeft = string.Empty;
 
     [ObservableProperty]
-    private string whatToExpect = string.Empty;
-
-    [ObservableProperty]
     private bool arePartnersAvailable;
 
     [ObservableProperty]
@@ -249,9 +246,6 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
             // Check for crashed/interrupted route sessions for this event
             await CheckForInterruptedSessionsAsync(eventId);
-
-            WhatToExpect =
-                "What to Expect:\n\u2022 Cleanup supplies provided\n\u2022 Meet fellow community members\n\u2022 Contribute to a cleaner environment";
 
             // Load only what the Details tab needs — registration status, attendee count, and metrics
             await Task.WhenAll(SetRegistrationOptions(), GetAttendeeCount());

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
@@ -134,9 +134,6 @@
                     <Label Text="{Binding EventViewModel.Description}"
                            FontSize="Micro"
                            TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
-                    <Label Text="{Binding WhatToExpect}"
-                           FontSize="Micro"
-                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
                 </VerticalStackLayout>
             </Border>
 


### PR DESCRIPTION
## Summary
Remove the static "What to Expect" section from the mobile event detail page. It was hardcoded with the same text for every event and not configurable by event leads.

## Changes
- **ViewEventViewModel.cs** — Remove `whatToExpect` property and hardcoded string assignment
- **TabDetails.xaml** — Remove the Label bound to `WhatToExpect`

Event leads can use the event description field for event-specific instructions.

## Test plan
- [ ] View an event on mobile — verify no "What to Expect" section appears
- [ ] Verify event description still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)