### PR TITLE
Fix Android DatePicker crash on handler disconnect

### DIFF
--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -22,6 +22,9 @@ public static class MauiProgram
 #if ANDROID || IOS || MACCATALYST
                 handlers.AddHandler<Microsoft.Maui.Controls.Maps.Map, CustomMapHandler>();
 #endif
+#if ANDROID
+                handlers.AddHandler<Microsoft.Maui.Controls.DatePicker, TrashMobMobile.Platforms.Android.SafeDatePickerHandler>();
+#endif
             })
             .UseMauiCommunityToolkit(options => { options.SetShouldSuppressExceptionsInBehaviors(true); })
             .ConfigureFonts(fonts =>

--- a/TrashMobMobile/Platforms/Android/SafeDatePickerHandler.cs
+++ b/TrashMobMobile/Platforms/Android/SafeDatePickerHandler.cs
@@ -1,0 +1,40 @@
+namespace TrashMobMobile.Platforms.Android;
+
+using global::Android.App;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+
+/// <summary>
+/// Workaround for MAUI bug where DatePickerHandler.OnDialogDismiss fires after the
+/// handler has been disconnected, causing "VirtualView cannot be null here"
+/// (System.InvalidOperationException) crashes on Android.
+///
+/// We dismiss any open dialog during DisconnectHandler so the dismiss listener
+/// cannot fire on a torn-down handler.
+/// </summary>
+internal class SafeDatePickerHandler : DatePickerHandler
+{
+    protected override void DisconnectHandler(MauiDatePicker platformView)
+    {
+        try
+        {
+            // Reflectively grab the private _dialog field MAUI uses internally
+            // and dismiss it before the base disconnects the virtual view.
+            var dialogField = typeof(DatePickerHandler).GetField(
+                "_dialog",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            if (dialogField?.GetValue(this) is DatePickerDialog dialog && dialog.IsShowing)
+            {
+                dialog.SetOnDismissListener(null);
+                dialog.Dismiss();
+            }
+        }
+        catch
+        {
+            // Best-effort: never let cleanup throw.
+        }
+
+        base.DisconnectHandler(platformView);
+    }
+}


### PR DESCRIPTION
## Summary
- Sentry was reporting `System.InvalidOperationException: VirtualView cannot be null here` from `DatePickerHandler.OnDialogDismiss` on Android
- The dismiss listener fires after MAUI has already torn down the handler, so `VirtualView` is null
- Added a custom `SafeDatePickerHandler` that overrides `DisconnectHandler` to dismiss any open dialog and detach its dismiss listener before the base teardown
- Registered under `#if ANDROID` in `MauiProgram.cs`

## Test plan
- [x] Android build succeeds
- [ ] Open a screen with a DatePicker, open the dialog, navigate back without selecting — verify no crash
- [ ] Open a DatePicker, rotate device — verify no crash
- [ ] Confirm Sentry stops receiving the exception in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)