### PR TITLE
Bump Xcode pin to 26.4 for iOS build

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -113,7 +113,7 @@ jobs:
           if: runner.os == 'macOS'
           uses: maxim-lobanov/setup-xcode@v1
           with:
-            xcode-version: '26.3'
+            xcode-version: '26.4'
 
         - name: Import Code-Signing Certificates
           uses: Apple-Actions/import-codesign-certs@v6


### PR DESCRIPTION
## Summary
The production iOS build is failing because the .NET iOS SDK workload bumped to 26.4.10259, which requires Xcode 26.4. Our workflow is still pinned to 26.3.

\`\`\`
This version of .NET for iOS (26.4.10259) requires Xcode 26.4.
The current version of Xcode is 26.3.
\`\`\`

Same recurring pattern as previous bumps (10.0.50, 26.2 → 26.3). One-line workflow change.

## Test plan
- [ ] Mobile PR build passes on this PR (runs the iOS workflow)
- [ ] After merge to release, prod iOS build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)