### PR TITLE
Add community prospect tools to MCP server

### DIFF
--- a/TrashMobMCP/Dtos/ProspectDto.cs
+++ b/TrashMobMCP/Dtos/ProspectDto.cs
@@ -1,0 +1,41 @@
+namespace TrashMobMCP.Dtos;
+
+/// <summary>
+/// MCP-safe representation of a community prospect in the pipeline.
+/// </summary>
+public class ProspectDto
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Type { get; set; } = string.Empty;
+
+    public string City { get; set; } = string.Empty;
+
+    public string Region { get; set; } = string.Empty;
+
+    public string Country { get; set; } = string.Empty;
+
+    public int? Population { get; set; }
+
+    public string? Website { get; set; }
+
+    public string? ContactName { get; set; }
+
+    public string? ContactEmail { get; set; }
+
+    public string? ContactTitle { get; set; }
+
+    public int PipelineStage { get; set; }
+
+    public string PipelineStageName { get; set; } = string.Empty;
+
+    public int FitScore { get; set; }
+
+    public DateTimeOffset? LastContactedDate { get; set; }
+
+    public DateTimeOffset? NextFollowUpDate { get; set; }
+
+    public string? Notes { get; set; }
+}

--- a/TrashMobMCP/Tools/AddProspectTool.cs
+++ b/TrashMobMCP/Tools/AddProspectTool.cs
@@ -1,0 +1,113 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Models;
+using TrashMob.Shared.Managers.Prospects;
+using TrashMobMCP.Dtos;
+
+/// <summary>
+/// MCP tool for adding a community prospect directly to the pipeline.
+/// </summary>
+[McpServerToolType]
+public class AddProspectTool(ICommunityProspectManager prospectManager)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private static readonly string[] StageNames =
+    [
+        "New", "Contacted", "Responded", "Interested", "Onboarding", "Active", "Declined"
+    ];
+
+    /// <summary>
+    /// Add a new community prospect to the TrashMob pipeline.
+    /// </summary>
+    /// <param name="name">Organization or municipality name (required)</param>
+    /// <param name="type">Prospect type: Municipality, Nonprofit, HOA, CivicOrg, or Other (required)</param>
+    /// <param name="city">City (required)</param>
+    /// <param name="region">State or region (required)</param>
+    /// <param name="country">Country (default: United States)</param>
+    /// <param name="population">Estimated population served</param>
+    /// <param name="website">Organization website URL</param>
+    /// <param name="contactName">Best contact person's full name</param>
+    /// <param name="contactEmail">Contact person's email address</param>
+    /// <param name="contactTitle">Contact person's job title (e.g., "Public Works Director")</param>
+    /// <param name="contactPhone">Contact person's phone number</param>
+    /// <param name="latitude">Latitude coordinate</param>
+    /// <param name="longitude">Longitude coordinate</param>
+    /// <param name="notes">Research notes or rationale for why this is a good prospect</param>
+    /// <returns>JSON with the created prospect record</returns>
+    [McpServerTool]
+    [Description("Add a new community prospect to the TrashMob pipeline. Use this after researching an organization to save it as a prospect for outreach. Provide as much detail as available — name, type, city, and region are required.")]
+    public async Task<string> AddProspect(
+        string name,
+        string type,
+        string city,
+        string region,
+        string country = "United States",
+        int? population = null,
+        string? website = null,
+        string? contactName = null,
+        string? contactEmail = null,
+        string? contactTitle = null,
+        string? contactPhone = null,
+        double? latitude = null,
+        double? longitude = null,
+        string? notes = null)
+    {
+        var prospect = new CommunityProspect
+        {
+            Name = name,
+            Type = type,
+            City = city,
+            Region = region,
+            Country = country,
+            Population = population,
+            Website = website,
+            ContactName = contactName,
+            ContactEmail = contactEmail,
+            ContactTitle = contactTitle,
+            ContactPhone = contactPhone,
+            Latitude = latitude,
+            Longitude = longitude,
+            Notes = notes,
+            PipelineStage = 0, // New
+            FitScore = 0,
+        };
+
+        var created = await prospectManager.AddAsync(prospect, CancellationToken.None);
+
+        return JsonSerializer.Serialize(new
+        {
+            message = $"Prospect '{created.Name}' added to pipeline.",
+            prospect = ToDto(created),
+        }, JsonOptions);
+    }
+
+    private static ProspectDto ToDto(CommunityProspect p)
+    {
+        return new ProspectDto
+        {
+            Id = p.Id,
+            Name = p.Name,
+            Type = p.Type,
+            City = p.City,
+            Region = p.Region,
+            Country = p.Country,
+            Population = p.Population,
+            Website = p.Website,
+            ContactName = p.ContactName,
+            ContactEmail = p.ContactEmail,
+            ContactTitle = p.ContactTitle,
+            PipelineStage = p.PipelineStage,
+            PipelineStageName = p.PipelineStage >= 0 && p.PipelineStage < StageNames.Length
+                ? StageNames[p.PipelineStage]
+                : "Unknown",
+            FitScore = p.FitScore,
+            LastContactedDate = p.LastContactedDate,
+            NextFollowUpDate = p.NextFollowUpDate,
+            Notes = p.Notes,
+        };
+    }
+}

