### PR TITLE
Fix Google Ads scripts for API v22

### DIFF
--- a/Planning/GoogleAds/02_create_conversions.py
+++ b/Planning/GoogleAds/02_create_conversions.py
@@ -7,7 +7,7 @@ from state import get_client, load_state, print_error, save_state
 
 # Map friendly names to enum values
 CATEGORY_MAP = {
-    "SIGNUP": "SIGN_UP",
+    "SIGNUP": "SIGNUP",
     "SUBMIT_LEAD_FORM": "SUBMIT_LEAD_FORM",
     "OTHER": "DEFAULT",
 }

--- a/Planning/GoogleAds/04_create_campaigns.py
+++ b/Planning/GoogleAds/04_create_campaigns.py
@@ -44,14 +44,16 @@ def main():
         campaign.campaign_budget = budget_resource
 
         # Maximize Conversions bidding (removes $2 CPC cap for Ad Grants)
-        campaign.maximize_conversions.target_cpa_micros = 0
+        # Setting the field triggers the oneof; no target_cpa needed
+        campaign.maximize_conversions.cpc_bid_ceiling_micros = 0
 
-        # Network settings
+        # Network settings — Ad Grants accounts cannot explicitly target search network
         campaign.network_settings.target_google_search = True
-        campaign.network_settings.target_search_network = True
+        campaign.network_settings.target_search_network = False
         campaign.network_settings.target_content_network = False
         campaign.network_settings.target_partner_search_network = False
 
+        campaign.contains_eu_political_advertising = 3  # DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING
         campaign.start_date = today
 
         print(f"Creating campaign: {campaign_def['name']}...")

--- a/Planning/GoogleAds/08_add_sitelinks.py
+++ b/Planning/GoogleAds/08_add_sitelinks.py
@@ -27,10 +27,10 @@ def main():
             op = client.get_type("AssetOperation")
             asset = op.create
 
+            asset.final_urls.append(sl_def["final_url"])
             asset.sitelink_asset.link_text = sl_def["link_text"]
             asset.sitelink_asset.description1 = sl_def["description1"]
             asset.sitelink_asset.description2 = sl_def["description2"]
-            asset.sitelink_asset.final_urls.append(sl_def["final_url"])
 
             operations.append(op)
             op_keys.append(key)

--- a/Planning/GoogleAds/state.py
+++ b/Planning/GoogleAds/state.py
@@ -42,7 +42,7 @@ def _load_from_keyvault() -> GoogleAdsClient | None:
                 raise
 
         print("Loaded credentials from Azure Key Vault.")
-        return GoogleAdsClient.load_from_dict(config, version="v18")
+        return GoogleAdsClient.load_from_dict(config, version="v22")
     except ImportError:
         return None
     except Exception as ex:
@@ -61,7 +61,7 @@ def get_client() -> GoogleAdsClient:
         print("Copy google-ads.yaml.template to google-ads.yaml and fill in your credentials,")
         print("or install azure-identity and azure-keyvault-secrets packages.")
         sys.exit(1)
-    return GoogleAdsClient.load_from_storage(_YAML_PATH, version="v18")
+    return GoogleAdsClient.load_from_storage(_YAML_PATH, version="v22")
 
 
 def load_state() -> dict:


### PR DESCRIPTION
## Summary
- Update Google Ads API version from v18 to v22
- Fix enum name change (`SIGN_UP` → `SIGNUP`)
- Fix campaign creation: Ad Grants can't target search network, add required `contains_eu_political_advertising` field
- Fix sitelink `final_urls` location (on `Asset`, not `SitelinkAsset`)

## Test plan
- [x] All 8 scripts run successfully against live Ad Grants account (458-730-8084)
- [x] 6 campaigns, 12 ad groups, 67 keywords, 12 RSAs, 8 sitelinks created

🤖 Generated with [Claude Code](https://claude.com/claude-code)