### PR TITLE
Show DOB requirement before PRIVO verify, expose validation messages

### DIFF
--- a/TrashMob.Shared.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
+++ b/TrashMob.Shared.Tests/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
@@ -132,6 +132,22 @@ namespace TrashMob.Shared.Tests.Middleware
         }
 
         [Fact]
+        public async Task InvokeAsync_IncludesDetail_ForMappedException_InProduction()
+        {
+            // Mapped exceptions like InvalidOperationException are intentional validation
+            // errors thrown by application code, so their messages are safe to expose.
+            var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+            var middleware = CreateMiddleware(
+                _ => throw new InvalidOperationException("Please set your date of birth on your profile."),
+                isDevelopment: false);
+
+            await middleware.InvokeAsync(context);
+
+            var problem = await GetProblemDetailsFromResponse(context);
+            Assert.Equal("Please set your date of birth on your profile.", problem.Detail);
+        }
+
+        [Fact]
         public async Task InvokeAsync_SetsContentType_ToProblemJson()
         {
             var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };

--- a/TrashMob/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/TrashMob/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -29,6 +29,17 @@ namespace TrashMob.Middleware
             [typeof(InvalidOperationException)] = (HttpStatusCode.Conflict, "Conflict"),
         };
 
+        // Mapped exceptions are intentional validation errors thrown by application code,
+        // so their messages are safe to expose to API clients in any environment.
+        private static readonly HashSet<Type> ExposeMessageInProduction =
+        [
+            typeof(ArgumentException),
+            typeof(ArgumentNullException),
+            typeof(KeyNotFoundException),
+            typeof(UnauthorizedAccessException),
+            typeof(InvalidOperationException),
+        ];
+
         public async Task InvokeAsync(HttpContext context)
         {
             try
@@ -55,12 +66,15 @@ namespace TrashMob.Middleware
 
             var statusCodeInt = (int)statusCode;
 
+            var includeMessage = environment.IsDevelopment()
+                || ExposeMessageInProduction.Contains(exception.GetType());
+
             var problemDetails = new ProblemDetails
             {
                 Type = $"https://httpstatuses.io/{statusCodeInt}",
                 Status = statusCodeInt,
                 Title = title,
-                Detail = environment.IsDevelopment() ? exception.Message : null,
+                Detail = includeMessage ? exception.Message : null,
                 Instance = context.Request.Path,
             };
 

--- a/TrashMob/client-app/src/components/privo/VerifyIdentityCard.tsx
+++ b/TrashMob/client-app/src/components/privo/VerifyIdentityCard.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { Link } from 'react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { BadgeCheck, ExternalLink, Loader2, RefreshCw, ShieldCheck } from 'lucide-react';
 
@@ -15,9 +16,10 @@ import {
 
 interface VerifyIdentityCardProps {
     isVerified: boolean;
+    hasDateOfBirth: boolean;
 }
 
-export const VerifyIdentityCard: FC<VerifyIdentityCardProps> = ({ isVerified }) => {
+export const VerifyIdentityCard: FC<VerifyIdentityCardProps> = ({ isVerified, hasDateOfBirth }) => {
     const { toast } = useToast();
     const queryClient = useQueryClient();
 
@@ -111,7 +113,16 @@ export const VerifyIdentityCard: FC<VerifyIdentityCardProps> = ({ isVerified }) 
                 </CardDescription>
             </CardHeader>
             <CardContent>
-                {isPending ? (
+                {!hasDateOfBirth ? (
+                    <div className='space-y-3'>
+                        <p className='text-sm text-muted-foreground'>
+                            PRIVO needs your date of birth to verify your identity. Please add it to your profile first.
+                        </p>
+                        <Button asChild variant='outline'>
+                            <Link to='/myprofile'>Go to My Profile</Link>
+                        </Button>
+                    </div>
+                ) : isPending ? (
                     <div className='space-y-3'>
                         <div className='flex items-center gap-2'>
                             <Badge variant='outline'>Pending</Badge>

--- a/TrashMob/client-app/src/pages/MyDashboard/index.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/index.tsx
@@ -680,7 +680,10 @@ const MyDashboard: FC<MyDashboardProps> = () => {
                                 ) : (
                                     <>
                                         <div className='mb-4'>
-                                            <VerifyIdentityCard isVerified={currentUser.isIdentityVerified} />
+                                            <VerifyIdentityCard
+                                                isVerified={currentUser.isIdentityVerified}
+                                                hasDateOfBirth={!!currentUser.dateOfBirth}
+                                            />
                                         </div>
                                         <MyDependentsCard
                                             userId={userId}

--- a/TrashMob/client-app/src/pages/myprofile/index.tsx
+++ b/TrashMob/client-app/src/pages/myprofile/index.tsx
@@ -228,7 +228,12 @@ export const MyProfile = () => {
         <div>
             <HeroSection Title='My Profile' Description='Manage your account information' />
             <div className='container mx-auto py-5 space-y-4'>
-                {!currentUser?.isMinor && <VerifyIdentityCard isVerified={currentUser?.isIdentityVerified ?? false} />}
+                {!currentUser?.isMinor && (
+                    <VerifyIdentityCard
+                        isVerified={currentUser?.isIdentityVerified ?? false}
+                        hasDateOfBirth={!!currentUser?.dateOfBirth}
+                    />
+                )}
                 {!currentUser?.isMinor && (
                     <MyDependentsCard
                         userId={currentUser?.id ?? ''}


### PR DESCRIPTION
## Summary
The PRIVO dev reported that clicking "Verify My Identity" gave a generic error. Container app logs showed:
\`\`\`
System.InvalidOperationException: Please set your date of birth on your profile before verifying your identity.
at TrashMob.Shared.Managers.PrivoConsentManager.InitiateAdultVerificationAsync (line 46)
\`\`\`

The backend correctly requires DOB before calling PRIVO, but two things hid the cause:
1. The frontend let the user click the button without checking if their profile was complete
2. \`GlobalExceptionHandlerMiddleware\` strips exception messages in production, so the response \`detail\` was \`null\` and the toast had nothing to show

## Changes
- **\`VerifyIdentityCard\`** now takes \`hasDateOfBirth\` and renders a "Go to My Profile" link when missing, before the user gets a chance to fail the click.
- **\`GlobalExceptionHandlerMiddleware\`** now exposes exception messages in production for the mapped exception types (\`Argument*\`, \`KeyNotFound\`, \`UnauthorizedAccess\`, \`InvalidOperation\`). These are intentional, user-facing validation errors thrown by application code — the messages are safe to expose. Unmapped exceptions (which fall through to 500) still hide their message in production.
- New unit test for the production-message behavior.

## Test plan
- [ ] Tests pass (10/10 verified locally)
- [ ] Build/lint clean (verified locally)
- [ ] After deploy, an unverified user with no DOB sees the "Go to My Profile" prompt instead of the verify button
- [ ] An unverified user with DOB still sees the verify button and the flow works as before
- [ ] If the backend returns \`InvalidOperationException\` for any other reason, the user sees the actual message in the toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)