--- a/TrashMobMCP/Tools/DiscoverProspectsTool.cs
+++ b/TrashMobMCP/Tools/DiscoverProspectsTool.cs
@@ -1,0 +1,54 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Models.Poco;
+using TrashMob.Shared.Managers.Interfaces;
+
+/// <summary>
+/// MCP tool for AI-powered community prospect discovery.
+/// </summary>
+[McpServerToolType]
+public class DiscoverProspectsTool(IClaudeDiscoveryService discoveryService)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    /// <summary>
+    /// Discover potential community partners using AI research.
+    /// </summary>
+    /// <param name="prompt">Freeform research query (e.g., "Find environmental nonprofits in Portland, OR that focus on waterway cleanup"). When provided, overrides city/region/country fields.</param>
+    /// <param name="city">City to search in (used when prompt is not provided)</param>
+    /// <param name="region">Region/state to search in (used when prompt is not provided)</param>
+    /// <param name="country">Country to search in (used when prompt is not provided, defaults to US)</param>
+    /// <param name="maxResults">Maximum number of prospects to return (default: 10, max: 25)</param>
+    /// <returns>JSON with discovered prospects including name, type, contact info, and rationale</returns>
+    [McpServerTool]
+    [Description("Discover potential community partners for TrashMob using AI research. Provide either a freeform research prompt OR city/region/country for location-based discovery. Returns organizations (municipalities, nonprofits, HOAs, civic orgs) with contact information and rationale for why they'd be good partners.")]
+    public async Task<string> DiscoverProspects(
+        string? prompt = null,
+        string? city = null,
+        string? region = null,
+        string? country = null,
+        int maxResults = 10)
+    {
+        var request = new DiscoveryRequest
+        {
+            Prompt = prompt,
+            City = city,
+            Region = region,
+            Country = country,
+            MaxResults = maxResults,
+        };
+
+        var result = await discoveryService.DiscoverProspectsAsync(request);
+
+        return JsonSerializer.Serialize(new
+        {
+            prospects = result.Prospects,
+            total_count = result.Prospects.Count,
+            tokens_used = result.TokensUsed,
+            message = result.Message,
+        }, JsonOptions);
+    }
+}

--- a/TrashMobMCP/Tools/GetGeographicGapsTool.cs
+++ b/TrashMobMCP/Tools/GetGeographicGapsTool.cs
@@ -1,0 +1,32 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Shared.Managers.Interfaces;
+
+/// <summary>
+/// MCP tool for finding geographic areas with events but no community partner.
+/// </summary>
+[McpServerToolType]
+public class GetGeographicGapsTool(IProspectScoringManager scoringManager)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    /// <summary>
+    /// Find geographic areas that have TrashMob events but no active community partner.
+    /// </summary>
+    /// <returns>JSON array of geographic gaps with event counts and nearest partner distances</returns>
+    [McpServerTool]
+    [Description("Find geographic areas where TrashMob events have been held but there is no active community partner. Useful for identifying high-potential areas for new community partnerships. Returns event counts, nearest partner distance, and any existing prospect in the pipeline.")]
+    public async Task<string> GetGeographicGaps()
+    {
+        var gaps = (await scoringManager.GetGeographicGapsAsync()).ToList();
+
+        return JsonSerializer.Serialize(new
+        {
+            gaps,
+            total_count = gaps.Count,
+        }, JsonOptions);
+    }
+}

