### PR TITLE
Add mobile dependent management features (consent, waivers, alerts)

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -48,5 +48,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(AgeGatePage), typeof(AgeGatePage));
         Routing.RegisterRoute(nameof(VerifyIdentityPage), typeof(VerifyIdentityPage));
         Routing.RegisterRoute(nameof(SyncStatusPage), typeof(SyncStatusPage));
+        Routing.RegisterRoute(nameof(DependentWaiverPage), typeof(DependentWaiverPage));
     }
 }

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -104,6 +104,7 @@ public static class MauiProgram
         builder.Services.AddTransient<AgeGatePage>();
         builder.Services.AddTransient<VerifyIdentityPage>();
         builder.Services.AddTransient<SyncStatusPage>();
+        builder.Services.AddTransient<DependentWaiverPage>();
 
         // ViewModels
         builder.Services.AddTransient<CreatePickupLocationViewModel>();
@@ -148,6 +149,7 @@ public static class MauiProgram
         builder.Services.AddTransient<AgeGateViewModel>();
         builder.Services.AddTransient<VerifyIdentityViewModel>();
         builder.Services.AddTransient<SyncStatusViewModel>();
+        builder.Services.AddTransient<DependentWaiverViewModel>();
 
 #if USETEST
         builder.Logging.AddDebug();

--- a/TrashMobMobile/Pages/DependentWaiverPage.xaml
+++ b/TrashMobMobile/Pages/DependentWaiverPage.xaml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="vm:DependentWaiverViewModel"
+             x:Class="TrashMobMobile.Pages.DependentWaiverPage"
+             Title="Sign Waivers">
+    <ScrollView>
+        <VerticalStackLayout Style="{StaticResource OuterVerticalStack}" Spacing="16">
+
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
+
+            <!-- List state: show waivers to sign -->
+            <VerticalStackLayout Spacing="12" IsVisible="{Binding IsListVisible}">
+
+                <Label FontFamily="LexendSemibold" FontSize="Large"
+                       HorizontalTextAlignment="Center">
+                    <Label.FormattedText>
+                        <FormattedString>
+                            <Span Text="Waivers for " />
+                            <Span Text="{Binding DependentName}" FontAttributes="Bold" />
+                        </FormattedString>
+                    </Label.FormattedText>
+                </Label>
+
+                <Label Text="{Binding EventName}"
+                       FontSize="Body"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                <Label Text="{Binding ProgressText}"
+                       FontSize="Caption"
+                       HorizontalTextAlignment="Center"
+                       TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+
+                <CollectionView ItemsSource="{Binding Waivers}" SelectionMode="None">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="vm:DependentWaiverItem">
+                            <Border Padding="16" Margin="0,0,0,8"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+                                    StrokeShape="RoundRectangle 12"
+                                    Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+                                    StrokeThickness="1">
+                                <Grid ColumnDefinitions="*, Auto">
+                                    <VerticalStackLayout Grid.Column="0" Spacing="4">
+                                        <Label Text="{Binding Name}"
+                                               FontFamily="LexendSemibold" FontSize="14" />
+                                        <Label Text="{Binding StatusText}" FontSize="12"
+                                               TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}" />
+                                    </VerticalStackLayout>
+                                    <Button Grid.Column="1" Text="Sign"
+                                            Style="{StaticResource PrimaryLargeButton}"
+                                            HeightRequest="36" Padding="12,0" FontSize="Small"
+                                            IsVisible="{Binding IsSigned, Converter={StaticResource InvertedBoolConverter}}"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DependentWaiverViewModel}}, Path=SelectWaiverCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    <Label Grid.Column="1" Text="✓" FontSize="24" TextColor="#16a34a"
+                                           VerticalOptions="Center" HorizontalOptions="Center"
+                                           IsVisible="{Binding IsSigned}" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <Button Text="Done" MaximumWidthRequest="200"
+                        Command="{Binding DoneCommand}"
+                        IsVisible="{Binding AllWaiversSigned}" />
+            </VerticalStackLayout>
+
+            <!-- Signing state: show waiver text and sign form -->
+            <VerticalStackLayout Spacing="12" IsVisible="{Binding IsSigningWaiver}">
+
+                <Label Text="{Binding WaiverName}"
+                       FontFamily="LexendSemibold" FontSize="Large"
+                       HorizontalTextAlignment="Center" />
+
+                <Border Padding="12"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource CardLight}, Dark={StaticResource CardDark}}"
+                        StrokeShape="RoundRectangle 8"
+                        Stroke="{AppThemeBinding Light={StaticResource BorderLight}, Dark={StaticResource BorderDark}}"
+                        StrokeThickness="1">
+                    <Label Text="{Binding WaiverText}" TextType="Html" FontSize="Small" />
+                </Border>
+
+                <HorizontalStackLayout Spacing="8" Margin="0,8,0,0">
+                    <CheckBox IsChecked="{Binding HasAgreed}" />
+                    <Label Text="I have read and agree to the waiver above."
+                           VerticalOptions="Center" FontSize="Small" />
+                </HorizontalStackLayout>
+
+                <VerticalStackLayout Spacing="4">
+                    <Label Text="Type your full legal name to sign:" FontSize="Small"
+                           FontFamily="LexendSemibold" />
+                    <Entry Text="{Binding TypedLegalName}" Placeholder="Full Legal Name" />
+                </VerticalStackLayout>
+
+                <HorizontalStackLayout HorizontalOptions="Center" Spacing="12">
+                    <Button Text="Back"
+                            MaximumWidthRequest="140"
+                            BackgroundColor="Transparent"
+                            TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            BorderWidth="1"
+                            Command="{Binding BackToListCommand}" />
+
+                    <Button Text="Sign Waiver"
+                            MaximumWidthRequest="200"
+                            Command="{Binding SignWaiverCommand}" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/TrashMobMobile/Pages/DependentWaiverPage.xaml.cs
+++ b/TrashMobMobile/Pages/DependentWaiverPage.xaml.cs
@@ -1,0 +1,38 @@
+namespace TrashMobMobile.Pages;
+
+using TrashMobMobile.ViewModels;
+
+[QueryProperty(nameof(DependentId), nameof(DependentId))]
+[QueryProperty(nameof(DependentName), nameof(DependentName))]
+[QueryProperty(nameof(EventName), nameof(EventName))]
+[QueryProperty(nameof(WaiverVersionIds), nameof(WaiverVersionIds))]
+public partial class DependentWaiverPage : ContentPage
+{
+    private readonly DependentWaiverViewModel viewModel;
+
+    public DependentWaiverPage(DependentWaiverViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        this.viewModel.Navigation = Navigation;
+        BindingContext = this.viewModel;
+    }
+
+    public string DependentId { get; set; } = string.Empty;
+
+    public string DependentName { get; set; } = string.Empty;
+
+    public string EventName { get; set; } = string.Empty;
+
+    public string WaiverVersionIds { get; set; } = string.Empty;
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init(
+            new Guid(DependentId),
+            Uri.UnescapeDataString(DependentName),
+            Uri.UnescapeDataString(EventName),
+            WaiverVersionIds);
+    }
+}

