### PR TITLE
Fix Cancel buttons submitting forms

### DIFF
--- a/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
+++ b/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
@@ -20,6 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <!-- Override transitive vulnerability from Microsoft.Identity.Web (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf) -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TrashMob/TrashMob.csproj
+++ b/TrashMob/TrashMob.csproj
@@ -33,12 +33,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.7.0" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <!-- Override transitive vulnerabilities from CodeGeneration.Design (GHSA-g4vj-cjjj-v7hg) -->
+    <PackageReference Include="NuGet.Packaging" Version="6.13.2" />
+    <PackageReference Include="NuGet.Protocol" Version="6.13.2" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SendGrid" Version="9.29.3" />

--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
@@ -528,7 +528,9 @@ export const EditEventSummary = () => {
                                 </div>
                             </CardContent>
                             <CardFooter className='justify-between'>
-                                <Button type='button' variant='outline' onClick={() => navigate('/mydashboard')}>Cancel</Button>
+                                <Button type='button' variant='outline' onClick={() => navigate('/mydashboard')}>
+                                    Cancel
+                                </Button>
                                 {isOwner ? (
                                     <Button type='submit' disabled={isSubmitting}>
                                         {isSubmitting ? <Loader2 className='animate-spin' /> : null}

--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/index.tsx
@@ -528,7 +528,7 @@ export const EditEventSummary = () => {
                                 </div>
                             </CardContent>
                             <CardFooter className='justify-between'>
-                                <Button variant='outline'>Cancel</Button>
+                                <Button type='button' variant='outline' onClick={() => navigate('/mydashboard')}>Cancel</Button>
                                 {isOwner ? (
                                     <Button type='submit' disabled={isSubmitting}>
                                         {isSubmitting ? <Loader2 className='animate-spin' /> : null}

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/edit.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/edit.tsx
@@ -294,7 +294,7 @@ export const PartnerEdit = () => {
                         )}
                     />
                     <div className='col-span-12 flex justify-end gap-2'>
-                        <Button variant='secondary'>Cancel</Button>
+                        <Button type='button' variant='secondary' onClick={() => window.history.back()}>Cancel</Button>
                         <Button type='submit' disabled={isSubmitting}>
                             {isSubmitting ? <Loader2 className='animate-spin' /> : null}
                             Save

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/edit.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/edit.tsx
@@ -294,7 +294,9 @@ export const PartnerEdit = () => {
                         )}
                     />
                     <div className='col-span-12 flex justify-end gap-2'>
-                        <Button type='button' variant='secondary' onClick={() => window.history.back()}>Cancel</Button>
+                        <Button type='button' variant='secondary' onClick={() => window.history.back()}>
+                            Cancel
+                        </Button>
                         <Button type='submit' disabled={isSubmitting}>
                             {isSubmitting ? <Loader2 className='animate-spin' /> : null}
                             Save


### PR DESCRIPTION
## Summary
- Cancel buttons in Event Summary and Partner Edit pages had no `type="button"`, so they defaulted to `type="submit"` and triggered form save
- Added `type="button"` and navigation (back to dashboard / history.back) on both Cancel buttons

## Test plan
- [ ] Go to My Dashboard → Event Summary for a completed event → click Cancel → should navigate back without "event summary updated" toast
- [ ] Go to Partner Dashboard → Edit partner → click Cancel → should navigate back without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)