### PR TITLE
Add participation report buttons to web event summary (Phase 2)

### DIFF
--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/services/locations';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Badge } from '@/components/ui/badge';
-import { Ellipsis, Loader2, Pencil, Plus, RefreshCw, SquareX } from 'lucide-react';
+import { Ellipsis, FileText, Loader2, Mail, Pencil, Plus, RefreshCw, SquareX } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import EventSummaryData from '@/components/Models/EventSummaryData';
@@ -40,6 +40,8 @@ import { GetEventSummaryPrefill } from '@/services/event-routes';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Select, SelectItem, SelectContent, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AssociatedLitterReports } from '@/components/eventsummary/associated-litter-reports';
+import { GetMyMetrics } from '@/services/event-attendee-metrics';
+import { RequestParticipationReport, SendAllParticipationReports } from '@/services/participation-report';
 
 const upsertEventSummarySchema = z.object({
     actualNumberOfAttendees: z.number(),
@@ -176,6 +178,55 @@ export const EditEventSummary = () => {
     });
 
     /** End of Hauling Partners */
+
+    /** Participation Reports */
+    const { data: myMetrics } = useQuery({
+        queryKey: GetMyMetrics({ eventId }).key,
+        queryFn: GetMyMetrics({ eventId }).service,
+        select: (res) => res.data,
+    });
+
+    const hasApprovedMetrics = myMetrics && (myMetrics.status === 'Approved' || myMetrics.status === 'Adjusted');
+
+    const requestReport = useMutation({
+        mutationKey: RequestParticipationReport().key,
+        mutationFn: RequestParticipationReport().service,
+        onSuccess: () => {
+            toast({
+                variant: 'primary',
+                title: 'Report sent!',
+                description: 'Check your email for the participation report with PDF attachment.',
+            });
+        },
+        onError: (error: Error) => {
+            toast({
+                variant: 'destructive',
+                title: 'Could not send report',
+                description: error.message,
+            });
+        },
+    });
+
+    const sendAllReports = useMutation({
+        mutationKey: SendAllParticipationReports().key,
+        mutationFn: SendAllParticipationReports().service,
+        onSuccess: (res) => {
+            const count = res.data?.sentCount ?? 0;
+            toast({
+                variant: 'primary',
+                title: 'Reports sent!',
+                description: `Sent ${count} participation report${count !== 1 ? 's' : ''} to verified attendees.`,
+            });
+        },
+        onError: (error: Error) => {
+            toast({
+                variant: 'destructive',
+                title: 'Could not send reports',
+                description: error.message,
+            });
+        },
+    });
+    /** End of Participation Reports */
 
     const form = useForm<z.infer<typeof upsertEventSummarySchema>>({
         resolver: zodResolver(upsertEventSummarySchema),
@@ -609,6 +660,50 @@ export const EditEventSummary = () => {
                     </CardHeader>
                     <CardContent>
                         <AssociatedLitterReports eventId={eventId} isOwner={isOwner} />
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Participation Reports</CardTitle>
+                        <CardDescription>
+                            Send official volunteer participation reports as proof of hours for school, court, or
+                            employer requirements. Reports are only available for attendees with approved metrics.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className='flex flex-col gap-3 sm:flex-row sm:items-center'>
+                        {hasApprovedMetrics ? (
+                            <Button
+                                variant='outline'
+                                onClick={() => requestReport.mutate({ eventId })}
+                                disabled={requestReport.isPending}
+                            >
+                                {requestReport.isPending ? (
+                                    <Loader2 className='h-4 w-4 mr-2 animate-spin' />
+                                ) : (
+                                    <FileText className='h-4 w-4 mr-2' />
+                                )}
+                                Request My Report
+                            </Button>
+                        ) : (
+                            <p className='text-sm text-muted-foreground'>
+                                {myMetrics
+                                    ? `Your metrics are ${myMetrics.status?.toLowerCase() ?? 'pending'}. Reports are available once approved by the event lead.`
+                                    : 'Submit your metrics for this event to be eligible for a participation report.'}
+                            </p>
+                        )}
+                        {isOwner ? (
+                            <Button
+                                onClick={() => sendAllReports.mutate({ eventId })}
+                                disabled={sendAllReports.isPending}
+                            >
+                                {sendAllReports.isPending ? (
+                                    <Loader2 className='h-4 w-4 mr-2 animate-spin' />
+                                ) : (
+                                    <Mail className='h-4 w-4 mr-2' />
+                                )}
+                                Send Reports to All Verified Attendees
+                            </Button>
+                        ) : null}
                     </CardContent>
                 </Card>
                 <Card>

--- a/TrashMob/client-app/src/services/participation-report.ts
+++ b/TrashMob/client-app/src/services/participation-report.ts
@@ -1,0 +1,24 @@
+// Participation Report API service
+
+import { ApiService } from '.';
+
+export type RequestReport_Params = { eventId: string };
+export const RequestParticipationReport = () => ({
+    key: ['/participation-report', 'request'],
+    service: async (params: RequestReport_Params) =>
+        ApiService('protected').fetchData<void>({
+            url: `/v2/events/${params.eventId}/participation-report`,
+            method: 'post',
+        }),
+});
+
+export type SendAllReports_Params = { eventId: string };
+export type SendAllReports_Response = { sentCount: number };
+export const SendAllParticipationReports = () => ({
+    key: ['/participation-report', 'send-all'],
+    service: async (params: SendAllReports_Params) =>
+        ApiService('protected').fetchData<SendAllReports_Response>({
+            url: `/v2/events/${params.eventId}/participation-report/send-all`,
+            method: 'post',
+        }),
+});


### PR DESCRIPTION
## Summary
Phase 2 of Project 57: adds web UI for requesting and sending volunteer participation reports from the event summary page.

## Changes

**New service:** `participation-report.ts`
- `RequestParticipationReport` — volunteer requests their own report
- `SendAllParticipationReports` — event lead sends to all verified attendees

**Event summary page** — new "Participation Reports" card with:
- **"Request My Report"** button (visible when attendee has Approved/Adjusted metrics)
- **"Send Reports to All Verified Attendees"** button (visible to event leads only)
- Status message when metrics are pending, rejected, or not yet submitted
- Loading spinners and toast notifications on success/error

## Test plan
- [ ] As an attendee with approved metrics: "Request My Report" button visible, sends email on click
- [ ] As an attendee with pending metrics: shows status message, no button
- [ ] As an attendee with no metrics: shows "submit your metrics" message
- [ ] As event lead: "Send Reports to All" button visible and functional
- [ ] As non-lead: "Send Reports to All" button hidden
- [ ] Verify toast notifications on success and error

Phase 3 (mobile UI) is next.

References #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)