### PR TITLE
Fix all 5 DTO violations: v2 controllers now 89/89 DTO-only compliant

### DIFF
--- a/TrashMob.Models/Extensions/V2/EventPartnerLocationServiceMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventPartnerLocationServiceMappingsV2.cs
@@ -20,5 +20,19 @@ namespace TrashMob.Models.Extensions.V2
                 EventPartnerLocationServiceStatusId = dto.EventPartnerLocationServiceStatusId,
             };
         }
+
+        /// <summary>
+        /// Maps an <see cref="EventPartnerLocationService"/> entity to a <see cref="EventPartnerLocationServiceDto"/>.
+        /// </summary>
+        public static EventPartnerLocationServiceDto ToV2Dto(this EventPartnerLocationService entity)
+        {
+            return new EventPartnerLocationServiceDto
+            {
+                EventId = entity.EventId,
+                PartnerLocationId = entity.PartnerLocationId,
+                ServiceTypeId = entity.ServiceTypeId,
+                EventPartnerLocationServiceStatusId = entity.EventPartnerLocationServiceStatusId,
+            };
+        }
     }
 }

--- a/TrashMob.Models/Extensions/V2/TeamPortalMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamPortalMappingsV2.cs
@@ -49,5 +49,36 @@ namespace TrashMob.Models.Extensions.V2
         }
 
         #endregion
+
+        #region TeamEvent
+
+        /// <summary>
+        /// Maps a TeamEvent entity to a V2 TeamEventDto.
+        /// </summary>
+        public static TeamEventDto ToV2Dto(this TeamEvent entity)
+        {
+            return new TeamEventDto
+            {
+                Id = entity.Id,
+                TeamId = entity.TeamId,
+                EventId = entity.EventId,
+                CreatedDate = entity.CreatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 TeamEventDto to a TeamEvent entity.
+        /// </summary>
+        public static TeamEvent ToEntity(this TeamEventDto dto)
+        {
+            return new TeamEvent
+            {
+                Id = dto.Id,
+                TeamId = dto.TeamId,
+                EventId = dto.EventId,
+            };
+        }
+
+        #endregion
     }
 }

--- a/TrashMob.Models/Extensions/V2/WaiverMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/WaiverMappingsV2.cs
@@ -65,6 +65,32 @@ namespace TrashMob.Models.Extensions.V2
         }
 
         /// <summary>
+        /// Maps a <see cref="Waiver"/> to a <see cref="WaiverDto"/>.
+        /// </summary>
+        public static WaiverDto ToV2Dto(this Waiver entity)
+        {
+            return new WaiverDto
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                IsWaiverEnabled = entity.IsWaiverEnabled,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 <see cref="WaiverDto"/> back to a <see cref="Waiver"/> entity.
+        /// </summary>
+        public static Waiver ToEntity(this WaiverDto dto)
+        {
+            return new Waiver
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                IsWaiverEnabled = dto.IsWaiverEnabled,
+            };
+        }
+
+        /// <summary>
         /// Maps a V2 <see cref="UserWaiverDto"/> back to a <see cref="UserWaiver"/> entity.
         /// </summary>
         public static UserWaiver ToEntity(this UserWaiverDto dto)

