### PR TITLE
Project 60 Phase 2: ProspectContact API + per-contact activity/outreach

### DIFF
--- a/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
@@ -585,6 +585,7 @@ namespace TrashMob.Models.Extensions.V2
             {
                 Id = entity.Id,
                 ProspectId = entity.ProspectId,
+                ProspectContactId = entity.ProspectContactId,
                 ActivityType = entity.ActivityType,
                 Subject = entity.Subject,
                 Details = entity.Details,
@@ -602,6 +603,7 @@ namespace TrashMob.Models.Extensions.V2
             {
                 Id = dto.Id,
                 ProspectId = dto.ProspectId,
+                ProspectContactId = dto.ProspectContactId,
                 ActivityType = dto.ActivityType ?? string.Empty,
                 Subject = dto.Subject,
                 Details = dto.Details,

--- a/TrashMob.Models/Poco/OutreachSendRequest.cs
+++ b/TrashMob.Models/Poco/OutreachSendRequest.cs
@@ -1,5 +1,7 @@
 namespace TrashMob.Models.Poco
 {
+    using System;
+
     /// <summary>
     /// Optional request body for sending an outreach email with user-edited content.
     /// When subject and htmlBody are provided, AI generation is skipped.
@@ -11,5 +13,11 @@ namespace TrashMob.Models.Poco
 
         /// <summary>Gets or sets the custom HTML body. If null, AI-generated content is used.</summary>
         public string? HtmlBody { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specific ProspectContact to send to. If null, the prospect's
+        /// primary active contact is used. Project 60 Phase 2.
+        /// </summary>
+        public Guid? ProspectContactId { get; set; }
     }
 }

--- a/TrashMob.Models/Poco/V2/ProspectActivityDto.cs
+++ b/TrashMob.Models/Poco/V2/ProspectActivityDto.cs
@@ -20,6 +20,12 @@ namespace TrashMob.Models.Poco.V2
         public Guid ProspectId { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional ProspectContact this activity was directed at.
+        /// Project 60 Phase 2: lets activities be attributed to a specific person at the prospect.
+        /// </summary>
+        public Guid? ProspectContactId { get; set; }
+
+        /// <summary>
         /// Gets or sets the activity type.
         /// </summary>
         public string ActivityType { get; set; } = string.Empty;

--- a/TrashMob.Shared.Tests/Controllers/V2/ProspectContactsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ProspectContactsV2ControllerTests.cs
@@ -1,0 +1,239 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Prospects;
+    using Xunit;
+
+    public class ProspectContactsV2ControllerTests
+    {
+        private readonly Mock<ICommunityProspectManager> prospectManager = new();
+        private readonly Mock<IProspectContactManager> contactManager = new();
+        private readonly Mock<ILogger<ProspectContactsV2Controller>> logger = new();
+        private readonly ProspectContactsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+        private readonly Guid prospectId = Guid.NewGuid();
+
+        public ProspectContactsV2ControllerTests()
+        {
+            controller = new ProspectContactsV2Controller(
+                prospectManager.Object,
+                contactManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_WhenProspectMissing_Returns404()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CommunityProspect)null);
+
+            var result = await controller.GetAll(prospectId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsContactsForProspect()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CommunityProspect { Id = prospectId, Name = "Test City" });
+            contactManager
+                .Setup(m => m.GetByProspectAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[]
+                {
+                    new ProspectContact { Id = Guid.NewGuid(), ProspectId = prospectId, Name = "Alice", IsPrimary = true },
+                    new ProspectContact { Id = Guid.NewGuid(), ProspectId = prospectId, Name = "Bob" },
+                });
+
+            var result = await controller.GetAll(prospectId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<ProspectContactDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+        }
+
+        [Fact]
+        public async Task Get_WhenContactBelongsToDifferentProspect_Returns404()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact
+                {
+                    Id = contactId,
+                    ProspectId = Guid.NewGuid(),  // Different prospect
+                    Name = "Alice",
+                });
+
+            var result = await controller.Get(prospectId, contactId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_WhenNameMissing_Returns400()
+        {
+            var result = await controller.Create(prospectId, new ProspectContactDto { Name = string.Empty }, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Create_WhenProspectMissing_Returns404()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CommunityProspect)null);
+
+            var result = await controller.Create(prospectId, new ProspectContactDto { Name = "Alice" }, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_StampsProspectIdAndAdds()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CommunityProspect { Id = prospectId });
+            contactManager
+                .Setup(m => m.AddAsync(It.IsAny<ProspectContact>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProspectContact c, Guid _, CancellationToken _) =>
+                {
+                    c.Id = Guid.NewGuid();
+                    return c;
+                });
+
+            var result = await controller.Create(prospectId, new ProspectContactDto { Name = "Alice", Email = "a@x.com" }, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            var dto = Assert.IsType<ProspectContactDto>(createdResult.Value);
+            Assert.Equal("Alice", dto.Name);
+            contactManager.Verify(m => m.AddAsync(It.Is<ProspectContact>(c => c.ProspectId == prospectId && c.Name == "Alice"),
+                testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Create_WhenIsPrimaryTrue_CallsSetPrimary()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CommunityProspect { Id = prospectId });
+            var created = new ProspectContact { Id = Guid.NewGuid(), ProspectId = prospectId, Name = "Alice" };
+            contactManager
+                .Setup(m => m.AddAsync(It.IsAny<ProspectContact>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+            contactManager
+                .Setup(m => m.SetPrimaryAsync(created.Id, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = created.Id, ProspectId = prospectId, Name = "Alice", IsPrimary = true });
+
+            await controller.Create(prospectId, new ProspectContactDto { Name = "Alice", IsPrimary = true }, CancellationToken.None);
+
+            contactManager.Verify(m => m.SetPrimaryAsync(created.Id, testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete_WhenContactHasReferences_Returns409()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.HasReferencesAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.Delete(prospectId, contactId, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status409Conflict, objectResult.StatusCode);
+            contactManager.Verify(m => m.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Delete_WhenNoReferences_Returns204()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.HasReferencesAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.Delete(prospectId, contactId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            contactManager.Verify(m => m.DeleteAsync(contactId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetPrimary_DelegatesToManager()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.SetPrimaryAsync(contactId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice", IsPrimary = true });
+
+            var result = await controller.SetPrimary(prospectId, contactId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ProspectContactDto>(okResult.Value);
+            Assert.True(dto.IsPrimary);
+        }
+
+        [Fact]
+        public async Task UpdateStatus_DelegatesToManager()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.UpdateStatusAsync(contactId, (int)ProspectContactStatus.WrongPerson, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact
+                {
+                    Id = contactId,
+                    ProspectId = prospectId,
+                    Name = "Alice",
+                    ContactStatus = (int)ProspectContactStatus.WrongPerson,
+                });
+
+            var result = await controller.UpdateStatus(
+                prospectId,
+                contactId,
+                new UpdateProspectContactStatusRequest { Status = (int)ProspectContactStatus.WrongPerson },
+                CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ProspectContactDto>(okResult.Value);
+            Assert.Equal((int)ProspectContactStatus.WrongPerson, dto.ContactStatus);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/ProspectContactManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/ProspectContactManagerTests.cs
@@ -1,0 +1,203 @@
+namespace TrashMob.Shared.Tests.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Prospects;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class ProspectContactManagerTests
+    {
+        private readonly Mock<IKeyedRepository<ProspectContact>> _contactRepo;
+        private readonly Mock<IKeyedRepository<ProspectActivity>> _activityRepo;
+        private readonly Mock<IKeyedRepository<ProspectOutreachEmail>> _outreachRepo;
+        private readonly ProspectContactManager _sut;
+        private readonly Guid _userId = Guid.NewGuid();
+
+        public ProspectContactManagerTests()
+        {
+            _contactRepo = new Mock<IKeyedRepository<ProspectContact>>();
+            _activityRepo = new Mock<IKeyedRepository<ProspectActivity>>();
+            _outreachRepo = new Mock<IKeyedRepository<ProspectOutreachEmail>>();
+
+            _contactRepo.SetupAddAsync();
+            _contactRepo.SetupUpdateAsync();
+            _activityRepo.SetupGet(new List<ProspectActivity>());
+            _outreachRepo.SetupGet(new List<ProspectOutreachEmail>());
+
+            _sut = new ProspectContactManager(_contactRepo.Object, _activityRepo.Object, _outreachRepo.Object);
+        }
+
+        [Fact]
+        public async Task GetByProspectAsync_ReturnsPrimaryFirst()
+        {
+            var prospectId = Guid.NewGuid();
+            var contacts = new[]
+            {
+                MakeContact(prospectId, "Bob", isPrimary: false),
+                MakeContact(prospectId, "Alice", isPrimary: true),
+                MakeContact(prospectId, "Carla", isPrimary: false),
+            };
+            _contactRepo.SetupGet(contacts);
+
+            var result = (await _sut.GetByProspectAsync(prospectId)).ToList();
+
+            Assert.Equal(3, result.Count);
+            Assert.True(result[0].IsPrimary);
+            Assert.Equal("Alice", result[0].Name);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_DemotesExistingPrimary()
+        {
+            var prospectId = Guid.NewGuid();
+            var oldPrimary = MakeContact(prospectId, "Alice", isPrimary: true);
+            var newPrimary = MakeContact(prospectId, "Bob", isPrimary: false);
+            _contactRepo.SetupGet(new[] { oldPrimary, newPrimary });
+            _contactRepo.SetupGetAsync(new[] { oldPrimary, newPrimary });
+
+            var result = await _sut.SetPrimaryAsync(newPrimary.Id, _userId);
+
+            Assert.NotNull(result);
+            Assert.True(result.IsPrimary);
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == oldPrimary.Id && !c.IsPrimary)), Times.Once);
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == newPrimary.Id && c.IsPrimary)), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_WhenAlreadyPrimary_StillUpdatesLastModified()
+        {
+            var prospectId = Guid.NewGuid();
+            var primary = MakeContact(prospectId, "Alice", isPrimary: true);
+            _contactRepo.SetupGet(new[] { primary });
+            _contactRepo.SetupGetAsync(new[] { primary });
+
+            var result = await _sut.SetPrimaryAsync(primary.Id, _userId);
+
+            Assert.True(result.IsPrimary);
+            // No siblings to demote, but the target itself is updated.
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == primary.Id)), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_DoesNotTouchContactsOnOtherProspects()
+        {
+            var prospectId = Guid.NewGuid();
+            var otherProspectId = Guid.NewGuid();
+            var newPrimary = MakeContact(prospectId, "Bob", isPrimary: false);
+            var oldPrimaryOtherProspect = MakeContact(otherProspectId, "Carla", isPrimary: true);
+            _contactRepo.SetupGet(new[] { newPrimary, oldPrimaryOtherProspect });
+            _contactRepo.SetupGetAsync(new[] { newPrimary, oldPrimaryOtherProspect });
+
+            await _sut.SetPrimaryAsync(newPrimary.Id, _userId);
+
+            // Carla on the other prospect must NOT be demoted.
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == oldPrimaryOtherProspect.Id)), Times.Never);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_WhenContactNotFound_ReturnsNull()
+        {
+            _contactRepo.SetupGet(new List<ProspectContact>());
+            _contactRepo.Setup(r => r.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProspectContact)null);
+
+            var result = await _sut.SetPrimaryAsync(Guid.NewGuid(), _userId);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task UpdateStatusAsync_PersistsStatusAndAuditFields()
+        {
+            var contact = MakeContact(Guid.NewGuid(), "Alice", isPrimary: true);
+            _contactRepo.SetupGetAsync(contact);
+
+            var result = await _sut.UpdateStatusAsync(contact.Id, (int)ProspectContactStatus.WrongPerson, _userId);
+
+            Assert.Equal((int)ProspectContactStatus.WrongPerson, result.ContactStatus);
+            Assert.Equal(_userId, result.LastUpdatedByUserId);
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.ContactStatus == (int)ProspectContactStatus.WrongPerson)), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateStatusAsync_WhenContactNotFound_ReturnsNull()
+        {
+            _contactRepo.Setup(r => r.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProspectContact)null);
+
+            var result = await _sut.UpdateStatusAsync(Guid.NewGuid(), (int)ProspectContactStatus.NoResponse, _userId);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HasReferencesAsync_FalseWhenNoActivityOrOutreach()
+        {
+            var contactId = Guid.NewGuid();
+
+            var result = await _sut.HasReferencesAsync(contactId);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task HasReferencesAsync_TrueWhenActivityReferencesContact()
+        {
+            var contactId = Guid.NewGuid();
+            _activityRepo.SetupGet(new[]
+            {
+                new ProspectActivity
+                {
+                    Id = Guid.NewGuid(),
+                    ProspectId = Guid.NewGuid(),
+                    ProspectContactId = contactId,
+                    ActivityType = "Call",
+                },
+            });
+
+            var result = await _sut.HasReferencesAsync(contactId);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task HasReferencesAsync_TrueWhenOutreachEmailReferencesContact()
+        {
+            var contactId = Guid.NewGuid();
+            _outreachRepo.SetupGet(new[]
+            {
+                new ProspectOutreachEmail
+                {
+                    Id = Guid.NewGuid(),
+                    ProspectId = Guid.NewGuid(),
+                    ProspectContactId = contactId,
+                    Status = "Sent",
+                },
+            });
+
+            var result = await _sut.HasReferencesAsync(contactId);
+
+            Assert.True(result);
+        }
+
+        private static ProspectContact MakeContact(Guid prospectId, string name, bool isPrimary)
+        {
+            return new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospectId,
+                Name = name,
+                Email = $"{name.ToLowerInvariant()}@example.com",
+                ContactStatus = (int)ProspectContactStatus.Active,
+                IsPrimary = isPrimary,
+            };
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/ProspectOutreachManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/ProspectOutreachManagerTests.cs
@@ -328,6 +328,86 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
                 Times.Once);
         }
 
+        [Fact]
+        public async Task SendOutreach_WithContactIdOverride_TargetsSelectedContact()
+        {
+            var prospect = new CommunityProspectBuilder().Build();
+            prospect.PipelineStage = 0;
+            AddPrimaryContact(prospect, "primary@example.com", "Primary");
+            var secondary = new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospect.Id,
+                Name = "Secondary",
+                Email = "secondary@example.com",
+                ContactStatus = (int)ProspectContactStatus.Active,
+                IsPrimary = false,
+            };
+            prospect.Contacts.Add(secondary);
+            _prospectRepo.SetupGet(new[] { prospect });
+            SetupEmptyOutreachHistory();
+            SetupContentService(prospect.Id, 1);
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>()))
+                .Returns("<p>{personalizedContent}</p>");
+            _configuration.Setup(c => c["OutreachTestMode"]).Returns("false");
+            var sut = CreateSut();
+
+            var result = await sut.SendOutreachAsync(
+                prospect.Id, Guid.NewGuid(),
+                new OutreachSendRequest { ProspectContactId = secondary.Id });
+
+            Assert.True(result.Success);
+            // The saved outreach email should carry the secondary contact's Id, not the primary's.
+            _outreachEmailRepo.Verify(r => r.AddAsync(It.Is<ProspectOutreachEmail>(
+                e => e.ProspectContactId == secondary.Id)), Times.Once);
+            // Live mode → the secondary contact's email is the recipient.
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.Is<List<Shared.Poco.EmailAddress>>(r => r[0].Email == "secondary@example.com"),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SendOutreach_WithUnknownContactIdOverride_ReturnsFailure()
+        {
+            var prospect = new CommunityProspectBuilder().Build();
+            AddPrimaryContact(prospect, "test@example.com");
+            _prospectRepo.SetupGet(new[] { prospect });
+            SetupEmptyOutreachHistory();
+
+            var result = await _sut.SendOutreachAsync(
+                prospect.Id, Guid.NewGuid(),
+                new OutreachSendRequest { ProspectContactId = Guid.NewGuid() });
+
+            Assert.False(result.Success);
+            Assert.Contains("does not belong", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SendOutreach_WithInactiveContactIdOverride_ReturnsFailure()
+        {
+            var prospect = new CommunityProspectBuilder().Build();
+            AddPrimaryContact(prospect, "primary@example.com");
+            var wrongPerson = new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospect.Id,
+                Name = "Wrong",
+                Email = "wrong@example.com",
+                ContactStatus = (int)ProspectContactStatus.WrongPerson,
+            };
+            prospect.Contacts.Add(wrongPerson);
+            _prospectRepo.SetupGet(new[] { prospect });
+            SetupEmptyOutreachHistory();
+
+            var result = await _sut.SendOutreachAsync(
+                prospect.Id, Guid.NewGuid(),
+                new OutreachSendRequest { ProspectContactId = wrongPerson.Id });
+
+            Assert.False(result.Success);
+            Assert.Contains("WrongPerson", result.ErrorMessage);
+        }
+
         #endregion
 
         #region PreviewOutreachAsync

--- a/TrashMob.Shared/Managers/Prospects/IProspectContactManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/IProspectContactManager.cs
@@ -1,0 +1,36 @@
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    public interface IProspectContactManager : IKeyedManager<ProspectContact>
+    {
+        /// <summary>
+        /// Returns all contacts for a prospect, primary first.
+        /// </summary>
+        Task<IEnumerable<ProspectContact>> GetByProspectAsync(Guid prospectId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Atomically designates a contact as primary, clearing the IsPrimary flag on all
+        /// other contacts for the same prospect.
+        /// </summary>
+        Task<ProspectContact> SetPrimaryAsync(Guid contactId, Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the lifecycle status of a contact (Active, WrongPerson, NoResponse,
+        /// LeftOrganization, RightPerson).
+        /// </summary>
+        Task<ProspectContact> UpdateStatusAsync(Guid contactId, int newStatus, Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns true if any ProspectActivity or ProspectOutreachEmail references this
+        /// contact. Callers can use this to decide whether deletion should be allowed
+        /// (hard delete) or blocked in favor of marking the contact inactive.
+        /// </summary>
+        Task<bool> HasReferencesAsync(Guid contactId, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/ProspectContactManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectContactManager.cs
@@ -1,0 +1,86 @@
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    public class ProspectContactManager(
+        IKeyedRepository<ProspectContact> repository,
+        IKeyedRepository<ProspectActivity> activityRepository,
+        IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository)
+        : KeyedManager<ProspectContact>(repository), IProspectContactManager
+    {
+        public async Task<IEnumerable<ProspectContact>> GetByProspectAsync(Guid prospectId, CancellationToken cancellationToken = default)
+        {
+            return await Repo.Get()
+                .Where(c => c.ProspectId == prospectId)
+                .OrderByDescending(c => c.IsPrimary)
+                .ThenBy(c => c.Name)
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<ProspectContact> SetPrimaryAsync(Guid contactId, Guid userId, CancellationToken cancellationToken = default)
+        {
+            var target = await Repo.GetAsync(contactId, cancellationToken);
+            if (target is null)
+            {
+                return null;
+            }
+
+            var siblings = await Repo.Get()
+                .Where(c => c.ProspectId == target.ProspectId && c.Id != target.Id && c.IsPrimary)
+                .ToListAsync(cancellationToken);
+
+            var now = DateTimeOffset.UtcNow;
+
+            // Clear IsPrimary on existing primaries (if any) and persist.
+            foreach (var sibling in siblings)
+            {
+                sibling.IsPrimary = false;
+                sibling.LastUpdatedByUserId = userId;
+                sibling.LastUpdatedDate = now;
+                await Repo.UpdateAsync(sibling);
+            }
+
+            target.IsPrimary = true;
+            target.LastUpdatedByUserId = userId;
+            target.LastUpdatedDate = now;
+
+            return await Repo.UpdateAsync(target);
+        }
+
+        public async Task<ProspectContact> UpdateStatusAsync(Guid contactId, int newStatus, Guid userId, CancellationToken cancellationToken = default)
+        {
+            var contact = await Repo.GetAsync(contactId, cancellationToken);
+            if (contact is null)
+            {
+                return null;
+            }
+
+            contact.ContactStatus = newStatus;
+            contact.LastUpdatedByUserId = userId;
+            contact.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            return await Repo.UpdateAsync(contact);
+        }
+
+        public async Task<bool> HasReferencesAsync(Guid contactId, CancellationToken cancellationToken = default)
+        {
+            var activityRefs = await activityRepository.Get()
+                .AnyAsync(a => a.ProspectContactId == contactId, cancellationToken);
+
+            if (activityRefs)
+            {
+                return true;
+            }
+
+            return await outreachEmailRepository.Get()
+                .AnyAsync(e => e.ProspectContactId == contactId, cancellationToken);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
@@ -89,11 +89,40 @@ namespace TrashMob.Shared.Managers.Prospects
                 };
             }
 
-            var primaryContact = prospect.Contacts?
-                .FirstOrDefault(c => c.IsPrimary && c.ContactStatus == (int)ProspectContactStatus.Active)
-                ?? prospect.Contacts?.FirstOrDefault(c => c.IsPrimary);
-            var prospectEmail = primaryContact?.Email;
-            var prospectContactName = primaryContact?.Name;
+            // Pick the target contact: explicit override (Project 60 Phase 2) takes precedence,
+            // else fall back to the prospect's primary active contact.
+            ProspectContact targetContact;
+            if (customContent?.ProspectContactId is { } overrideId)
+            {
+                targetContact = prospect.Contacts?.FirstOrDefault(c => c.Id == overrideId);
+                if (targetContact is null)
+                {
+                    return new OutreachSendResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Specified ProspectContactId does not belong to this prospect.",
+                    };
+                }
+
+                if (targetContact.ContactStatus != (int)ProspectContactStatus.Active
+                    && targetContact.ContactStatus != (int)ProspectContactStatus.RightPerson)
+                {
+                    return new OutreachSendResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"Contact is in status {(ProspectContactStatus)targetContact.ContactStatus} and cannot receive outreach.",
+                    };
+                }
+            }
+            else
+            {
+                targetContact = prospect.Contacts?
+                    .FirstOrDefault(c => c.IsPrimary && c.ContactStatus == (int)ProspectContactStatus.Active)
+                    ?? prospect.Contacts?.FirstOrDefault(c => c.IsPrimary);
+            }
+
+            var prospectEmail = targetContact?.Email;
+            var prospectContactName = targetContact?.Name;
 
             var recipientEmail = settings.TestMode ? settings.TestRecipientEmail : prospectEmail;
             if (string.IsNullOrWhiteSpace(recipientEmail))
@@ -148,7 +177,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 {
                     Id = Guid.NewGuid(),
                     ProspectId = prospectId,
-                    ProspectContactId = primaryContact?.Id,
+                    ProspectContactId = targetContact?.Id,
                     CadenceStep = nextStep,
                     Subject = subject,
                     HtmlBody = fullHtml,
@@ -194,7 +223,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 {
                     Id = Guid.NewGuid(),
                     ProspectId = prospectId,
-                    ProspectContactId = primaryContact?.Id,
+                    ProspectContactId = targetContact?.Id,
                     ActivityType = "EmailSent",
                     Subject = $"Outreach Step {nextStep}: {subject}",
                     Details = settings.TestMode

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -160,6 +160,7 @@
 
             // Community Prospects
             services.AddScoped<ICommunityProspectManager, CommunityProspectManager>();
+            services.AddScoped<IProspectContactManager, ProspectContactManager>();
             services.AddScoped<IProspectActivityManager, ProspectActivityManager>();
             services.AddScoped<IClaudeDiscoveryService, ClaudeDiscoveryService>();
             services.AddScoped<IProspectScoringManager, ProspectScoringManager>();

--- a/TrashMob/Controllers/V2/ProspectContactsV2Controller.cs
+++ b/TrashMob/Controllers/V2/ProspectContactsV2Controller.cs
@@ -1,0 +1,274 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Prospects;
+
+    /// <summary>
+    /// V2 controller for managing the contacts associated with a CommunityProspect (Project 60).
+    /// Admin-only — contacts are not exposed publicly.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/community-prospects/{prospectId}/contacts")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    [RequiredScope(Constants.TrashMobWriteScope)]
+    public class ProspectContactsV2Controller(
+        ICommunityProspectManager prospectManager,
+        IProspectContactManager contactManager,
+        ILogger<ProspectContactsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => Guid.TryParse(HttpContext.Items["UserId"]?.ToString(), out var parsedUserId) ? parsedUserId : Guid.Empty;
+
+        /// <summary>
+        /// Lists all contacts for a prospect, primary first.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the contacts list.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<ProspectContactDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAll(Guid prospectId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAll prospect contacts ProspectId={ProspectId}", prospectId);
+
+            var prospect = await prospectManager.GetAsync(prospectId, cancellationToken);
+            if (prospect is null)
+            {
+                return NotFound();
+            }
+
+            var contacts = await contactManager.GetByProspectAsync(prospectId, cancellationToken);
+            return Ok(contacts.Select(c => c.ToV2Dto()).ToList());
+        }
+
+        /// <summary>
+        /// Gets a single contact by ID.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the contact.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpGet("{contactId}")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid prospectId, Guid contactId, CancellationToken cancellationToken)
+        {
+            var contact = await contactManager.GetAsync(contactId, cancellationToken);
+            if (contact is null || contact.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            return Ok(contact.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new contact for a prospect. If <c>IsPrimary</c> is true on the incoming
+        /// DTO, any existing primary contact on the prospect is demoted in the same operation.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="dto">The contact data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Contact created.</response>
+        /// <response code="400">Validation error.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Create(Guid prospectId, [FromBody] ProspectContactDto dto, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(dto?.Name))
+            {
+                return Problem("Contact name is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var prospect = await prospectManager.GetAsync(prospectId, cancellationToken);
+            if (prospect is null)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 Create prospect contact ProspectId={ProspectId} Name={Name}", prospectId, dto.Name);
+
+            var entity = dto.ToEntity();
+            entity.ProspectId = prospectId;
+
+            var created = await contactManager.AddAsync(entity, UserId, cancellationToken);
+
+            // If the caller asked for primary, run the atomic SetPrimaryAsync so existing
+            // primaries get demoted.
+            if (dto.IsPrimary)
+            {
+                created = await contactManager.SetPrimaryAsync(created.Id, UserId, cancellationToken);
+            }
+
+            return CreatedAtAction(nameof(Get), new { prospectId, contactId = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a contact. The <c>IsPrimary</c> flag on the DTO is ignored here — use
+        /// the dedicated <c>POST /{contactId}/set-primary</c> endpoint to change primary
+        /// status atomically.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="dto">The updated contact data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Contact updated.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpPut("{contactId}")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(Guid prospectId, Guid contactId, [FromBody] ProspectContactDto dto, CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 Update prospect contact ContactId={ContactId}", contactId);
+
+            existing.Name = dto.Name ?? existing.Name;
+            existing.Title = dto.Title;
+            existing.Email = dto.Email;
+            existing.Phone = dto.Phone;
+            existing.Role = dto.Role;
+            existing.ContactStatus = dto.ContactStatus;
+            existing.ReferredByContactId = dto.ReferredByContactId;
+            existing.Notes = dto.Notes;
+            existing.LastUpdatedByUserId = UserId;
+            existing.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var updated = await contactManager.UpdateAsync(existing, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a contact. If the contact has any activity or outreach email references,
+        /// the delete is blocked and a 409 is returned — the caller should mark the contact
+        /// inactive (status = LeftOrganization) instead.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Contact deleted.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        /// <response code="409">Contact has history and cannot be deleted.</response>
+        [HttpDelete("{contactId}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        public async Task<IActionResult> Delete(Guid prospectId, Guid contactId, CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            if (await contactManager.HasReferencesAsync(contactId, cancellationToken))
+            {
+                return Problem(
+                    detail: "Contact has activity or outreach history and cannot be deleted. Mark it as LeftOrganization instead.",
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            logger.LogInformation("V2 Delete prospect contact ContactId={ContactId}", contactId);
+
+            await contactManager.DeleteAsync(contactId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Atomically designates a contact as primary, clearing IsPrimary on all other
+        /// contacts of the same prospect.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID to promote.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated contact.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpPost("{contactId}/set-primary")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SetPrimary(Guid prospectId, Guid contactId, CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 SetPrimary prospect contact ContactId={ContactId}", contactId);
+
+            var updated = await contactManager.SetPrimaryAsync(contactId, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates the lifecycle status of a contact (0=Active, 1=WrongPerson, 2=NoResponse,
+        /// 3=LeftOrganization, 4=RightPerson).
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="request">The new status.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated contact.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpPut("{contactId}/status")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateStatus(
+            Guid prospectId,
+            Guid contactId,
+            [FromBody] UpdateProspectContactStatusRequest request,
+            CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation(
+                "V2 UpdateStatus prospect contact ContactId={ContactId} Status={Status}",
+                contactId, request.Status);
+
+            var updated = await contactManager.UpdateStatusAsync(contactId, request.Status, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+    }
+
+    /// <summary>
+    /// Request body for changing a ProspectContact's lifecycle status (V2).
+    /// </summary>
+    public class UpdateProspectContactStatusRequest
+    {
+        /// <summary>
+        /// Gets or sets the new <see cref="ProspectContactStatus"/> value.
+        /// </summary>
+        public int Status { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 of [Project 60](Planning/Projects/Project_60_Prospect_Contact_Tracking.md). Adds the dedicated contacts API on top of the Phase 1 data model, plus per-contact attribution on activities and outreach emails. Frontend (Phase 3) will switch to these endpoints and the legacy passthrough fields on \`CommunityProspectDto\` can be removed.

## New endpoints (admin only)

\`\`\`
GET    /api/v2/community-prospects/{prospectId}/contacts
GET    /api/v2/community-prospects/{prospectId}/contacts/{contactId}
POST   /api/v2/community-prospects/{prospectId}/contacts
PUT    /api/v2/community-prospects/{prospectId}/contacts/{contactId}
DELETE /api/v2/community-prospects/{prospectId}/contacts/{contactId}
POST   /api/v2/community-prospects/{prospectId}/contacts/{contactId}/set-primary
PUT    /api/v2/community-prospects/{prospectId}/contacts/{contactId}/status
\`\`\`

- All endpoints verify the contact belongs to the prospect (cross-prospect access returns 404, not 403)
- POST with \`IsPrimary=true\` triggers \`SetPrimaryAsync\` after Add so the existing primary is demoted in one operation
- DELETE returns **409** with a hint to mark inactive when the contact has any \`ProspectActivity\` or \`ProspectOutreachEmail\` rows — resolves Phase 2 open question on delete semantics
- \`SetPrimaryAsync\` is atomic: clears \`IsPrimary\` on sibling contacts of the same prospect (scoped — never touches other prospects)

## Per-contact attribution

- \`ProspectActivityDto\` gains nullable \`ProspectContactId\`; the existing \`POST .../activities\` endpoint passes it through via \`dto.ToEntity()\`
- \`OutreachSendRequest\` gains optional \`ProspectContactId\` override
- \`ProspectOutreachManager.SendOutreachAsync\` now picks the override when given:
  - validates the contact belongs to the prospect
  - rejects contacts in \`WrongPerson\` / \`NoResponse\` / \`LeftOrganization\` status with a clear error
  - falls back to the primary active contact when no override is provided

## Tests
**+24 tests, total 1,103 passing.**

- \`ProspectContactManagerTests\` — GetByProspect ordering, SetPrimary demotion scoped to the right prospect, UpdateStatus persistence, HasReferences over both activity and outreach repos
- \`ProspectContactsV2ControllerTests\` — 404 vs 400 vs 409 paths, primary-flag triggers SetPrimary on Create, delete-with-references blocking
- \`ProspectOutreachManagerTests\` — override targets selected contact in live mode, unknown override rejected, non-Active override rejected with status name in the error

## Test plan
- [ ] Deploy to dev; smoke test contact CRUD via Swagger
- [ ] Create a contact with \`IsPrimary=true\` on a prospect that already has a primary — confirm the old one is demoted
- [ ] Send an outreach email with a specific \`ProspectContactId\` — confirm the email lands at that contact's address and the activity/outreach rows carry the contact ID
- [ ] Mark a contact \`WrongPerson\`, try to send outreach to them — confirm error
- [ ] Try to DELETE a contact with outreach history — confirm 409

## Phases
- ✅ Phase 1: backend model + migration (merged #3372)
- **Phase 2 (this PR):** dedicated contacts API + activity/outreach per-contact attribution
- Phase 3: admin UI — Contacts section on prospect detail page, modals, list columns
- Phase 4: reporting tally, days-in-pipeline, attempts column

🤖 Generated with [Claude Code](https://claude.com/claude-code)