### PR TITLE
Add Privo--BaseUrl to documented prod Key Vault secrets

### DIFF
--- a/Planning/Projects/Project_23_Parental_Consent.md
+++ b/Planning/Projects/Project_23_Parental_Consent.md
@@ -42,6 +42,7 @@ PRIVO confirmed prod activation on their side; TrashMob enabled the integration 
 
 **Prod Key Vault (`kv-tm-pr-westus2`) configured:**
 - `Privo--Enabled` = `true`
+- `Privo--BaseUrl` = `https://consent-svc.privo.com` (set May 20; without this, `PrivoService` defaults to the INT URL hardcoded in the service)
 - `Privo--RedirectBaseUrl` = `https://www.trashmob.eco`
 - `Privo-ClientId` — production OAuth client (set May 20)
 - `Privo-ClientSecret` — production OAuth secret (set May 20)


### PR DESCRIPTION
## Summary
Follow-up to #3369. The first prod verify attempt after enabling PRIVO 409'd because \`Privo--BaseUrl\` wasn't set in prod Key Vault — \`PrivoService\` fell back to the INT URL hardcoded in the service (\`https://consent-svc-int.privo.com\`), and PRIVO's INT environment didn't recognize the prod client ID.

The secret has been added in prod (\`https://consent-svc.privo.com\`), the prod container app was restarted, and verification succeeded. This PR just keeps the deployment status documentation accurate so future ops aren't missing this secret from the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)