--- a/TrashMob.Models/Poco/V2/EventPartnerLocationServiceDto.cs
+++ b/TrashMob.Models/Poco/V2/EventPartnerLocationServiceDto.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// V2 API response representation of an event partner location service.
+/// </summary>
+public class EventPartnerLocationServiceDto
+{
+    /// <summary>Gets or sets the event identifier.</summary>
+    public Guid EventId { get; set; }
+
+    /// <summary>Gets or sets the partner location identifier.</summary>
+    public Guid PartnerLocationId { get; set; }
+
+    /// <summary>Gets or sets the service type identifier.</summary>
+    public int ServiceTypeId { get; set; }
+
+    /// <summary>Gets or sets the service status identifier.</summary>
+    public int EventPartnerLocationServiceStatusId { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/TeamEventDto.cs
+++ b/TrashMob.Models/Poco/V2/TeamEventDto.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// V2 API representation of a team-event association.
+/// </summary>
+public class TeamEventDto
+{
+    /// <summary>Gets or sets the unique identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the team identifier.</summary>
+    public Guid TeamId { get; set; }
+
+    /// <summary>Gets or sets the event identifier.</summary>
+    public Guid EventId { get; set; }
+
+    /// <summary>Gets or sets when this association was created.</summary>
+    public DateTimeOffset? CreatedDate { get; set; }
+}

--- a/TrashMob.Models/Poco/V2/WaiverDto.cs
+++ b/TrashMob.Models/Poco/V2/WaiverDto.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// V2 API representation of a waiver definition.
+/// </summary>
+public class WaiverDto
+{
+    /// <summary>Gets or sets the unique identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the name of the waiver.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether the waiver is enabled and required.</summary>
+    public bool IsWaiverEnabled { get; set; }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventPartnerLocationServicesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventPartnerLocationServicesV2ControllerTests.cs
@@ -12,6 +12,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     using TrashMob.Controllers.V2;
     using TrashMob.Models;
     using TrashMob.Models.Poco;
+    using TrashMob.Models.Poco.V2;
     using TrashMob.Shared.Managers.Interfaces;
     using Xunit;
 
@@ -65,7 +66,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetHaulingPartnerLocation(eventId, CancellationToken.None);
 
             var okResult = Assert.IsType<OkObjectResult>(result);
-            Assert.IsType<PartnerLocation>(okResult.Value);
+            Assert.IsType<PartnerLocationDto>(okResult.Value);
         }
 
         [Fact]

--- a/TrashMob/Controllers/V2/AdoptableAreasV2Controller.cs
+++ b/TrashMob/Controllers/V2/AdoptableAreasV2Controller.cs
@@ -353,7 +353,7 @@ namespace TrashMob.Controllers.V2
         /// Bulk imports areas into a community. Only community admins can import areas.
         /// </summary>
         /// <param name="partnerId">The community (partner) ID.</param>
-        /// <param name="areas">The areas to import.</param>
+        /// <param name="areaDtos">The areas to import.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         [HttpPost("import")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
@@ -364,10 +364,10 @@ namespace TrashMob.Controllers.V2
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
         public async Task<IActionResult> BulkImportAreas(
             Guid partnerId,
-            [FromBody] List<AdoptableArea> areas,
+            [FromBody] List<AdoptableAreaDto> areaDtos,
             CancellationToken cancellationToken)
         {
-            logger.LogInformation("V2 BulkImportAreas for Partner={PartnerId}, Count={Count}", partnerId, areas?.Count ?? 0);
+            logger.LogInformation("V2 BulkImportAreas for Partner={PartnerId}, Count={Count}", partnerId, areaDtos?.Count ?? 0);
 
             var partner = await partnerManager.GetAsync(partnerId, cancellationToken);
             if (partner is null)
@@ -380,16 +380,17 @@ namespace TrashMob.Controllers.V2
                 return Forbid();
             }
 
-            if (areas is null || areas.Count == 0)
+            if (areaDtos is null || areaDtos.Count == 0)
             {
                 return BadRequest("At least one area is required.");
             }
 
-            if (areas.Count > 500)
+            if (areaDtos.Count > 500)
             {
                 return BadRequest("Maximum 500 areas per import. Please split into smaller batches.");
             }
 
+            var areas = areaDtos.Select(dto => dto.ToEntity()).ToList();
             var result = await areaManager.BulkCreateAsync(partnerId, UserId, areas, cancellationToken);
             return Ok(result);
         }

--- a/TrashMob/Controllers/V2/EventPartnerLocationServicesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventPartnerLocationServicesV2Controller.cs
@@ -60,14 +60,14 @@ namespace TrashMob.Controllers.V2
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <response code="200">Returns the hauling partner location.</response>
         [HttpGet("hauling/{eventId}")]
-        [ProducesResponseType(typeof(PartnerLocation), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(PartnerLocationDto), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetHaulingPartnerLocation(Guid eventId, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 GetHaulingPartnerLocation for Event={EventId}", eventId);
 
             var result = await eventPartnerLocationServiceManager.GetHaulingPartnerLocationForEvent(eventId, cancellationToken);
 
-            return Ok(result);
+            return Ok(result?.ToV2Dto());
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace TrashMob.Controllers.V2
         [HttpPut("{acceptDecline}/{eventId}/{partnerLocationId}/{serviceTypeId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(EventPartnerLocationService), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(EventPartnerLocationServiceDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -221,7 +221,7 @@ namespace TrashMob.Controllers.V2
             var updatedService = await eventPartnerLocationServiceManager
                 .UpdateAsync(eventPartnerLocationService, UserId, cancellationToken);
 
-            return Ok(updatedService);
+            return Ok(updatedService.ToV2Dto());
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/TeamEventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/TeamEventsV2Controller.cs
@@ -142,7 +142,7 @@ namespace TrashMob.Controllers.V2
         [HttpPost("{eventId}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobWriteScope)]
-        [ProducesResponseType(typeof(TeamEvent), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(TeamEventDto), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -188,7 +188,7 @@ namespace TrashMob.Controllers.V2
             };
 
             var created = await teamEventRepository.AddAsync(teamEvent);
-            return CreatedAtAction(nameof(GetUpcomingTeamEvents), new { teamId }, created);
+            return CreatedAtAction(nameof(GetUpcomingTeamEvents), new { teamId }, created.ToV2Dto());
         }
 
         /// <summary>

--- a/TrashMob/Controllers/V2/WaiversV2Controller.cs
+++ b/TrashMob/Controllers/V2/WaiversV2Controller.cs
@@ -364,7 +364,7 @@ namespace TrashMob.Controllers.V2
         [HttpGet("by-name/{name}")]
         [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
         [RequiredScope(Constants.TrashMobReadScope)]
-        [ProducesResponseType(typeof(Waiver), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(WaiverDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetWaiverByName(
             string name,
@@ -379,7 +379,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            return Ok(waiver);
+            return Ok(waiver.ToV2Dto());
         }
 
         private string GetClientIpAddress()


### PR DESCRIPTION
## Summary
Fixes the 5 remaining DTO violations identified in the production readiness audit. All 89 v2 controllers now return DTOs only — zero raw EF entities cross the wire.

## Changes

### New DTOs (3)
- `WaiverDto` — Id, Name, IsWaiverEnabled
- `EventPartnerLocationServiceDto` — EventId, PartnerLocationId, ServiceTypeId, StatusId
- `TeamEventDto` — Id, TeamId, EventId, CreatedDate

### New Mappings (3)
- `WaiverMappingsV2` — Waiver.ToV2Dto() + WaiverDto.ToEntity()
- `EventPartnerLocationServiceMappingsV2` — .ToV2Dto()
- `TeamPortalMappingsV2` — TeamEvent.ToV2Dto() + .ToEntity()

### Controller Fixes (5)
| Controller | Method | Before | After |
|---|---|---|---|
| WaiversV2 | GetWaiverByName | `Waiver` entity | `WaiverDto` |
| EventPartnerLocationServicesV2 | GetHaulingPartnerLocation | `PartnerLocation` entity | `PartnerLocationDto` |
| EventPartnerLocationServicesV2 | AcceptOrDecline | `EventPartnerLocationService` entity | `EventPartnerLocationServiceDto` |
| TeamEventsV2 | LinkEventToTeam | `TeamEvent` entity | `TeamEventDto` |
| AdoptableAreasV2 | BulkImportAreas | `List<AdoptableArea>` input | `List<AdoptableAreaDto>` input |

## Test Results
- **1005 tests passing** (0 failed, 0 skipped)
- Updated test assertion for PartnerLocationDto

🤖 Generated with [Claude Code](https://claude.com/claude-code)