--- a/TrashMobMobile/Pages/MyDashboardPage.xaml
+++ b/TrashMobMobile/Pages/MyDashboardPage.xaml
@@ -8,11 +8,64 @@
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
              xmlns:tabs="http://sharpnado.com"
              xmlns:views="clr-namespace:TrashMobMobile.Views.MyDashboard"
+             xmlns:poco="clr-namespace:TrashMob.Models.Poco.V2;assembly=TrashMob.Models"
              Title="My Dashboard">
 
     <ScrollView>
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
+
+                <!-- Pending Waiver Alerts -->
+                <Border Padding="12" Margin="5,5"
+                        BackgroundColor="{AppThemeBinding Light=#fef2f2, Dark=#450a0a}"
+                        StrokeShape="RoundRectangle 10"
+                        Stroke="{AppThemeBinding Light=#fca5a5, Dark=#dc2626}"
+                        StrokeThickness="1"
+                        IsVisible="{Binding HasPendingWaiverAlerts}">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Waiver Signatures Required"
+                               FontFamily="LexendSemibold" FontSize="14"
+                               TextColor="{AppThemeBinding Light=#991b1b, Dark=#fca5a5}" />
+                        <Label Text="Your child has registered for an event that requires your signature on a waiver."
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#991b1b, Dark=#fecaca}" />
+                        <CollectionView ItemsSource="{Binding PendingWaiverAlerts}" SelectionMode="None">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate x:DataType="poco:PendingDependentWaiverDto">
+                                    <Border Padding="10" Margin="0,4"
+                                            BackgroundColor="{AppThemeBinding Light=#ffffff, Dark=#1c1917}"
+                                            StrokeShape="RoundRectangle 8"
+                                            Stroke="{AppThemeBinding Light=#fca5a5, Dark=#7f1d1d}"
+                                            StrokeThickness="1">
+                                        <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto">
+                                            <Label Grid.Row="0" Grid.Column="0"
+                                                   FontFamily="LexendSemibold" FontSize="13">
+                                                <Label.FormattedText>
+                                                    <FormattedString>
+                                                        <Span Text="{Binding DependentFirstName}" />
+                                                        <Span Text=" — " />
+                                                        <Span Text="{Binding EventName}" />
+                                                    </FormattedString>
+                                                </Label.FormattedText>
+                                            </Label>
+                                            <Label Grid.Row="1" Grid.Column="0" FontSize="12"
+                                                   TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
+                                                   Text="{Binding RequiredWaivers.Count, StringFormat='{0} waiver(s) to sign'}" />
+                                            <Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                                    Text="Sign"
+                                                    Style="{StaticResource PrimaryLargeButton}"
+                                                    HeightRequest="36" Padding="12,0" FontSize="Small"
+                                                    VerticalOptions="Center"
+                                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:MyDashboardViewModel}}, Path=SignDependentWaiversCommand}"
+                                                    CommandParameter="{Binding .}" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </VerticalStackLayout>
+                </Border>
+
                 <Border Style="{x:StaticResource RoundBorder}" Margin="5,5">
                     <Grid RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="*, *, *, *">
                         <Label Text="Here's what you have done so far!" Grid.Row="0" Grid.Column="0"

