### PR TITLE
Add mobile child-initiated parental consent (COPPA)

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -46,6 +46,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(WaiverPage), typeof(WaiverPage));
         Routing.RegisterRoute(nameof(WelcomePage), typeof(WelcomePage));
         Routing.RegisterRoute(nameof(AgeGatePage), typeof(AgeGatePage));
+        Routing.RegisterRoute(nameof(ChildSignupPage), typeof(ChildSignupPage));
         Routing.RegisterRoute(nameof(VerifyIdentityPage), typeof(VerifyIdentityPage));
         Routing.RegisterRoute(nameof(SyncStatusPage), typeof(SyncStatusPage));
     }

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -102,6 +102,7 @@ public static class MauiProgram
         builder.Services.AddTransient<WaiverPage>();
         builder.Services.AddTransient<WelcomePage>();
         builder.Services.AddTransient<AgeGatePage>();
+        builder.Services.AddTransient<ChildSignupPage>();
         builder.Services.AddTransient<VerifyIdentityPage>();
         builder.Services.AddTransient<SyncStatusPage>();
 
@@ -146,6 +147,7 @@ public static class MauiProgram
         builder.Services.AddTransient<WaiverViewModel>();
         builder.Services.AddTransient<WelcomeViewModel>();
         builder.Services.AddTransient<AgeGateViewModel>();
+        builder.Services.AddTransient<ChildSignupViewModel>();
         builder.Services.AddTransient<VerifyIdentityViewModel>();
         builder.Services.AddTransient<SyncStatusViewModel>();
 

--- a/TrashMobMobile/Pages/AgeGatePage.xaml.cs
+++ b/TrashMobMobile/Pages/AgeGatePage.xaml.cs
@@ -20,6 +20,14 @@ public partial class AgeGatePage : ContentPage
 
     private async void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
