### PR TITLE
Fix flaky short-username E2E test

### DIFF
--- a/TrashMob/client-app/e2e/tests/profile-edit.spec.ts
+++ b/TrashMob/client-app/e2e/tests/profile-edit.spec.ts
@@ -55,6 +55,10 @@ test.describe('Profile Edit Flow', () => {
         const usernameInput = page.locator('input[name="userName"]');
         await expect(usernameInput).toBeVisible({ timeout: 15000 });
 
+        // Wait for React Query to populate the form before editing — otherwise a
+        // late-arriving form.reset() will overwrite the test's fill().
+        await expect(usernameInput).not.toHaveValue('', { timeout: 15000 });
+
         // Save original
         const originalUsername = await usernameInput.inputValue();
 


### PR DESCRIPTION
## Summary
The \`profile-edit.spec.ts > should show validation error for short username\` test started failing on main after PR #3357 merged (E2E run [25087659874](https://github.com/TrashMob-eco/TrashMob/actions/runs/25087659874)).

## Root cause
The test races against the My Profile page's \`useEffect(() => form.reset({...}), [user])\`:

1. Page loads → user fetched → form.reset() with original username
2. \`fill('ab')\` updates the input
3. **Some render fires** → \`useEffect\` runs again → \`form.reset()\` overwrites 'ab' back to the original
4. Save click submits original (valid) username → "Profile updated!" toast
5. Test waits for "at least 3" message that never appears

The Playwright snapshot from the failure confirmed it: toast says "Profile updated!" and the username field still shows the original \`testtrashmob26\`.

PRIVO PR #3357 added two queries on the page (\`GetPrivoEnabled\`, \`GetVerificationStatus\` in \`VerifyIdentityCard\`) which added enough render churn to widen the race window from "rarely fails" to "always fails."

## Fix
Match the pattern the other tests in this file already use (e.g. line 12) — wait for the input to populate from React Query before filling. This ensures the form's controlled state has settled before the test interacts with it.

\`\`\`ts
await expect(usernameInput).toBeVisible({ timeout: 15000 });
+ await expect(usernameInput).not.toHaveValue('', { timeout: 15000 });
\`\`\`

## Test plan
- [ ] E2E run on this PR passes
- [ ] After merge, main E2E run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)