### PR TITLE
Fix 4 PRIVO test walkthrough bugs

### DIFF
--- a/TrashMob.Shared.Tests/Controllers/V2/DependentsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/DependentsV2ControllerTests.cs
@@ -18,13 +18,14 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     {
         private readonly Mock<IDependentManager> dependentManager = new();
         private readonly Mock<IDependentWaiverManager> dependentWaiverManager = new();
+        private readonly Mock<IKeyedManager<User>> userManager = new();
         private readonly Mock<ILogger<DependentsV2Controller>> logger = new();
         private readonly DependentsV2Controller controller;
         private readonly Guid userId = Guid.NewGuid();
 
         public DependentsV2ControllerTests()
         {
-            controller = new DependentsV2Controller(dependentManager.Object, dependentWaiverManager.Object, logger.Object);
+            controller = new DependentsV2Controller(dependentManager.Object, dependentWaiverManager.Object, userManager.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -69,6 +70,9 @@ namespace TrashMob.Shared.Tests.Controllers.V2
                 DateOfBirth = new DateOnly(2015, 1, 1),
                 Relationship = "Child",
             };
+
+            userManager.Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = userId, IsIdentityVerified = true });
 
             dependentManager.Setup(m => m.AddAsync(It.IsAny<Dependent>(), userId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Dependent

--- a/TrashMob.Shared.Tests/Services/PrivoServicePayloadTests.cs
+++ b/TrashMob.Shared.Tests/Services/PrivoServicePayloadTests.cs
@@ -155,7 +155,7 @@ namespace TrashMob.Shared.Tests.Services
         }
 
         [Fact]
-        public async Task AdultVerification_MissingBirthdate_UsesFallback()
+        public async Task AdultVerification_MissingBirthdate_ReturnsNull()
         {
             var service = CreateServiceWithCapture();
             var user = new User
@@ -165,12 +165,9 @@ namespace TrashMob.Shared.Tests.Services
                 DateOfBirth = null,
             };
 
-            await service.CreateAdultVerificationRequestAsync(user, CancellationToken.None);
+            var result = await service.CreateAdultVerificationRequestAsync(user, CancellationToken.None);
 
-            using var doc = JsonDocument.Parse(capturedRequestBody);
-            var birthdate = doc.RootElement.GetProperty("principal").GetProperty("birthdate").GetString();
-
-            Assert.Equal("19900101", birthdate);
+            Assert.Null(result);
         }
 
         [Fact]