+        if (e.PropertyName == nameof(AgeGateViewModel.IsMinor) && viewModel.IsMinor)
+        {
+            viewModel.IsMinor = false;
+            var dob = viewModel.DateOfBirth.ToString("yyyy-MM-dd");
+            await Shell.Current.GoToAsync($"{nameof(ChildSignupPage)}?DateOfBirth={dob}");
+            return;
+        }
+
         if (e.PropertyName == nameof(AgeGateViewModel.IsAgeVerified) && viewModel.IsAgeVerified)
         {
             viewModel.IsAgeVerified = false;

--- a/TrashMobMobile/Pages/ChildSignupPage.xaml
+++ b/TrashMobMobile/Pages/ChildSignupPage.xaml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="vm:ChildSignupViewModel"
+             x:Class="TrashMobMobile.Pages.ChildSignupPage"
+             Shell.NavBarIsVisible="False">
+    <ScrollView>
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="16"
+                             VerticalOptions="Center">
+
+            <!-- Logo -->
+            <Image Source="{AppThemeBinding Light=bannerlogo_light.png, Dark=bannerlogo_dark.png}"
+                   MaximumHeightRequest="72"
+                   HorizontalOptions="Center"
+                   Margin="0,24,0,0" />
+
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
+
+            <!-- Form state -->
+            <VerticalStackLayout Spacing="16" IsVisible="{Binding IsFormVisible}">
+                <Label Text="Create Account (Under 18)"
+                       FontFamily="LexendSemibold"
+                       FontSize="Large"
+                       HorizontalTextAlignment="Center" />
+
+                <Label Text="Since you are under 18, we need your parent or guardian's consent. Please fill in the information below and we'll send them a consent request."
+                       FontSize="Body"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0" />
+
+                <VerticalStackLayout Spacing="4" Margin="20,0">
+                    <Label Text="Parent/Guardian Email *" FontFamily="LexendSemibold" FontSize="Caption" />
+                    <Entry Text="{Binding ParentEmail}"
+                           Placeholder="parent@example.com"
+                           Keyboard="Email" />
+                </VerticalStackLayout>
+
+                <VerticalStackLayout Spacing="4" Margin="20,0">
+                    <Label Text="Your First Name *" FontFamily="LexendSemibold" FontSize="Caption" />
+                    <Entry Text="{Binding ChildFirstName}"
+                           Placeholder="First name" />
+                </VerticalStackLayout>
+
+                <VerticalStackLayout Spacing="4" Margin="20,0">
+                    <Label Text="Your Email *" FontFamily="LexendSemibold" FontSize="Caption" />
+                    <Entry Text="{Binding ChildEmail}"
+                           Placeholder="your@email.com"
+                           Keyboard="Email" />
+                </VerticalStackLayout>
+
+                <VerticalStackLayout Spacing="4" Margin="20,0">
+                    <Label Text="Date of Birth" FontFamily="LexendSemibold" FontSize="Caption" />
+                    <DatePicker Date="{Binding DateOfBirth}"
+                                HorizontalOptions="Start"
+                                Format="d"
+                                IsEnabled="False" />
+                </VerticalStackLayout>
+
+                <HorizontalStackLayout HorizontalOptions="Center" Spacing="12">
+                    <Button Text="Cancel"
+                            MaximumWidthRequest="140"
+                            BackgroundColor="Transparent"
+                            TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderWidth="1"
+                            Command="{Binding GoBackCommand}" />
+
+                    <Button Text="Request Consent"
+                            MaximumWidthRequest="200"
+                            Command="{Binding SubmitConsentRequestCommand}"
+                            IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
+
+            <!-- Consent Pending state -->
+            <VerticalStackLayout Spacing="16" IsVisible="{Binding IsConsentPending}">
+                <Label Text="Consent Requested"
+                       FontFamily="LexendSemibold"
+                       FontSize="Large"
+                       HorizontalTextAlignment="Center" />
+
+                <Label HorizontalTextAlignment="Center"
+                       FontSize="Body"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="We've sent a consent request to your parent/guardian at " />
+                            <Span Text="{Binding ResultParentEmail}" FontAttributes="Bold" />
+                            <Span Text="." />
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+
+                <Label Text="Once they approve, you'll receive an email with a link to create your TrashMob account. This usually takes a few minutes."
+                       FontSize="Caption"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0" />
+
+                <Button Text="Done"
+                        MaximumWidthRequest="200"
+                        Command="{Binding GoHomeCommand}" />
+            </VerticalStackLayout>
+
+            <!-- Parent Not Found state -->
+            <VerticalStackLayout Spacing="16" IsVisible="{Binding IsParentNotFound}">
+                <Label Text="Parent Account Needed"
+                       FontFamily="LexendSemibold"
+                       FontSize="Large"
+                       HorizontalTextAlignment="Center" />
+
+                <Label HorizontalTextAlignment="Center"
+                       FontSize="Body"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="We couldn't find a TrashMob account for " />
+                            <Span Text="{Binding ResultParentEmail}" FontAttributes="Bold" />
+                            <Span Text="." />
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+
+                <Label Text="Before you can create an account, your parent/guardian needs to:&#10;&#10;1. Go to trashmob.eco and create an account&#10;2. Log in and go to their Profile page&#10;3. Complete the Identity Verification step&#10;4. Come back here and try again"
+                       FontSize="Caption"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0" />
+
+                <Button Text="Try a Different Email"
+                        MaximumWidthRequest="200"
+                        Command="{Binding TryDifferentEmailCommand}" />
+            </VerticalStackLayout>
+
+            <!-- Parent Not Verified state -->
+            <VerticalStackLayout Spacing="16" IsVisible="{Binding IsParentNotVerified}">
+                <Label Text="Parent Verification Needed"
+                       FontFamily="LexendSemibold"
+                       FontSize="Large"
+                       HorizontalTextAlignment="Center" />
+
+                <Label HorizontalTextAlignment="Center"
+                       FontSize="Body"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="We found an account for " />
+                            <Span Text="{Binding ResultParentEmail}" FontAttributes="Bold" />
+                            <Span Text=", but they haven't verified their identity yet." />
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+
+                <Label Text="Ask your parent/guardian to:&#10;&#10;1. Log in to trashmob.eco&#10;2. Go to their Profile page&#10;3. Click 'Verify My Identity' and complete the process&#10;4. Once verified, come back here and try again"
+                       FontSize="Caption"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                       Margin="20,0" />
+
+                <Button Text="Try a Different Email"
+                        MaximumWidthRequest="200"
+                        Command="{Binding TryDifferentEmailCommand}" />
+            </VerticalStackLayout>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/TrashMobMobile/Pages/ChildSignupPage.xaml.cs
+++ b/TrashMobMobile/Pages/ChildSignupPage.xaml.cs
@@ -1,0 +1,25 @@
+namespace TrashMobMobile.Pages;
+
+using TrashMobMobile.ViewModels;
+
+[QueryProperty(nameof(DateOfBirth), nameof(DateOfBirth))]
+public partial class ChildSignupPage : ContentPage
+{
+    private readonly ChildSignupViewModel viewModel;
+
+    public ChildSignupPage(ChildSignupViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        this.viewModel.Navigation = Navigation;
+        BindingContext = this.viewModel;
+    }
+
+    public string DateOfBirth { get; set; } = string.Empty;
+
+    protected override void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        viewModel.Init(DateOfBirth);
+    }
+}

