### PR TITLE
Add participation report buttons to mobile app (Phase 3)

### DIFF
--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@
             services.AddSingleton<IWaiverManager, WaiverManager>();
             services.AddSingleton<IWaiverRestService, WaiverRestService>();
             services.AddSingleton<IRouteTrackingSessionManager, RouteTrackingSessionManager>();
+            services.AddSingleton<IParticipationReportRestService, ParticipationReportRestService>();
 
             // Offline persistence services
             services.AddSingleton<OfflineDatabase>();

--- a/TrashMobMobile/Services/IParticipationReportRestService.cs
+++ b/TrashMobMobile/Services/IParticipationReportRestService.cs
@@ -1,0 +1,9 @@
+namespace TrashMobMobile.Services
+{
+    public interface IParticipationReportRestService
+    {
+        Task RequestReportAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+        Task<int> SendAllReportsAsync(Guid eventId, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMobMobile/Services/ParticipationReportRestService.cs
+++ b/TrashMobMobile/Services/ParticipationReportRestService.cs
@@ -1,0 +1,31 @@
+namespace TrashMobMobile.Services
+{
+    using System.Net.Http.Json;
+    using Newtonsoft.Json;
+
+    public class ParticipationReportRestService(IHttpClientFactory httpClientFactory)
+        : RestServiceBase(httpClientFactory), IParticipationReportRestService
+    {
+        protected override string Controller => "events/";
+
+        public async Task RequestReportAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/participation-report";
+
+            using var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task<int> SendAllReportsAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = eventId + "/participation-report/send-all";
+
+            using var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            var result = JsonConvert.DeserializeAnonymousType(content, new { sentCount = 0 });
+            return result?.sentCount ?? 0;
+        }
+    }
+}

--- a/TrashMobMobile/ViewModels/ViewEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/ViewEventViewModel.cs
@@ -29,7 +29,8 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
     IEventAttendeeMetricsRestService eventAttendeeMetricsRestService,
     RoutePointWriter routePointWriter,
     SyncQueue syncQueue,
-    IDependentRestService dependentRestService) : BaseViewModel(notificationService)
+    IDependentRestService dependentRestService,
+    IParticipationReportRestService participationReportRestService) : BaseViewModel(notificationService)
 {
     private readonly IEventAttendeeRestService eventAttendeeRestService = eventAttendeeRestService;
     private readonly IEventLitterReportManager eventLitterReportManager = eventLitterReportManager;
@@ -178,6 +179,12 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
     [ObservableProperty]
     private bool showLeadMetricsActions;
+
+    [ObservableProperty]
+    private bool canRequestReport;
+
+    [ObservableProperty]
+    private bool canSendAllReports;
 
     private EventAttendeeMetrics? existingMetrics;
 
@@ -1245,6 +1252,26 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
         HasDensityData = EventAttendeeRoutes.Any(r => r.DensityGramsPerMeter is not null and > 0);
     }
 
+    [RelayCommand]
+    private async Task RequestParticipationReport()
+    {
+        await ExecuteAsync(async () =>
+        {
+            await participationReportRestService.RequestReportAsync(mobEvent.Id);
+            await NotificationService.Notify("Participation report sent! Check your email.");
+        }, "Failed to send participation report. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task SendAllParticipationReports()
+    {
+        await ExecuteAsync(async () =>
+        {
+            var count = await participationReportRestService.SendAllReportsAsync(mobEvent.Id);
+            await NotificationService.Notify($"Sent {count} participation report{(count != 1 ? "s" : "")} to verified attendees.");
+        }, "Failed to send participation reports. Please try again.");
+    }
+
     private async Task LoadMyMetrics()
     {
         if (!mobEvent.IsCompleted())
@@ -1286,7 +1313,12 @@ public partial class ViewEventViewModel(IMobEventManager mobEventManager,
 
             PendingMetricsCount = PendingMetricsList.Count;
             ShowLeadMetricsActions = PendingMetricsCount > 0;
+            CanSendAllReports = true;
         }
+
+        // Show report button if metrics are approved or adjusted
+        CanRequestReport = existingMetrics != null
+            && (existingMetrics.Status == "Approved" || existingMetrics.Status == "Adjusted");
     }
 
     private static string FormatWeight(decimal? weight, int? unitId)

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
@@ -323,6 +323,40 @@
                 </VerticalStackLayout>
             </Border>
 
+            <!-- Participation Reports -->
+            <Border IsVisible="{Binding CanRequestReport}"
+                    Style="{StaticResource CardBorder}"
+                    Margin="5,4">
+                <VerticalStackLayout Spacing="8" Padding="12">
+                    <Label Text="Participation Report"
+                           FontFamily="LexendSemibold"
+                           FontSize="Small" />
+                    <Label Text="Request an official report of your volunteer participation for this event. The report will be emailed to you as a PDF."
+                           FontSize="Micro"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <Button Text="Request My Report"
+                            Command="{Binding RequestParticipationReportCommand}"
+                            Style="{StaticResource SecondarySmallButton}"
+                            HorizontalOptions="Fill" />
+                </VerticalStackLayout>
+            </Border>
+
+            <Border IsVisible="{Binding CanSendAllReports}"
+                    Style="{StaticResource CardBorder}"
+                    Margin="5,4">
+                <VerticalStackLayout Spacing="8" Padding="12">
+                    <Label Text="Send Reports to Attendees"
+                           FontFamily="LexendSemibold"
+                           FontSize="Small" />
+                    <Label Text="Send participation report emails to all attendees with verified metrics."
+                           FontSize="Micro"
+                           TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                    <Button Text="Send All Reports"
+                            Command="{Binding SendAllParticipationReportsCommand}"
+                            HorizontalOptions="Fill" />
+                </VerticalStackLayout>
+            </Border>
+
         </VerticalStackLayout>
     </ScrollView>
 </ContentView>


### PR DESCRIPTION
## Summary
Phase 3 of Project 57: adds mobile UI for requesting and sending volunteer participation reports from the View Event screen.

## Changes

**New files:**
- `IParticipationReportRestService` — interface with `RequestReportAsync` and `SendAllReportsAsync`
- `ParticipationReportRestService` — REST client implementation

**ViewEventViewModel:**
- `CanRequestReport` — true when user's metrics are Approved or Adjusted
- `CanSendAllReports` — true for event leads
- `RequestParticipationReportCommand` — sends report email to current user
- `SendAllParticipationReportsCommand` — bulk sends to all verified attendees

**TabDetails.xaml:**
- "Participation Report" card with "Request My Report" button (post-event, approved metrics)
- "Send Reports to Attendees" card with "Send All Reports" button (event leads only)

**ServiceCollectionExtensions.cs** — DI registration

## Test plan
- [ ] View completed event with approved metrics → "Request My Report" card visible
- [ ] Tap "Request My Report" → success notification, email received
- [ ] View completed event with pending metrics → report card NOT visible
- [ ] As event lead → "Send All Reports" card visible
- [ ] Tap "Send All Reports" → success notification with count
- [ ] As non-lead → "Send All Reports" card NOT visible

Completes Project 57 Phases 1-3. Phase 4 (verification URLs) is future.

References #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)