### PR TITLE
Add participation report email with PDF (Project 57 Phase 1)

### DIFF
--- a/TrashMob.Shared.Tests/Managers/Events/ParticipationReportServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/ParticipationReportServiceTests.cs
@@ -1,0 +1,288 @@
+namespace TrashMob.Shared.Tests.Managers.Events
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Events;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+    using TrashMob.Shared.Tests.Builders;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="ParticipationReportService"/>.
+    /// </summary>
+    public class ParticipationReportServiceTests
+    {
+        private readonly Mock<IEventManager> _eventManager = new();
+        private readonly Mock<IEventAttendeeMetricsManager> _metricsManager = new();
+        private readonly Mock<IEventAttendeeManager> _attendeeManager = new();
+        private readonly Mock<IUserManager> _userManager = new();
+        private readonly Mock<IEmailManager> _emailManager = new();
+        private readonly Mock<ILogger<ParticipationReportService>> _logger = new();
+        private readonly ParticipationReportService _sut;
+
+        public ParticipationReportServiceTests()
+        {
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>()))
+                .Returns("<p>{eventName} {eventDate} {duration} {bagsCollected} {weightPicked} {verifiedBy}</p>");
+            _emailManager.Setup(e => e.SendTemplatedEmailAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                    It.IsAny<object>(), It.IsAny<List<EmailAddress>>(),
+                    It.IsAny<List<EmailAttachment>>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            _sut = new ParticipationReportService(
+                _eventManager.Object,
+                _metricsManager.Object,
+                _attendeeManager.Object,
+                _userManager.Object,
+                _emailManager.Object,
+                _logger.Object);
+        }
+
+        #region SendReportAsync Tests
+
+        [Fact]
+        public async Task SendReportAsync_WithApprovedMetrics_SendsEmailWithPdf()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var reviewerId = Guid.NewGuid();
+
+            var evt = new EventBuilder().WithId(eventId).WithName("Beach Cleanup").Build();
+            var user = new UserBuilder().WithId(userId).WithEmail("volunteer@test.com").Build();
+            var reviewer = new UserBuilder().WithId(reviewerId).WithUserName("leaduser").Build();
+            var metrics = new EventAttendeeMetricsBuilder()
+                .ForEvent(eventId).ForUser(userId)
+                .AsApproved(reviewerId)
+                .Build();
+
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+            _metricsManager.Setup(m => m.GetMyMetricsAsync(eventId, userId, It.IsAny<CancellationToken>())).ReturnsAsync(metrics);
+            _userManager.Setup(u => u.GetUserByInternalIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+            _userManager.Setup(u => u.GetUserByInternalIdAsync(reviewerId, It.IsAny<CancellationToken>())).ReturnsAsync(reviewer);
+
+            // Act
+            var result = await _sut.SendReportAsync(eventId, userId, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.Is<string>(s => s.Contains("Participation Report")),
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.Is<List<EmailAddress>>(r => r[0].Email == "volunteer@test.com"),
+                It.Is<List<EmailAttachment>>(a => a.Count == 1 && a[0].MimeType == "application/pdf"),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SendReportAsync_WithPendingMetrics_ReturnsFailure()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            var evt = new EventBuilder().WithId(eventId).Build();
+            var metrics = new EventAttendeeMetricsBuilder()
+                .ForEvent(eventId).ForUser(userId)
+                .AsPending()
+                .Build();
+
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+            _metricsManager.Setup(m => m.GetMyMetricsAsync(eventId, userId, It.IsAny<CancellationToken>())).ReturnsAsync(metrics);
+
+            // Act
+            var result = await _sut.SendReportAsync(eventId, userId, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("not been approved", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SendReportAsync_WithRejectedMetrics_ReturnsFailure()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            var evt = new EventBuilder().WithId(eventId).Build();
+            var metrics = new EventAttendeeMetricsBuilder()
+                .ForEvent(eventId).ForUser(userId)
+                .AsRejected("Inaccurate")
+                .Build();
+
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+            _metricsManager.Setup(m => m.GetMyMetricsAsync(eventId, userId, It.IsAny<CancellationToken>())).ReturnsAsync(metrics);
+
+            // Act
+            var result = await _sut.SendReportAsync(eventId, userId, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+        }
+
+        [Fact]
+        public async Task SendReportAsync_WithNoMetrics_ReturnsFailure()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            var evt = new EventBuilder().WithId(eventId).Build();
+
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+            _metricsManager.Setup(m => m.GetMyMetricsAsync(eventId, userId, It.IsAny<CancellationToken>())).ReturnsAsync((EventAttendeeMetrics)null);
+
+            // Act
+            var result = await _sut.SendReportAsync(eventId, userId, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("No metrics", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SendReportAsync_WithNonExistentEvent_ReturnsFailure()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync((Event)null);
+
+            // Act
+            var result = await _sut.SendReportAsync(eventId, userId, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("Event not found", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SendReportAsync_WithAdjustedMetrics_SendsEmail()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+            var reviewerId = Guid.NewGuid();
+
+            var evt = new EventBuilder().WithId(eventId).WithName("Park Cleanup").Build();
+            var user = new UserBuilder().WithId(userId).WithEmail("user@test.com").Build();
+            var reviewer = new UserBuilder().WithId(reviewerId).Build();
+            var metrics = new EventAttendeeMetricsBuilder()
+                .ForEvent(eventId).ForUser(userId)
+                .AsAdjusted(bags: 3, weight: 8.0m, duration: 90, reviewerId: reviewerId)
+                .Build();
+
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+            _metricsManager.Setup(m => m.GetMyMetricsAsync(eventId, userId, It.IsAny<CancellationToken>())).ReturnsAsync(metrics);
+            _userManager.Setup(u => u.GetUserByInternalIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+            _userManager.Setup(u => u.GetUserByInternalIdAsync(reviewerId, It.IsAny<CancellationToken>())).ReturnsAsync(reviewer);
+
+            // Act
+            var result = await _sut.SendReportAsync(eventId, userId, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(), It.IsAny<List<EmailAttachment>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+
+        #region SendAllReportsAsync Tests
+
+        [Fact]
+        public async Task SendAllReportsAsync_AsEventLead_SendsToAllApproved()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var leadId = Guid.NewGuid();
+            var user1Id = Guid.NewGuid();
+            var user2Id = Guid.NewGuid();
+
+            var evt = new EventBuilder().WithId(eventId).WithName("River Cleanup").Build();
+            var user1 = new UserBuilder().WithId(user1Id).WithEmail("user1@test.com").Build();
+            var user2 = new UserBuilder().WithId(user2Id).WithEmail("user2@test.com").Build();
+            var reviewer = new UserBuilder().WithId(leadId).Build();
+
+            var metrics = new List<EventAttendeeMetrics>
+            {
+                new EventAttendeeMetricsBuilder().ForEvent(eventId).ForUser(user1Id).AsApproved(leadId).Build(),
+                new EventAttendeeMetricsBuilder().ForEvent(eventId).ForUser(user2Id).AsApproved(leadId).Build(),
+                new EventAttendeeMetricsBuilder().ForEvent(eventId).ForUser(Guid.NewGuid()).AsPending().Build(),
+            };
+
+            _attendeeManager.Setup(a => a.IsEventLeadAsync(eventId, leadId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+            _metricsManager.Setup(m => m.GetByEventIdAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(metrics);
+            _userManager.Setup(u => u.GetUserByInternalIdAsync(user1Id, It.IsAny<CancellationToken>())).ReturnsAsync(user1);
+            _userManager.Setup(u => u.GetUserByInternalIdAsync(user2Id, It.IsAny<CancellationToken>())).ReturnsAsync(user2);
+            _userManager.Setup(u => u.GetUserByInternalIdAsync(leadId, It.IsAny<CancellationToken>())).ReturnsAsync(reviewer);
+
+            // Act
+            var result = await _sut.SendAllReportsAsync(eventId, leadId, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Equal(2, result.Data);
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(), It.IsAny<List<EmailAttachment>>(),
+                It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task SendAllReportsAsync_AsNonLead_ReturnsFailure()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var userId = Guid.NewGuid();
+
+            _attendeeManager.Setup(a => a.IsEventLeadAsync(eventId, userId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+            // Act
+            var result = await _sut.SendAllReportsAsync(eventId, userId, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("event lead", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task SendAllReportsAsync_WithNoApprovedMetrics_ReturnsFailure()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid();
+            var leadId = Guid.NewGuid();
+
+            var evt = new EventBuilder().WithId(eventId).Build();
+            var metrics = new List<EventAttendeeMetrics>
+            {
+                new EventAttendeeMetricsBuilder().ForEvent(eventId).AsPending().Build(),
+            };
+
+            _attendeeManager.Setup(a => a.IsEventLeadAsync(eventId, leadId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            _eventManager.Setup(e => e.GetAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+            _metricsManager.Setup(m => m.GetByEventIdAsync(eventId, It.IsAny<CancellationToken>())).ReturnsAsync(metrics);
+
+            // Act
+            var result = await _sut.SendAllReportsAsync(eventId, leadId, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.IsSuccess);
+            Assert.Contains("No approved", result.ErrorMessage);
+        }
+
+        #endregion
+    }
+}

--- a/TrashMob.Shared/Engine/EmailCopy/ParticipationReport.html
+++ b/TrashMob.Shared/Engine/EmailCopy/ParticipationReport.html
@@ -1,0 +1,26 @@
+<p style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 16px;">
+    Your volunteer participation report for <strong>{eventName}</strong> on <strong>{eventDate}</strong> is attached to this email as a PDF.
+</p>
+
+<table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+    <tr style="background-color: #F0F9F9;">
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0; font-weight: bold; color: #005C5C; width: 40%;">Duration</td>
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0;">{duration}</td>
+    </tr>
+    <tr>
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0; font-weight: bold; color: #005C5C;">Bags Collected</td>
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0;">{bagsCollected}</td>
+    </tr>
+    <tr style="background-color: #F0F9F9;">
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0; font-weight: bold; color: #005C5C;">Weight Picked Up</td>
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0;">{weightPicked}</td>
+    </tr>
+    <tr>
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0; font-weight: bold; color: #005C5C;">Verified By</td>
+        <td style="padding: 12px 16px; border: 1px solid #e0e0e0;">{verifiedBy}</td>
+    </tr>
+</table>
+
+<p style="margin: 16px 0 0 0; line-height: 1.6; color: #666666; font-size: 14px;">
+    You can use this report and the attached PDF as proof of volunteer participation. If you need additional documentation, please contact the event organizer or reach out to us at <a href="mailto:info@trashmob.eco" style="color: #005C5C;">info@trashmob.eco</a>.
+</p>

--- a/TrashMob.Shared/Managers/Events/ParticipationReportPdfGenerator.cs
+++ b/TrashMob.Shared/Managers/Events/ParticipationReportPdfGenerator.cs
@@ -1,0 +1,175 @@
+namespace TrashMob.Shared.Managers.Events
+{
+    using System;
+    using System.Linq;
+    using QuestPDF.Fluent;
+    using QuestPDF.Helpers;
+    using QuestPDF.Infrastructure;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Generates PDF participation reports for volunteers.
+    /// </summary>
+    public static class ParticipationReportPdfGenerator
+    {
+        /// <summary>
+        /// Generates a PDF participation report as a byte array.
+        /// </summary>
+        public static byte[] Generate(
+            Event evt,
+            User volunteer,
+            EventAttendeeMetrics metrics,
+            string verifiedByName)
+        {
+            QuestPDF.Settings.License = LicenseType.Community;
+
+            var effectiveBags = metrics.Status == "Adjusted" && metrics.AdjustedBagsCollected.HasValue
+                ? metrics.AdjustedBagsCollected.Value
+                : metrics.BagsCollected ?? 0;
+
+            var effectiveWeight = metrics.Status == "Adjusted" && metrics.AdjustedPickedWeight.HasValue
+                ? metrics.AdjustedPickedWeight.Value
+                : metrics.PickedWeight ?? 0;
+
+            var effectiveWeightUnitId = metrics.Status == "Adjusted" && metrics.AdjustedPickedWeightUnitId.HasValue
+                ? metrics.AdjustedPickedWeightUnitId.Value
+                : metrics.PickedWeightUnitId ?? 1;
+
+            var effectiveDuration = metrics.Status == "Adjusted" && metrics.AdjustedDurationMinutes.HasValue
+                ? metrics.AdjustedDurationMinutes.Value
+                : metrics.DurationMinutes ?? 0;
+
+            var weightUnit = effectiveWeightUnitId == 2 ? "kg" : "lbs";
+            var hours = effectiveDuration / 60;
+            var minutes = effectiveDuration % 60;
+            var durationText = hours > 0
+                ? $"{hours} hour{(hours != 1 ? "s" : "")}{(minutes > 0 ? $" {minutes} min" : "")}"
+                : $"{minutes} minutes";
+
+            var eventDate = evt.EventDate.ToLocalTime();
+
+            var document = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Size(PageSizes.Letter);
+                    page.Margin(50);
+                    page.DefaultTextStyle(x => x.FontSize(11).FontColor(Colors.Grey.Darken3));
+
+                    page.Header().Column(col =>
+                    {
+                        col.Item().Row(row =>
+                        {
+                            row.RelativeItem().Text("TrashMob.eco")
+                                .FontSize(28).Bold().FontColor("#005C5C");
+                            row.ConstantItem(150).AlignRight().Text("Volunteer\nParticipation Report")
+                                .FontSize(12).FontColor(Colors.Grey.Medium).AlignRight();
+                        });
+
+                        col.Item().PaddingTop(5).LineHorizontal(2).LineColor("#005C5C");
+                    });
+
+                    page.Content().PaddingVertical(20).Column(col =>
+                    {
+                        // Volunteer info
+                        col.Item().PaddingBottom(15).Text(text =>
+                        {
+                            text.Span("This report certifies that ").FontSize(12);
+                            text.Span(volunteer.DisplayFirstName)
+                                .FontSize(12).Bold();
+                            text.Span(" participated in the following community cleanup event organized through TrashMob.eco.")
+                                .FontSize(12);
+                        });
+
+                        // Event details card
+                        col.Item().Border(1).BorderColor(Colors.Grey.Lighten2).Padding(15).Column(card =>
+                        {
+                            card.Item().Text("Event Details").FontSize(14).Bold().FontColor("#005C5C");
+                            card.Item().PaddingTop(8).Table(table =>
+                            {
+                                table.ColumnsDefinition(columns =>
+                                {
+                                    columns.ConstantColumn(130);
+                                    columns.RelativeColumn();
+                                });
+
+                                AddRow(table, "Event Name:", evt.Name);
+                                AddRow(table, "Date:", eventDate.ToString("D"));
+                                AddRow(table, "Time:", eventDate.ToString("t"));
+                                AddRow(table, "Location:", FormatLocation(evt));
+                            });
+                        });
+
+                        col.Item().PaddingTop(15);
+
+                        // Volunteer contribution card
+                        col.Item().Border(1).BorderColor(Colors.Grey.Lighten2).Padding(15).Column(card =>
+                        {
+                            card.Item().Text("Volunteer Contribution").FontSize(14).Bold().FontColor("#005C5C");
+                            card.Item().PaddingTop(8).Table(table =>
+                            {
+                                table.ColumnsDefinition(columns =>
+                                {
+                                    columns.ConstantColumn(130);
+                                    columns.RelativeColumn();
+                                });
+
+                                AddRow(table, "Duration:", durationText);
+                                AddRow(table, "Bags Collected:", effectiveBags.ToString());
+                                AddRow(table, "Weight Picked Up:", $"{effectiveWeight:F1} {weightUnit}");
+                            });
+                        });
+
+                        col.Item().PaddingTop(25);
+
+                        // Verification
+                        col.Item().Border(1).BorderColor("#005C5C").Background("#F0F9F9").Padding(15).Column(card =>
+                        {
+                            card.Item().Row(row =>
+                            {
+                                row.RelativeItem().Column(vcol =>
+                                {
+                                    vcol.Item().Text("Verified").FontSize(16).Bold().FontColor("#005C5C");
+                                    vcol.Item().PaddingTop(5).Text($"Reviewed by: {verifiedByName}")
+                                        .FontSize(11);
+                                    vcol.Item().Text($"Review date: {metrics.ReviewedDate?.ToLocalTime().ToString("D") ?? eventDate.ToString("D")}")
+                                        .FontSize(11);
+                                });
+                            });
+                        });
+
+                        col.Item().PaddingTop(20);
+
+                        // Disclaimer
+                        col.Item().Text("This document is a record of volunteer participation tracked through TrashMob.eco. " +
+                                       "TrashMob.eco is a 501(c)(3) non-profit organization dedicated to community environmental cleanups.")
+                            .FontSize(9).FontColor(Colors.Grey.Medium).Italic();
+                    });
+
+                    page.Footer().Row(row =>
+                    {
+                        row.RelativeItem().Text($"Generated {DateTime.UtcNow:MMMM d, yyyy} — trashmob.eco")
+                            .FontSize(8).FontColor(Colors.Grey.Medium);
+                        row.ConstantItem(100).AlignRight().Text($"Report ID: {Guid.NewGuid().ToString()[..8].ToUpperInvariant()}")
+                            .FontSize(8).FontColor(Colors.Grey.Medium);
+                    });
+                });
+            });
+
+            return document.GeneratePdf();
+        }
+
+        private static void AddRow(TableDescriptor table, string label, string value)
+        {
+            table.Cell().PaddingVertical(3).Text(label).Bold().FontSize(11);
+            table.Cell().PaddingVertical(3).Text(value).FontSize(11);
+        }
+
+        private static string FormatLocation(Event evt)
+        {
+            var parts = new[] { evt.StreetAddress, evt.City, evt.Region, evt.PostalCode }
+                .Where(p => !string.IsNullOrWhiteSpace(p));
+            return string.Join(", ", parts);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Events/ParticipationReportService.cs
+++ b/TrashMob.Shared/Managers/Events/ParticipationReportService.cs
@@ -1,0 +1,197 @@
+namespace TrashMob.Shared.Managers.Events
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models;
+    using TrashMob.Shared.Engine;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// Generates and sends official participation report emails with PDF attachments.
+    /// </summary>
+    public class ParticipationReportService(
+        IEventManager eventManager,
+        IEventAttendeeMetricsManager metricsManager,
+        IEventAttendeeManager attendeeManager,
+        IUserManager userManager,
+        IEmailManager emailManager,
+        ILogger<ParticipationReportService> logger) : IParticipationReportService
+    {
+        /// <inheritdoc />
+        public async Task<ServiceResult<bool>> SendReportAsync(Guid eventId, Guid userId,
+            CancellationToken cancellationToken)
+        {
+            var evt = await eventManager.GetAsync(eventId, cancellationToken);
+            if (evt == null)
+            {
+                return ServiceResult<bool>.Failure("Event not found.");
+            }
+
+            var metrics = await metricsManager.GetMyMetricsAsync(eventId, userId, cancellationToken);
+            if (metrics == null)
+            {
+                return ServiceResult<bool>.Failure("No metrics submission found for this event.");
+            }
+
+            if (metrics.Status != EventAttendeeMetricsStatus.Approved &&
+                metrics.Status != EventAttendeeMetricsStatus.Adjusted)
+            {
+                return ServiceResult<bool>.Failure("Your metrics have not been approved by the event lead yet.");
+            }
+
+            var user = await userManager.GetUserByInternalIdAsync(userId, cancellationToken);
+            if (user == null || string.IsNullOrWhiteSpace(user.Email))
+            {
+                return ServiceResult<bool>.Failure("Could not find your account or email address.");
+            }
+
+            var reviewerName = await GetReviewerNameAsync(metrics, cancellationToken);
+
+            await SendReportEmailAsync(evt, user, metrics, reviewerName, cancellationToken);
+
+            logger.LogInformation("Participation report sent to user {UserId} for event {EventId}", userId, eventId);
+            return ServiceResult<bool>.Success(true);
+        }
+
+        /// <inheritdoc />
+        public async Task<ServiceResult<int>> SendAllReportsAsync(Guid eventId, Guid requestingUserId,
+            CancellationToken cancellationToken)
+        {
+            var isLead = await attendeeManager.IsEventLeadAsync(eventId, requestingUserId, cancellationToken);
+            if (!isLead)
+            {
+                return ServiceResult<int>.Failure("Only event leads can send reports to all attendees.");
+            }
+
+            var evt = await eventManager.GetAsync(eventId, cancellationToken);
+            if (evt == null)
+            {
+                return ServiceResult<int>.Failure("Event not found.");
+            }
+
+            var allMetrics = await metricsManager.GetByEventIdAsync(eventId, cancellationToken);
+            var approvedMetrics = allMetrics
+                .Where(m => m.Status is EventAttendeeMetricsStatus.Approved or EventAttendeeMetricsStatus.Adjusted)
+                .ToList();
+
+            if (approvedMetrics.Count == 0)
+            {
+                return ServiceResult<int>.Failure("No approved metrics found for this event.");
+            }
+
+            var sentCount = 0;
+            foreach (var metrics in approvedMetrics)
+            {
+                try
+                {
+                    var user = await userManager.GetUserByInternalIdAsync(metrics.UserId, cancellationToken);
+                    if (user == null || string.IsNullOrWhiteSpace(user.Email)) continue;
+
+                    var reviewerName = await GetReviewerNameAsync(metrics, cancellationToken);
+                    await SendReportEmailAsync(evt, user, metrics, reviewerName, cancellationToken);
+                    sentCount++;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to send participation report to user {UserId} for event {EventId}",
+                        metrics.UserId, eventId);
+                }
+            }
+
+            logger.LogInformation("Sent {Count} participation reports for event {EventId}", sentCount, eventId);
+            return ServiceResult<int>.Success(sentCount);
+        }
+
+        private async Task SendReportEmailAsync(Event evt, User volunteer, EventAttendeeMetrics metrics,
+            string reviewerName, CancellationToken cancellationToken)
+        {
+            // Generate PDF
+            var pdfBytes = ParticipationReportPdfGenerator.Generate(evt, volunteer, metrics, reviewerName);
+
+            // Build email body from template
+            var emailCopy = emailManager.GetHtmlEmailCopy("ParticipationReport");
+            var eventDate = evt.EventDate.ToLocalTime();
+
+            var effectiveDuration = metrics.Status == "Adjusted" && metrics.AdjustedDurationMinutes.HasValue
+                ? metrics.AdjustedDurationMinutes.Value
+                : metrics.DurationMinutes ?? 0;
+            var effectiveBags = metrics.Status == "Adjusted" && metrics.AdjustedBagsCollected.HasValue
+                ? metrics.AdjustedBagsCollected.Value
+                : metrics.BagsCollected ?? 0;
+            var effectiveWeight = metrics.Status == "Adjusted" && metrics.AdjustedPickedWeight.HasValue
+                ? metrics.AdjustedPickedWeight.Value
+                : metrics.PickedWeight ?? 0;
+            var effectiveWeightUnitId = metrics.Status == "Adjusted" && metrics.AdjustedPickedWeightUnitId.HasValue
+                ? metrics.AdjustedPickedWeightUnitId.Value
+                : metrics.PickedWeightUnitId ?? 1;
+
+            var weightUnit = effectiveWeightUnitId == 2 ? "kg" : "lbs";
+            var hours = effectiveDuration / 60;
+            var minutes = effectiveDuration % 60;
+            var durationText = hours > 0
+                ? $"{hours} hour{(hours != 1 ? "s" : "")}{(minutes > 0 ? $" {minutes} min" : "")}"
+                : $"{minutes} minutes";
+
+            emailCopy = emailCopy.Replace("{eventName}", evt.Name);
+            emailCopy = emailCopy.Replace("{eventDate}", eventDate.ToString("D"));
+            emailCopy = emailCopy.Replace("{duration}", durationText);
+            emailCopy = emailCopy.Replace("{bagsCollected}", effectiveBags.ToString());
+            emailCopy = emailCopy.Replace("{weightPicked}", $"{effectiveWeight:F1} {weightUnit}");
+            emailCopy = emailCopy.Replace("{verifiedBy}", reviewerName);
+
+            var subject = $"Volunteer Participation Report — {evt.Name}";
+
+            List<EmailAddress> recipients =
+            [
+                new() { Name = volunteer.DisplayFirstName, Email = volunteer.Email },
+            ];
+
+            var dynamicTemplateData = new
+            {
+                username = volunteer.DisplayFirstName,
+                emailCopy,
+                subject,
+            };
+
+            List<EmailAttachment> attachments =
+            [
+                new()
+                {
+                    Filename = $"TrashMob_Participation_Report_{evt.EventDate:yyyy-MM-dd}.pdf",
+                    Base64Content = Convert.ToBase64String(pdfBytes),
+                    MimeType = "application/pdf",
+                },
+            ];
+
+            await emailManager.SendTemplatedEmailAsync(
+                subject,
+                SendGridEmailTemplateId.GenericEmail,
+                SendGridEmailGroupId.EventRelated,
+                dynamicTemplateData,
+                recipients,
+                attachments,
+                cancellationToken);
+        }
+
+        private async Task<string> GetReviewerNameAsync(EventAttendeeMetrics metrics,
+            CancellationToken cancellationToken)
+        {
+            if (metrics.ReviewedByUserId.HasValue)
+            {
+                var reviewer = await userManager.GetUserByInternalIdAsync(
+                    metrics.ReviewedByUserId.Value, cancellationToken);
+                if (reviewer != null)
+                {
+                    return reviewer.DisplayFirstName;
+                }
+            }
+
+            return "Event Lead";
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/IParticipationReportService.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IParticipationReportService.cs
@@ -1,0 +1,25 @@
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// Generates and sends official participation report emails with PDF attachments.
+    /// </summary>
+    public interface IParticipationReportService
+    {
+        /// <summary>
+        /// Sends a participation report email to a specific attendee for an event.
+        /// Only sends if the attendee has Approved or Adjusted metrics.
+        /// </summary>
+        Task<ServiceResult<bool>> SendReportAsync(Guid eventId, Guid userId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sends participation report emails to all attendees with Approved or Adjusted metrics.
+        /// Must be called by an event lead.
+        /// </summary>
+        Task<ServiceResult<int>> SendAllReportsAsync(Guid eventId, Guid requestingUserId, CancellationToken cancellationToken);
+    }
+}

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -177,6 +177,9 @@
             services.AddScoped<IDonationEmailManager, DonationEmailManager>();
             services.AddScoped<IFundraisingAnalyticsManager, FundraisingAnalyticsManager>();
 
+            // Participation Reports
+            services.AddScoped<IParticipationReportService, ParticipationReportService>();
+
             // Newsletter
             services.AddScoped<INewsletterManager, NewsletterManager>();
             services.AddScoped<IUserNewsletterPreferenceManager, UserNewsletterPreferenceManager>();

--- a/TrashMob.Shared/TrashMob.Shared.csproj
+++ b/TrashMob.Shared/TrashMob.Shared.csproj
@@ -130,7 +130,7 @@
     </PackageReference>
     <PackageReference Include="Markdig" Version="0.44.0" />
     <PackageReference Include="NetTopologySuite.IO.Esri.Shapefile" Version="1.2.0" />
-    <PackageReference Include="QuestPDF" Version="2025.12.4" />
+    <PackageReference Include="QuestPDF" Version="2026.2.3" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>

--- a/TrashMob/Controllers/V2/ParticipationReportV2Controller.cs
+++ b/TrashMob/Controllers/V2/ParticipationReportV2Controller.cs
@@ -1,0 +1,96 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for generating and sending volunteer participation reports.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/events/{eventId}/participation-report")]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+    public class ParticipationReportV2Controller(
+        IParticipationReportService reportService,
+        ILogger<ParticipationReportV2Controller> logger) : SecureController
+    {
+        /// <summary>
+        /// Sends a participation report email with PDF attachment to the requesting user.
+        /// Only available for attendees with Approved or Adjusted metrics.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Report sent successfully.</response>
+        /// <response code="400">Metrics not approved or other validation error.</response>
+        [HttpPost]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> RequestReport(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 RequestParticipationReport Event={EventId}, User={UserId}", eventId, UserId);
+
+            var result = await reportService.SendReportAsync(eventId, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                return Problem(
+                    detail: result.ErrorMessage,
+                    statusCode: StatusCodes.Status400BadRequest,
+                    title: "Cannot generate report");
+            }
+
+            TrackEvent("ParticipationReport_Requested");
+            return Ok();
+        }
+
+        /// <summary>
+        /// Sends participation report emails to all attendees with approved metrics.
+        /// Must be called by an event lead.
+        /// </summary>
+        /// <param name="eventId">The event ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Reports sent with count.</response>
+        /// <response code="400">Validation error.</response>
+        /// <response code="403">User is not an event lead.</response>
+        [HttpPost("send-all")]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> SendAllReports(Guid eventId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 SendAllParticipationReports Event={EventId}, User={UserId}", eventId, UserId);
+
+            var result = await reportService.SendAllReportsAsync(eventId, UserId, cancellationToken);
+
+            if (!result.IsSuccess)
+            {
+                if (result.ErrorMessage.Contains("event lead", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Forbid();
+                }
+
+                return Problem(
+                    detail: result.ErrorMessage,
+                    statusCode: StatusCodes.Status400BadRequest,
+                    title: "Cannot send reports");
+            }
+
+            TrackEvent("ParticipationReport_SentAll");
+            return Ok(new { sentCount = result.Data });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Phase 1 of Project 57: backend infrastructure for official volunteer participation report emails with branded PDF attachments. Supports proof of volunteer hours for schools, courts, and employers.

## New Files
- **IParticipationReportService** — Interface with `SendReportAsync` and `SendAllReportsAsync`
- **ParticipationReportService** — Orchestrates validation, PDF generation, and email delivery
- **ParticipationReportPdfGenerator** — QuestPDF-based PDF with TrashMob branding, event details, individual metrics, verification stamp, and 501(c)(3) disclaimer
- **ParticipationReport.html** — Email template with metrics summary table
- **ParticipationReportV2Controller** — Two endpoints:
  - `POST /api/v2/events/{eventId}/participation-report` — volunteer requests own report
  - `POST /api/v2/events/{eventId}/participation-report/send-all` — event lead sends to all verified attendees
- **ParticipationReportServiceTests** — 9 unit tests

## Key Design Decisions
- Only sends for **Approved** or **Adjusted** metrics (server-enforced)
- Uses **adjusted values** when status is Adjusted (event lead corrections)
- PDF includes reviewer name and date for official verification
- Uses GenericEmail SendGrid template with custom HTML body
- PDF attached as Base64-encoded email attachment

## Test plan
- [ ] `dotnet test` passes (1005 tests including 9 new)
- [ ] Deploy to dev and test: create event → submit metrics → approve → request report
- [ ] Verify PDF opens correctly and looks professional
- [ ] Verify "send all" only accessible by event leads
- [ ] Verify pending/rejected metrics are denied

Phase 2 (web UI) and Phase 3 (mobile UI) will add buttons to trigger these endpoints.

References #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)