--- a/TrashMobMCP/Tools/SearchProspectsTool.cs
+++ b/TrashMobMCP/Tools/SearchProspectsTool.cs
@@ -1,0 +1,97 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Models;
+using TrashMob.Shared.Managers.Prospects;
+using TrashMobMCP.Dtos;
+
+/// <summary>
+/// MCP tool for searching existing community prospects in the pipeline.
+/// </summary>
+[McpServerToolType]
+public class SearchProspectsTool(ICommunityProspectManager prospectManager)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private static readonly string[] StageNames =
+    [
+        "New", "Contacted", "Responded", "Interested", "Onboarding", "Active", "Declined"
+    ];
+
+    /// <summary>
+    /// Search existing community prospects in the TrashMob pipeline.
+    /// </summary>
+    /// <param name="searchTerm">Search by name, city, or region (optional)</param>
+    /// <param name="pipelineStage">Filter by pipeline stage: 0=New, 1=Contacted, 2=Responded, 3=Interested, 4=Onboarding, 5=Active, 6=Declined (optional)</param>
+    /// <param name="maxResults">Maximum number of results to return (default: 20, max: 100)</param>
+    /// <returns>JSON array of matching prospects with pipeline status</returns>
+    [McpServerTool]
+    [Description("Search existing community prospects in the TrashMob pipeline. Prospects are organizations being evaluated as potential community partners. Filter by search term, pipeline stage, or both.")]
+    public async Task<string> SearchProspects(
+        string? searchTerm = null,
+        int? pipelineStage = null,
+        int maxResults = 20)
+    {
+        IEnumerable<CommunityProspect> prospects;
+
+        if (pipelineStage.HasValue)
+        {
+            prospects = await prospectManager.GetByPipelineStageAsync(pipelineStage.Value);
+        }
+        else if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            prospects = await prospectManager.SearchAsync(searchTerm);
+        }
+        else
+        {
+            prospects = await prospectManager.GetAsync(CancellationToken.None);
+        }
+
+        var sanitized = prospects
+            .Take(Math.Min(maxResults, 100))
+            .Select(ToDto)
+            .ToList();
+
+        return JsonSerializer.Serialize(new
+        {
+            prospects = sanitized,
+            total_count = sanitized.Count,
+            search_criteria = new
+            {
+                search_term = searchTerm,
+                pipeline_stage = pipelineStage,
+                pipeline_stage_name = pipelineStage.HasValue && pipelineStage.Value >= 0 && pipelineStage.Value < StageNames.Length
+                    ? StageNames[pipelineStage.Value]
+                    : null,
+            }
+        }, JsonOptions);
+    }
+
+    private static ProspectDto ToDto(CommunityProspect p)
+    {
+        return new ProspectDto
+        {
+            Id = p.Id,
+            Name = p.Name,
+            Type = p.Type,
+            City = p.City,
+            Region = p.Region,
+            Country = p.Country,
+            Population = p.Population,
+            Website = p.Website,
+            ContactName = p.ContactName,
+            ContactEmail = p.ContactEmail,
+            ContactTitle = p.ContactTitle,
+            PipelineStage = p.PipelineStage,
+            PipelineStageName = p.PipelineStage >= 0 && p.PipelineStage < StageNames.Length
+                ? StageNames[p.PipelineStage]
+                : "Unknown",
+            FitScore = p.FitScore,
+            LastContactedDate = p.LastContactedDate,
+            NextFollowUpDate = p.NextFollowUpDate,
+            Notes = p.Notes,
+        };
+    }
+}