--- a/TrashMobMobile/Pages/MyDependentsPage.xaml
+++ b/TrashMobMobile/Pages/MyDependentsPage.xaml
@@ -107,8 +107,14 @@
                                                         <DataTrigger TargetType="Border" Binding="{Binding HasActiveInvitation}" Value="True">
                                                             <Setter Property="BackgroundColor" Value="#dbeafe" />
                                                         </DataTrigger>
-                                                        <DataTrigger TargetType="Border" Binding="{Binding IsEligibleForInvite}" Value="True">
+                                                        <DataTrigger TargetType="Border" Binding="{Binding IsConsentPending}" Value="True">
                                                             <Setter Property="BackgroundColor" Value="#fef3c7" />
+                                                        </DataTrigger>
+                                                        <DataTrigger TargetType="Border" Binding="{Binding NeedsConsent}" Value="True">
+                                                            <Setter Property="BackgroundColor" Value="#fef3c7" />
+                                                        </DataTrigger>
+                                                        <DataTrigger TargetType="Border" Binding="{Binding IsEligibleForInvite}" Value="True">
+                                                            <Setter Property="BackgroundColor" Value="#dbeafe" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -125,8 +131,14 @@
                                                             <DataTrigger TargetType="Label" Binding="{Binding HasActiveInvitation}" Value="True">
                                                                 <Setter Property="TextColor" Value="#1e40af" />
                                                             </DataTrigger>
-                                                            <DataTrigger TargetType="Label" Binding="{Binding IsEligibleForInvite}" Value="True">
+                                                            <DataTrigger TargetType="Label" Binding="{Binding IsConsentPending}" Value="True">
                                                                 <Setter Property="TextColor" Value="#92400e" />
+                                                            </DataTrigger>
+                                                            <DataTrigger TargetType="Label" Binding="{Binding NeedsConsent}" Value="True">
+                                                                <Setter Property="TextColor" Value="#92400e" />
+                                                            </DataTrigger>
+                                                            <DataTrigger TargetType="Label" Binding="{Binding IsEligibleForInvite}" Value="True">
+                                                                <Setter Property="TextColor" Value="#1e40af" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
@@ -137,7 +149,17 @@
 
                                     <!-- Action buttons -->
                                     <HorizontalStackLayout Spacing="8" HorizontalOptions="End">