--- a/TrashMobMobile/Services/IPrivoConsentRestService.cs
+++ b/TrashMobMobile/Services/IPrivoConsentRestService.cs
@@ -32,5 +32,14 @@ namespace TrashMobMobile.Services
         /// Revokes consent for a specific consent record.
         /// </summary>
         Task RevokeConsentAsync(Guid consentId, string reason, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Initiates a child-driven consent request (Flow 3). No authentication required.
+        /// Returns null if the parent account was not found (204).
+        /// Throws InvalidOperationException with "PARENT_NOT_VERIFIED" if parent exists but is not verified.
+        /// </summary>
+        Task<ParentalConsentDto?> InitiateChildInitiatedConsentAsync(
+            InitiateChildConsentRequest request,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobMobile/Services/PrivoConsentRestService.cs
+++ b/TrashMobMobile/Services/PrivoConsentRestService.cs
@@ -69,5 +69,34 @@ namespace TrashMobMobile.Services
             using var response = await AuthorizedHttpClient.PostAsync(requestUri, null, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
+
+        /// <inheritdoc />
+        public async Task<ParentalConsentDto?> InitiateChildInitiatedConsentAsync(
+            InitiateChildConsentRequest request, CancellationToken cancellationToken)
+        {
+            var json = JsonSerializer.Serialize(request, SerializerOptions);
+            using var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            using var response = await AnonymousHttpClient.PostAsync("consent/child-initiated", content, cancellationToken);
+
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                return null;
+            }
+
+            if (response.StatusCode == HttpStatusCode.BadRequest)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (errorContent.Contains("verify", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException("PARENT_NOT_VERIFIED");
+                }
+
+                response.EnsureSuccessStatusCode();
+            }
+
+            response.EnsureSuccessStatusCode();
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonSerializer.Deserialize<ParentalConsentDto>(responseContent, SerializerOptions);
+        }
     }
 }

--- a/TrashMobMobile/ViewModels/AgeGateViewModel.cs
+++ b/TrashMobMobile/ViewModels/AgeGateViewModel.cs
@@ -21,6 +21,9 @@ public partial class AgeGateViewModel(INotificationService notificationService) 
     [ObservableProperty]
     private bool isAgeVerified;
 
+    [ObservableProperty]
+    private bool isMinor;
+
     public DateTime MaxDate => DateTime.Today;
     public DateTime MinDate => DateTime.Today.AddYears(-120);
 
@@ -33,6 +36,12 @@ public partial class AgeGateViewModel(INotificationService notificationService) 
         {
             IsBlocked = true;
             BlockMessage = "You must be 13 or older to join TrashMob. Thank you for your interest in keeping our communities clean!";
+            return;
+        }
+
+        if (age < 18)
+        {
+            IsMinor = true;
             return;
         }
 

