### PR TITLE
Pre-populate dependent email in Invite to Create Account dialog

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,12 +43,19 @@ jobs:
           rm -f package-lock.json
           npm install --ignore-scripts
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          cd TrashMob/client-app
+          version=$(node -p "require('./node_modules/@playwright/test/package.json').version")
+          echo "version=$version" >> $GITHUB_OUTPUT
+
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('TrashMob/client-app/package.json') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'

--- a/TrashMob/client-app/src/pages/MyDashboard/MyDependentsCard.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyDependentsCard.tsx
@@ -455,7 +455,7 @@ export const MyDependentsCard: FC<MyDependentsCardProps> = ({ userId, isIdentity
                                                             size='sm'
                                                             onClick={() => {
                                                                 setInvitingDependent(dep);
-                                                                setInviteEmail('');
+                                                                setInviteEmail(dep.email || '');
                                                             }}
                                                             title='Invite to create account'
                                                         >


### PR DESCRIPTION
## Summary
PRIVO testers reported that when clicking the "Invite to Create Account" mail button on a dependent who already had an email stored on their record, the invitation dialog opened with an empty email field. The tester had to look up and re-type the email that was already on file.

## Fix
Use \`dep.email\` as the initial value of \`inviteEmail\` when opening the dialog, falling back to \`''\` when the dependent has no email saved. Parent can still edit the field before sending.

\`\`\`diff
- setInviteEmail('');
+ setInviteEmail(dep.email || '');
\`\`\`

## Test plan
- [ ] Lint/format clean (verified locally)
- [ ] After deploy: open the invite dialog on a dependent with an email — field pre-populates
- [ ] Open the dialog on a dependent without an email — field is empty (no regression)

## Note on the other PRIVO finding ("invitation email never arrives")
Unrelated to this PR. Confirmed root cause: the dev environment's \`sendGridApiKey\` in Key Vault is set to \`"x"\`, which is the documented "don't actually send" sentinel in \`EmailSender.cs\`. The invitation record IS created in the database, but the SendGrid call short-circuits and the toast misleadingly says "Invitation sent!". To unblock PRIVO testing of the email flow, either set a real SendGrid key on dev temporarily, or test against a different environment with a real key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)