-                                        <!-- Invite button (eligible dependents) -->
+                                        <!-- Consent button (needs PRIVO consent) -->
+                                        <Button Text="Consent"
+                                                Style="{StaticResource PrimaryLargeButton}"
+                                                HeightRequest="36"
+                                                Padding="12,0"
+                                                FontSize="Small"
+                                                IsVisible="{Binding NeedsConsent}"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:MyDependentsViewModel}}, Path=StartConsentCommand}"
+                                                CommandParameter="{Binding .}" />
+
+                                        <!-- Invite button (consent approved, ready to invite) -->
                                         <Button Text="Invite"
                                                 Style="{StaticResource PrimaryLargeButton}"
                                                 HeightRequest="36"

--- a/TrashMobMobile/Services/DependentRestService.cs
+++ b/TrashMobMobile/Services/DependentRestService.cs
@@ -17,13 +17,18 @@ namespace TrashMobMobile.Services
 
         public async Task<List<Dependent>> GetDependentsAsync(Guid userId, CancellationToken cancellationToken = default)
         {
+            var dtos = await GetDependentDtosAsync(userId, cancellationToken);
+            return dtos.Select(d => d.ToEntity()).ToList();
+        }
+
+        public async Task<List<DependentDto>> GetDependentDtosAsync(Guid userId, CancellationToken cancellationToken = default)
+        {
             var requestUri = userId + "/dependents";
 
             using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
             response.EnsureSuccessStatusCode();
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
-            var dtos = JsonConvert.DeserializeObject<List<DependentDto>>(content) ?? [];
-            return dtos.Select(d => d.ToEntity()).ToList();
+            return JsonConvert.DeserializeObject<List<DependentDto>>(content) ?? [];
         }
 
         public async Task<Dependent> AddDependentAsync(Guid userId, Dependent dependent, CancellationToken cancellationToken = default)
@@ -192,6 +197,19 @@ namespace TrashMobMobile.Services
 
             using var response = await client.DeleteAsync(requestUri, cancellationToken);
             response.EnsureSuccessStatusCode();
+        }
+
+        // Pending Waiver Requests
+
+        public async Task<List<PendingDependentWaiverDto>> GetPendingWaiverRequestsAsync(
+            Guid userId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = userId + "/dependents/pending-waivers";
+
+            using var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonConvert.DeserializeObject<List<PendingDependentWaiverDto>>(content) ?? [];
         }
     }
 }