@@ -277,7 +274,12 @@ namespace TrashMob.Shared.Tests.Services
         public async Task RequestUrl_IncludesServiceIdentifier()
         {
             var service = CreateServiceWithCapture();
-            var user = new User { Id = Guid.NewGuid(), Email = "test@example.com" };
+            var user = new User
+            {
+                Id = Guid.NewGuid(),
+                Email = "test@example.com",
+                DateOfBirth = new DateTimeOffset(1990, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            };
 
             await service.CreateAdultVerificationRequestAsync(user, CancellationToken.None);
 

--- a/TrashMob.Shared/Managers/PrivoConsentManager.cs
+++ b/TrashMob.Shared/Managers/PrivoConsentManager.cs
@@ -41,6 +41,11 @@ namespace TrashMob.Shared.Managers
                 throw new InvalidOperationException("User identity is already verified.");
             }
 
+            if (!user.DateOfBirth.HasValue)
+            {
+                throw new InvalidOperationException("Please set your date of birth on your profile before verifying your identity.");
+            }
+
             // Step 1: Call PRIVO Section 2 — create the consent/verification request
             var privoResponse = await privoService.CreateAdultVerificationRequestAsync(user, cancellationToken)
                 ?? throw new InvalidOperationException("Failed to create PRIVO verification request. Please try again.");

--- a/TrashMob/Controllers/V2/DependentsV2Controller.cs
+++ b/TrashMob/Controllers/V2/DependentsV2Controller.cs
@@ -29,6 +29,7 @@ namespace TrashMob.Controllers.V2
     public class DependentsV2Controller(
         IDependentManager dependentManager,
         IDependentWaiverManager dependentWaiverManager,
+        IKeyedManager<User> userManager,
         ILogger<DependentsV2Controller> logger) : ControllerBase
     {
         private Guid UserId => Guid.TryParse(HttpContext.Items["UserId"]?.ToString(), out var parsedUserId) ? parsedUserId : Guid.Empty;
@@ -80,6 +81,13 @@ namespace TrashMob.Controllers.V2
             if (userId != UserId)
             {
                 return Forbid();
+            }
+
+            // Require identity verification before adding dependents
+            var user = await userManager.GetAsync(userId, cancellationToken);
+            if (user is not { IsIdentityVerified: true })
+            {
+                return BadRequest("You must verify your identity before adding dependents. Visit your profile to verify.");
             }
 
             var entity = dto.ToEntity();

--- a/TrashMob/Services/PrivoService.cs
+++ b/TrashMob/Services/PrivoService.cs
@@ -66,9 +66,13 @@ namespace TrashMob.Services
             var token = await GetAccessTokenAsync(cancellationToken);
             if (token == null) return null;
 
-            var birthdate = user.DateOfBirth.HasValue
-                ? user.DateOfBirth.Value.ToString("yyyyMMdd")
-                : "19900101";
+            if (!user.DateOfBirth.HasValue)
+            {
+                logger.LogWarning("PRIVO adult verification: User {UserId} has no date of birth set", user.Id);
+                return null;
+            }
+
+            var birthdate = user.DateOfBirth.Value.ToString("yyyyMMdd");
 
             var payload = new Dictionary<string, object>
             {
@@ -498,6 +502,19 @@ namespace TrashMob.Services
             if (!string.IsNullOrEmpty(child.Email))
             {
                 principal["email"] = child.Email;
+            }
+
+            // Add last name as an attribute (matches adult verification pattern)
+            if (!string.IsNullOrEmpty(child.LastName))
+            {
+                principal["attributes"] = new[]
+                {
+                    new
+                    {
+                        attribute_identifier = AttrPrincipalFamilyName,
+                        value = new[] { child.LastName },
+                    },
+                };
             }
 
             return principal;

--- a/TrashMob/client-app/src/pages/MyDashboard/MyDependentsCard.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyDependentsCard.tsx
@@ -307,7 +307,15 @@ export const MyDependentsCard: FC<MyDependentsCardProps> = ({ userId, isIdentity
                     <div className='flex flex-row items-center'>
                         <Baby className='inline-block h-5 w-5 mr-2 text-primary' />
                         <CardTitle className='grow text-primary'>My Dependents ({dependentCount})</CardTitle>
-                        <Button variant='outline' size='sm' onClick={openAddDialog}>
+                        <Button
+                            variant='outline'
+                            size='sm'
+                            onClick={openAddDialog}
+                            disabled={!isIdentityVerified}
+                            title={
+                                isIdentityVerified ? 'Add a dependent' : 'Verify your identity first to add dependents'
+                            }
+                        >
                             <Plus className='h-4 w-4 mr-1' />
                             Add Dependent
                         </Button>

--- a/TrashMob/client-app/src/pages/myprofile/index.tsx
+++ b/TrashMob/client-app/src/pages/myprofile/index.tsx
@@ -17,6 +17,7 @@ import { ExportUserData, GetUserById, UpdateUser, UploadProfilePhoto, VerifyUniq
 import { useLogin } from '@/hooks/useLogin';
 import { useToast } from '@/hooks/use-toast';
 import UserData from '@/components/Models/UserData';
+import { VerifyIdentityCard } from '@/components/privo/VerifyIdentityCard';
 
 const profileSchema = z.object({
     userName: z
@@ -225,7 +226,8 @@ export const MyProfile = () => {
     return (
         <div>
             <HeroSection Title='My Profile' Description='Manage your account information' />
-            <div className='container mx-auto py-5'>
+            <div className='container mx-auto py-5 space-y-4'>
+                {!currentUser?.isMinor && <VerifyIdentityCard isVerified={currentUser?.isIdentityVerified ?? false} />}
                 <Card>
                     <CardHeader>
                         <CardTitle>Profile Information</CardTitle>


### PR DESCRIPTION
## Summary
Fixes found during joint PRIVO integration test walkthrough:

- **#3306**: Remove hardcoded birthdate `19900101` — require actual DOB before verification
- **#3307**: Add VerifyIdentityCard to profile page (was only on dashboard)
- **#3309**: Block Add Dependent for unverified adults (frontend + backend)
- **#3311**: Pass child last name via `trashmobservice_att_principal_family_name` attribute

## Test plan
- [x] 1078 tests pass (updated payload tests for new behavior)
- [x] Frontend builds
- [ ] Verify identity requires DOB set first
- [ ] Verify Identity card visible on profile page
- [ ] Add Dependent disabled when not verified
- [ ] Child consent request includes family name

🤖 Generated with [Claude Code](https://claude.com/claude-code)