### PR TITLE
Send null dateOfBirth instead of empty string on profile save

### DIFF
--- a/TrashMob/client-app/src/components/Models/UserData.tsx
+++ b/TrashMob/client-app/src/components/Models/UserData.tsx
@@ -35,7 +35,7 @@ class UserData {
 
     surname: string = '';
 
-    dateOfBirth: string = '';
+    dateOfBirth: string | null = null;
 
     profilePhotoUrl: string = '';
 

--- a/TrashMob/client-app/src/pages/myprofile/index.tsx
+++ b/TrashMob/client-app/src/pages/myprofile/index.tsx
@@ -193,8 +193,9 @@ export const MyProfile = () => {
             body.userName = values.userName;
             body.givenName = values.givenName ?? '';
             body.surname = values.surname ?? '';
-            // Convert YYYY-MM-DD from <input type="date"> to ISO 8601 for DateTimeOffset?
-            body.dateOfBirth = values.dateOfBirth ? `${values.dateOfBirth}T00:00:00Z` : '';
+            // Convert YYYY-MM-DD from <input type="date"> to ISO 8601 for DateTimeOffset?.
+            // Empty string must become null — System.Text.Json rejects "" for nullable DateTimeOffset.
+            body.dateOfBirth = values.dateOfBirth ? `${values.dateOfBirth}T00:00:00Z` : null;
             body.city = values.city ?? '';
             body.region = values.region ?? '';
             body.country = values.country ?? '';


### PR DESCRIPTION
## Summary
After PR #3365 merged, the main-branch E2E test \`profile-edit > should edit and save profile name fields\` started failing because the profile Save was returning 400 Bad Request:

\`\`\`
$.dateOfBirth: The JSON value could not be converted to
System.Nullable[System.DateTimeOffset]. Path: $.dateOfBirth ...
\`\`\`

## Root cause
The form sends \`dateOfBirth: ""\` when the user has no DOB. \`System.Text.Json\` refuses to coerce \`""\` to a nullable \`DateTimeOffset\` — it requires \`null\`.

Before #3365, the body just propagated \`currentUser.dateOfBirth\` through, which at runtime was \`null\` (the TypeScript type said \`string\` but users without a DOB actually had \`null\` from the API). #3365 swapped this to \`values.dateOfBirth\` (form input), which is genuinely an empty string when unset — and that hit the parser error.

## Fix
- Type \`UserData.dateOfBirth\` as \`string | null\` to match the actual runtime shape.
- In \`onSubmit\`, send \`null\` when the form input is empty; otherwise send the ISO 8601 datetime.

## Test plan
- [ ] Build/lint passes (verified locally)
- [ ] After deploy, profile save succeeds for users with no DOB
- [ ] Profile save succeeds when setting a DOB for the first time
- [ ] E2E run on main passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)