### PR TITLE
Add Date of Birth field to profile, hide redundant link

### DIFF
--- a/TrashMob/client-app/src/components/privo/VerifyIdentityCard.tsx
+++ b/TrashMob/client-app/src/components/privo/VerifyIdentityCard.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { BadgeCheck, ExternalLink, Loader2, RefreshCw, ShieldCheck } from 'lucide-react';
 
@@ -22,6 +22,8 @@ interface VerifyIdentityCardProps {
 export const VerifyIdentityCard: FC<VerifyIdentityCardProps> = ({ isVerified, hasDateOfBirth }) => {
     const { toast } = useToast();
     const queryClient = useQueryClient();
+    const location = useLocation();
+    const isOnProfilePage = location.pathname.startsWith('/myprofile');
 
     const enabledQuery = useQuery({
         queryKey: GetPrivoEnabled().key,
@@ -115,12 +117,22 @@ export const VerifyIdentityCard: FC<VerifyIdentityCardProps> = ({ isVerified, ha
             <CardContent>
                 {!hasDateOfBirth ? (
                     <div className='space-y-3'>
-                        <p className='text-sm text-muted-foreground'>
-                            PRIVO needs your date of birth to verify your identity. Please add it to your profile first.
-                        </p>
-                        <Button asChild variant='outline'>
-                            <Link to='/myprofile'>Go to My Profile</Link>
-                        </Button>
+                        {isOnProfilePage ? (
+                            <p className='text-sm text-muted-foreground'>
+                                PRIVO needs your date of birth to verify your identity. Please set it in the Profile
+                                Information section below, then save your profile.
+                            </p>
+                        ) : (
+                            <>
+                                <p className='text-sm text-muted-foreground'>
+                                    PRIVO needs your date of birth to verify your identity. Please add it to your
+                                    profile first.
+                                </p>
+                                <Button asChild variant='outline'>
+                                    <Link to='/myprofile#date-of-birth'>Go to My Profile</Link>
+                                </Button>
+                            </>
+                        )}
                     </div>
                 ) : isPending ? (
                     <div className='space-y-3'>

--- a/TrashMob/client-app/src/pages/myprofile/index.tsx
+++ b/TrashMob/client-app/src/pages/myprofile/index.tsx
@@ -27,11 +27,20 @@ const profileSchema = z.object({
         .max(64, 'Username must be at most 64 characters.'),
     givenName: z.string().max(64, 'First name must be at most 64 characters.'),
     surname: z.string().max(64, 'Last name must be at most 64 characters.'),
+    dateOfBirth: z.string(),
     city: z.string(),
     region: z.string(),
     country: z.string(),
     postalCode: z.string(),
 });
+
+// Backend returns ISO 8601 (e.g. "2026-04-24T00:00:00+00:00"); HTML date input wants YYYY-MM-DD.
+const toDateInputValue = (iso: string | null | undefined): string => {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    return d.toISOString().slice(0, 10);
+};
 
 export const MyProfile = () => {
     const navigate = useNavigate();
@@ -122,6 +131,7 @@ export const MyProfile = () => {
             userName: '',
             givenName: '',
             surname: '',
+            dateOfBirth: '',
             city: '',
             region: '',
             country: '',
@@ -136,6 +146,7 @@ export const MyProfile = () => {
             userName: user.userName,
             givenName: user.givenName || '',
             surname: user.surname || '',
+            dateOfBirth: toDateInputValue(user.dateOfBirth),
             city: user.city || '',
             region: user.region || '',
             country: user.country || '',
@@ -177,12 +188,13 @@ export const MyProfile = () => {
             body.prefersMetric = currentUser.prefersMetric;
             body.travelLimitForLocalEvents = currentUser.travelLimitForLocalEvents;
             body.isSiteAdmin = currentUser.isSiteAdmin;
-            body.dateOfBirth = currentUser.dateOfBirth;
             body.profilePhotoUrl = currentUser.profilePhotoUrl;
 
             body.userName = values.userName;
             body.givenName = values.givenName ?? '';
             body.surname = values.surname ?? '';
+            // Convert YYYY-MM-DD from <input type="date"> to ISO 8601 for DateTimeOffset?
+            body.dateOfBirth = values.dateOfBirth ? `${values.dateOfBirth}T00:00:00Z` : '';
             body.city = values.city ?? '';
             body.region = values.region ?? '';
             body.country = values.country ?? '';
@@ -365,6 +377,23 @@ export const MyProfile = () => {
                                                 <FormControl>
                                                     <Input {...field} />
                                                 </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
+                                    <FormField
+                                        control={form.control}
+                                        name='dateOfBirth'
+                                        render={({ field }) => (
+                                            <FormItem id='date-of-birth' className='col-span-12 sm:col-span-6'>
+                                                <FormLabel>Date of Birth</FormLabel>
+                                                <FormControl>
+                                                    <Input type='date' {...field} />
+                                                </FormControl>
+                                                <FormDescription>
+                                                    Required for identity verification (PRIVO).
+                                                </FormDescription>
                                                 <FormMessage />
                                             </FormItem>
                                         )}


### PR DESCRIPTION
## Summary
PRIVO dev reported they're still blocked: the Verify Identity card said "Go to My Profile" — but they were *already* on the profile page, and the profile form didn't even have a Date of Birth field to fill out.

## Two real bugs

1. **No DOB field on the profile form.** Username, names, member since, location — but no DOB. The instruction was unactionable.
2. **Redundant link on /myprofile.** The card unconditionally rendered a "Go to My Profile" button, even when the user was already on /myprofile.

## Fixes

- **Add a Date of Birth field** to the profile form (schema, default, reset-from-user, and submit conversion). The form input is YYYY-MM-DD via \`<input type="date">\`; on submit it's expanded to a full ISO 8601 string (\`...T00:00:00Z\`) so the backend's \`DateTimeOffset?\` parser is happy.
- The field is anchored with \`id="date-of-birth"\`, so deep-links from elsewhere can target it.
- **\`VerifyIdentityCard\` now uses \`useLocation()\`** to detect when it's on /myprofile. On /myprofile it shows a message pointing to the form below (no button). On /mydashboard or elsewhere, it still shows the "Go to My Profile" link, now pointing at \`/myprofile#date-of-birth\`.

## Test plan
- [ ] Build passes (verified locally — 0 errors)
- [ ] On /myprofile with no DOB: card says "set it in the section below" — no button
- [ ] On /mydashboard with no DOB: card shows "Go to My Profile" link
- [ ] Setting DOB and saving the profile clears the message and shows the verify button
- [ ] Existing users with DOB already set see the verify button as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)