### PR TITLE
Add dependents management to My Profile page

### DIFF
--- a/TrashMob/client-app/src/pages/myprofile/index.tsx
+++ b/TrashMob/client-app/src/pages/myprofile/index.tsx
@@ -18,6 +18,7 @@ import { useLogin } from '@/hooks/useLogin';
 import { useToast } from '@/hooks/use-toast';
 import UserData from '@/components/Models/UserData';
 import { VerifyIdentityCard } from '@/components/privo/VerifyIdentityCard';
+import { MyDependentsCard } from '@/pages/MyDashboard/MyDependentsCard';
 
 const profileSchema = z.object({
     userName: z
@@ -228,6 +229,12 @@ export const MyProfile = () => {
             <HeroSection Title='My Profile' Description='Manage your account information' />
             <div className='container mx-auto py-5 space-y-4'>
                 {!currentUser?.isMinor && <VerifyIdentityCard isVerified={currentUser?.isIdentityVerified ?? false} />}
+                {!currentUser?.isMinor && (
+                    <MyDependentsCard
+                        userId={currentUser?.id ?? ''}
+                        isIdentityVerified={currentUser?.isIdentityVerified ?? false}
+                    />
+                )}
                 <Card>
                     <CardHeader>
                         <CardTitle>Profile Information</CardTitle>


### PR DESCRIPTION
## Summary
- Adds the existing `MyDependentsCard` component to the My Profile page, below the Identity Verified card
- Allows verified parents to add, view, edit, and delete dependents directly from their profile
- Only shown for non-minor users (same gate as identity verification)
- No new components — reuses the fully-featured card already on the Dashboard

## Test plan
- [ ] Verify the dependents card appears on My Profile for verified adult users
- [ ] Verify it does not appear for minor users
- [ ] Verify add/edit/delete dependent flows work from the profile page
- [ ] Verify invitation workflow works for 13+ dependents

🤖 Generated with [Claude Code](https://claude.com/claude-code)