### PR TITLE
Project 60 Phase 1: ProspectContact model + drop legacy contact fields

### DIFF
--- a/TrashMob.Models/CommunityProspect.cs
+++ b/TrashMob.Models/CommunityProspect.cs
@@ -25,14 +25,6 @@ namespace TrashMob.Models
 
         public string Website { get; set; }
 
-        public string ContactEmail { get; set; }
-
-        public string ContactName { get; set; }
-
-        public string ContactTitle { get; set; }
-
-        public string ContactPhone { get; set; }
-
         public int PipelineStage { get; set; }
 
         public int FitScore { get; set; }
@@ -44,6 +36,8 @@ namespace TrashMob.Models
         public DateTimeOffset? NextFollowUpDate { get; set; }
 
         public Guid? ConvertedPartnerId { get; set; }
+
+        public virtual ICollection<ProspectContact> Contacts { get; set; } = [];
 
         public virtual ICollection<ProspectActivity> Activities { get; set; } = [];
 

--- a/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
@@ -1,5 +1,6 @@
 namespace TrashMob.Models.Extensions.V2
 {
+    using System.Linq;
     using TrashMob.Models.Poco.V2;
 
     /// <summary>
@@ -429,10 +430,15 @@ namespace TrashMob.Models.Extensions.V2
         #region CommunityProspect
 
         /// <summary>
-        /// Maps a CommunityProspect entity to a V2 CommunityProspectDto.
+        /// Maps a CommunityProspect entity to a V2 CommunityProspectDto. The legacy flat
+        /// contact fields (ContactName / ContactEmail / ContactTitle / ContactPhone) are
+        /// populated from the primary <see cref="ProspectContact"/> as a backward-compat
+        /// shortcut. Requires <see cref="CommunityProspect.Contacts"/> to be loaded.
         /// </summary>
         public static CommunityProspectDto ToV2Dto(this CommunityProspect entity)
         {
+            var primary = entity.GetPrimaryContact();
+
             return new CommunityProspectDto
             {
                 Id = entity.Id,
@@ -445,22 +451,26 @@ namespace TrashMob.Models.Extensions.V2
                 Longitude = entity.Longitude,
                 Population = entity.Population,
                 Website = entity.Website,
-                ContactEmail = entity.ContactEmail,
-                ContactName = entity.ContactName,
-                ContactTitle = entity.ContactTitle,
-                ContactPhone = entity.ContactPhone,
+                ContactEmail = primary?.Email,
+                ContactName = primary?.Name,
+                ContactTitle = primary?.Title,
+                ContactPhone = primary?.Phone,
                 PipelineStage = entity.PipelineStage,
                 FitScore = entity.FitScore,
                 Notes = entity.Notes,
                 LastContactedDate = entity.LastContactedDate,
                 NextFollowUpDate = entity.NextFollowUpDate,
                 ConvertedPartnerId = entity.ConvertedPartnerId,
+                Contacts = entity.Contacts?.Select(c => c.ToV2Dto()).ToList() ?? [],
                 CreatedDate = entity.CreatedDate,
             };
         }
 
         /// <summary>
-        /// Maps a V2 CommunityProspectDto to a CommunityProspect entity.
+        /// Maps a V2 CommunityProspectDto to a CommunityProspect entity. The legacy flat
+        /// contact fields on the DTO are NOT applied here — callers (controller / manager)
+        /// must call <see cref="HasLegacyContactFields"/> and orchestrate the primary
+        /// contact upsert separately.
         /// </summary>
         public static CommunityProspect ToEntity(this CommunityProspectDto dto)
         {
@@ -476,16 +486,89 @@ namespace TrashMob.Models.Extensions.V2
                 Longitude = dto.Longitude,
                 Population = dto.Population,
                 Website = dto.Website,
-                ContactEmail = dto.ContactEmail,
-                ContactName = dto.ContactName,
-                ContactTitle = dto.ContactTitle,
-                ContactPhone = dto.ContactPhone,
                 PipelineStage = dto.PipelineStage,
                 FitScore = dto.FitScore,
                 Notes = dto.Notes,
                 LastContactedDate = dto.LastContactedDate,
                 NextFollowUpDate = dto.NextFollowUpDate,
                 ConvertedPartnerId = dto.ConvertedPartnerId,
+            };
+        }
+
+        /// <summary>
+        /// Returns the primary contact for a prospect, or null. Falls back to the first
+        /// contact if no row is explicitly flagged primary (defensive — should not happen
+        /// for migrated data).
+        /// </summary>
+        public static ProspectContact? GetPrimaryContact(this CommunityProspect entity)
+        {
+            if (entity.Contacts == null)
+            {
+                return null;
+            }
+
+            return entity.Contacts.FirstOrDefault(c => c.IsPrimary)
+                ?? entity.Contacts.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Returns true if the DTO has any non-whitespace legacy contact field set.
+        /// Used by controllers to decide whether to upsert the primary contact after
+        /// a prospect create/update.
+        /// </summary>
+        public static bool HasLegacyContactFields(this CommunityProspectDto dto)
+        {
+            return !string.IsNullOrWhiteSpace(dto.ContactName)
+                || !string.IsNullOrWhiteSpace(dto.ContactEmail)
+                || !string.IsNullOrWhiteSpace(dto.ContactTitle)
+                || !string.IsNullOrWhiteSpace(dto.ContactPhone);
+        }
+
+        #endregion
+
+        #region ProspectContact
+
+        /// <summary>
+        /// Maps a ProspectContact entity to a V2 ProspectContactDto.
+        /// </summary>
+        public static ProspectContactDto ToV2Dto(this ProspectContact entity)
+        {
+            return new ProspectContactDto
+            {
+                Id = entity.Id,
+                ProspectId = entity.ProspectId,
+                Name = entity.Name ?? string.Empty,
+                Title = entity.Title,
+                Email = entity.Email,
+                Phone = entity.Phone,
+                Role = entity.Role,
+                ContactStatus = entity.ContactStatus,
+                IsPrimary = entity.IsPrimary,
+                ReferredByContactId = entity.ReferredByContactId,
+                Notes = entity.Notes,
+                CreatedDate = entity.CreatedDate,
+                LastUpdatedDate = entity.LastUpdatedDate,
+            };
+        }
+
+        /// <summary>
+        /// Maps a V2 ProspectContactDto to a ProspectContact entity.
+        /// </summary>
+        public static ProspectContact ToEntity(this ProspectContactDto dto)
+        {
+            return new ProspectContact
+            {
+                Id = dto.Id,
+                ProspectId = dto.ProspectId,
+                Name = dto.Name ?? string.Empty,
+                Title = dto.Title,
+                Email = dto.Email,
+                Phone = dto.Phone,
+                Role = dto.Role,
+                ContactStatus = dto.ContactStatus,
+                IsPrimary = dto.IsPrimary,
+                ReferredByContactId = dto.ReferredByContactId,
+                Notes = dto.Notes,
             };
         }
 

--- a/TrashMob.Models/Poco/V2/CommunityProspectDto.cs
+++ b/TrashMob.Models/Poco/V2/CommunityProspectDto.cs
@@ -3,6 +3,7 @@
 namespace TrashMob.Models.Poco.V2
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// V2 API representation of a community prospect. Flat DTO excluding navigation properties.
@@ -60,22 +61,27 @@ namespace TrashMob.Models.Poco.V2
         public string? Website { get; set; }
 
         /// <summary>
-        /// Gets or sets the contact email.
+        /// Gets or sets the primary contact email. Backward-compat: maps to the prospect's
+        /// primary <see cref="ProspectContactDto"/>. Will be removed once frontend migrates
+        /// to the dedicated /contacts endpoints (Project 60 Phase 3).
         /// </summary>
         public string? ContactEmail { get; set; }
 
         /// <summary>
-        /// Gets or sets the contact name.
+        /// Gets or sets the primary contact name. Backward-compat shortcut for the primary
+        /// <see cref="ProspectContactDto"/>.
         /// </summary>
         public string? ContactName { get; set; }
 
         /// <summary>
-        /// Gets or sets the contact title.
+        /// Gets or sets the primary contact title. Backward-compat shortcut for the primary
+        /// <see cref="ProspectContactDto"/>.
         /// </summary>
         public string? ContactTitle { get; set; }
 
         /// <summary>
-        /// Gets or sets the contact phone.
+        /// Gets or sets the primary contact phone. Backward-compat shortcut for the primary
+        /// <see cref="ProspectContactDto"/>.
         /// </summary>
         public string? ContactPhone { get; set; }
 
@@ -108,6 +114,13 @@ namespace TrashMob.Models.Poco.V2
         /// Gets or sets the partner identifier if this prospect was converted.
         /// </summary>
         public Guid? ConvertedPartnerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contacts associated with this prospect (Project 60).
+        /// Populated on read; ignored on write — contacts are managed via the dedicated
+        /// /contacts endpoints introduced in Phase 2.
+        /// </summary>
+        public List<ProspectContactDto> Contacts { get; set; } = [];
 
         /// <summary>
         /// Gets or sets when the prospect was created.

--- a/TrashMob.Models/Poco/V2/ProspectContactDto.cs
+++ b/TrashMob.Models/Poco/V2/ProspectContactDto.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a prospect contact. Flat DTO excluding navigation properties.
+    /// </summary>
+    public class ProspectContactDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the prospect identifier.
+        /// </summary>
+        public Guid ProspectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact's name.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the contact's job title.
+        /// </summary>
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact email.
+        /// </summary>
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact phone number.
+        /// </summary>
+        public string? Phone { get; set; }
+
+        /// <summary>
+        /// Gets or sets a free-text role descriptor.
+        /// </summary>
+        public string? Role { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lifecycle status (Active, WrongPerson, NoResponse, LeftOrganization, RightPerson).
+        /// </summary>
+        public int ContactStatus { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this is the primary contact for the prospect.
+        /// </summary>
+        public bool IsPrimary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id of the contact that referred us to this one, if any.
+        /// </summary>
+        public Guid? ReferredByContactId { get; set; }
+
+        /// <summary>
+        /// Gets or sets notes about this contact.
+        /// </summary>
+        public string? Notes { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the contact record was created.
+        /// </summary>
+        public DateTimeOffset? CreatedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets when the contact record was last updated.
+        /// </summary>
+        public DateTimeOffset? LastUpdatedDate { get; set; }
+    }
+}

--- a/TrashMob.Models/ProspectActivity.cs
+++ b/TrashMob.Models/ProspectActivity.cs
@@ -8,6 +8,8 @@ namespace TrashMob.Models
     {
         public Guid ProspectId { get; set; }
 
+        public Guid? ProspectContactId { get; set; }
+
         public string ActivityType { get; set; }
 
         public string Subject { get; set; }
@@ -17,5 +19,7 @@ namespace TrashMob.Models
         public string SentimentScore { get; set; }
 
         public virtual CommunityProspect Prospect { get; set; }
+
+        public virtual ProspectContact Contact { get; set; }
     }
 }

--- a/TrashMob.Models/ProspectContact.cs
+++ b/TrashMob.Models/ProspectContact.cs
@@ -1,0 +1,96 @@
+#nullable disable
+
+namespace TrashMob.Models
+{
+    using System;
+
+    /// <summary>
+    /// A person (or generic mailbox) at a CommunityProspect organization. A prospect
+    /// can have multiple contacts so outreach history is preserved as we try different
+    /// people before finding the right one.
+    /// </summary>
+    public class ProspectContact : KeyedModel
+    {
+        /// <summary>
+        /// Gets or sets the prospect this contact belongs to.
+        /// </summary>
+        public Guid ProspectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact's name (person or mailbox label).
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact's job title at the prospect organization.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact email address.
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact phone number.
+        /// </summary>
+        public string Phone { get; set; }
+
+        /// <summary>
+        /// Gets or sets a free-text role descriptor (e.g., "Decision-maker", "Gatekeeper", "Referral").
+        /// </summary>
+        public string Role { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current status of this contact. See <see cref="ProspectContactStatus"/>.
+        /// </summary>
+        public int ContactStatus { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this contact is the current best (primary)
+        /// contact for the prospect. At most one ProspectContact per prospect should have IsPrimary=true.
+        /// </summary>
+        public bool IsPrimary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id of the ProspectContact that pointed us at this contact, if any.
+        /// </summary>
+        public Guid? ReferredByContactId { get; set; }
+
+        /// <summary>
+        /// Gets or sets free-form notes about this specific person.
+        /// </summary>
+        public string Notes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent prospect navigation property.
+        /// </summary>
+        public virtual CommunityProspect Prospect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact who referred us to this contact, if any.
+        /// </summary>
+        public virtual ProspectContact ReferredByContact { get; set; }
+    }
+
+    /// <summary>
+    /// Lifecycle status for a <see cref="ProspectContact"/>.
+    /// </summary>
+    public enum ProspectContactStatus
+    {
+        /// <summary>Default state — this contact is in play.</summary>
+        Active = 0,
+
+        /// <summary>Contact responded but is not the right person to talk to.</summary>
+        WrongPerson = 1,
+
+        /// <summary>Contact has not responded to multiple outreach attempts.</summary>
+        NoResponse = 2,
+
+        /// <summary>Contact has left the organization (per their reply or a bounce).</summary>
+        LeftOrganization = 3,
+
+        /// <summary>Contact is confirmed as the right decision-maker.</summary>
+        RightPerson = 4,
+    }
+}

--- a/TrashMob.Models/ProspectOutreachEmail.cs
+++ b/TrashMob.Models/ProspectOutreachEmail.cs
@@ -15,6 +15,12 @@ namespace TrashMob.Models
         public Guid ProspectId { get; set; }
 
         /// <summary>
+        /// Gets or sets the specific ProspectContact this email was sent to, if known.
+        /// Null for emails sent before per-contact tracking was introduced.
+        /// </summary>
+        public Guid? ProspectContactId { get; set; }
+
+        /// <summary>
         /// Gets or sets the cadence step (1=Initial, 2=Follow-up, 3=Value-add, 4=Final).
         /// </summary>
         public int CadenceStep { get; set; }
@@ -58,5 +64,10 @@ namespace TrashMob.Models
         /// Gets or sets the associated prospect.
         /// </summary>
         public virtual CommunityProspect Prospect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the associated prospect contact, if a specific person was targeted.
+        /// </summary>
+        public virtual ProspectContact Contact { get; set; }
     }
 }

--- a/TrashMob.Shared.Tests/Builders/CommunityProspectBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/CommunityProspectBuilder.cs
@@ -1,6 +1,7 @@
 namespace TrashMob.Shared.Tests.Builders
 {
     using System;
+    using System.Linq;
     using TrashMob.Models;
 
     /// <summary>
@@ -86,9 +87,35 @@ namespace TrashMob.Shared.Tests.Builders
 
         public CommunityProspectBuilder WithContactInfo(string email, string name, string title)
         {
-            _prospect.ContactEmail = email;
-            _prospect.ContactName = name;
-            _prospect.ContactTitle = title;
+            return WithPrimaryContact(name: name, email: email, title: title);
+        }
+
+        public CommunityProspectBuilder WithPrimaryContact(string name, string email = null, string title = null, string phone = null)
+        {
+            var creatorId = _prospect.CreatedByUserId == Guid.Empty ? Guid.NewGuid() : _prospect.CreatedByUserId;
+
+            // Remove any existing primary contact so callers can chain WithPrimaryContact to replace.
+            foreach (var existing in _prospect.Contacts.Where(c => c.IsPrimary).ToList())
+            {
+                _prospect.Contacts.Remove(existing);
+            }
+
+            _prospect.Contacts.Add(new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = _prospect.Id,
+                Name = name,
+                Email = email,
+                Title = title,
+                Phone = phone,
+                ContactStatus = (int)ProspectContactStatus.Active,
+                IsPrimary = true,
+                CreatedByUserId = creatorId,
+                CreatedDate = DateTimeOffset.UtcNow,
+                LastUpdatedByUserId = creatorId,
+                LastUpdatedDate = DateTimeOffset.UtcNow,
+            });
+
             return this;
         }
 

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunityProspectsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunityProspectsV2ControllerTests.cs
@@ -125,6 +125,9 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             communityProspectManager
                 .Setup(m => m.AddAsync(It.IsAny<CommunityProspect>(), testUserId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(createdProspect);
+            communityProspectManager
+                .Setup(m => m.GetAsync(createdProspect.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createdProspect);
 
             var result = await controller.Create(prospectDto, CancellationToken.None);
 

--- a/TrashMob.Shared.Tests/Managers/Prospects/CsvImportManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/CsvImportManagerTests.cs
@@ -19,6 +19,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
     public class CsvImportManagerTests
     {
         private readonly Mock<IKeyedRepository<CommunityProspect>> _prospectRepo;
+        private readonly Mock<IKeyedRepository<ProspectContact>> _contactRepo;
         private readonly Mock<IProspectScoringManager> _scoringManager;
         private readonly Mock<ILogger<CsvImportManager>> _logger;
         private readonly CsvImportManager _sut;
@@ -28,17 +29,19 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public CsvImportManagerTests()
         {
             _prospectRepo = new Mock<IKeyedRepository<CommunityProspect>>();
+            _contactRepo = new Mock<IKeyedRepository<ProspectContact>>();
             _scoringManager = new Mock<IProspectScoringManager>();
             _logger = new Mock<ILogger<CsvImportManager>>();
 
             _prospectRepo.SetupGet(new List<CommunityProspect>());
             _prospectRepo.SetupAddAsync();
+            _contactRepo.SetupAddAsync();
 
             _scoringManager
                 .Setup(s => s.CalculateFitScoreAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FitScoreBreakdown { TotalScore = 50 });
 
-            _sut = new CsvImportManager(_prospectRepo.Object, _scoringManager.Object, _logger.Object);
+            _sut = new CsvImportManager(_prospectRepo.Object, _contactRepo.Object, _scoringManager.Object, _logger.Object);
         }
 
         [Fact]

--- a/TrashMob.Shared.Tests/Managers/Prospects/ProspectConversionManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/ProspectConversionManagerTests.cs
@@ -36,6 +36,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
             _logger = new Mock<ILogger<ProspectConversionManager>>();
 
             _prospectRepo.SetupUpdateAsync();
+            _prospectRepo.SetupGet(new List<CommunityProspect>());
             _activityRepo.SetupAddAsync();
 
             _sut = new ProspectConversionManager(
@@ -114,7 +115,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         {
             var prospect = CreateProspect();
             prospect.ConvertedPartnerId = Guid.NewGuid();
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
 
             var result = await _sut.ConvertToPartnerAsync(
                 new ProspectConversionRequest { ProspectId = prospect.Id },
@@ -194,7 +195,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
 
         private void SetupForConversion(CommunityProspect prospect)
         {
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
 
             _partnerManager.Setup(m => m.AddAsync(It.IsAny<Partner>(), _userId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Partner p, Guid _, CancellationToken _) =>

--- a/TrashMob.Shared.Tests/Managers/Prospects/ProspectOutreachManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/ProspectOutreachManagerTests.cs
@@ -50,6 +50,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
             _outreachEmailRepo.SetupAddAsync();
             _activityRepo.SetupAddAsync();
             _prospectRepo.SetupUpdateAsync();
+            _prospectRepo.SetupGet(new List<CommunityProspect>());
 
             _sut = new ProspectOutreachManager(
                 _prospectRepo.Object,
@@ -93,8 +94,8 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         {
             var prospect = new CommunityProspectBuilder().Build();
             prospect.PipelineStage = 5;
-            prospect.ContactEmail = "test@example.com";
-            _prospectRepo.SetupGetAsync(prospect);
+            AddPrimaryContact(prospect, "test@example.com");
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
 
             var result = await _sut.SendOutreachAsync(prospect.Id, Guid.NewGuid());
@@ -107,8 +108,8 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_WhenNoContactEmail_ReturnsFailure()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = null;
-            _prospectRepo.SetupGetAsync(prospect);
+            // No primary contact added — exercise the "no contact email" failure path.
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
 
             // In test mode, test recipient email is used, so this won't fail for missing contact email.
@@ -126,8 +127,8 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_WhenCadenceComplete_ReturnsFailure()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
-            _prospectRepo.SetupGetAsync(prospect);
+            AddPrimaryContact(prospect, "test@example.com");
+            _prospectRepo.SetupGet(new[] { prospect });
 
             // Set up 4 existing outreach emails (cadence complete)
             var existingEmails = Enumerable.Range(1, 4).Select(step =>
@@ -147,9 +148,9 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_SuccessfulSend_CreatesEmailAndActivity()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
+            AddPrimaryContact(prospect, "test@example.com");
             prospect.PipelineStage = 0;
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
             SetupContentService(prospect.Id, 1);
 
@@ -170,9 +171,9 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_AdvancesPipelineStage_FromNewToContacted()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
+            AddPrimaryContact(prospect, "test@example.com");
             prospect.PipelineStage = 0;
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
             SetupContentService(prospect.Id, 1);
 
@@ -189,9 +190,9 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_TestMode_SendsToTestEmail()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "real@example.com";
+            AddPrimaryContact(prospect, "real@example.com");
             prospect.PipelineStage = 0;
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
             SetupContentService(prospect.Id, 1);
 
@@ -218,9 +219,9 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
             var sut = CreateSut();
 
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "real@example.com";
+            AddPrimaryContact(prospect, "real@example.com");
             prospect.PipelineStage = 0;
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
             SetupContentService(prospect.Id, 1);
 
@@ -244,9 +245,9 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_SetsNextFollowUpDate()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
+            AddPrimaryContact(prospect, "test@example.com");
             prospect.PipelineStage = 0;
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
             SetupContentService(prospect.Id, 1);
 
@@ -263,9 +264,9 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_WithCustomContent_UsesCustomContentInsteadOfAI()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
+            AddPrimaryContact(prospect, "test@example.com");
             prospect.PipelineStage = 0;
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
 
             _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>()))
@@ -306,9 +307,9 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendOutreach_WithEmptyCustomContent_FallsBackToAIGeneration()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
+            AddPrimaryContact(prospect, "test@example.com");
             prospect.PipelineStage = 0;
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
             SetupEmptyOutreachHistory();
             SetupContentService(prospect.Id, 1);
 
@@ -346,8 +347,8 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task PreviewOutreach_DeterminesCorrectCadenceStep()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
-            _prospectRepo.SetupGetAsync(prospect);
+            AddPrimaryContact(prospect, "test@example.com");
+            _prospectRepo.SetupGet(new[] { prospect });
 
             // One existing email at step 1
             var existingEmails = new List<ProspectOutreachEmail>
@@ -371,11 +372,11 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task SendBatchOutreach_ProcessesMultipleProspects()
         {
             var prospect1 = new CommunityProspectBuilder().Build();
-            prospect1.ContactEmail = "p1@example.com";
+            AddPrimaryContact(prospect1, "p1@example.com");
             var prospect2 = new CommunityProspectBuilder().Build();
-            prospect2.ContactEmail = "p2@example.com";
+            AddPrimaryContact(prospect2, "p2@example.com");
 
-            _prospectRepo.SetupGetAsync(new[] { prospect1, prospect2 });
+            _prospectRepo.SetupGet(new[] { prospect1, prospect2 });
             SetupEmptyOutreachHistory();
             _contentService.Setup(s => s.GenerateOutreachContentAsync(
                     It.IsAny<CommunityProspect>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
@@ -411,12 +412,12 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         public async Task ProcessDueFollowUps_ProcessesDueProspects()
         {
             var prospect = new CommunityProspectBuilder().Build();
-            prospect.ContactEmail = "test@example.com";
+            AddPrimaryContact(prospect, "test@example.com");
             prospect.PipelineStage = 1;
             prospect.NextFollowUpDate = DateTimeOffset.UtcNow.AddHours(-1);
 
             _prospectRepo.SetupGetWithFilter(new[] { prospect });
-            _prospectRepo.SetupGetAsync(prospect);
+            _prospectRepo.SetupGet(new[] { prospect });
 
             // One existing email at step 1
             var existingEmails = new List<ProspectOutreachEmail>
@@ -484,6 +485,19 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
         private void SetupEmptyOutreachHistory()
         {
             _outreachEmailRepo.SetupGetWithFilter(new List<ProspectOutreachEmail>());
+        }
+
+        private static void AddPrimaryContact(CommunityProspect prospect, string email, string name = "Primary Contact")
+        {
+            prospect.Contacts.Add(new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospect.Id,
+                Name = name,
+                Email = email,
+                ContactStatus = (int)ProspectContactStatus.Active,
+                IsPrimary = true,
+            });
         }
 
         private void SetupContentService(Guid prospectId, int expectedStep)

--- a/TrashMob.Shared/Extensions/CommunityProspectExtensions.cs
+++ b/TrashMob.Shared/Extensions/CommunityProspectExtensions.cs
@@ -1,6 +1,7 @@
 namespace TrashMob.Shared.Extensions
 {
     using System;
+    using System.Linq;
     using TrashMob.Models;
 
     /// <summary>
@@ -9,19 +10,23 @@ namespace TrashMob.Shared.Extensions
     public static class CommunityProspectExtensions
     {
         /// <summary>
-        /// Converts a CommunityProspect to a new Partner entity with an associated PartnerContact.
+        /// Converts a CommunityProspect to a new Partner entity, copying the primary
+        /// ProspectContact (if one exists) into a PartnerContact.
         /// </summary>
-        /// <param name="prospect">The prospect to convert.</param>
+        /// <param name="prospect">The prospect to convert. Caller is responsible for loading <see cref="CommunityProspect.Contacts"/>.</param>
         /// <param name="partnerTypeId">The partner type ID to assign.</param>
         /// <returns>A new Partner entity with the prospect data.</returns>
         public static Partner ToPartner(this CommunityProspect prospect, int partnerTypeId)
         {
+            var primaryContact = prospect.Contacts?.FirstOrDefault(c => c.IsPrimary)
+                ?? prospect.Contacts?.FirstOrDefault();
+
             var partner = new Partner
             {
                 Id = Guid.NewGuid(),
                 Name = prospect.Name,
                 Website = prospect.Website,
-                ContactEmail = prospect.ContactEmail,
+                ContactEmail = primaryContact?.Email,
                 City = prospect.City,
                 Region = prospect.Region,
                 Country = prospect.Country,
@@ -36,16 +41,14 @@ namespace TrashMob.Shared.Extensions
                 LastUpdatedDate = DateTimeOffset.UtcNow,
             };
 
-            if (!string.IsNullOrWhiteSpace(prospect.ContactName))
+            if (primaryContact != null && !string.IsNullOrWhiteSpace(primaryContact.Name))
             {
-                var partnerContact = new PartnerContact
+                partner.PartnerContacts.Add(new PartnerContact
                 {
                     Id = Guid.NewGuid(),
-                    Name = prospect.ContactName,
-                    Email = prospect.ContactEmail,
-                };
-
-                partner.PartnerContacts.Add(partnerContact);
+                    Name = primaryContact.Name,
+                    Email = primaryContact.Email,
+                });
             }
 
             return partner;

--- a/TrashMob.Shared/Managers/Prospects/CommunityProspectManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/CommunityProspectManager.cs
@@ -7,15 +7,32 @@ namespace TrashMob.Shared.Managers.Prospects
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using TrashMob.Models;
+    using TrashMob.Shared.Managers;
     using TrashMob.Shared.Persistence.Interfaces;
 
-    public class CommunityProspectManager(IKeyedRepository<CommunityProspect> repository)
+    public class CommunityProspectManager(
+        IKeyedRepository<CommunityProspect> repository,
+        IKeyedRepository<ProspectContact> contactRepository)
         : KeyedManager<CommunityProspect>(repository), ICommunityProspectManager
     {
+        public override Task<CommunityProspect> GetAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            return Repo.Get()
+                .Include(p => p.Contacts)
+                .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+        }
+
+        public override async Task<IEnumerable<CommunityProspect>> GetAsync(CancellationToken cancellationToken = default)
+        {
+            return await Repo.Get()
+                .Include(p => p.Contacts)
+                .ToListAsync(cancellationToken);
+        }
 
         public async Task<IEnumerable<CommunityProspect>> GetByPipelineStageAsync(int stage, CancellationToken cancellationToken = default)
         {
             return await Repo.Get()
+                .Include(p => p.Contacts)
                 .Where(p => p.PipelineStage == stage)
                 .OrderByDescending(p => p.FitScore)
                 .ToListAsync(cancellationToken);
@@ -24,14 +41,17 @@ namespace TrashMob.Shared.Managers.Prospects
         public async Task<IEnumerable<CommunityProspect>> SearchAsync(string searchTerm, CancellationToken cancellationToken = default)
         {
             var term = searchTerm.Trim().ToLowerInvariant();
+            var like = $"%{term}%";
 
             return await Repo.Get()
+                .Include(p => p.Contacts)
                 .Where(p =>
-                    EF.Functions.Like(p.Name, $"%{term}%") ||
-                    EF.Functions.Like(p.City, $"%{term}%") ||
-                    EF.Functions.Like(p.Region, $"%{term}%") ||
-                    EF.Functions.Like(p.ContactName, $"%{term}%") ||
-                    EF.Functions.Like(p.ContactEmail, $"%{term}%"))
+                    EF.Functions.Like(p.Name, like) ||
+                    EF.Functions.Like(p.City, like) ||
+                    EF.Functions.Like(p.Region, like) ||
+                    p.Contacts.Any(c =>
+                        EF.Functions.Like(c.Name, like) ||
+                        EF.Functions.Like(c.Email, like)))
                 .OrderByDescending(p => p.FitScore)
                 .ToListAsync(cancellationToken);
         }
@@ -50,6 +70,71 @@ namespace TrashMob.Shared.Managers.Prospects
             prospect.LastUpdatedDate = DateTimeOffset.UtcNow;
 
             return await Repo.UpdateAsync(prospect);
+        }
+
+        public async Task<ProspectContact> UpsertPrimaryContactAsync(
+            Guid prospectId,
+            string name,
+            string email,
+            string title,
+            string phone,
+            Guid userId,
+            CancellationToken cancellationToken = default)
+        {
+            // Find the existing primary contact, if any.
+            var primary = await contactRepository.Get()
+                .Where(c => c.ProspectId == prospectId && c.IsPrimary)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            var now = DateTimeOffset.UtcNow;
+
+            if (primary == null)
+            {
+                primary = new ProspectContact
+                {
+                    Id = Guid.NewGuid(),
+                    ProspectId = prospectId,
+                    Name = string.IsNullOrWhiteSpace(name) ? "(unknown)" : name,
+                    Email = email,
+                    Title = title,
+                    Phone = phone,
+                    ContactStatus = (int)ProspectContactStatus.Active,
+                    IsPrimary = true,
+                    CreatedByUserId = userId,
+                    CreatedDate = now,
+                    LastUpdatedByUserId = userId,
+                    LastUpdatedDate = now,
+                };
+
+                return await contactRepository.AddAsync(primary);
+            }
+
+            // Update fields that were provided (treat empty string as "no change" too — callers
+            // who want to clear a field should use the dedicated contacts API in Phase 2).
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                primary.Name = name;
+            }
+
+            if (!string.IsNullOrWhiteSpace(email))
+            {
+                primary.Email = email;
+            }
+
+            if (!string.IsNullOrWhiteSpace(title))
+            {
+                primary.Title = title;
+            }
+
+            if (!string.IsNullOrWhiteSpace(phone))
+            {
+                primary.Phone = phone;
+            }
+
+            primary.LastUpdatedByUserId = userId;
+            primary.LastUpdatedDate = now;
+
+            return await contactRepository.UpdateAsync(primary);
         }
     }
 }

--- a/TrashMob.Shared/Managers/Prospects/CsvImportManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/CsvImportManager.cs
@@ -18,6 +18,7 @@ namespace TrashMob.Shared.Managers.Prospects
     /// </summary>
     public class CsvImportManager(
         IKeyedRepository<CommunityProspect> prospectRepository,
+        IKeyedRepository<ProspectContact> contactRepository,
         IProspectScoringManager scoringManager,
         ILogger<CsvImportManager> logger)
         : ICsvImportManager
@@ -92,6 +93,10 @@ namespace TrashMob.Shared.Managers.Prospects
                     population = pop;
                 }
 
+                var contactEmail = fields[7].Trim();
+                var contactName = fields[8].Trim();
+                var contactTitle = fields[9].Trim();
+
                 var prospect = new CommunityProspect
                 {
                     Id = Guid.NewGuid(),
@@ -102,9 +107,6 @@ namespace TrashMob.Shared.Managers.Prospects
                     Country = fields[4].Trim(),
                     Population = population,
                     Website = fields[6].Trim(),
-                    ContactEmail = fields[7].Trim(),
-                    ContactName = fields[8].Trim(),
-                    ContactTitle = fields[9].Trim(),
                     PipelineStage = 0,
                     FitScore = 0,
                     CreatedByUserId = userId,
@@ -116,6 +118,28 @@ namespace TrashMob.Shared.Managers.Prospects
                 try
                 {
                     var added = await prospectRepository.AddAsync(prospect);
+
+                    // Create the primary contact if any contact field is present in the CSV row.
+                    if (!string.IsNullOrWhiteSpace(contactName)
+                        || !string.IsNullOrWhiteSpace(contactEmail)
+                        || !string.IsNullOrWhiteSpace(contactTitle))
+                    {
+                        var primaryContact = new ProspectContact
+                        {
+                            Id = Guid.NewGuid(),
+                            ProspectId = added.Id,
+                            Name = string.IsNullOrWhiteSpace(contactName) ? "(unknown)" : contactName,
+                            Email = contactEmail,
+                            Title = contactTitle,
+                            ContactStatus = (int)ProspectContactStatus.Active,
+                            IsPrimary = true,
+                            CreatedByUserId = userId,
+                            CreatedDate = DateTimeOffset.UtcNow,
+                            LastUpdatedByUserId = userId,
+                            LastUpdatedDate = DateTimeOffset.UtcNow,
+                        };
+                        await contactRepository.AddAsync(primaryContact);
+                    }
 
                     // Calculate and persist FitScore
                     var breakdown = await scoringManager.CalculateFitScoreAsync(added.Id, cancellationToken);

--- a/TrashMob.Shared/Managers/Prospects/ICommunityProspectManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ICommunityProspectManager.cs
@@ -14,5 +14,19 @@ namespace TrashMob.Shared.Managers.Prospects
         Task<IEnumerable<CommunityProspect>> SearchAsync(string searchTerm, CancellationToken cancellationToken = default);
 
         Task<CommunityProspect> UpdatePipelineStageAsync(Guid id, int newStage, Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates or updates the primary <see cref="ProspectContact"/> for a prospect using
+        /// the legacy flat contact fields. Phase 1 backward-compat path — the dedicated
+        /// contacts API in Phase 2 supersedes this.
+        /// </summary>
+        Task<ProspectContact> UpsertPrimaryContactAsync(
+            Guid prospectId,
+            string name,
+            string email,
+            string title,
+            string phone,
+            Guid userId,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMob.Shared/Managers/Prospects/OutreachContentService.cs
+++ b/TrashMob.Shared/Managers/Prospects/OutreachContentService.cs
@@ -1,6 +1,7 @@
 namespace TrashMob.Shared.Managers.Prospects
 {
     using System;
+    using System.Linq;
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
@@ -144,7 +145,10 @@ namespace TrashMob.Shared.Managers.Prospects
                 : prospect.Region ?? "their area";
 
             var prospectType = prospect.Type ?? "community organization";
-            var contactName = prospect.ContactName ?? "the appropriate contact";
+            var primaryContact = prospect.Contacts?
+                .FirstOrDefault(c => c.IsPrimary)
+                ?? prospect.Contacts?.FirstOrDefault();
+            var contactName = primaryContact?.Name ?? "the appropriate contact";
 
             return cadenceStep switch
             {

--- a/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectConversionManager.cs
@@ -2,8 +2,10 @@ namespace TrashMob.Shared.Managers.Prospects
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
     using TrashMob.Models;
     using TrashMob.Models.Poco;
@@ -29,7 +31,9 @@ namespace TrashMob.Shared.Managers.Prospects
             ProspectConversionRequest request, Guid userId,
             CancellationToken cancellationToken = default)
         {
-            var prospect = await prospectRepository.GetAsync(request.ProspectId, cancellationToken);
+            var prospect = await prospectRepository.Get()
+                .Include(p => p.Contacts)
+                .FirstOrDefaultAsync(p => p.Id == request.ProspectId, cancellationToken);
             if (prospect is null)
             {
                 return new ProspectConversionResult { Success = false, ErrorMessage = "Prospect not found." };
@@ -76,10 +80,12 @@ namespace TrashMob.Shared.Managers.Prospects
                 };
                 await activityRepository.AddAsync(activity);
 
-                // 5. Send welcome email if requested and contact email exists
-                if (request.SendWelcomeEmail && !string.IsNullOrWhiteSpace(prospect.ContactEmail))
+                // 5. Send welcome email if requested and a primary contact has an email
+                var primaryContact = prospect.Contacts?.FirstOrDefault(c => c.IsPrimary)
+                    ?? prospect.Contacts?.FirstOrDefault();
+                if (request.SendWelcomeEmail && !string.IsNullOrWhiteSpace(primaryContact?.Email))
                 {
-                    await SendWelcomeEmailAsync(prospect, newPartner, cancellationToken);
+                    await SendWelcomeEmailAsync(prospect, primaryContact, newPartner, cancellationToken);
                 }
 
                 logger.LogInformation("Converted prospect {ProspectId} to partner {PartnerId}", prospect.Id, newPartner.Id);
@@ -98,7 +104,7 @@ namespace TrashMob.Shared.Managers.Prospects
         }
 
         private async Task SendWelcomeEmailAsync(
-            CommunityProspect prospect, Partner partner,
+            CommunityProspect prospect, ProspectContact primaryContact, Partner partner,
             CancellationToken cancellationToken)
         {
             try
@@ -109,7 +115,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 var subject = $"Welcome to TrashMob.eco, {partner.Name}!";
                 var dynamicTemplateData = new
                 {
-                    username = prospect.ContactName ?? prospect.Name,
+                    username = primaryContact?.Name ?? prospect.Name,
                     emailCopy = htmlCopy,
                     subject,
                 };
@@ -118,8 +124,8 @@ namespace TrashMob.Shared.Managers.Prospects
                 [
                     new()
                     {
-                        Name = prospect.ContactName ?? prospect.Name,
-                        Email = prospect.ContactEmail,
+                        Name = primaryContact?.Name ?? prospect.Name,
+                        Email = primaryContact?.Email,
                     },
                 ];
 

--- a/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
@@ -38,7 +38,7 @@ namespace TrashMob.Shared.Managers.Prospects
         public async Task<OutreachPreview> PreviewOutreachAsync(Guid prospectId,
             CancellationToken cancellationToken = default)
         {
-            var prospect = await prospectRepository.GetAsync(prospectId, cancellationToken);
+            var prospect = await GetProspectWithContactsAsync(prospectId, cancellationToken);
             if (prospect is null)
             {
                 return new OutreachPreview { ProspectId = prospectId, Subject = "Prospect not found" };
@@ -73,7 +73,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 };
             }
 
-            var prospect = await prospectRepository.GetAsync(prospectId, cancellationToken);
+            var prospect = await GetProspectWithContactsAsync(prospectId, cancellationToken);
             if (prospect is null)
             {
                 return new OutreachSendResult { Success = false, ErrorMessage = "Prospect not found." };
@@ -89,7 +89,13 @@ namespace TrashMob.Shared.Managers.Prospects
                 };
             }
 
-            var recipientEmail = settings.TestMode ? settings.TestRecipientEmail : prospect.ContactEmail;
+            var primaryContact = prospect.Contacts?
+                .FirstOrDefault(c => c.IsPrimary && c.ContactStatus == (int)ProspectContactStatus.Active)
+                ?? prospect.Contacts?.FirstOrDefault(c => c.IsPrimary);
+            var prospectEmail = primaryContact?.Email;
+            var prospectContactName = primaryContact?.Name;
+
+            var recipientEmail = settings.TestMode ? settings.TestRecipientEmail : prospectEmail;
             if (string.IsNullOrWhiteSpace(recipientEmail))
             {
                 return new OutreachSendResult
@@ -142,6 +148,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 {
                     Id = Guid.NewGuid(),
                     ProspectId = prospectId,
+                    ProspectContactId = primaryContact?.Id,
                     CadenceStep = nextStep,
                     Subject = subject,
                     HtmlBody = fullHtml,
@@ -156,14 +163,14 @@ namespace TrashMob.Shared.Managers.Prospects
                 // Send via SendGrid
                 var dynamicTemplateData = new
                 {
-                    username = prospect.ContactName ?? prospect.Name,
+                    username = prospectContactName ?? prospect.Name,
                     subject,
                     emailCopy = fullHtml,
                 };
 
                 List<EmailAddress> recipients =
                 [
-                    new() { Name = prospect.ContactName ?? prospect.Name, Email = recipientEmail },
+                    new() { Name = prospectContactName ?? prospect.Name, Email = recipientEmail },
                 ];
 
                 // Use the sending admin's trashmob.eco email if available, otherwise fall back to Joe
@@ -187,6 +194,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 {
                     Id = Guid.NewGuid(),
                     ProspectId = prospectId,
+                    ProspectContactId = primaryContact?.Id,
                     ActivityType = "EmailSent",
                     Subject = $"Outreach Step {nextStep}: {subject}",
                     Details = settings.TestMode
@@ -296,7 +304,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 .Get(p => p.NextFollowUpDate != null
                     && p.NextFollowUpDate <= now
                     && p.PipelineStage == 1  // Contacted
-                    && !string.IsNullOrWhiteSpace(p.ContactEmail))
+                    && p.Contacts.Any(c => c.IsPrimary && c.Email != null && c.Email != string.Empty))
                 .Take(settings.MaxFollowUpsPerRun)
                 .ToListAsync(cancellationToken);
 
@@ -342,6 +350,13 @@ namespace TrashMob.Shared.Managers.Prospects
                 .MaxAsync(e => (int?)e.CadenceStep, cancellationToken) ?? 0;
 
             return lastStep + 1;
+        }
+
+        private Task<CommunityProspect> GetProspectWithContactsAsync(Guid prospectId, CancellationToken cancellationToken)
+        {
+            return prospectRepository.Get()
+                .Include(p => p.Contacts)
+                .FirstOrDefaultAsync(p => p.Id == prospectId, cancellationToken);
         }
 
         private static DateTimeOffset? GetNextFollowUpDate(int currentStep)

--- a/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using TrashMob.Shared.Persistence;
 
 #nullable disable
 
-namespace TrashMob.Migrations
+namespace TrashMob.Shared.Migrations
 {
     [DbContext(typeof(MobDbContext))]
-    partial class MobDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260521030318_AddProspectContactsAndDropLegacyContactFields")]
+    partial class AddProspectContactsAndDropLegacyContactFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.cs
+++ b/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.cs
@@ -1,0 +1,238 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrashMob.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProspectContactsAndDropLegacyContactFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1. Create ProspectContacts table.
+            migrationBuilder.CreateTable(
+                name: "ProspectContacts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ProspectId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Phone = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: true),
+                    Role = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    ContactStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 0),
+                    IsPrimary = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    ReferredByContactId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    CreatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastUpdatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LastUpdatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProspectContacts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProspectContacts_CommunityProspect",
+                        column: x => x.ProspectId,
+                        principalTable: "CommunityProspects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ProspectContacts_ReferredByContact",
+                        column: x => x.ReferredByContactId,
+                        principalTable: "ProspectContacts",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_ProspectContacts_User_CreatedBy",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_ProspectContacts_User_LastUpdatedBy",
+                        column: x => x.LastUpdatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProspectContacts_CreatedByUserId",
+                table: "ProspectContacts",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProspectContacts_LastUpdatedByUserId",
+                table: "ProspectContacts",
+                column: "LastUpdatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProspectContacts_ProspectId",
+                table: "ProspectContacts",
+                column: "ProspectId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProspectContacts_ReferredByContactId",
+                table: "ProspectContacts",
+                column: "ReferredByContactId");
+
+            // 2. Add nullable ProspectContactId FK columns to existing activity/outreach tables.
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProspectContactId",
+                table: "ProspectOutreachEmails",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProspectContactId",
+                table: "ProspectActivities",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            // 3. Backfill ProspectContacts from existing CommunityProspect contact columns.
+            //    One row per prospect that had ANY contact field populated. Marked primary.
+            //    This step MUST run before the DropColumn calls below.
+            migrationBuilder.Sql(@"
+                INSERT INTO ProspectContacts
+                    (Id, ProspectId, Name, Title, Email, Phone, ContactStatus, IsPrimary,
+                     CreatedByUserId, CreatedDate, LastUpdatedByUserId, LastUpdatedDate)
+                SELECT
+                    NEWID(),
+                    p.Id,
+                    ISNULL(NULLIF(LTRIM(RTRIM(p.ContactName)), ''), '(unknown)'),
+                    NULLIF(LTRIM(RTRIM(p.ContactTitle)), ''),
+                    NULLIF(LTRIM(RTRIM(p.ContactEmail)), ''),
+                    NULLIF(LTRIM(RTRIM(p.ContactPhone)), ''),
+                    0, -- ContactStatus.Active
+                    1, -- IsPrimary
+                    p.CreatedByUserId,
+                    ISNULL(p.CreatedDate, SYSDATETIMEOFFSET()),
+                    p.LastUpdatedByUserId,
+                    ISNULL(p.LastUpdatedDate, SYSDATETIMEOFFSET())
+                FROM CommunityProspects p
+                WHERE
+                    (p.ContactName IS NOT NULL AND LTRIM(RTRIM(p.ContactName)) <> '')
+                 OR (p.ContactEmail IS NOT NULL AND LTRIM(RTRIM(p.ContactEmail)) <> '')
+                 OR (p.ContactTitle IS NOT NULL AND LTRIM(RTRIM(p.ContactTitle)) <> '')
+                 OR (p.ContactPhone IS NOT NULL AND LTRIM(RTRIM(p.ContactPhone)) <> '');
+            ");
+
+            // 4. Now safe to drop the legacy columns.
+            migrationBuilder.DropColumn(
+                name: "ContactEmail",
+                table: "CommunityProspects");
+
+            migrationBuilder.DropColumn(
+                name: "ContactName",
+                table: "CommunityProspects");
+
+            migrationBuilder.DropColumn(
+                name: "ContactPhone",
+                table: "CommunityProspects");
+
+            migrationBuilder.DropColumn(
+                name: "ContactTitle",
+                table: "CommunityProspects");
+
+            // 5. Indexes + FKs for the new ProspectContactId columns.
+            migrationBuilder.CreateIndex(
+                name: "IX_ProspectOutreachEmails_ProspectContactId",
+                table: "ProspectOutreachEmails",
+                column: "ProspectContactId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProspectActivities_ProspectContactId",
+                table: "ProspectActivities",
+                column: "ProspectContactId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProspectActivities_ProspectContact",
+                table: "ProspectActivities",
+                column: "ProspectContactId",
+                principalTable: "ProspectContacts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProspectOutreachEmails_ProspectContact",
+                table: "ProspectOutreachEmails",
+                column: "ProspectContactId",
+                principalTable: "ProspectContacts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Recreate legacy columns (as nullable). Backfill primary-contact data into them
+            // so a rollback preserves the data we previously moved into ProspectContacts.
+            migrationBuilder.AddColumn<string>(
+                name: "ContactEmail",
+                table: "CommunityProspects",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContactName",
+                table: "CommunityProspects",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContactPhone",
+                table: "CommunityProspects",
+                type: "nvarchar(32)",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContactTitle",
+                table: "CommunityProspects",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+                UPDATE p
+                SET p.ContactName = c.Name,
+                    p.ContactTitle = c.Title,
+                    p.ContactEmail = c.Email,
+                    p.ContactPhone = c.Phone
+                FROM CommunityProspects p
+                INNER JOIN ProspectContacts c ON c.ProspectId = p.Id AND c.IsPrimary = 1;
+            ");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProspectActivities_ProspectContact",
+                table: "ProspectActivities");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProspectOutreachEmails_ProspectContact",
+                table: "ProspectOutreachEmails");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProspectOutreachEmails_ProspectContactId",
+                table: "ProspectOutreachEmails");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ProspectActivities_ProspectContactId",
+                table: "ProspectActivities");
+
+            migrationBuilder.DropColumn(
+                name: "ProspectContactId",
+                table: "ProspectOutreachEmails");
+
+            migrationBuilder.DropColumn(
+                name: "ProspectContactId",
+                table: "ProspectActivities");
+
+            migrationBuilder.DropTable(
+                name: "ProspectContacts");
+        }
+    }
+}

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -160,6 +160,8 @@
 
         public virtual DbSet<CommunityProspect> CommunityProspects { get; set; }
 
+        public virtual DbSet<ProspectContact> ProspectContacts { get; set; }
+
         public virtual DbSet<ProspectActivity> ProspectActivities { get; set; }
 
         public virtual DbSet<ProspectOutreachEmail> ProspectOutreachEmails { get; set; }
@@ -3367,18 +3369,6 @@
                 entity.Property(e => e.Website)
                     .HasMaxLength(2048);
 
-                entity.Property(e => e.ContactEmail)
-                    .HasMaxLength(256);
-
-                entity.Property(e => e.ContactName)
-                    .HasMaxLength(128);
-
-                entity.Property(e => e.ContactTitle)
-                    .HasMaxLength(128);
-
-                entity.Property(e => e.ContactPhone)
-                    .HasMaxLength(32);
-
                 entity.Property(e => e.Notes)
                     .HasMaxLength(2000);
 
@@ -3407,6 +3397,62 @@
                     .HasConstraintName("FK_CommunityProspects_User_LastUpdatedBy");
             });
 
+            modelBuilder.Entity<ProspectContact>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                entity.Property(e => e.Name)
+                    .IsRequired()
+                    .HasMaxLength(200);
+
+                entity.Property(e => e.Title)
+                    .HasMaxLength(200);
+
+                entity.Property(e => e.Email)
+                    .HasMaxLength(256);
+
+                entity.Property(e => e.Phone)
+                    .HasMaxLength(30);
+
+                entity.Property(e => e.Role)
+                    .HasMaxLength(100);
+
+                entity.Property(e => e.ContactStatus)
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.IsPrimary)
+                    .HasDefaultValue(false);
+
+                entity.Property(e => e.Notes)
+                    .HasMaxLength(2000);
+
+                entity.HasIndex(e => e.ProspectId);
+
+                entity.HasOne(d => d.Prospect)
+                    .WithMany(p => p.Contacts)
+                    .HasForeignKey(d => d.ProspectId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .HasConstraintName("FK_ProspectContacts_CommunityProspect");
+
+                entity.HasOne(d => d.ReferredByContact)
+                    .WithMany()
+                    .HasForeignKey(d => d.ReferredByContactId)
+                    .OnDelete(DeleteBehavior.NoAction)
+                    .HasConstraintName("FK_ProspectContacts_ReferredByContact");
+
+                entity.HasOne(d => d.CreatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.CreatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_ProspectContacts_User_CreatedBy");
+
+                entity.HasOne(d => d.LastUpdatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.LastUpdatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_ProspectContacts_User_LastUpdatedBy");
+            });
+
             modelBuilder.Entity<ProspectActivity>(entity =>
             {
                 entity.Property(e => e.Id).ValueGeneratedNever();
@@ -3428,6 +3474,12 @@
                     .HasForeignKey(d => d.ProspectId)
                     .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("FK_ProspectActivities_CommunityProspect");
+
+                entity.HasOne(d => d.Contact)
+                    .WithMany()
+                    .HasForeignKey(d => d.ProspectContactId)
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .HasConstraintName("FK_ProspectActivities_ProspectContact");
 
                 entity.HasOne(d => d.CreatedByUser)
                     .WithMany()
@@ -3464,6 +3516,12 @@
                     .HasForeignKey(d => d.ProspectId)
                     .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("FK_ProspectOutreachEmails_CommunityProspect");
+
+                entity.HasOne(d => d.Contact)
+                    .WithMany()
+                    .HasForeignKey(d => d.ProspectContactId)
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .HasConstraintName("FK_ProspectOutreachEmails_ProspectContact");
 
                 entity.HasOne(d => d.CreatedByUser)
                     .WithMany()

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -299,6 +299,7 @@
 
             // Community Prospect repositories
             services.AddScoped<IKeyedRepository<CommunityProspect>, KeyedRepository<CommunityProspect>>();
+            services.AddScoped<IKeyedRepository<ProspectContact>, KeyedRepository<ProspectContact>>();
             services.AddScoped<IKeyedRepository<ProspectActivity>, KeyedRepository<ProspectActivity>>();
             services.AddScoped<IKeyedRepository<ProspectOutreachEmail>, KeyedRepository<ProspectOutreachEmail>>();
 

--- a/TrashMob/Controllers/V2/CommunityProspectsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunityProspectsV2Controller.cs
@@ -115,7 +115,15 @@ namespace TrashMob.Controllers.V2
             var entity = dto.ToEntity();
             var result = await communityProspectManager.AddAsync(entity, UserId, cancellationToken);
 
-            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result.ToV2Dto());
+            if (dto.HasLegacyContactFields())
+            {
+                await communityProspectManager.UpsertPrimaryContactAsync(
+                    result.Id, dto.ContactName, dto.ContactEmail, dto.ContactTitle, dto.ContactPhone,
+                    UserId, cancellationToken);
+            }
+
+            var refreshed = await communityProspectManager.GetAsync(result.Id, cancellationToken);
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, refreshed.ToV2Dto());
         }
 
         /// <summary>
@@ -133,7 +141,15 @@ namespace TrashMob.Controllers.V2
             var entity = dto.ToEntity();
             var result = await communityProspectManager.UpdateAsync(entity, UserId, cancellationToken);
 
-            return Ok(result.ToV2Dto());
+            if (dto.HasLegacyContactFields())
+            {
+                await communityProspectManager.UpsertPrimaryContactAsync(
+                    result.Id, dto.ContactName, dto.ContactEmail, dto.ContactTitle, dto.ContactPhone,
+                    UserId, cancellationToken);
+            }
+
+            var refreshed = await communityProspectManager.GetAsync(result.Id, cancellationToken);
+            return Ok(refreshed.ToV2Dto());
         }
 
         /// <summary>

--- a/TrashMobMCP/Tools/AddProspectTool.cs
+++ b/TrashMobMCP/Tools/AddProspectTool.cs
@@ -30,7 +30,7 @@ public class AddProspectTool(ICommunityProspectManager prospectManager)
     /// <param name="country">Country (default: United States)</param>
     /// <param name="population">Estimated population served</param>
     /// <param name="website">Organization website URL</param>
-    /// <param name="contactName">Best contact person's full name</param>
+    /// <param name="contactName">Best contact person's full name (saved as primary contact)</param>
     /// <param name="contactEmail">Contact person's email address</param>
     /// <param name="contactTitle">Contact person's job title (e.g., "Public Works Director")</param>
     /// <param name="contactPhone">Contact person's phone number</param>
@@ -39,7 +39,7 @@ public class AddProspectTool(ICommunityProspectManager prospectManager)
     /// <param name="notes">Research notes or rationale for why this is a good prospect</param>
     /// <returns>JSON with the created prospect record</returns>
     [McpServerTool]
-    [Description("Add a new community prospect to the TrashMob pipeline. Use this after researching an organization to save it as a prospect for outreach. Provide as much detail as available — name, type, city, and region are required.")]
+    [Description("Add a new community prospect to the TrashMob pipeline. Use this after researching an organization to save it as a prospect for outreach. Provide as much detail as available — name, type, city, and region are required. Any contact info given is saved as the prospect's primary contact.")]
     public async Task<string> AddProspect(
         string name,
         string type,
@@ -65,10 +65,6 @@ public class AddProspectTool(ICommunityProspectManager prospectManager)
             Country = country,
             Population = population,
             Website = website,
-            ContactName = contactName,
-            ContactEmail = contactEmail,
-            ContactTitle = contactTitle,
-            ContactPhone = contactPhone,
             Latitude = latitude,
             Longitude = longitude,
             Notes = notes,
@@ -78,36 +74,26 @@ public class AddProspectTool(ICommunityProspectManager prospectManager)
 
         var created = await prospectManager.AddAsync(prospect, CancellationToken.None);
 
+        ProspectContact? primary = null;
+        if (!string.IsNullOrWhiteSpace(contactName)
+            || !string.IsNullOrWhiteSpace(contactEmail)
+            || !string.IsNullOrWhiteSpace(contactTitle)
+            || !string.IsNullOrWhiteSpace(contactPhone))
+        {
+            primary = await prospectManager.UpsertPrimaryContactAsync(
+                created.Id,
+                contactName ?? string.Empty,
+                contactEmail ?? string.Empty,
+                contactTitle ?? string.Empty,
+                contactPhone ?? string.Empty,
+                created.CreatedByUserId,
+                CancellationToken.None);
+        }
+
         return JsonSerializer.Serialize(new
         {
             message = $"Prospect '{created.Name}' added to pipeline.",
-            prospect = ToDto(created),
+            prospect = ProspectDtoMapper.ToDto(created, primary, StageNames),
         }, JsonOptions);
-    }
-
-    private static ProspectDto ToDto(CommunityProspect p)
-    {
-        return new ProspectDto
-        {
-            Id = p.Id,
-            Name = p.Name,
-            Type = p.Type,
-            City = p.City,
-            Region = p.Region,
-            Country = p.Country,
-            Population = p.Population,
-            Website = p.Website,
-            ContactName = p.ContactName,
-            ContactEmail = p.ContactEmail,
-            ContactTitle = p.ContactTitle,
-            PipelineStage = p.PipelineStage,
-            PipelineStageName = p.PipelineStage >= 0 && p.PipelineStage < StageNames.Length
-                ? StageNames[p.PipelineStage]
-                : "Unknown",
-            FitScore = p.FitScore,
-            LastContactedDate = p.LastContactedDate,
-            NextFollowUpDate = p.NextFollowUpDate,
-            Notes = p.Notes,
-        };
     }
 }

--- a/TrashMobMCP/Tools/ProspectDtoMapper.cs
+++ b/TrashMobMCP/Tools/ProspectDtoMapper.cs
@@ -1,0 +1,36 @@
+namespace TrashMobMCP.Tools;
+
+using TrashMob.Models;
+using TrashMobMCP.Dtos;
+
+/// <summary>
+/// Maps a CommunityProspect + its primary ProspectContact to the MCP-facing ProspectDto.
+/// </summary>
+internal static class ProspectDtoMapper
+{
+    public static ProspectDto ToDto(CommunityProspect p, ProspectContact? primary, string[] stageNames)
+    {
+        return new ProspectDto
+        {
+            Id = p.Id,
+            Name = p.Name,
+            Type = p.Type,
+            City = p.City,
+            Region = p.Region,
+            Country = p.Country,
+            Population = p.Population,
+            Website = p.Website,
+            ContactName = primary?.Name,
+            ContactEmail = primary?.Email,
+            ContactTitle = primary?.Title,
+            PipelineStage = p.PipelineStage,
+            PipelineStageName = p.PipelineStage >= 0 && p.PipelineStage < stageNames.Length
+                ? stageNames[p.PipelineStage]
+                : "Unknown",
+            FitScore = p.FitScore,
+            LastContactedDate = p.LastContactedDate,
+            NextFollowUpDate = p.NextFollowUpDate,
+            Notes = p.Notes,
+        };
+    }
+}

--- a/TrashMobMCP/Tools/SearchProspectsTool.cs
+++ b/TrashMobMCP/Tools/SearchProspectsTool.cs
@@ -1,6 +1,7 @@
 namespace TrashMobMCP.Tools;
 
 using System.ComponentModel;
+using System.Linq;
 using System.Text.Json;
 using ModelContextProtocol.Server;
 using TrashMob.Models;
@@ -23,7 +24,7 @@ public class SearchProspectsTool(ICommunityProspectManager prospectManager)
     /// <summary>
     /// Search existing community prospects in the TrashMob pipeline.
     /// </summary>
-    /// <param name="searchTerm">Search by name, city, or region (optional)</param>
+    /// <param name="searchTerm">Search by name, city, region, or any contact name/email (optional)</param>
     /// <param name="pipelineStage">Filter by pipeline stage: 0=New, 1=Contacted, 2=Responded, 3=Interested, 4=Onboarding, 5=Active, 6=Declined (optional)</param>
     /// <param name="maxResults">Maximum number of results to return (default: 20, max: 100)</param>
     /// <returns>JSON array of matching prospects with pipeline status</returns>
@@ -51,7 +52,12 @@ public class SearchProspectsTool(ICommunityProspectManager prospectManager)
 
         var sanitized = prospects
             .Take(Math.Min(maxResults, 100))
-            .Select(ToDto)
+            .Select(p =>
+            {
+                var primary = p.Contacts?.FirstOrDefault(c => c.IsPrimary)
+                    ?? p.Contacts?.FirstOrDefault();
+                return ProspectDtoMapper.ToDto(p, primary, StageNames);
+            })
             .ToList();
 
         return JsonSerializer.Serialize(new
@@ -67,31 +73,5 @@ public class SearchProspectsTool(ICommunityProspectManager prospectManager)
                     : null,
             }
         }, JsonOptions);
-    }
-
-    private static ProspectDto ToDto(CommunityProspect p)
-    {
-        return new ProspectDto
-        {
-            Id = p.Id,
-            Name = p.Name,
-            Type = p.Type,
-            City = p.City,
-            Region = p.Region,
-            Country = p.Country,
-            Population = p.Population,
-            Website = p.Website,
-            ContactName = p.ContactName,
-            ContactEmail = p.ContactEmail,
-            ContactTitle = p.ContactTitle,
-            PipelineStage = p.PipelineStage,
-            PipelineStageName = p.PipelineStage >= 0 && p.PipelineStage < StageNames.Length
-                ? StageNames[p.PipelineStage]
-                : "Unknown",
-            FitScore = p.FitScore,
-            LastContactedDate = p.LastContactedDate,
-            NextFollowUpDate = p.NextFollowUpDate,
-            Notes = p.Notes,
-        };
     }
 }

--- a/TrashMobMCP/Tools/UpdateProspectTool.cs
+++ b/TrashMobMCP/Tools/UpdateProspectTool.cs
@@ -1,6 +1,7 @@
 namespace TrashMobMCP.Tools;
 
 using System.ComponentModel;
+using System.Linq;
 using System.Text.Json;
 using ModelContextProtocol.Server;
 using TrashMob.Models;
@@ -31,7 +32,7 @@ public class UpdateProspectTool(ICommunityProspectManager prospectManager)
     /// <param name="country">Updated country</param>
     /// <param name="population">Updated population served</param>
     /// <param name="website">Updated website URL</param>
-    /// <param name="contactName">Updated contact person's full name</param>
+    /// <param name="contactName">Updated contact person's full name (applied to primary contact)</param>
     /// <param name="contactEmail">Updated contact email address</param>
     /// <param name="contactTitle">Updated contact job title</param>
     /// <param name="contactPhone">Updated contact phone number</param>
@@ -41,7 +42,7 @@ public class UpdateProspectTool(ICommunityProspectManager prospectManager)
     /// <param name="pipelineStage">Updated pipeline stage: 0=New, 1=Contacted, 2=Responded, 3=Interested, 4=Onboarding, 5=Active, 6=Declined</param>
     /// <returns>JSON with the updated prospect record</returns>
     [McpServerTool]
-    [Description("Update an existing community prospect in the TrashMob pipeline. Only provided fields are updated — omitted fields keep their current values. Use this to add contact info, update notes, or advance the pipeline stage.")]
+    [Description("Update an existing community prospect in the TrashMob pipeline. Only provided fields are updated — omitted fields keep their current values. Contact fields update the prospect's primary contact (creating one if none exists).")]
     public async Task<string> UpdateProspect(
         Guid id,
         string? name = null,
@@ -78,10 +79,6 @@ public class UpdateProspectTool(ICommunityProspectManager prospectManager)
         if (country is not null) prospect.Country = country;
         if (population.HasValue) prospect.Population = population.Value;
         if (website is not null) prospect.Website = website;
-        if (contactName is not null) prospect.ContactName = contactName;
-        if (contactEmail is not null) prospect.ContactEmail = contactEmail;
-        if (contactTitle is not null) prospect.ContactTitle = contactTitle;
-        if (contactPhone is not null) prospect.ContactPhone = contactPhone;
         if (latitude.HasValue) prospect.Latitude = latitude.Value;
         if (longitude.HasValue) prospect.Longitude = longitude.Value;
         if (notes is not null) prospect.Notes = notes;
@@ -91,36 +88,32 @@ public class UpdateProspectTool(ICommunityProspectManager prospectManager)
 
         var updated = await prospectManager.UpdateAsync(prospect, CancellationToken.None);
 
+        // Apply contact-field updates to the primary contact via the manager helper.
+        if (contactName is not null
+            || contactEmail is not null
+            || contactTitle is not null
+            || contactPhone is not null)
+        {
+            await prospectManager.UpsertPrimaryContactAsync(
+                updated.Id,
+                contactName ?? string.Empty,
+                contactEmail ?? string.Empty,
+                contactTitle ?? string.Empty,
+                contactPhone ?? string.Empty,
+                updated.LastUpdatedByUserId,
+                CancellationToken.None);
+
+            // Reload to get the freshly-saved primary contact.
+            updated = await prospectManager.GetAsync(updated.Id, CancellationToken.None);
+        }
+
+        var primary = updated.Contacts?.FirstOrDefault(c => c.IsPrimary)
+            ?? updated.Contacts?.FirstOrDefault();
+
         return JsonSerializer.Serialize(new
         {
             message = $"Prospect '{updated.Name}' updated.",
-            prospect = ToDto(updated),
+            prospect = ProspectDtoMapper.ToDto(updated, primary, StageNames),
         }, JsonOptions);
-    }
-
-    private static ProspectDto ToDto(CommunityProspect p)
-    {
-        return new ProspectDto
-        {
-            Id = p.Id,
-            Name = p.Name,
-            Type = p.Type,
-            City = p.City,
-            Region = p.Region,
-            Country = p.Country,
-            Population = p.Population,
-            Website = p.Website,
-            ContactName = p.ContactName,
-            ContactEmail = p.ContactEmail,
-            ContactTitle = p.ContactTitle,
-            PipelineStage = p.PipelineStage,
-            PipelineStageName = p.PipelineStage >= 0 && p.PipelineStage < StageNames.Length
-                ? StageNames[p.PipelineStage]
-                : "Unknown",
-            FitScore = p.FitScore,
-            LastContactedDate = p.LastContactedDate,
-            NextFollowUpDate = p.NextFollowUpDate,
-            Notes = p.Notes,
-        };
     }
 }


### PR DESCRIPTION
## Summary
Phase 1 of [Project 60 — Prospect Multi-Contact Tracking](Planning/Projects/Project_60_Prospect_Contact_Tracking.md). Introduces a `ProspectContact` entity so a `CommunityProspect` can have many contacts, drops the single-contact columns (`ContactName/Email/Title/Phone`) on `CommunityProspects`, and refactors the entire blast radius of those columns (managers, MCP tools, CSV import, conversion path, outreach engine) in one go so the DB drop is safe.

The legacy fields stay on `CommunityProspectDto` (and the MCP DTO) as a temporary backward-compat shortcut — the mapper reads/writes them through the primary contact so the existing admin frontend keeps working. Frontend will migrate to the dedicated contacts API in Phase 3.

## Key changes

- **Model:** new `ProspectContact` (Project 60 entity) + `ProspectContactDto`; `ProspectActivity` / `ProspectOutreachEmail` gain a nullable `ProspectContactId`
- **Migration `20260521030318_AddProspectContactsAndDropLegacyContactFields`:** creates table → adds nullable FKs → backfills `ProspectContacts` from legacy columns → drops legacy columns (in that order, hand-edited from EF scaffold). Down migration recreates the columns and copies primary-contact data back into them
- **Manager refactors:**
  - `CommunityProspectManager.SearchAsync` searches via `p.Contacts.Any(...)`; `GetAsync` overloads include `p.Contacts`
  - new `UpsertPrimaryContactAsync` helper used by the controller and MCP tools
  - `ProspectOutreachManager` resolves recipient + name from the primary contact, stamps `ProspectContactId` on activities/outreach emails, due-followup query filters via `Contacts.Any(...)`
  - `ProspectConversionManager` + `CommunityProspectExtensions.ToPartner` read from the primary contact
  - `OutreachContentService` AI prompt uses primary contact name
  - `CsvImportManager` creates the prospect AND a primary `ProspectContact`
- **MCP tools** (`AddProspectTool`, `UpdateProspectTool`, `SearchProspectsTool`) route contact fields through `UpsertPrimaryContactAsync` and share a new `ProspectDtoMapper` helper
- **Controller:** `CommunityProspectsV2Controller.Create` / `Update` call `UpsertPrimaryContactAsync` when the DTO has legacy contact fields, then return the refreshed prospect
- **Tests:** `CommunityProspectBuilder` adds `WithPrimaryContact(...)`; outreach/conversion/csv-import tests updated to mock the new `Get()` lookup and seed contacts via the builder. **All 1,079 tests pass.**

## Test plan
- [ ] Restore a recent dev DB backup and run the migration against it; verify row counts: `SELECT COUNT(*) FROM ProspectContacts` matches `SELECT COUNT(*) FROM CommunityProspects WHERE ISNULL(LTRIM(RTRIM(ContactName)),'') <> '' OR ISNULL(LTRIM(RTRIM(ContactEmail)),'') <> '' OR ISNULL(LTRIM(RTRIM(ContactTitle)),'') <> '' OR ISNULL(LTRIM(RTRIM(ContactPhone)),'') <> ''` (pre-migration)
- [ ] Run the migration's Down on the restored backup; confirm legacy columns are recreated and primary-contact data is in them
- [ ] Smoke-test admin prospect create/edit flows on dev — contact info should round-trip through the legacy DTO fields
- [ ] CSV import a row with contact info; confirm a `ProspectContact` row is created with `IsPrimary = 1`
- [ ] Send an outreach email via the admin UI; confirm recipient resolves correctly and `ProspectContactId` is stamped on the activity + outreach email row
- [ ] Convert a prospect to a partner; confirm the welcome email targets the primary contact and the new Partner has a PartnerContact

## Phases
- **Phase 1 (this PR):** backend model + migration + manager/CSV/outreach/MCP refactor
- Phase 2: dedicated `ProspectContactsController` + activity/outreach endpoints accept `prospectContactId`
- Phase 3: admin UI for managing the contacts list per prospect
- Phase 4: reporting (per-user touchpoint tally, attempts column, days-in-pipeline)

Project plan: [Project_60_Prospect_Contact_Tracking.md](Planning/Projects/Project_60_Prospect_Contact_Tracking.md) (pending merge in #3371)

🤖 Generated with [Claude Code](https://claude.com/claude-code)