### PR TITLE
Add enhanced conversions data to Google Ads events

### DIFF
--- a/TrashMob/TrashMob.csproj
+++ b/TrashMob/TrashMob.csproj
@@ -57,6 +57,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
+    <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
 
   </ItemGroup>
 

--- a/TrashMob/client-app/src/components/Customization/RegisterBtn.tsx
+++ b/TrashMob/client-app/src/components/Customization/RegisterBtn.tsx
@@ -85,7 +85,7 @@ export const RegisterBtn: FC<RegisterBtnProps> = ({
 
             // Track attendance registration
             trackAttendance('Register', eventId);
-            trackRsvpConversion();
+            trackRsvpConversion(currentUser.email ? { email: currentUser.email } : undefined);
 
             // Invalidate user's list of attended events, triggering refetch
             queryClient.invalidateQueries(GetAllEventsBeingAttendedByUser({ userId }).key);

--- a/TrashMob/client-app/src/components/partner-requests/partner-request-form.tsx
+++ b/TrashMob/client-app/src/components/partner-requests/partner-request-form.tsx
@@ -108,8 +108,11 @@ export const PartnerRequestForm: React.FC<PartnerRequestFormProps> = (props) => 
     const createPartnerRequest = useMutation({
         mutationKey: CreatePartnerRequest().key,
         mutationFn: CreatePartnerRequest().service,
-        onSuccess: () => {
-            trackPartnerInquiryConversion();
+        onSuccess: (_, variables) => {
+            trackPartnerInquiryConversion({
+                email: variables.email || undefined,
+                phone_number: variables.phone || undefined,
+            });
             toast({
                 variant: 'primary',
                 title: 'Request Submitted',

--- a/TrashMob/client-app/src/hooks/useLogin.ts
+++ b/TrashMob/client-app/src/hooks/useLogin.ts
@@ -87,7 +87,7 @@ export const useLogin = () => {
                 if (user.memberSince) {
                     const ageMs = Date.now() - new Date(user.memberSince).getTime();
                     if (ageMs < 60_000) {
-                        trackSignUpConversion();
+                        trackSignUpConversion(email ? { email } : undefined);
                     }
                 }
             }

--- a/TrashMob/client-app/src/lib/analytics.ts
+++ b/TrashMob/client-app/src/lib/analytics.ts
@@ -140,7 +140,12 @@ function initAppInsightsSnippet(instrumentationKey: string): void {
     w[sdkName] = appInsights;
 }
 
-function fireGoogleAdsConversion(sendTo: string, value?: number): void {
+interface EnhancedConversionUserData {
+    email?: string;
+    phone_number?: string;
+}
+
+function fireGoogleAdsConversion(sendTo: string, value?: number, userData?: EnhancedConversionUserData): void {
     const w = window as unknown as Record<string, unknown>;
     const dataLayer = w.dataLayer as unknown[] | undefined;
     if (!dataLayer) return;
@@ -148,6 +153,13 @@ function fireGoogleAdsConversion(sendTo: string, value?: number): void {
     function gtag(...args: unknown[]) {
         dataLayer!.push(args);
     }
+
+    // Set user-provided data for enhanced conversions BEFORE firing the event.
+    // gtag.js hashes these values client-side (SHA-256) before sending to Google.
+    if (userData && (userData.email || userData.phone_number)) {
+        gtag('set', 'user_data', userData);
+    }
+
     const params: Record<string, unknown> = { send_to: sendTo };
     if (value !== undefined) {
         params.value = value;
@@ -157,23 +169,23 @@ function fireGoogleAdsConversion(sendTo: string, value?: number): void {
 }
 
 /** Fire a Google Ads conversion event for new sign-ups. */
-export function trackSignUpConversion(): void {
-    fireGoogleAdsConversion('AW-18035648449/V0zjCL3Hh48cEMHPiJhD', 1.0);
+export function trackSignUpConversion(userData?: EnhancedConversionUserData): void {
+    fireGoogleAdsConversion('AW-18035648449/V0zjCL3Hh48cEMHPiJhD', 1.0, userData);
 }
 
 /** Fire a Google Ads conversion event for event RSVPs. */
-export function trackRsvpConversion(): void {
-    fireGoogleAdsConversion('AW-18035648449/uhNBCKDbpJwcEMHPiJhD');
+export function trackRsvpConversion(userData?: EnhancedConversionUserData): void {
+    fireGoogleAdsConversion('AW-18035648449/uhNBCKDbpJwcEMHPiJhD', undefined, userData);
 }
 
 /** Fire a Google Ads conversion event for event creation by organizers. */
-export function trackEventCreatedConversion(): void {
-    fireGoogleAdsConversion('AW-18035648449/zEXMCKbbpJwcEMHPiJhD');
+export function trackEventCreatedConversion(userData?: EnhancedConversionUserData): void {
+    fireGoogleAdsConversion('AW-18035648449/zEXMCKbbpJwcEMHPiJhD', undefined, userData);
 }
 
 /** Fire a Google Ads conversion event for city partner inquiries. */
-export function trackPartnerInquiryConversion(): void {
-    fireGoogleAdsConversion('AW-18035648449/98NDCKPbpJwcEMHPiJhD');
+export function trackPartnerInquiryConversion(userData?: EnhancedConversionUserData): void {
+    fireGoogleAdsConversion('AW-18035648449/98NDCKPbpJwcEMHPiJhD', undefined, userData);
 }
 
 /** Initialize analytics scripts if the user has previously consented. */

--- a/TrashMob/client-app/src/pages/events/create.tsx
+++ b/TrashMob/client-app/src/pages/events/create.tsx
@@ -131,7 +131,7 @@ export const CreateEventPage = () => {
                     eventTypeId: variable.eventTypeId,
                     fromLitterReport: !!fromLitterReport,
                 });
-                trackEventCreatedConversion();
+                trackEventCreatedConversion(currentUser.email ? { email: currentUser.email } : undefined);
             }
 
             // If this event was created from a litter report, associate them

--- a/TrashMobDailyJobs/TrashMobDailyJobs.csproj
+++ b/TrashMobDailyJobs/TrashMobDailyJobs.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
   </ItemGroup>
   <ItemGroup>

--- a/TrashMobHourlyJobs/TrashMobHourlyJobs.csproj
+++ b/TrashMobHourlyJobs/TrashMobHourlyJobs.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TrashMob.Shared\TrashMob.Shared.csproj" />


### PR DESCRIPTION
## Summary
Google Ads flagged our Sign-up conversion as needing in-page enhanced conversion data — the conversion event was firing without any user-provided data attached, so Google can't reliably match conversions to ad clicks.

This patch passes the user's email (and phone, where available) to `gtag('set', 'user_data', ...)` before firing each conversion event. **gtag.js hashes the values client-side (SHA-256) before sending — no PII leaves the browser unhashed.**

Updated all four conversions for consistency:
- **Sign-up** — email from JWT claims at signup
- **Event RSVP** — email from `currentUser`
- **Event Created** — email from `currentUser`
- **Partner Inquiry** — email + phone from the form data (the contact info the partner provided)

## How it works
\`\`\`js
gtag('set', 'user_data', { email: 'user@example.com' });  // hashed client-side
gtag('event', 'conversion', { send_to: 'AW-XXX/YYY' });
\`\`\`

## Test plan
- [ ] Build succeeds (verified locally with \`npm run check\` — 0 errors)
- [ ] After deploy, do a fresh sign-up and confirm the conversion fires (Google Ads diagnostics has a delayed feedback loop — alert may take a few days to clear)
- [ ] Spot-check the network tab for a \`/g/collect\` request with hashed em parameter on conversion events

🤖 Generated with [Claude Code](https://claude.com/claude-code)