--- a/TrashMobMobile/Services/IDependentRestService.cs
+++ b/TrashMobMobile/Services/IDependentRestService.cs
@@ -1,11 +1,17 @@
 namespace TrashMobMobile.Services
 {
     using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
 
     public interface IDependentRestService
     {
         // Dependent CRUD (api/users/{userId}/dependents)
         Task<List<Dependent>> GetDependentsAsync(Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets dependents as DTOs (preserves PrivoConsentStatus).
+        /// </summary>
+        Task<List<DependentDto>> GetDependentDtosAsync(Guid userId, CancellationToken cancellationToken = default);
 
         Task<Dependent> AddDependentAsync(Guid userId, Dependent dependent, CancellationToken cancellationToken = default);
 
@@ -35,5 +41,8 @@ namespace TrashMobMobile.Services
         Task<int> GetEventDependentCountAsync(Guid eventId, CancellationToken cancellationToken = default);
 
         Task UnregisterDependentFromEventAsync(Guid eventId, Guid dependentId, CancellationToken cancellationToken = default);
+
+        // Pending Waiver Requests (api/users/{userId}/dependents/pending-waivers)
+        Task<List<PendingDependentWaiverDto>> GetPendingWaiverRequestsAsync(Guid userId, CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobMobile/ViewModels/DependentWaiverViewModel.cs
+++ b/TrashMobMobile/ViewModels/DependentWaiverViewModel.cs
@@ -1,0 +1,168 @@
+namespace TrashMobMobile.ViewModels;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TrashMobMobile.Services;
+
+public partial class DependentWaiverViewModel(
+    IDependentRestService dependentRestService,
+    IWaiverManager waiverManager,
+    INotificationService notificationService)
+    : BaseViewModel(notificationService)
+{
+    private Guid dependentId;
+    private Guid selectedWaiverVersionId;
+
+    [ObservableProperty]
+    private string dependentName = string.Empty;
+
+    [ObservableProperty]
+    private string eventName = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<DependentWaiverItem> waivers = [];
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsListVisible))]
+    private bool isSigningWaiver;
+
+    [ObservableProperty]
+    private string waiverName = string.Empty;
+
+    [ObservableProperty]
+    private string waiverText = string.Empty;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SignWaiverCommand))]
+    private string typedLegalName = string.Empty;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SignWaiverCommand))]
+    private bool hasAgreed;
+
+    [ObservableProperty]
+    private bool allWaiversSigned;
+
+    [ObservableProperty]
+    private string progressText = string.Empty;
+
+    public bool IsListVisible => !IsSigningWaiver;
+
+    private bool CanSignWaiver => HasAgreed && TypedLegalName.Trim().Length >= 2;
+
+    public async Task Init(Guid depId, string depName, string evtName, string waiverVersionIdsCsv)
+    {
+        dependentId = depId;
+        DependentName = depName;
+        EventName = evtName;
+        IsSigningWaiver = false;
+        AllWaiversSigned = false;
+
+        await ExecuteAsync(async () =>
+        {
+            var versionIds = waiverVersionIdsCsv
+                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(Guid.Parse)
+                .ToList();
+
+            var requiredWaivers = await waiverManager.GetRequiredWaiversAsync();
+            var items = new ObservableCollection<DependentWaiverItem>();
+
+            foreach (var id in versionIds)
+            {
+                var waiver = requiredWaivers.Find(w => w.Id == id);
+                items.Add(new DependentWaiverItem
+                {
+                    WaiverVersionId = id,
+                    Name = waiver?.Name ?? "Waiver",
+                    WaiverText = waiver?.WaiverText ?? string.Empty,
+                    IsSigned = false,
+                });
+            }
+
+            Waivers = items;
+            UpdateProgress();
+
+            // If only one waiver, go straight to signing
+            if (Waivers.Count == 1)
+            {
+                OpenWaiverForSigning(Waivers[0]);
+            }
+        }, "Failed to load waiver details. Please try again.");
+    }
+
+    [RelayCommand]
+    private void SelectWaiver(DependentWaiverItem item)
+    {
+        if (item == null || item.IsSigned) return;
+        OpenWaiverForSigning(item);
+    }
+
+    private void OpenWaiverForSigning(DependentWaiverItem item)
+    {
+        selectedWaiverVersionId = item.WaiverVersionId;
+        WaiverName = item.Name;
+        WaiverText = item.WaiverText;
+        TypedLegalName = string.Empty;
+        HasAgreed = false;
+        IsSigningWaiver = true;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanSignWaiver))]
+    private async Task SignWaiver()
+    {
+        await ExecuteAsync(async () =>
+        {
+            await dependentRestService.SignWaiverAsync(dependentId, selectedWaiverVersionId, TypedLegalName.Trim());
+
+            var item = Waivers.FirstOrDefault(w => w.WaiverVersionId == selectedWaiverVersionId);
+            if (item != null) item.IsSigned = true;
+
+            UpdateProgress();
+
+            if (AllWaiversSigned)
+            {
+                await NotificationService.Notify($"All waivers signed for {DependentName}.");
+                await Shell.Current.GoToAsync("..");
+            }
+            else
+            {
+                IsSigningWaiver = false;
+            }
+        }, "Failed to sign waiver. Please try again.");
+    }
+
+    [RelayCommand]
+    private void BackToList()
+    {
+        IsSigningWaiver = false;
+    }
+
+    [RelayCommand]
+    private async Task Done()
+    {
+        await Shell.Current.GoToAsync("..");
+    }
+
+    private void UpdateProgress()
+    {
+        var signed = Waivers.Count(w => w.IsSigned);
+        var total = Waivers.Count;
+        AllWaiversSigned = signed == total;
+        ProgressText = $"{signed} of {total} waiver(s) signed";
+    }
+}
+
+public class DependentWaiverItem
+{
+    public Guid WaiverVersionId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string WaiverText { get; set; } = string.Empty;
+
+    public bool IsSigned { get; set; }
+
+    public string StatusText => IsSigned ? "Signed" : "Needs Signature";
+}

