### PR TITLE
Add Google Ads conversion tracking for RSVP, events, partners

### DIFF
--- a/TrashMob/client-app/src/components/Customization/RegisterBtn.tsx
+++ b/TrashMob/client-app/src/components/Customization/RegisterBtn.tsx
@@ -15,6 +15,7 @@ import { GetMyDependents } from '@/services/dependents';
 import DependentData from '@/components/Models/DependentData';
 import { DependentRegistrationDialog } from '@/components/events/DependentRegistrationDialog';
 import { cn } from '@/lib/utils';
+import { trackRsvpConversion } from '@/lib/analytics';
 import { useFeatureMetrics } from '@/hooks/useFeatureMetrics';
 import { usePrivoPermissions } from '@/hooks/usePrivoPermissions';
 import { PrivoFeature } from '@/lib/privo-features';
@@ -84,6 +85,7 @@ export const RegisterBtn: FC<RegisterBtnProps> = ({
 
             // Track attendance registration
             trackAttendance('Register', eventId);
+            trackRsvpConversion();
 
             // Invalidate user's list of attended events, triggering refetch
             queryClient.invalidateQueries(GetAllEventsBeingAttendedByUser({ userId }).key);

--- a/TrashMob/client-app/src/components/partner-requests/partner-request-form.tsx
+++ b/TrashMob/client-app/src/components/partner-requests/partner-request-form.tsx
@@ -22,6 +22,7 @@ import PartnerRequestData from '@/components/Models/PartnerRequestData';
 import * as Constants from '@/components/Models/Constants';
 import { CharacterCounter } from '@/components/ui/character-counter';
 import { CreatePartnerRequest } from '@/services/partners';
+import { trackPartnerInquiryConversion } from '@/lib/analytics';
 import { GoogleMapWithKey as GoogleMap } from '@/components/Map/GoogleMap';
 import { Marker } from '@vis.gl/react-google-maps';
 import { AzureSearchLocationInput, SearchLocationOption } from '@/components/Map/AzureSearchLocationInput';
@@ -108,6 +109,7 @@ export const PartnerRequestForm: React.FC<PartnerRequestFormProps> = (props) => 
         mutationKey: CreatePartnerRequest().key,
         mutationFn: CreatePartnerRequest().service,
         onSuccess: () => {
+            trackPartnerInquiryConversion();
             toast({
                 variant: 'primary',
                 title: 'Request Submitted',

--- a/TrashMob/client-app/src/lib/analytics.ts
+++ b/TrashMob/client-app/src/lib/analytics.ts
@@ -140,8 +140,7 @@ function initAppInsightsSnippet(instrumentationKey: string): void {
     w[sdkName] = appInsights;
 }
 
-/** Fire a Google Ads conversion event for new sign-ups. */
-export function trackSignUpConversion(): void {
+function fireGoogleAdsConversion(sendTo: string, value?: number): void {
     const w = window as unknown as Record<string, unknown>;
     const dataLayer = w.dataLayer as unknown[] | undefined;
     if (!dataLayer) return;
@@ -149,11 +148,32 @@ export function trackSignUpConversion(): void {
     function gtag(...args: unknown[]) {
         dataLayer!.push(args);
     }
-    gtag('event', 'conversion', {
-        send_to: 'AW-18035648449/V0zjCL3Hh48cEMHPiJhD',
-        value: 1.0,
-        currency: 'USD',
-    });
+    const params: Record<string, unknown> = { send_to: sendTo };
+    if (value !== undefined) {
+        params.value = value;
+        params.currency = 'USD';
+    }
+    gtag('event', 'conversion', params);
+}
+
+/** Fire a Google Ads conversion event for new sign-ups. */
+export function trackSignUpConversion(): void {
+    fireGoogleAdsConversion('AW-18035648449/V0zjCL3Hh48cEMHPiJhD', 1.0);
+}
+
+/** Fire a Google Ads conversion event for event RSVPs. */
+export function trackRsvpConversion(): void {
+    fireGoogleAdsConversion('AW-18035648449/uhNBCKDbpJwcEMHPiJhD');
+}
+
+/** Fire a Google Ads conversion event for event creation by organizers. */
+export function trackEventCreatedConversion(): void {
+    fireGoogleAdsConversion('AW-18035648449/zEXMCKbbpJwcEMHPiJhD');
+}
+
+/** Fire a Google Ads conversion event for city partner inquiries. */
+export function trackPartnerInquiryConversion(): void {
+    fireGoogleAdsConversion('AW-18035648449/98NDCKPbpJwcEMHPiJhD');
 }
 
 /** Initialize analytics scripts if the user has previously consented. */

--- a/TrashMob/client-app/src/pages/events/create.tsx
+++ b/TrashMob/client-app/src/pages/events/create.tsx
@@ -33,6 +33,7 @@ import { ReverseGeocode, ReverseGeocode_Params } from '@/services/maps';
 import { useLogin } from '@/hooks/useLogin';
 import { useToast } from '@/hooks/use-toast';
 import { useFeatureMetrics } from '@/hooks/useFeatureMetrics';
+import { trackEventCreatedConversion } from '@/lib/analytics';
 import { useLocation, useNavigate } from 'react-router';
 import { Badge } from '@/components/ui/badge';
 import { Loader2 } from 'lucide-react';
@@ -130,6 +131,7 @@ export const CreateEventPage = () => {
                     eventTypeId: variable.eventTypeId,
                     fromLitterReport: !!fromLitterReport,
                 });
+                trackEventCreatedConversion();
             }
 
             // If this event was created from a litter report, associate them


### PR DESCRIPTION
## Summary
- Add conversion tracking for 3 additional Google Ads actions: Event RSVP, Event Created, Partner Inquiry
- Refactor analytics.ts to share a common `fireGoogleAdsConversion` helper
- Wire conversion calls into RegisterBtn, create event page, and partner request form

## Test plan
- [ ] RSVP to an event → verify `gtag('event', 'conversion', ...)` fires in browser devtools Network tab
- [ ] Create a new event → same verification
- [ ] Submit a partner request → same verification
- [ ] Existing sign-up conversion still fires on account creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)