### PR TITLE
Bump minimum mobile app version to 2.11.800

### DIFF
--- a/TrashMob/appsettings.Development.json
+++ b/TrashMob/appsettings.Development.json
@@ -26,7 +26,7 @@
   "StorageAccountUri": "https://stortmdevwestus2.blob.core.windows.net",
   "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb",
   "AppVersion": {
-    "MinimumVersion": "2.11.707",
-    "RecommendedVersion": "2.11.707"
+    "MinimumVersion": "2.11.800",
+    "RecommendedVersion": "2.11.800"
   }
 }

--- a/TrashMob/appsettings.json
+++ b/TrashMob/appsettings.json
@@ -22,7 +22,7 @@
   },
   "TrashMobBackendTenantId": "f0062da2-b273-427c-b99e-6e85f75b23eb",
   "AppVersion": {
-    "MinimumVersion": "2.11.709",
-    "RecommendedVersion": "2.11.709"
+    "MinimumVersion": "2.11.800",
+    "RecommendedVersion": "2.11.800"
   }
 }


### PR DESCRIPTION
## Summary
Sets minimum and recommended mobile app version to 2.11.800 for both dev and prod environments.

## Changes
- `appsettings.Development.json`: 2.11.707 → 2.11.800
- `appsettings.json`: 2.11.709 → 2.11.800

🤖 Generated with [Claude Code](https://claude.com/claude-code)