--- a/TrashMobMobile/ViewModels/DependentWithInvitation.cs
+++ b/TrashMobMobile/ViewModels/DependentWithInvitation.cs
@@ -7,15 +7,18 @@ namespace TrashMobMobile.ViewModels
     /// </summary>
     public class DependentWithInvitation
     {
-        public DependentWithInvitation(Dependent dependent, DependentInvitation? activeInvitation = null)
+        public DependentWithInvitation(Dependent dependent, DependentInvitation? activeInvitation = null, int? privoConsentStatus = null)
         {
             Dependent = dependent;
             ActiveInvitation = activeInvitation;
+            PrivoConsentStatus = privoConsentStatus;
         }
 
         public Dependent Dependent { get; }
 
         public DependentInvitation? ActiveInvitation { get; set; }
+
+        public int? PrivoConsentStatus { get; set; }
 
         public int Age
         {
@@ -29,7 +32,16 @@ namespace TrashMobMobile.ViewModels
             }
         }
 
-        public bool IsEligibleForInvite => Age >= 13 && !HasActiveInvitation && !HasAcceptedInvitation;
+        /// <summary>PRIVO consent has been approved for this dependent.</summary>
+        public bool IsConsentApproved => PrivoConsentStatus == 2;
+
+        /// <summary>PRIVO consent is pending approval.</summary>
+        public bool IsConsentPending => PrivoConsentStatus == 1;
+
+        /// <summary>Dependent is 13+ and needs PRIVO consent initiated.</summary>
+        public bool NeedsConsent => Age >= 13 && !IsConsentApproved && !IsConsentPending && !HasAcceptedInvitation;
+
+        public bool IsEligibleForInvite => Age >= 13 && IsConsentApproved && !HasActiveInvitation && !HasAcceptedInvitation;
 
         public bool HasActiveInvitation =>
             ActiveInvitation != null &&
@@ -45,7 +57,9 @@ namespace TrashMobMobile.ViewModels
             {
                 if (HasAcceptedInvitation) return "Account Created";
                 if (HasActiveInvitation) return "Invited";
-                if (IsEligibleForInvite) return "Eligible";
+                if (IsConsentPending) return "Consent Pending";
+                if (NeedsConsent) return "Needs Consent";
+                if (IsEligibleForInvite) return "Ready to Invite";
                 return string.Empty;
             }
         }

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using TrashMob.Models;
 using TrashMob.Models.Poco;
+using TrashMob.Models.Poco.V2;
 using Sentry;
 using TrashMobMobile.Extensions;
 using TrashMobMobile.Services;
@@ -14,7 +15,8 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
                                           ILitterReportManager litterReportManager,
                                           INotificationService notificationService,
                                           IUserManager userManager,
-                                          IWaiverManager waiverManager)
+                                          IWaiverManager waiverManager,
+                                          IDependentRestService dependentRestService)
     : BaseViewModel(notificationService)
 {
     private readonly ILitterReportManager litterReportManager = litterReportManager;
@@ -22,6 +24,7 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
     private readonly IMobEventManager mobEventManager = mobEventManager;
     private readonly IStatsRestService statsRestService = statsRestService;
     private readonly IWaiverManager waiverManager = waiverManager;
+    private readonly IDependentRestService dependentRestService = dependentRestService;
     private EventViewModel? completedSelectedEvent;
     private LitterReportViewModel? selectedLitterReport;
 
@@ -35,6 +38,11 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
     public ObservableCollection<EventViewModel> CompletedEvents { get; set; } = [];
 
     public ObservableCollection<LitterReportViewModel> LitterReports { get; set; } = [];
+
+    public ObservableCollection<PendingDependentWaiverDto> PendingWaiverAlerts { get; set; } = [];
+
+    [ObservableProperty]
+    private bool hasPendingWaiverAlerts;
 
     public ObservableCollection<string> UpcomingDateRanges { get; set; } = [];
 
@@ -212,7 +220,7 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
 
             SelectedCreatedDateRange = DateRanges.LastMonth;
 
-            await Task.WhenAll(RefreshEvents(), RefreshStatistics(), RefreshLitterReports());
+            await Task.WhenAll(RefreshEvents(), RefreshStatistics(), RefreshLitterReports(), RefreshPendingWaiverAlerts());
         }, "An error has occurred while loading the dashboard. Please wait and try again in a moment.");
     }
 
@@ -358,6 +366,42 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
 
         AreLitterReportsFound = LitterReports.Any();
         AreNoLitterReportsFound = !LitterReports.Any();