--- a/TrashMobMobile/ViewModels/ChildSignupViewModel.cs
+++ b/TrashMobMobile/ViewModels/ChildSignupViewModel.cs
@@ -1,0 +1,138 @@
+namespace TrashMobMobile.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMob.Models.Poco.V2;
+using TrashMobMobile.Services;
+
+public partial class ChildSignupViewModel(
+    IPrivoConsentRestService privoConsentRestService,
+    INotificationService notificationService)
+    : BaseViewModel(notificationService)
+{
+    [ObservableProperty]
+    private string parentEmail = string.Empty;
+
+    [ObservableProperty]
+    private string childFirstName = string.Empty;
+
+    [ObservableProperty]
+    private string childEmail = string.Empty;
+
+    [ObservableProperty]
+    private DateTime dateOfBirth = DateTime.Today.AddYears(-15);
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFormVisible))]
+    private bool isParentNotFound;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFormVisible))]
+    private bool isParentNotVerified;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFormVisible))]
+    private bool isConsentPending;
+
+    [ObservableProperty]
+    private string resultParentEmail = string.Empty;
+
+    public bool IsFormVisible => !IsParentNotFound && !IsParentNotVerified && !IsConsentPending;
+
+    public void Init(string dateOfBirthString)
+    {
+        if (DateTime.TryParse(dateOfBirthString, out var dob))
+        {
+            DateOfBirth = dob;
+        }
+
+        // Reset state
+        IsParentNotFound = false;
+        IsParentNotVerified = false;
+        IsConsentPending = false;
+        ParentEmail = string.Empty;
+        ChildFirstName = string.Empty;
+        ChildEmail = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task SubmitConsentRequest()
+    {
+        if (string.IsNullOrWhiteSpace(ParentEmail) || !ParentEmail.Contains('@'))
+        {
+            await NotificationService.NotifyError("Please enter a valid parent/guardian email address.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(ChildFirstName))
+        {
+            await NotificationService.NotifyError("Please enter your first name.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(ChildEmail) || !ChildEmail.Contains('@'))
+        {
+            await NotificationService.NotifyError("Please enter a valid email address.");
+            return;
+        }
+
+        ResultParentEmail = ParentEmail;
+
+        try
+        {
+            IsBusy = true;
+
+            var request = new InitiateChildConsentRequest
+            {
+                ParentEmail = ParentEmail,
+                ChildFirstName = ChildFirstName,
+                ChildEmail = ChildEmail,
+                ChildBirthDate = DateOnly.FromDateTime(DateOfBirth),
+            };
+
+            var result = await privoConsentRestService.InitiateChildInitiatedConsentAsync(request);
+
+            if (result == null)
+            {
+                IsParentNotFound = true;
+            }
+            else
+            {
+                IsConsentPending = true;
+            }
+        }
+        catch (InvalidOperationException ex) when (ex.Message == "PARENT_NOT_VERIFIED")
+        {
+            IsParentNotVerified = true;
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+            await NotificationService.NotifyError("Unable to submit consent request. Please try again.");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void TryDifferentEmail()
+    {
+        IsParentNotFound = false;
+        IsParentNotVerified = false;
+        ParentEmail = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task GoBack()
+    {
+        await Shell.Current.GoToAsync("..");
+    }
+
+    [RelayCommand]
+    private async Task GoHome()
+    {
+        await Shell.Current.GoToAsync("../..");
+    }
+}


### PR DESCRIPTION
## Summary
- **COPPA compliance fix**: Minors (13-17) could create accounts on the mobile app without parental consent, bypassing the PRIVO consent flow enforced by the web app
- AgeGateViewModel now routes 13-17 to a new `ChildSignupPage` instead of direct signup
- ChildSignupPage collects parent email, child name/email, and calls the unauthenticated `POST /v2/privo/consent/child-initiated` endpoint
- Handles three outcomes: consent requested (success), parent account not found, parent not verified
- Uses `AnonymousHttpClient` since the child is not yet authenticated
- Mirrors the web app's `/child-signup` flow

## Files changed
- **New**: `ChildSignupViewModel.cs`, `ChildSignupPage.xaml/.cs`
- **Modified**: `AgeGateViewModel.cs` (branch 13-17 vs 18+), `AgeGatePage.xaml.cs` (navigate on IsMinor), `IPrivoConsentRestService.cs` + impl, `MauiProgram.cs`, `AppShell.xaml.cs`

## Test plan
- [ ] Age gate: enter DOB making user 15 → should navigate to ChildSignupPage (not direct signup)
- [ ] Age gate: enter DOB making user 25 → should proceed to normal signup (unchanged)
- [ ] Age gate: enter DOB making user 10 → should show blocked message (unchanged)
- [ ] ChildSignupPage: enter valid parent email (existing verified account) → consent pending state
- [ ] ChildSignupPage: enter non-existent parent email → parent not found state with instructions
- [ ] ChildSignupPage: enter unverified parent email → parent not verified state with instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)