--- a/TrashMobMCP/Tools/UpdateProspectTool.cs
+++ b/TrashMobMCP/Tools/UpdateProspectTool.cs
@@ -1,0 +1,126 @@
+namespace TrashMobMCP.Tools;
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using TrashMob.Models;
+using TrashMob.Shared.Managers.Prospects;
+using TrashMobMCP.Dtos;
+
+/// <summary>
+/// MCP tool for updating an existing community prospect in the pipeline.
+/// </summary>
+[McpServerToolType]
+public class UpdateProspectTool(ICommunityProspectManager prospectManager)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private static readonly string[] StageNames =
+    [
+        "New", "Contacted", "Responded", "Interested", "Onboarding", "Active", "Declined"
+    ];
+
+    /// <summary>
+    /// Update an existing community prospect in the TrashMob pipeline.
+    /// </summary>
+    /// <param name="id">The prospect ID (GUID) to update</param>
+    /// <param name="name">Updated organization name</param>
+    /// <param name="type">Updated type: Municipality, Nonprofit, HOA, CivicOrg, or Other</param>
+    /// <param name="city">Updated city</param>
+    /// <param name="region">Updated state or region</param>
+    /// <param name="country">Updated country</param>
+    /// <param name="population">Updated population served</param>
+    /// <param name="website">Updated website URL</param>
+    /// <param name="contactName">Updated contact person's full name</param>
+    /// <param name="contactEmail">Updated contact email address</param>
+    /// <param name="contactTitle">Updated contact job title</param>
+    /// <param name="contactPhone">Updated contact phone number</param>
+    /// <param name="latitude">Updated latitude</param>
+    /// <param name="longitude">Updated longitude</param>
+    /// <param name="notes">Updated notes (replaces existing notes)</param>
+    /// <param name="pipelineStage">Updated pipeline stage: 0=New, 1=Contacted, 2=Responded, 3=Interested, 4=Onboarding, 5=Active, 6=Declined</param>
+    /// <returns>JSON with the updated prospect record</returns>
+    [McpServerTool]
+    [Description("Update an existing community prospect in the TrashMob pipeline. Only provided fields are updated — omitted fields keep their current values. Use this to add contact info, update notes, or advance the pipeline stage.")]
+    public async Task<string> UpdateProspect(
+        Guid id,
+        string? name = null,
+        string? type = null,
+        string? city = null,
+        string? region = null,
+        string? country = null,
+        int? population = null,
+        string? website = null,
+        string? contactName = null,
+        string? contactEmail = null,
+        string? contactTitle = null,
+        string? contactPhone = null,
+        double? latitude = null,
+        double? longitude = null,
+        string? notes = null,
+        int? pipelineStage = null)
+    {
+        var prospect = await prospectManager.GetAsync(id, CancellationToken.None);
+
+        if (prospect is null)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = $"Prospect with ID '{id}' not found.",
+            }, JsonOptions);
+        }
+
+        // Only update fields that were explicitly provided
+        if (name is not null) prospect.Name = name;
+        if (type is not null) prospect.Type = type;
+        if (city is not null) prospect.City = city;
+        if (region is not null) prospect.Region = region;
+        if (country is not null) prospect.Country = country;
+        if (population.HasValue) prospect.Population = population.Value;
+        if (website is not null) prospect.Website = website;
+        if (contactName is not null) prospect.ContactName = contactName;
+        if (contactEmail is not null) prospect.ContactEmail = contactEmail;
+        if (contactTitle is not null) prospect.ContactTitle = contactTitle;
+        if (contactPhone is not null) prospect.ContactPhone = contactPhone;
+        if (latitude.HasValue) prospect.Latitude = latitude.Value;
+        if (longitude.HasValue) prospect.Longitude = longitude.Value;
+        if (notes is not null) prospect.Notes = notes;
+        if (pipelineStage.HasValue) prospect.PipelineStage = pipelineStage.Value;
+
+        prospect.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+        var updated = await prospectManager.UpdateAsync(prospect, CancellationToken.None);
+
+        return JsonSerializer.Serialize(new
+        {
+            message = $"Prospect '{updated.Name}' updated.",
+            prospect = ToDto(updated),
+        }, JsonOptions);
+    }
+
+    private static ProspectDto ToDto(CommunityProspect p)
+    {
+        return new ProspectDto
+        {
+            Id = p.Id,
+            Name = p.Name,
+            Type = p.Type,
+            City = p.City,
+            Region = p.Region,
+            Country = p.Country,
+            Population = p.Population,
+            Website = p.Website,
+            ContactName = p.ContactName,
+            ContactEmail = p.ContactEmail,
+            ContactTitle = p.ContactTitle,
+            PipelineStage = p.PipelineStage,
+            PipelineStageName = p.PipelineStage >= 0 && p.PipelineStage < StageNames.Length
+                ? StageNames[p.PipelineStage]
+                : "Unknown",
+            FitScore = p.FitScore,
+            LastContactedDate = p.LastContactedDate,
+            NextFollowUpDate = p.NextFollowUpDate,
+            Notes = p.Notes,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add 5 new MCP tools for community prospect research and pipeline management
- **DiscoverProspects**: AI-powered prospect discovery via freeform research prompt or location-based search
- **SearchProspects**: Query existing pipeline prospects by name/city/region or filter by pipeline stage
- **GetGeographicGaps**: Find areas with TrashMob events but no active community partner
- **AddProspect**: Create prospect records directly from Claude research (bypasses the backend Claude API call since Claude is already doing the research)
- **UpdateProspect**: Enrich prospects with contact info, update notes, or advance pipeline stage
- Supporting ProspectDto for MCP-safe response serialization

## Motivation
When using Claude via MCP for prospect research, Claude *is* the research engine — it can search the web, analyze results, and write better queries than the backend discovery endpoint. These tools close the loop by letting Claude push results directly into the pipeline.

## Test plan
- [ ] Build succeeds (`dotnet build TrashMobMCP/TrashMobMCP.csproj` — verified locally, 0 warnings, 0 errors)
- [ ] MCP server starts and exposes all 5 new tools via `WithToolsFromAssembly()` auto-discovery
- [ ] AddProspect creates records in the database with correct field mapping
- [ ] UpdateProspect only modifies provided fields, preserves others
- [ ] SearchProspects returns results filtered by stage or search term
- [ ] GetGeographicGaps returns areas with events but no partner

🤖 Generated with [Claude Code](https://claude.com/claude-code)