+    }
+
+    private async Task RefreshPendingWaiverAlerts()
+    {
+        PendingWaiverAlerts.Clear();
+
+        // Only check for non-minor users (parents)
+        if (userManager.CurrentUser.IsMinor) return;
+
+        try
+        {
+            var alerts = await dependentRestService.GetPendingWaiverRequestsAsync(userManager.CurrentUser.Id);
+            foreach (var alert in alerts)
+            {
+                PendingWaiverAlerts.Add(alert);
+            }
+        }
+        catch
+        {
+            // Non-critical — don't break the dashboard if this fails
+        }
+
+        HasPendingWaiverAlerts = PendingWaiverAlerts.Count > 0;
+    }
+
+    [RelayCommand]
+    private async Task SignDependentWaivers(PendingDependentWaiverDto item)
+    {
+        if (item == null) return;
+
+        var waiverIds = string.Join(",", item.RequiredWaivers.Select(w => w.Id));
+        await Shell.Current.GoToAsync(
+            $"{nameof(DependentWaiverPage)}?DependentId={item.DependentId}" +
+            $"&DependentName={Uri.EscapeDataString(item.DependentFirstName)}" +
+            $"&EventName={Uri.EscapeDataString(item.EventName)}" +
+            $"&WaiverVersionIds={waiverIds}");
     }
 
     [RelayCommand]

--- a/TrashMobMobile/ViewModels/MyDependentsViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDependentsViewModel.cs
@@ -5,11 +5,13 @@ namespace TrashMobMobile.ViewModels
     using CommunityToolkit.Mvvm.ComponentModel;
     using CommunityToolkit.Mvvm.Input;
     using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
     using TrashMobMobile.Controls;
     using TrashMobMobile.Services;
 
     public partial class MyDependentsViewModel(
         IDependentRestService dependentRestService,
+        IPrivoConsentRestService privoConsentRestService,
         IUserManager userManager,
         INotificationService notificationService)
         : BaseViewModel(notificationService)
@@ -36,19 +38,20 @@ namespace TrashMobMobile.ViewModels
             await ExecuteAsync(async () =>
             {
                 var userId = userManager.CurrentUser.Id;
-                var dependents = await dependentRestService.GetDependentsAsync(userId);
+                var dtos = await dependentRestService.GetDependentDtosAsync(userId);
                 Dependents.Clear();
 
-                foreach (var d in dependents.OrderBy(x => x.FirstName))
+                foreach (var dto in dtos.OrderBy(x => x.FirstName))
                 {
+                    var entity = dto.ToEntity();
                     DependentInvitation? activeInvitation = null;
 
-                    var wrapper = new DependentWithInvitation(d);
-                    if (wrapper.Age >= 13)
+                    var tempWrapper = new DependentWithInvitation(entity);
+                    if (tempWrapper.Age >= 13)
                     {
                         try
                         {
-                            var invitations = await dependentRestService.GetDependentInvitationsAsync(userId, d.Id);
+                            var invitations = await dependentRestService.GetDependentInvitationsAsync(userId, entity.Id);
                             activeInvitation = invitations
                                 .OrderByDescending(i => i.DateInvited)
                                 .FirstOrDefault(i =>
@@ -61,20 +64,34 @@ namespace TrashMobMobile.ViewModels
                         }
                     }
 
-                    Dependents.Add(new DependentWithInvitation(d, activeInvitation));
+                    Dependents.Add(new DependentWithInvitation(entity, activeInvitation, dto.PrivoConsentStatus));
                 }
 
                 AreDependentsFound = Dependents.Count > 0;
                 AreNoDependentsFound = !AreDependentsFound;
                 IsIdentityVerified = userManager.CurrentUser.IsIdentityVerified;
 
+                var needsConsentCount = Dependents.Count(d => d.NeedsConsent);
                 var eligibleCount = Dependents.Count(d => d.IsEligibleForInvite);
-                HasEligibleDependents = eligibleCount > 0;
-                EligibleDependentsMessage = eligibleCount == 1
-                    ? $"{Dependents.First(d => d.IsEligibleForInvite).Dependent.FirstName} is old enough (13+) to create their own TrashMob account."
-                        + (IsIdentityVerified ? " Tap Invite to send them an invitation!" : " Verify your identity first to send invitations.")
-                    : $"{eligibleCount} of your dependents are old enough (13+) to create their own accounts."
-                        + (IsIdentityVerified ? " Tap Invite to send them invitations!" : " Verify your identity first to send invitations.");
+                HasEligibleDependents = eligibleCount > 0 || needsConsentCount > 0;
+
+                if (needsConsentCount > 0 && !IsIdentityVerified)
+                {
+                    EligibleDependentsMessage = "Verify your identity first to manage consent and send invitations for your 13+ dependents.";
+                }
+                else if (needsConsentCount > 0)
+                {
+                    EligibleDependentsMessage = $"{needsConsentCount} dependent(s) need parental consent before they can be invited. Tap Consent to start.";
+                }
+                else if (eligibleCount > 0)
+                {
+                    EligibleDependentsMessage = $"{eligibleCount} dependent(s) are ready to be invited. Tap Invite to send them an invitation!";
+                }
+                else
+                {
+                    EligibleDependentsMessage = string.Empty;
+                    HasEligibleDependents = false;
+                }
             }, "Failed to load dependents. Please try again.");
         }
 
