### PR TITLE
Fix EF tracking collision in PUT endpoints returning 409

### DIFF
--- a/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
+++ b/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
@@ -21,7 +21,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- Override transitive vulnerability from Microsoft.Identity.Web (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf) -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <!-- Override transitive vulnerability in Microsoft.AspNetCore.DataProtection 10.0.0 (GHSA-9mv3-2cwr-p262) -->
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TrashMob/Controllers/V2/DependentsV2Controller.cs
+++ b/TrashMob/Controllers/V2/DependentsV2Controller.cs
@@ -130,11 +130,16 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            var entity = dto.ToEntity();
-            entity.Id = dependentId;
-            entity.ParentUserId = userId;
+            existing.FirstName = dto.FirstName;
+            existing.LastName = dto.LastName;
+            existing.DateOfBirth = dto.DateOfBirth;
+            existing.Relationship = dto.Relationship;
+            existing.MedicalNotes = dto.MedicalNotes;
+            existing.EmergencyContactPhone = dto.EmergencyContactPhone;
+            existing.Email = dto.Email;
+            existing.IsActive = dto.IsActive;
 
-            var result = await dependentManager.UpdateAsync(entity, UserId, cancellationToken);
+            var result = await dependentManager.UpdateAsync(existing, UserId, cancellationToken);
 
             return Ok(result.ToV2Dto());
         }

--- a/TrashMob/Controllers/V2/JobOpportunitiesV2Controller.cs
+++ b/TrashMob/Controllers/V2/JobOpportunitiesV2Controller.cs
@@ -117,10 +117,12 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            var entity = dto.ToEntity();
-            entity.Id = id;
+            existing.Title = dto.Title;
+            existing.TagLine = dto.TagLine;
+            existing.FullDescription = dto.FullDescription;
+            existing.IsActive = dto.IsActive;
 
-            var updated = await jobOpportunityManager.UpdateAsync(entity, UserId, cancellationToken);
+            var updated = await jobOpportunityManager.UpdateAsync(existing, UserId, cancellationToken);
 
             return Ok(updated.ToV2Dto());
         }


### PR DESCRIPTION
## Summary
Fixes a bug where PUT requests to update job opportunities and dependents returned `409 Conflict` instead of `200 OK`.

## Root cause
Both affected Update methods called `SomeManager.GetAsync(id, ct)` (which tracks the entity via `FindAsync`) and then tried to pass a **new** entity instance (from `dto.ToEntity()` with `Id` set) to `UpdateAsync`. EF Core rejected this with:

> The instance of entity type 'X' cannot be tracked because another instance with the same key value for {'Id'} is already being tracked.

The `GlobalExceptionHandlerMiddleware` maps `InvalidOperationException` to `409 Conflict`.

## Fix
Mutate the already-tracked `existing` entity directly and pass it to `UpdateAsync` — this is the pattern already used in `AdoptableAreasV2Controller`.

## Affected endpoints
- `PUT /api/v2/jobopportunities/{id}`
- `PUT /api/v2/dependents/{userId}/{dependentId}`

Audited all 39 V2 controllers that call `UpdateAsync` — only these two had the bug.

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] PUT to a job opportunity (e.g., toggling IsActive) returns 200 instead of 409
- [ ] PUT to a dependent returns 200 instead of 409
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)