### PR TITLE
Add API key authentication to MCP server

### DIFF
--- a/TrashMobMCP/ApiKeyAuthMiddleware.cs
+++ b/TrashMobMCP/ApiKeyAuthMiddleware.cs
@@ -1,0 +1,50 @@
+namespace TrashMobMCP;
+
+/// <summary>
+/// Middleware that validates an API key from the Authorization header.
+/// The expected key is read from the MCP_API_KEY environment variable.
+/// </summary>
+public class ApiKeyAuthMiddleware(RequestDelegate next, ILogger<ApiKeyAuthMiddleware> logger)
+{
+    private const string ApiKeyHeaderName = "Authorization";
+    private const string BearerPrefix = "Bearer ";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var expectedKey = Environment.GetEnvironmentVariable("MCP_API_KEY");
+
+        if (string.IsNullOrWhiteSpace(expectedKey))
+        {
+            logger.LogWarning("MCP_API_KEY environment variable is not set. All requests will be rejected.");
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            await context.Response.WriteAsync("Server is not configured for authentication.");
+            return;
+        }
+
+        if (!context.Request.Headers.TryGetValue(ApiKeyHeaderName, out var headerValue))
+        {
+            logger.LogWarning("Request rejected: missing Authorization header");
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Missing Authorization header.");
+            return;
+        }
+
+        var providedKey = headerValue.ToString();
+
+        // Support both "Bearer <key>" and raw "<key>" formats
+        if (providedKey.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            providedKey = providedKey[BearerPrefix.Length..];
+        }
+
+        if (!string.Equals(providedKey, expectedKey, StringComparison.Ordinal))
+        {
+            logger.LogWarning("Request rejected: invalid API key");
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Invalid API key.");
+            return;
+        }
+
+        await next(context);
+    }
+}

--- a/TrashMobMCP/Program.cs
+++ b/TrashMobMCP/Program.cs
@@ -29,6 +29,7 @@ public class Program
         builder.Logging.SetMinimumLevel(LogLevel.Information);
 
         var app = builder.Build();
+        app.UseMiddleware<ApiKeyAuthMiddleware>();
         app.MapMcp();
         app.Run();
     }

--- a/TrashMobMCP/README.md
+++ b/TrashMobMCP/README.md
@@ -1,0 +1,138 @@
+# TrashMob MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that exposes TrashMob data and tools to AI assistants like Claude.
+
+## Available Tools
+
+### Read-Only (Public Data)
+- **SearchCommunities** - Search community pages by location or slug
+- **SearchEvents** - Search cleanup events by location, date, and status
+- **SearchLitterReports** - Search litter reports by location and status
+- **SearchPartnerLocations** - Search partner locations by service type
+- **SearchTeams** - Search volunteer teams by location or name
+- **GetStats** - Get platform-wide statistics
+- **GetLeaderboard** - Get volunteer/team leaderboards
+- **GetAchievementTypes** - Get available achievement badges
+- **GetEventRouteStats** - Get statistics for event routes
+
+### Prospect Management (Admin)
+- **DiscoverProspects** - AI-powered discovery of potential community partners
+- **SearchProspects** - Search existing prospects in the pipeline
+- **GetGeographicGaps** - Find areas with events but no community partner
+- **AddProspect** - Create a new prospect from research
+- **UpdateProspect** - Update an existing prospect's details or pipeline stage
+
+## Authentication
+
+All requests require an API key passed via the `Authorization` header. The server validates against the `MCP_API_KEY` environment variable.
+
+## Connecting from Claude Desktop
+
+### 1. Get the API Key
+
+The MCP API key is stored in Azure Key Vault. Retrieve it with:
+
+```bash
+az keyvault secret show --vault-name kv-tm-dev-westus2 --name MCP-API-KEY --query value -o tsv
+```
+
+Or ask a project admin for the key.
+
+### 2. Configure Claude Desktop
+
+Open Claude Desktop settings and navigate to the MCP servers configuration. On Windows, edit:
+
+```
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+On macOS, edit:
+
+```
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+Add the TrashMob MCP server entry:
+
+```json
+{
+  "mcpServers": {
+    "trashmob": {
+      "type": "http",
+      "url": "https://ca-mcp-tm-dev-westus2.<region>.azurecontainerapps.io/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_API_KEY_HERE` with the actual API key and `<region>` with the Azure region (e.g., `westus2`).
+
+### 3. Connecting to a Local Server
+
+If running the MCP server locally for development:
+
+```bash
+# Set the API key
+export MCP_API_KEY="your-dev-api-key"
+
+# Set required environment variables
+export ASPNETCORE_ENVIRONMENT=Development
+export StorageAccountUri="https://your-storage-account.blob.core.windows.net/"
+export TrashMobBackendTenantId="your-tenant-id"
+
+# Run the server
+cd TrashMobMCP
+dotnet run
+```
+
+Then configure Claude Desktop to point to localhost:
+
+```json
+{
+  "mcpServers": {
+    "trashmob-local": {
+      "type": "http",
+      "url": "http://localhost:5000/mcp",
+      "headers": {
+        "Authorization": "Bearer your-dev-api-key"
+      }
+    }
+  }
+}
+```
+
+### 4. Restart Claude Desktop
+
+After saving the configuration, restart Claude Desktop. The TrashMob tools should appear in the tools list (hammer icon).
+
+## Connecting from Claude Code
+
+Add the server to your project's `.mcp.json` or your user-level MCP config:
+
+```json
+{
+  "mcpServers": {
+    "trashmob": {
+      "type": "http",
+      "url": "https://ca-mcp-tm-dev-westus2.<region>.azurecontainerapps.io/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+## Example Prompts
+
+Once connected, you can ask Claude things like:
+
+- "Search for community cleanup events in Seattle"
+- "Find geographic gaps where we have events but no community partner"
+- "Discover potential nonprofit partners in Portland, OR that focus on waterway cleanup"
+- "Add City of Bellevue as a municipality prospect with the Parks Department as the contact"
+- "Show me all prospects in the Contacted stage"
+- "What are the platform-wide stats for TrashMob?"


### PR DESCRIPTION
## Summary
- Add `ApiKeyAuthMiddleware` that validates all MCP requests against the `MCP_API_KEY` environment variable
- Supports both `Bearer <key>` and raw key in the `Authorization` header
- Returns 401 for missing/invalid keys, 503 if `MCP_API_KEY` isn't set
- Protects prospect write tools (AddProspect, UpdateProspect), contact data (SearchProspects), API-credit-consuming tools (DiscoverProspects), and strategy data (GetGeographicGaps)

## Client configuration
```json
{
  "mcpServers": {
    "trashmob": {
      "type": "http",
      "url": "http://localhost:5000/mcp",
      "headers": {
        "Authorization": "Bearer your-api-key-here"
      }
    }
  }
}
```

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] MCP server rejects requests without `Authorization` header (401)
- [ ] MCP server rejects requests with wrong API key (401)
- [ ] MCP server returns 503 when `MCP_API_KEY` env var is not set
- [ ] MCP server accepts requests with valid `Bearer <key>` header
- [ ] MCP server accepts requests with valid raw key header

🤖 Generated with [Claude Code](https://claude.com/claude-code)