@@ -186,6 +203,43 @@ namespace TrashMobMobile.ViewModels
                 await NotificationService.Notify($"Invitation resent to {item.ActiveInvitation.Email}.");
                 await Init();
             }, "Failed to resend invitation. Please try again.");
+        }
+
+        [RelayCommand]
+        private async Task StartConsent(DependentWithInvitation item)
+        {
+            if (item == null) return;
+
+            if (!userManager.CurrentUser.IsIdentityVerified)
+            {
+                var goToVerify = await Shell.Current.DisplayAlertAsync(
+                    "Identity Verification Required",
+                    "You must verify your identity before providing consent for dependents aged 13-17. Would you like to verify now?",
+                    "Verify Now", "Cancel");
+
+                if (goToVerify)
+                {
+                    await Shell.Current.GoToAsync(nameof(Pages.VerifyIdentityPage));
+                }
+
+                return;
+            }
+
+            await ExecuteAsync(async () =>
+            {
+                var consent = await privoConsentRestService.InitiateChildConsentAsync(item.Dependent.Id);
+
+                if (!string.IsNullOrEmpty(consent.ConsentUrl))
+                {
+                    await Browser.Default.OpenAsync(consent.ConsentUrl, BrowserLaunchMode.SystemPreferred);
+                }
+                else
+                {
+                    await NotificationService.Notify("Consent request initiated. Check your email for a link from PRIVO.");
+                }
+
+                await Init();
+            }, "Failed to initiate consent. Please try again.");
         }
 
         [RelayCommand]


### PR DESCRIPTION
## Summary
Three features to close the web/mobile gap for dependent management:

1. **PRIVO consent button on My Dependents page** — 13+ dependents now show a "Consent" button to initiate parent-to-child PRIVO consent before they can be invited. Status badges updated: Needs Consent → Consent Pending → Ready to Invite → Invited → Account Created.

2. **Dependent waiver signing flow** (new `DependentWaiverPage`) — Parents can sign waivers on behalf of their dependents. Supports single and multi-waiver flows with waiver text display, agreement checkbox, and typed legal name.

3. **Pending waiver alerts on dashboard** — Red alert card at top of My Dashboard when a child has registered for an event requiring the parent's waiver signature. Sign button navigates directly to the signing flow.

## Files changed
- **New**: `DependentWaiverViewModel.cs`, `DependentWaiverPage.xaml/.cs`
- **Modified**: `DependentWithInvitation.cs` (consent status support), `IDependentRestService.cs` + impl (DTO method, pending waivers), `MyDependentsViewModel.cs` (consent command), `MyDependentsPage.xaml` (consent button + badges), `MyDashboardViewModel.cs` (waiver alerts), `MyDashboardPage.xaml` (alert card), `MauiProgram.cs`, `AppShell.xaml.cs`

## Test plan
- [ ] My Dependents: 13+ dependent without consent shows "Needs Consent" badge and Consent button
- [ ] Tapping Consent opens PRIVO consent flow in browser
- [ ] After consent approved, dependent shows "Ready to Invite" and Invite button
- [ ] Dashboard: when child has pending waivers, red alert card appears at top
- [ ] Tapping Sign on alert navigates to DependentWaiverPage
- [ ] DependentWaiverPage: can read waiver, agree, type name, and sign
- [ ] After all waivers signed, navigates back with success notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)