### PR TITLE
Project 60 Phase 3: prospect contacts admin UI

### DIFF
--- a/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/CommunityManagementMappingsV2.cs
@@ -585,6 +585,7 @@ namespace TrashMob.Models.Extensions.V2
             {
                 Id = entity.Id,
                 ProspectId = entity.ProspectId,
+                ProspectContactId = entity.ProspectContactId,
                 ActivityType = entity.ActivityType,
                 Subject = entity.Subject,
                 Details = entity.Details,
@@ -602,6 +603,7 @@ namespace TrashMob.Models.Extensions.V2
             {
                 Id = dto.Id,
                 ProspectId = dto.ProspectId,
+                ProspectContactId = dto.ProspectContactId,
                 ActivityType = dto.ActivityType ?? string.Empty,
                 Subject = dto.Subject,
                 Details = dto.Details,

--- a/TrashMob.Models/Poco/OutreachSendRequest.cs
+++ b/TrashMob.Models/Poco/OutreachSendRequest.cs
@@ -1,5 +1,7 @@
 namespace TrashMob.Models.Poco
 {
+    using System;
+
     /// <summary>
     /// Optional request body for sending an outreach email with user-edited content.
     /// When subject and htmlBody are provided, AI generation is skipped.
@@ -11,5 +13,11 @@ namespace TrashMob.Models.Poco
 
         /// <summary>Gets or sets the custom HTML body. If null, AI-generated content is used.</summary>
         public string? HtmlBody { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specific ProspectContact to send to. If null, the prospect's
+        /// primary active contact is used. Project 60 Phase 2.
+        /// </summary>
+        public Guid? ProspectContactId { get; set; }
     }
 }

--- a/TrashMob.Models/Poco/V2/ProspectActivityDto.cs
+++ b/TrashMob.Models/Poco/V2/ProspectActivityDto.cs
@@ -20,6 +20,12 @@ namespace TrashMob.Models.Poco.V2
         public Guid ProspectId { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional ProspectContact this activity was directed at.
+        /// Project 60 Phase 2: lets activities be attributed to a specific person at the prospect.
+        /// </summary>
+        public Guid? ProspectContactId { get; set; }
+
+        /// <summary>
         /// Gets or sets the activity type.
         /// </summary>
         public string ActivityType { get; set; } = string.Empty;

--- a/TrashMob.Shared.Tests/Controllers/V2/ProspectContactsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/ProspectContactsV2ControllerTests.cs
@@ -1,0 +1,239 @@
+namespace TrashMob.Shared.Tests.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Controllers.V2;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Prospects;
+    using Xunit;
+
+    public class ProspectContactsV2ControllerTests
+    {
+        private readonly Mock<ICommunityProspectManager> prospectManager = new();
+        private readonly Mock<IProspectContactManager> contactManager = new();
+        private readonly Mock<ILogger<ProspectContactsV2Controller>> logger = new();
+        private readonly ProspectContactsV2Controller controller;
+        private readonly Guid testUserId = Guid.NewGuid();
+        private readonly Guid prospectId = Guid.NewGuid();
+
+        public ProspectContactsV2ControllerTests()
+        {
+            controller = new ProspectContactsV2Controller(
+                prospectManager.Object,
+                contactManager.Object,
+                logger.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items["UserId"] = testUserId.ToString();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, testUserId.ToString()),
+            ], "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task GetAll_WhenProspectMissing_Returns404()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CommunityProspect)null);
+
+            var result = await controller.GetAll(prospectId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task GetAll_ReturnsContactsForProspect()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CommunityProspect { Id = prospectId, Name = "Test City" });
+            contactManager
+                .Setup(m => m.GetByProspectAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[]
+                {
+                    new ProspectContact { Id = Guid.NewGuid(), ProspectId = prospectId, Name = "Alice", IsPrimary = true },
+                    new ProspectContact { Id = Guid.NewGuid(), ProspectId = prospectId, Name = "Bob" },
+                });
+
+            var result = await controller.GetAll(prospectId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<List<ProspectContactDto>>(okResult.Value);
+            Assert.Equal(2, dtos.Count);
+        }
+
+        [Fact]
+        public async Task Get_WhenContactBelongsToDifferentProspect_Returns404()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact
+                {
+                    Id = contactId,
+                    ProspectId = Guid.NewGuid(),  // Different prospect
+                    Name = "Alice",
+                });
+
+            var result = await controller.Get(prospectId, contactId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_WhenNameMissing_Returns400()
+        {
+            var result = await controller.Create(prospectId, new ProspectContactDto { Name = string.Empty }, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Create_WhenProspectMissing_Returns404()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CommunityProspect)null);
+
+            var result = await controller.Create(prospectId, new ProspectContactDto { Name = "Alice" }, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_StampsProspectIdAndAdds()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CommunityProspect { Id = prospectId });
+            contactManager
+                .Setup(m => m.AddAsync(It.IsAny<ProspectContact>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProspectContact c, Guid _, CancellationToken _) =>
+                {
+                    c.Id = Guid.NewGuid();
+                    return c;
+                });
+
+            var result = await controller.Create(prospectId, new ProspectContactDto { Name = "Alice", Email = "a@x.com" }, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            var dto = Assert.IsType<ProspectContactDto>(createdResult.Value);
+            Assert.Equal("Alice", dto.Name);
+            contactManager.Verify(m => m.AddAsync(It.Is<ProspectContact>(c => c.ProspectId == prospectId && c.Name == "Alice"),
+                testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Create_WhenIsPrimaryTrue_CallsSetPrimary()
+        {
+            prospectManager
+                .Setup(m => m.GetAsync(prospectId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CommunityProspect { Id = prospectId });
+            var created = new ProspectContact { Id = Guid.NewGuid(), ProspectId = prospectId, Name = "Alice" };
+            contactManager
+                .Setup(m => m.AddAsync(It.IsAny<ProspectContact>(), testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(created);
+            contactManager
+                .Setup(m => m.SetPrimaryAsync(created.Id, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = created.Id, ProspectId = prospectId, Name = "Alice", IsPrimary = true });
+
+            await controller.Create(prospectId, new ProspectContactDto { Name = "Alice", IsPrimary = true }, CancellationToken.None);
+
+            contactManager.Verify(m => m.SetPrimaryAsync(created.Id, testUserId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete_WhenContactHasReferences_Returns409()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.HasReferencesAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.Delete(prospectId, contactId, CancellationToken.None);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status409Conflict, objectResult.StatusCode);
+            contactManager.Verify(m => m.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Delete_WhenNoReferences_Returns204()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.HasReferencesAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            var result = await controller.Delete(prospectId, contactId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            contactManager.Verify(m => m.DeleteAsync(contactId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetPrimary_DelegatesToManager()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.SetPrimaryAsync(contactId, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice", IsPrimary = true });
+
+            var result = await controller.SetPrimary(prospectId, contactId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ProspectContactDto>(okResult.Value);
+            Assert.True(dto.IsPrimary);
+        }
+
+        [Fact]
+        public async Task UpdateStatus_DelegatesToManager()
+        {
+            var contactId = Guid.NewGuid();
+            contactManager
+                .Setup(m => m.GetAsync(contactId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact { Id = contactId, ProspectId = prospectId, Name = "Alice" });
+            contactManager
+                .Setup(m => m.UpdateStatusAsync(contactId, (int)ProspectContactStatus.WrongPerson, testUserId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProspectContact
+                {
+                    Id = contactId,
+                    ProspectId = prospectId,
+                    Name = "Alice",
+                    ContactStatus = (int)ProspectContactStatus.WrongPerson,
+                });
+
+            var result = await controller.UpdateStatus(
+                prospectId,
+                contactId,
+                new UpdateProspectContactStatusRequest { Status = (int)ProspectContactStatus.WrongPerson },
+                CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ProspectContactDto>(okResult.Value);
+            Assert.Equal((int)ProspectContactStatus.WrongPerson, dto.ContactStatus);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/ProspectContactManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/ProspectContactManagerTests.cs
@@ -1,0 +1,203 @@
+namespace TrashMob.Shared.Tests.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Prospects;
+    using TrashMob.Shared.Persistence.Interfaces;
+    using TrashMob.Shared.Tests.Fixtures;
+    using Xunit;
+
+    public class ProspectContactManagerTests
+    {
+        private readonly Mock<IKeyedRepository<ProspectContact>> _contactRepo;
+        private readonly Mock<IKeyedRepository<ProspectActivity>> _activityRepo;
+        private readonly Mock<IKeyedRepository<ProspectOutreachEmail>> _outreachRepo;
+        private readonly ProspectContactManager _sut;
+        private readonly Guid _userId = Guid.NewGuid();
+
+        public ProspectContactManagerTests()
+        {
+            _contactRepo = new Mock<IKeyedRepository<ProspectContact>>();
+            _activityRepo = new Mock<IKeyedRepository<ProspectActivity>>();
+            _outreachRepo = new Mock<IKeyedRepository<ProspectOutreachEmail>>();
+
+            _contactRepo.SetupAddAsync();
+            _contactRepo.SetupUpdateAsync();
+            _activityRepo.SetupGet(new List<ProspectActivity>());
+            _outreachRepo.SetupGet(new List<ProspectOutreachEmail>());
+
+            _sut = new ProspectContactManager(_contactRepo.Object, _activityRepo.Object, _outreachRepo.Object);
+        }
+
+        [Fact]
+        public async Task GetByProspectAsync_ReturnsPrimaryFirst()
+        {
+            var prospectId = Guid.NewGuid();
+            var contacts = new[]
+            {
+                MakeContact(prospectId, "Bob", isPrimary: false),
+                MakeContact(prospectId, "Alice", isPrimary: true),
+                MakeContact(prospectId, "Carla", isPrimary: false),
+            };
+            _contactRepo.SetupGet(contacts);
+
+            var result = (await _sut.GetByProspectAsync(prospectId)).ToList();
+
+            Assert.Equal(3, result.Count);
+            Assert.True(result[0].IsPrimary);
+            Assert.Equal("Alice", result[0].Name);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_DemotesExistingPrimary()
+        {
+            var prospectId = Guid.NewGuid();
+            var oldPrimary = MakeContact(prospectId, "Alice", isPrimary: true);
+            var newPrimary = MakeContact(prospectId, "Bob", isPrimary: false);
+            _contactRepo.SetupGet(new[] { oldPrimary, newPrimary });
+            _contactRepo.SetupGetAsync(new[] { oldPrimary, newPrimary });
+
+            var result = await _sut.SetPrimaryAsync(newPrimary.Id, _userId);
+
+            Assert.NotNull(result);
+            Assert.True(result.IsPrimary);
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == oldPrimary.Id && !c.IsPrimary)), Times.Once);
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == newPrimary.Id && c.IsPrimary)), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_WhenAlreadyPrimary_StillUpdatesLastModified()
+        {
+            var prospectId = Guid.NewGuid();
+            var primary = MakeContact(prospectId, "Alice", isPrimary: true);
+            _contactRepo.SetupGet(new[] { primary });
+            _contactRepo.SetupGetAsync(new[] { primary });
+
+            var result = await _sut.SetPrimaryAsync(primary.Id, _userId);
+
+            Assert.True(result.IsPrimary);
+            // No siblings to demote, but the target itself is updated.
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == primary.Id)), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_DoesNotTouchContactsOnOtherProspects()
+        {
+            var prospectId = Guid.NewGuid();
+            var otherProspectId = Guid.NewGuid();
+            var newPrimary = MakeContact(prospectId, "Bob", isPrimary: false);
+            var oldPrimaryOtherProspect = MakeContact(otherProspectId, "Carla", isPrimary: true);
+            _contactRepo.SetupGet(new[] { newPrimary, oldPrimaryOtherProspect });
+            _contactRepo.SetupGetAsync(new[] { newPrimary, oldPrimaryOtherProspect });
+
+            await _sut.SetPrimaryAsync(newPrimary.Id, _userId);
+
+            // Carla on the other prospect must NOT be demoted.
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.Id == oldPrimaryOtherProspect.Id)), Times.Never);
+        }
+
+        [Fact]
+        public async Task SetPrimaryAsync_WhenContactNotFound_ReturnsNull()
+        {
+            _contactRepo.SetupGet(new List<ProspectContact>());
+            _contactRepo.Setup(r => r.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProspectContact)null);
+
+            var result = await _sut.SetPrimaryAsync(Guid.NewGuid(), _userId);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task UpdateStatusAsync_PersistsStatusAndAuditFields()
+        {
+            var contact = MakeContact(Guid.NewGuid(), "Alice", isPrimary: true);
+            _contactRepo.SetupGetAsync(contact);
+
+            var result = await _sut.UpdateStatusAsync(contact.Id, (int)ProspectContactStatus.WrongPerson, _userId);
+
+            Assert.Equal((int)ProspectContactStatus.WrongPerson, result.ContactStatus);
+            Assert.Equal(_userId, result.LastUpdatedByUserId);
+            _contactRepo.Verify(r => r.UpdateAsync(It.Is<ProspectContact>(c => c.ContactStatus == (int)ProspectContactStatus.WrongPerson)), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateStatusAsync_WhenContactNotFound_ReturnsNull()
+        {
+            _contactRepo.Setup(r => r.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProspectContact)null);
+
+            var result = await _sut.UpdateStatusAsync(Guid.NewGuid(), (int)ProspectContactStatus.NoResponse, _userId);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task HasReferencesAsync_FalseWhenNoActivityOrOutreach()
+        {
+            var contactId = Guid.NewGuid();
+
+            var result = await _sut.HasReferencesAsync(contactId);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task HasReferencesAsync_TrueWhenActivityReferencesContact()
+        {
+            var contactId = Guid.NewGuid();
+            _activityRepo.SetupGet(new[]
+            {
+                new ProspectActivity
+                {
+                    Id = Guid.NewGuid(),
+                    ProspectId = Guid.NewGuid(),
+                    ProspectContactId = contactId,
+                    ActivityType = "Call",
+                },
+            });
+
+            var result = await _sut.HasReferencesAsync(contactId);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task HasReferencesAsync_TrueWhenOutreachEmailReferencesContact()
+        {
+            var contactId = Guid.NewGuid();
+            _outreachRepo.SetupGet(new[]
+            {
+                new ProspectOutreachEmail
+                {
+                    Id = Guid.NewGuid(),
+                    ProspectId = Guid.NewGuid(),
+                    ProspectContactId = contactId,
+                    Status = "Sent",
+                },
+            });
+
+            var result = await _sut.HasReferencesAsync(contactId);
+
+            Assert.True(result);
+        }
+
+        private static ProspectContact MakeContact(Guid prospectId, string name, bool isPrimary)
+        {
+            return new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospectId,
+                Name = name,
+                Email = $"{name.ToLowerInvariant()}@example.com",
+                ContactStatus = (int)ProspectContactStatus.Active,
+                IsPrimary = isPrimary,
+            };
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/ProspectOutreachManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/ProspectOutreachManagerTests.cs
@@ -328,6 +328,86 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
                 Times.Once);
         }
 
+        [Fact]
+        public async Task SendOutreach_WithContactIdOverride_TargetsSelectedContact()
+        {
+            var prospect = new CommunityProspectBuilder().Build();
+            prospect.PipelineStage = 0;
+            AddPrimaryContact(prospect, "primary@example.com", "Primary");
+            var secondary = new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospect.Id,
+                Name = "Secondary",
+                Email = "secondary@example.com",
+                ContactStatus = (int)ProspectContactStatus.Active,
+                IsPrimary = false,
+            };
+            prospect.Contacts.Add(secondary);
+            _prospectRepo.SetupGet(new[] { prospect });
+            SetupEmptyOutreachHistory();
+            SetupContentService(prospect.Id, 1);
+            _emailManager.Setup(e => e.GetHtmlEmailCopy(It.IsAny<string>()))
+                .Returns("<p>{personalizedContent}</p>");
+            _configuration.Setup(c => c["OutreachTestMode"]).Returns("false");
+            var sut = CreateSut();
+
+            var result = await sut.SendOutreachAsync(
+                prospect.Id, Guid.NewGuid(),
+                new OutreachSendRequest { ProspectContactId = secondary.Id });
+
+            Assert.True(result.Success);
+            // The saved outreach email should carry the secondary contact's Id, not the primary's.
+            _outreachEmailRepo.Verify(r => r.AddAsync(It.Is<ProspectOutreachEmail>(
+                e => e.ProspectContactId == secondary.Id)), Times.Once);
+            // Live mode → the secondary contact's email is the recipient.
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.Is<List<Shared.Poco.EmailAddress>>(r => r[0].Email == "secondary@example.com"),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task SendOutreach_WithUnknownContactIdOverride_ReturnsFailure()
+        {
+            var prospect = new CommunityProspectBuilder().Build();
+            AddPrimaryContact(prospect, "test@example.com");
+            _prospectRepo.SetupGet(new[] { prospect });
+            SetupEmptyOutreachHistory();
+
+            var result = await _sut.SendOutreachAsync(
+                prospect.Id, Guid.NewGuid(),
+                new OutreachSendRequest { ProspectContactId = Guid.NewGuid() });
+
+            Assert.False(result.Success);
+            Assert.Contains("does not belong", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task SendOutreach_WithInactiveContactIdOverride_ReturnsFailure()
+        {
+            var prospect = new CommunityProspectBuilder().Build();
+            AddPrimaryContact(prospect, "primary@example.com");
+            var wrongPerson = new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospect.Id,
+                Name = "Wrong",
+                Email = "wrong@example.com",
+                ContactStatus = (int)ProspectContactStatus.WrongPerson,
+            };
+            prospect.Contacts.Add(wrongPerson);
+            _prospectRepo.SetupGet(new[] { prospect });
+            SetupEmptyOutreachHistory();
+
+            var result = await _sut.SendOutreachAsync(
+                prospect.Id, Guid.NewGuid(),
+                new OutreachSendRequest { ProspectContactId = wrongPerson.Id });
+
+            Assert.False(result.Success);
+            Assert.Contains("WrongPerson", result.ErrorMessage);
+        }
+
         #endregion
 
         #region PreviewOutreachAsync

--- a/TrashMob.Shared/Managers/Prospects/IProspectContactManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/IProspectContactManager.cs
@@ -1,0 +1,36 @@
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    public interface IProspectContactManager : IKeyedManager<ProspectContact>
+    {
+        /// <summary>
+        /// Returns all contacts for a prospect, primary first.
+        /// </summary>
+        Task<IEnumerable<ProspectContact>> GetByProspectAsync(Guid prospectId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Atomically designates a contact as primary, clearing the IsPrimary flag on all
+        /// other contacts for the same prospect.
+        /// </summary>
+        Task<ProspectContact> SetPrimaryAsync(Guid contactId, Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the lifecycle status of a contact (Active, WrongPerson, NoResponse,
+        /// LeftOrganization, RightPerson).
+        /// </summary>
+        Task<ProspectContact> UpdateStatusAsync(Guid contactId, int newStatus, Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns true if any ProspectActivity or ProspectOutreachEmail references this
+        /// contact. Callers can use this to decide whether deletion should be allowed
+        /// (hard delete) or blocked in favor of marking the contact inactive.
+        /// </summary>
+        Task<bool> HasReferencesAsync(Guid contactId, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/ProspectContactManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectContactManager.cs
@@ -1,0 +1,86 @@
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Persistence.Interfaces;
+
+    public class ProspectContactManager(
+        IKeyedRepository<ProspectContact> repository,
+        IKeyedRepository<ProspectActivity> activityRepository,
+        IKeyedRepository<ProspectOutreachEmail> outreachEmailRepository)
+        : KeyedManager<ProspectContact>(repository), IProspectContactManager
+    {
+        public async Task<IEnumerable<ProspectContact>> GetByProspectAsync(Guid prospectId, CancellationToken cancellationToken = default)
+        {
+            return await Repo.Get()
+                .Where(c => c.ProspectId == prospectId)
+                .OrderByDescending(c => c.IsPrimary)
+                .ThenBy(c => c.Name)
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<ProspectContact> SetPrimaryAsync(Guid contactId, Guid userId, CancellationToken cancellationToken = default)
+        {
+            var target = await Repo.GetAsync(contactId, cancellationToken);
+            if (target is null)
+            {
+                return null;
+            }
+
+            var siblings = await Repo.Get()
+                .Where(c => c.ProspectId == target.ProspectId && c.Id != target.Id && c.IsPrimary)
+                .ToListAsync(cancellationToken);
+
+            var now = DateTimeOffset.UtcNow;
+
+            // Clear IsPrimary on existing primaries (if any) and persist.
+            foreach (var sibling in siblings)
+            {
+                sibling.IsPrimary = false;
+                sibling.LastUpdatedByUserId = userId;
+                sibling.LastUpdatedDate = now;
+                await Repo.UpdateAsync(sibling);
+            }
+
+            target.IsPrimary = true;
+            target.LastUpdatedByUserId = userId;
+            target.LastUpdatedDate = now;
+
+            return await Repo.UpdateAsync(target);
+        }
+
+        public async Task<ProspectContact> UpdateStatusAsync(Guid contactId, int newStatus, Guid userId, CancellationToken cancellationToken = default)
+        {
+            var contact = await Repo.GetAsync(contactId, cancellationToken);
+            if (contact is null)
+            {
+                return null;
+            }
+
+            contact.ContactStatus = newStatus;
+            contact.LastUpdatedByUserId = userId;
+            contact.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            return await Repo.UpdateAsync(contact);
+        }
+
+        public async Task<bool> HasReferencesAsync(Guid contactId, CancellationToken cancellationToken = default)
+        {
+            var activityRefs = await activityRepository.Get()
+                .AnyAsync(a => a.ProspectContactId == contactId, cancellationToken);
+
+            if (activityRefs)
+            {
+                return true;
+            }
+
+            return await outreachEmailRepository.Get()
+                .AnyAsync(e => e.ProspectContactId == contactId, cancellationToken);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
+++ b/TrashMob.Shared/Managers/Prospects/ProspectOutreachManager.cs
@@ -89,11 +89,40 @@ namespace TrashMob.Shared.Managers.Prospects
                 };
             }
 
-            var primaryContact = prospect.Contacts?
-                .FirstOrDefault(c => c.IsPrimary && c.ContactStatus == (int)ProspectContactStatus.Active)
-                ?? prospect.Contacts?.FirstOrDefault(c => c.IsPrimary);
-            var prospectEmail = primaryContact?.Email;
-            var prospectContactName = primaryContact?.Name;
+            // Pick the target contact: explicit override (Project 60 Phase 2) takes precedence,
+            // else fall back to the prospect's primary active contact.
+            ProspectContact targetContact;
+            if (customContent?.ProspectContactId is { } overrideId)
+            {
+                targetContact = prospect.Contacts?.FirstOrDefault(c => c.Id == overrideId);
+                if (targetContact is null)
+                {
+                    return new OutreachSendResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Specified ProspectContactId does not belong to this prospect.",
+                    };
+                }
+
+                if (targetContact.ContactStatus != (int)ProspectContactStatus.Active
+                    && targetContact.ContactStatus != (int)ProspectContactStatus.RightPerson)
+                {
+                    return new OutreachSendResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"Contact is in status {(ProspectContactStatus)targetContact.ContactStatus} and cannot receive outreach.",
+                    };
+                }
+            }
+            else
+            {
+                targetContact = prospect.Contacts?
+                    .FirstOrDefault(c => c.IsPrimary && c.ContactStatus == (int)ProspectContactStatus.Active)
+                    ?? prospect.Contacts?.FirstOrDefault(c => c.IsPrimary);
+            }
+
+            var prospectEmail = targetContact?.Email;
+            var prospectContactName = targetContact?.Name;
 
             var recipientEmail = settings.TestMode ? settings.TestRecipientEmail : prospectEmail;
             if (string.IsNullOrWhiteSpace(recipientEmail))
@@ -148,7 +177,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 {
                     Id = Guid.NewGuid(),
                     ProspectId = prospectId,
-                    ProspectContactId = primaryContact?.Id,
+                    ProspectContactId = targetContact?.Id,
                     CadenceStep = nextStep,
                     Subject = subject,
                     HtmlBody = fullHtml,
@@ -194,7 +223,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 {
                     Id = Guid.NewGuid(),
                     ProspectId = prospectId,
-                    ProspectContactId = primaryContact?.Id,
+                    ProspectContactId = targetContact?.Id,
                     ActivityType = "EmailSent",
                     Subject = $"Outreach Step {nextStep}: {subject}",
                     Details = settings.TestMode

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -160,6 +160,7 @@
 
             // Community Prospects
             services.AddScoped<ICommunityProspectManager, CommunityProspectManager>();
+            services.AddScoped<IProspectContactManager, ProspectContactManager>();
             services.AddScoped<IProspectActivityManager, ProspectActivityManager>();
             services.AddScoped<IClaudeDiscoveryService, ClaudeDiscoveryService>();
             services.AddScoped<IProspectScoringManager, ProspectScoringManager>();

--- a/TrashMob/Controllers/V2/ProspectContactsV2Controller.cs
+++ b/TrashMob/Controllers/V2/ProspectContactsV2Controller.cs
@@ -1,0 +1,274 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Prospects;
+
+    /// <summary>
+    /// V2 controller for managing the contacts associated with a CommunityProspect (Project 60).
+    /// Admin-only — contacts are not exposed publicly.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/community-prospects/{prospectId}/contacts")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    [RequiredScope(Constants.TrashMobWriteScope)]
+    public class ProspectContactsV2Controller(
+        ICommunityProspectManager prospectManager,
+        IProspectContactManager contactManager,
+        ILogger<ProspectContactsV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => Guid.TryParse(HttpContext.Items["UserId"]?.ToString(), out var parsedUserId) ? parsedUserId : Guid.Empty;
+
+        /// <summary>
+        /// Lists all contacts for a prospect, primary first.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the contacts list.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<ProspectContactDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetAll(Guid prospectId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetAll prospect contacts ProspectId={ProspectId}", prospectId);
+
+            var prospect = await prospectManager.GetAsync(prospectId, cancellationToken);
+            if (prospect is null)
+            {
+                return NotFound();
+            }
+
+            var contacts = await contactManager.GetByProspectAsync(prospectId, cancellationToken);
+            return Ok(contacts.Select(c => c.ToV2Dto()).ToList());
+        }
+
+        /// <summary>
+        /// Gets a single contact by ID.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the contact.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpGet("{contactId}")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Get(Guid prospectId, Guid contactId, CancellationToken cancellationToken)
+        {
+            var contact = await contactManager.GetAsync(contactId, cancellationToken);
+            if (contact is null || contact.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            return Ok(contact.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Creates a new contact for a prospect. If <c>IsPrimary</c> is true on the incoming
+        /// DTO, any existing primary contact on the prospect is demoted in the same operation.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="dto">The contact data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Contact created.</response>
+        /// <response code="400">Validation error.</response>
+        /// <response code="404">Prospect not found.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Create(Guid prospectId, [FromBody] ProspectContactDto dto, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(dto?.Name))
+            {
+                return Problem("Contact name is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var prospect = await prospectManager.GetAsync(prospectId, cancellationToken);
+            if (prospect is null)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 Create prospect contact ProspectId={ProspectId} Name={Name}", prospectId, dto.Name);
+
+            var entity = dto.ToEntity();
+            entity.ProspectId = prospectId;
+
+            var created = await contactManager.AddAsync(entity, UserId, cancellationToken);
+
+            // If the caller asked for primary, run the atomic SetPrimaryAsync so existing
+            // primaries get demoted.
+            if (dto.IsPrimary)
+            {
+                created = await contactManager.SetPrimaryAsync(created.Id, UserId, cancellationToken);
+            }
+
+            return CreatedAtAction(nameof(Get), new { prospectId, contactId = created.Id }, created.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates a contact. The <c>IsPrimary</c> flag on the DTO is ignored here — use
+        /// the dedicated <c>POST /{contactId}/set-primary</c> endpoint to change primary
+        /// status atomically.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="dto">The updated contact data.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Contact updated.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpPut("{contactId}")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(Guid prospectId, Guid contactId, [FromBody] ProspectContactDto dto, CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 Update prospect contact ContactId={ContactId}", contactId);
+
+            existing.Name = dto.Name ?? existing.Name;
+            existing.Title = dto.Title;
+            existing.Email = dto.Email;
+            existing.Phone = dto.Phone;
+            existing.Role = dto.Role;
+            existing.ContactStatus = dto.ContactStatus;
+            existing.ReferredByContactId = dto.ReferredByContactId;
+            existing.Notes = dto.Notes;
+            existing.LastUpdatedByUserId = UserId;
+            existing.LastUpdatedDate = DateTimeOffset.UtcNow;
+
+            var updated = await contactManager.UpdateAsync(existing, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Deletes a contact. If the contact has any activity or outreach email references,
+        /// the delete is blocked and a 409 is returned — the caller should mark the contact
+        /// inactive (status = LeftOrganization) instead.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Contact deleted.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        /// <response code="409">Contact has history and cannot be deleted.</response>
+        [HttpDelete("{contactId}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        public async Task<IActionResult> Delete(Guid prospectId, Guid contactId, CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            if (await contactManager.HasReferencesAsync(contactId, cancellationToken))
+            {
+                return Problem(
+                    detail: "Contact has activity or outreach history and cannot be deleted. Mark it as LeftOrganization instead.",
+                    statusCode: StatusCodes.Status409Conflict);
+            }
+
+            logger.LogInformation("V2 Delete prospect contact ContactId={ContactId}", contactId);
+
+            await contactManager.DeleteAsync(contactId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Atomically designates a contact as primary, clearing IsPrimary on all other
+        /// contacts of the same prospect.
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID to promote.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated contact.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpPost("{contactId}/set-primary")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SetPrimary(Guid prospectId, Guid contactId, CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation("V2 SetPrimary prospect contact ContactId={ContactId}", contactId);
+
+            var updated = await contactManager.SetPrimaryAsync(contactId, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates the lifecycle status of a contact (0=Active, 1=WrongPerson, 2=NoResponse,
+        /// 3=LeftOrganization, 4=RightPerson).
+        /// </summary>
+        /// <param name="prospectId">The parent prospect ID.</param>
+        /// <param name="contactId">The contact ID.</param>
+        /// <param name="request">The new status.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated contact.</response>
+        /// <response code="404">Contact not found or doesn't belong to the given prospect.</response>
+        [HttpPut("{contactId}/status")]
+        [ProducesResponseType(typeof(ProspectContactDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UpdateStatus(
+            Guid prospectId,
+            Guid contactId,
+            [FromBody] UpdateProspectContactStatusRequest request,
+            CancellationToken cancellationToken)
+        {
+            var existing = await contactManager.GetAsync(contactId, cancellationToken);
+            if (existing is null || existing.ProspectId != prospectId)
+            {
+                return NotFound();
+            }
+
+            logger.LogInformation(
+                "V2 UpdateStatus prospect contact ContactId={ContactId} Status={Status}",
+                contactId, request.Status);
+
+            var updated = await contactManager.UpdateStatusAsync(contactId, request.Status, UserId, cancellationToken);
+            return Ok(updated.ToV2Dto());
+        }
+    }
+
+    /// <summary>
+    /// Request body for changing a ProspectContact's lifecycle status (V2).
+    /// </summary>
+    public class UpdateProspectContactStatusRequest
+    {
+        /// <summary>
+        /// Gets or sets the new <see cref="ProspectContactStatus"/> value.
+        /// </summary>
+        public int Status { get; set; }
+    }
+}

--- a/TrashMob/client-app/src/components/Models/CommunityProspectData.ts
+++ b/TrashMob/client-app/src/components/Models/CommunityProspectData.ts
@@ -1,3 +1,5 @@
+import ProspectContactData from './ProspectContactData';
+
 class CommunityProspectData {
     id: string = '00000000-0000-0000-0000-000000000000';
     name: string = '';
@@ -9,6 +11,10 @@ class CommunityProspectData {
     longitude: number | null = null;
     population: number | null = null;
     website: string = '';
+    // Legacy primary-contact shortcuts: still read on POST/PUT by the backend to upsert
+    // the primary contact, populated on read from the primary ProspectContact. Frontend
+    // forms continue to use these for the time being; the dedicated contacts list (below)
+    // is the source of truth for everything else.
     contactEmail: string = '';
     contactName: string = '';
     contactTitle: string = '';
@@ -19,6 +25,7 @@ class CommunityProspectData {
     lastContactedDate: string | null = null;
     nextFollowUpDate: string | null = null;
     convertedPartnerId: string | null = null;
+    contacts: ProspectContactData[] = [];
     createdDate: string | null = null;
     lastUpdatedDate: string | null = null;
 }

--- a/TrashMob/client-app/src/components/Models/ProspectActivityData.ts
+++ b/TrashMob/client-app/src/components/Models/ProspectActivityData.ts
@@ -1,6 +1,7 @@
 class ProspectActivityData {
     id: string = '00000000-0000-0000-0000-000000000000';
     prospectId: string = '';
+    prospectContactId: string | null = null;
     activityType: string = 'Note';
     subject: string = '';
     details: string = '';

--- a/TrashMob/client-app/src/components/Models/ProspectContactData.ts
+++ b/TrashMob/client-app/src/components/Models/ProspectContactData.ts
@@ -1,0 +1,17 @@
+class ProspectContactData {
+    id: string = '00000000-0000-0000-0000-000000000000';
+    prospectId: string = '';
+    name: string = '';
+    title: string | null = null;
+    email: string | null = null;
+    phone: string | null = null;
+    role: string | null = null;
+    contactStatus: number = 0;
+    isPrimary: boolean = false;
+    referredByContactId: string | null = null;
+    notes: string | null = null;
+    createdDate: string | null = null;
+    lastUpdatedDate: string | null = null;
+}
+
+export default ProspectContactData;

--- a/TrashMob/client-app/src/components/prospects/outreach-preview-dialog.tsx
+++ b/TrashMob/client-app/src/components/prospects/outreach-preview-dialog.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import {
     PreviewOutreach,
@@ -14,6 +15,8 @@ import {
     GetCommunityProspectById,
 } from '@/services/community-prospects';
 import OutreachPreviewData from '@/components/Models/OutreachPreviewData';
+import ProspectContactData from '@/components/Models/ProspectContactData';
+import { ProspectContactStatusBadge } from '@/components/prospects/prospect-contact-status-badge';
 
 const CADENCE_STEP_LABELS: Record<number, string> = {
     1: 'Initial Outreach',
@@ -22,19 +25,49 @@ const CADENCE_STEP_LABELS: Record<number, string> = {
     4: 'Final Follow-up',
 };
 
+const PRIMARY_CONTACT_VALUE = '__primary__';
+
 interface OutreachPreviewDialogProps {
     prospectId: string;
     open: boolean;
     onOpenChange: (open: boolean) => void;
+    /**
+     * The prospect's contacts. The dialog pre-selects the primary active contact and
+     * lets the user pick a different one before sending. Pass [] to fall back to the
+     * backend's automatic primary-contact resolution.
+     */
+    contacts?: ProspectContactData[];
 }
 
-export function OutreachPreviewDialog({ prospectId, open, onOpenChange }: OutreachPreviewDialogProps) {
+export function OutreachPreviewDialog({ prospectId, open, onOpenChange, contacts = [] }: OutreachPreviewDialogProps) {
     const { toast } = useToast();
     const queryClient = useQueryClient();
     const [preview, setPreview] = useState<OutreachPreviewData | null>(null);
     const [loading, setLoading] = useState(false);
     const [editedSubject, setEditedSubject] = useState('');
     const [editedBody, setEditedBody] = useState('');
+    const [selectedContactId, setSelectedContactId] = useState<string>(PRIMARY_CONTACT_VALUE);
+
+    const sendableContacts = useMemo(
+        () => contacts.filter((c) => c.contactStatus === 0 /* Active */ || c.contactStatus === 4 /* RightPerson */),
+        [contacts],
+    );
+
+    // When the dialog opens (or the contacts list changes), default to the primary
+    // contact's id so the dropdown reflects who the email will actually go to.
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        const primary = sendableContacts.find((c) => c.isPrimary);
+        if (primary) {
+            setSelectedContactId(primary.id);
+        } else if (sendableContacts.length === 1) {
+            setSelectedContactId(sendableContacts[0].id);
+        } else {
+            setSelectedContactId(PRIMARY_CONTACT_VALUE);
+        }
+    }, [open, sendableContacts]);
 
     const generatePreview = async () => {
         setLoading(true);
@@ -89,6 +122,9 @@ export function OutreachPreviewDialog({ prospectId, open, onOpenChange }: Outrea
     const isCadenceComplete = preview?.subject?.includes('complete') ?? false;
     const canSend = preview && preview.cadenceStep <= 4 && !isCadenceComplete;
 
+    const selectedContact =
+        selectedContactId === PRIMARY_CONTACT_VALUE ? null : (contacts.find((c) => c.id === selectedContactId) ?? null);
+
     return (
         <Dialog open={open} onOpenChange={handleOpen}>
             <DialogContent className='max-w-2xl max-h-[80vh] overflow-y-auto'>
@@ -111,6 +147,40 @@ export function OutreachPreviewDialog({ prospectId, open, onOpenChange }: Outrea
 
                         {!isCadenceComplete ? (
                             <>
+                                {contacts.length > 0 ? (
+                                    <div>
+                                        <label htmlFor='outreach-contact' className='text-sm font-medium'>
+                                            Send to
+                                        </label>
+                                        <Select value={selectedContactId} onValueChange={setSelectedContactId}>
+                                            <SelectTrigger id='outreach-contact'>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value={PRIMARY_CONTACT_VALUE}>
+                                                    Auto (primary active contact)
+                                                </SelectItem>
+                                                {sendableContacts.map((c) => (
+                                                    <SelectItem key={c.id} value={c.id}>
+                                                        {c.name}
+                                                        {c.email ? ` <${c.email}>` : ''}
+                                                        {c.isPrimary ? ' — primary' : ''}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        {selectedContact && !selectedContact.email ? (
+                                            <p className='text-xs text-destructive mt-1'>
+                                                This contact has no email address — the send will fail.
+                                            </p>
+                                        ) : null}
+                                        {selectedContact ? (
+                                            <div className='mt-1'>
+                                                <ProspectContactStatusBadge status={selectedContact.contactStatus} />
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                ) : null}
                                 <div>
                                     <label htmlFor='outreach-subject' className='text-sm font-medium'>
                                         Subject
@@ -155,6 +225,8 @@ export function OutreachPreviewDialog({ prospectId, open, onOpenChange }: Outrea
                                     id: prospectId,
                                     subject: editedSubject,
                                     htmlBody: editedBody,
+                                    prospectContactId:
+                                        selectedContactId === PRIMARY_CONTACT_VALUE ? undefined : selectedContactId,
                                 })
                             }
                             disabled={sendOutreach.isPending || !editedSubject.trim() || !editedBody.trim()}

--- a/TrashMob/client-app/src/components/prospects/prospect-contact-form-dialog.tsx
+++ b/TrashMob/client-app/src/components/prospects/prospect-contact-form-dialog.tsx
@@ -1,0 +1,357 @@
+import { useEffect } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { EnhancedFormLabel as FormLabel } from '@/components/ui/custom/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useToast } from '@/hooks/use-toast';
+import { getErrorMessage } from '@/lib/api-errors';
+import {
+    CreateProspectContact,
+    GetCommunityProspectById,
+    GetProspectContacts,
+    UpdateProspectContact,
+} from '@/services/community-prospects';
+import ProspectContactData from '@/components/Models/ProspectContactData';
+import { PROSPECT_CONTACT_STATUSES } from './prospect-contact-status-badge';
+
+interface ProspectContactFormDialogProps {
+    prospectId: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** When provided, the dialog is in edit mode. Omit for create. */
+    contact?: ProspectContactData;
+    /** Other contacts on this prospect (for the "Referred by" dropdown). */
+    referralCandidates: ProspectContactData[];
+}
+
+interface FormInputs {
+    name: string;
+    title: string;
+    email: string;
+    phone: string;
+    role: string;
+    contactStatus: string;
+    isPrimary: boolean;
+    referredByContactId: string;
+    notes: string;
+}
+
+const NO_REFERRAL_VALUE = '__none__';
+
+const formSchema = z.object({
+    name: z.string().min(1, 'Name is required'),
+    title: z.string(),
+    email: z.string().email('Invalid email').or(z.literal('')),
+    phone: z.string(),
+    role: z.string(),
+    contactStatus: z.string(),
+    isPrimary: z.boolean(),
+    referredByContactId: z.string(),
+    notes: z.string(),
+});
+
+export function ProspectContactFormDialog({
+    prospectId,
+    open,
+    onOpenChange,
+    contact,
+    referralCandidates,
+}: ProspectContactFormDialogProps) {
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+    const isEdit = !!contact;
+
+    const form = useForm<FormInputs>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            name: '',
+            title: '',
+            email: '',
+            phone: '',
+            role: '',
+            contactStatus: '0',
+            isPrimary: false,
+            referredByContactId: NO_REFERRAL_VALUE,
+            notes: '',
+        },
+    });
+
+    // When the dialog opens (or the contact prop changes), seed the form.
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        if (contact) {
+            form.reset({
+                name: contact.name ?? '',
+                title: contact.title ?? '',
+                email: contact.email ?? '',
+                phone: contact.phone ?? '',
+                role: contact.role ?? '',
+                contactStatus: String(contact.contactStatus ?? 0),
+                isPrimary: contact.isPrimary,
+                referredByContactId: contact.referredByContactId ?? NO_REFERRAL_VALUE,
+                notes: contact.notes ?? '',
+            });
+        } else {
+            form.reset({
+                name: '',
+                title: '',
+                email: '',
+                phone: '',
+                role: '',
+                contactStatus: '0',
+                isPrimary: referralCandidates.length === 0,
+                referredByContactId: NO_REFERRAL_VALUE,
+                notes: '',
+            });
+        }
+    }, [open, contact, referralCandidates.length, form]);
+
+    const invalidateAfterChange = () => {
+        queryClient.invalidateQueries({
+            queryKey: GetProspectContacts({ prospectId }).key,
+            refetchType: 'all',
+        });
+        queryClient.invalidateQueries({
+            queryKey: GetCommunityProspectById({ id: prospectId }).key,
+            refetchType: 'all',
+        });
+    };
+
+    const createContact = useMutation({
+        mutationKey: CreateProspectContact({ prospectId }).key,
+        mutationFn: CreateProspectContact({ prospectId }).service,
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Contact added' });
+            invalidateAfterChange();
+            onOpenChange(false);
+        },
+        onError: (error: Error) => {
+            toast({ variant: 'destructive', title: 'Failed to add contact', description: getErrorMessage(error) });
+        },
+    });
+
+    const updateContact = useMutation({
+        mutationKey: UpdateProspectContact({ prospectId, contactId: contact?.id ?? '' }).key,
+        mutationFn: async (body: ProspectContactData) => {
+            if (!contact) {
+                throw new Error('No contact in edit mode');
+            }
+            return UpdateProspectContact({ prospectId, contactId: contact.id }).service(body);
+        },
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Contact updated' });
+            invalidateAfterChange();
+            onOpenChange(false);
+        },
+        onError: (error: Error) => {
+            toast({ variant: 'destructive', title: 'Failed to update contact', description: getErrorMessage(error) });
+        },
+    });
+
+    const isPending = createContact.isPending || updateContact.isPending;
+
+    const onSubmit: SubmitHandler<FormInputs> = (values) => {
+        const body = new ProspectContactData();
+        body.id = contact?.id ?? '00000000-0000-0000-0000-000000000000';
+        body.prospectId = prospectId;
+        body.name = values.name;
+        body.title = values.title || null;
+        body.email = values.email || null;
+        body.phone = values.phone || null;
+        body.role = values.role || null;
+        body.contactStatus = parseInt(values.contactStatus, 10);
+        body.isPrimary = values.isPrimary;
+        body.referredByContactId = values.referredByContactId === NO_REFERRAL_VALUE ? null : values.referredByContactId;
+        body.notes = values.notes || null;
+
+        if (isEdit) {
+            updateContact.mutate(body);
+        } else {
+            createContact.mutate(body);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className='max-w-xl'>
+                <DialogHeader>
+                    <DialogTitle>{isEdit ? 'Edit Contact' : 'Add Contact'}</DialogTitle>
+                </DialogHeader>
+                <Form {...form}>
+                    <form id='prospect-contact-form' onSubmit={form.handleSubmit(onSubmit)} className='space-y-4'>
+                        <FormField
+                            control={form.control}
+                            name='name'
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Name *</FormLabel>
+                                    <FormControl>
+                                        <Input {...field} placeholder='Jane Doe' />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        <div className='grid grid-cols-2 gap-4'>
+                            <FormField
+                                control={form.control}
+                                name='title'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Title</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} placeholder='Sustainability Coordinator' />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name='role'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Role</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} placeholder='Decision-maker, Gatekeeper, Referral...' />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                        <div className='grid grid-cols-2 gap-4'>
+                            <FormField
+                                control={form.control}
+                                name='email'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Email</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} type='email' placeholder='jane@city.gov' />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name='phone'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Phone</FormLabel>
+                                        <FormControl>
+                                            <Input {...field} placeholder='(555) 555-5555' />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                        <div className='grid grid-cols-2 gap-4'>
+                            <FormField
+                                control={form.control}
+                                name='contactStatus'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Status</FormLabel>
+                                        <FormControl>
+                                            <Select value={field.value} onValueChange={field.onChange}>
+                                                <SelectTrigger>
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    {PROSPECT_CONTACT_STATUSES.map((s) => (
+                                                        <SelectItem key={s.value} value={String(s.value)}>
+                                                            {s.label}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name='referredByContactId'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Referred by</FormLabel>
+                                        <FormControl>
+                                            <Select value={field.value} onValueChange={field.onChange}>
+                                                <SelectTrigger>
+                                                    <SelectValue placeholder='None' />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value={NO_REFERRAL_VALUE}>None</SelectItem>
+                                                    {referralCandidates
+                                                        .filter((c) => c.id !== contact?.id)
+                                                        .map((c) => (
+                                                            <SelectItem key={c.id} value={c.id}>
+                                                                {c.name}
+                                                            </SelectItem>
+                                                        ))}
+                                                </SelectContent>
+                                            </Select>
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                        <FormField
+                            control={form.control}
+                            name='isPrimary'
+                            render={({ field }) => (
+                                <FormItem className='flex flex-row items-center gap-2 space-y-0'>
+                                    <FormControl>
+                                        <Checkbox
+                                            checked={field.value}
+                                            onCheckedChange={(checked) => field.onChange(checked === true)}
+                                        />
+                                    </FormControl>
+                                    <FormLabel className='mb-0'>
+                                        Primary contact (demotes any existing primary)
+                                    </FormLabel>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={form.control}
+                            name='notes'
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Notes</FormLabel>
+                                    <FormControl>
+                                        <Textarea {...field} rows={3} placeholder='Internal notes about this contact' />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    </form>
+                </Form>
+                <DialogFooter>
+                    <Button variant='outline' onClick={() => onOpenChange(false)} disabled={isPending}>
+                        Cancel
+                    </Button>
+                    <Button type='submit' form='prospect-contact-form' disabled={isPending}>
+                        {isEdit ? 'Save' : 'Add Contact'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/TrashMob/client-app/src/components/prospects/prospect-contact-status-badge.tsx
+++ b/TrashMob/client-app/src/components/prospects/prospect-contact-status-badge.tsx
@@ -1,0 +1,36 @@
+import { Badge } from '@/components/ui/badge';
+
+export const PROSPECT_CONTACT_STATUSES = [
+    { value: 0, label: 'Active' },
+    { value: 1, label: 'Wrong Person' },
+    { value: 2, label: 'No Response' },
+    { value: 3, label: 'Left Org' },
+    { value: 4, label: 'Right Person' },
+] as const;
+
+export function getProspectContactStatusLabel(status: number): string {
+    return PROSPECT_CONTACT_STATUSES.find((s) => s.value === status)?.label ?? 'Unknown';
+}
+
+interface ProspectContactStatusBadgeProps {
+    status: number;
+}
+
+export const ProspectContactStatusBadge = ({ status }: ProspectContactStatusBadgeProps) => {
+    const label = getProspectContactStatusLabel(status);
+
+    switch (status) {
+        case 0: // Active
+            return <Badge>{label}</Badge>;
+        case 1: // WrongPerson
+            return <Badge variant='outline'>{label}</Badge>;
+        case 2: // NoResponse
+            return <Badge className='bg-yellow-100 text-yellow-800'>{label}</Badge>;
+        case 3: // LeftOrganization
+            return <Badge variant='secondary'>{label}</Badge>;
+        case 4: // RightPerson
+            return <Badge variant='success'>{label}</Badge>;
+        default:
+            return <Badge variant='outline'>{label}</Badge>;
+    }
+};

--- a/TrashMob/client-app/src/components/prospects/prospect-contacts-card.tsx
+++ b/TrashMob/client-app/src/components/prospects/prospect-contacts-card.tsx
@@ -1,0 +1,288 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Edit, Mail, MoreVertical, Phone, Plus, Star, Trash2, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { getErrorMessage } from '@/lib/api-errors';
+import {
+    DeleteProspectContact,
+    GetCommunityProspectById,
+    GetProspectContacts,
+    SetPrimaryProspectContact,
+    UpdateProspectContactStatus,
+} from '@/services/community-prospects';
+import ProspectContactData from '@/components/Models/ProspectContactData';
+import { ProspectContactFormDialog } from './prospect-contact-form-dialog';
+import { PROSPECT_CONTACT_STATUSES, ProspectContactStatusBadge } from './prospect-contact-status-badge';
+
+interface ProspectContactsCardProps {
+    prospectId: string;
+}
+
+export function ProspectContactsCard({ prospectId }: ProspectContactsCardProps) {
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+    const [formOpen, setFormOpen] = useState(false);
+    const [editingContact, setEditingContact] = useState<ProspectContactData | undefined>(undefined);
+    const [contactToDelete, setContactToDelete] = useState<ProspectContactData | undefined>(undefined);
+
+    const { data: contacts, isLoading } = useQuery({
+        queryKey: GetProspectContacts({ prospectId }).key,
+        queryFn: GetProspectContacts({ prospectId }).service,
+        select: (res) => res.data,
+        enabled: !!prospectId,
+    });
+
+    const invalidate = () => {
+        queryClient.invalidateQueries({
+            queryKey: GetProspectContacts({ prospectId }).key,
+            refetchType: 'all',
+        });
+        queryClient.invalidateQueries({
+            queryKey: GetCommunityProspectById({ id: prospectId }).key,
+            refetchType: 'all',
+        });
+    };
+
+    const setPrimary = useMutation({
+        mutationKey: SetPrimaryProspectContact().key,
+        mutationFn: SetPrimaryProspectContact().service,
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Primary contact updated' });
+            invalidate();
+        },
+        onError: (error: Error) => {
+            toast({
+                variant: 'destructive',
+                title: 'Failed to set primary',
+                description: getErrorMessage(error),
+            });
+        },
+    });
+
+    const updateStatus = useMutation({
+        mutationKey: UpdateProspectContactStatus().key,
+        mutationFn: UpdateProspectContactStatus().service,
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Status updated' });
+            invalidate();
+        },
+        onError: (error: Error) => {
+            toast({
+                variant: 'destructive',
+                title: 'Failed to update status',
+                description: getErrorMessage(error),
+            });
+        },
+    });
+
+    const deleteContact = useMutation({
+        mutationKey: DeleteProspectContact().key,
+        mutationFn: DeleteProspectContact().service,
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Contact deleted' });
+            invalidate();
+            setContactToDelete(undefined);
+        },
+        onError: (error: Error) => {
+            toast({
+                variant: 'destructive',
+                title: 'Cannot delete contact',
+                description: getErrorMessage(error),
+            });
+            setContactToDelete(undefined);
+        },
+    });
+
+    const sortedContacts = useMemo(() => contacts ?? [], [contacts]);
+
+    function handleAdd() {
+        setEditingContact(undefined);
+        setFormOpen(true);
+    }
+
+    function handleEdit(contact: ProspectContactData) {
+        setEditingContact(contact);
+        setFormOpen(true);
+    }
+
+    return (
+        <>
+            <Card>
+                <CardHeader className='flex flex-row items-center justify-between'>
+                    <CardTitle>Contacts ({sortedContacts.length})</CardTitle>
+                    <Button variant='outline' onClick={handleAdd}>
+                        <Plus className='mr-2 h-4 w-4' /> Add Contact
+                    </Button>
+                </CardHeader>
+                <CardContent>
+                    {isLoading ? (
+                        <p className='text-muted-foreground text-sm'>Loading contacts...</p>
+                    ) : sortedContacts.length === 0 ? (
+                        <p className='text-muted-foreground text-sm'>
+                            No contacts yet. Add a contact to start tracking outreach attempts.
+                        </p>
+                    ) : (
+                        <div className='space-y-3'>
+                            {sortedContacts.map((contact) => (
+                                <div
+                                    key={contact.id}
+                                    className='border rounded-md p-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between'
+                                >
+                                    <div className='flex-1 space-y-1'>
+                                        <div className='flex flex-wrap items-center gap-2'>
+                                            <User className='h-4 w-4 text-muted-foreground' />
+                                            <span className='font-medium'>{contact.name}</span>
+                                            {contact.title ? (
+                                                <span className='text-sm text-muted-foreground'>({contact.title})</span>
+                                            ) : null}
+                                            {contact.isPrimary ? (
+                                                <span className='inline-flex items-center gap-1 text-xs bg-amber-100 text-amber-800 px-2 py-0.5 rounded-full'>
+                                                    <Star className='h-3 w-3' /> Primary
+                                                </span>
+                                            ) : null}
+                                            <ProspectContactStatusBadge status={contact.contactStatus} />
+                                        </div>
+                                        <div className='flex flex-wrap items-center gap-4 text-sm text-muted-foreground'>
+                                            {contact.email ? (
+                                                <a
+                                                    href={`mailto:${contact.email}`}
+                                                    className='flex items-center gap-1 hover:underline'
+                                                >
+                                                    <Mail className='h-3 w-3' /> {contact.email}
+                                                </a>
+                                            ) : null}
+                                            {contact.phone ? (
+                                                <span className='flex items-center gap-1'>
+                                                    <Phone className='h-3 w-3' /> {contact.phone}
+                                                </span>
+                                            ) : null}
+                                            {contact.role ? <span>{contact.role}</span> : null}
+                                        </div>
+                                        {contact.notes ? (
+                                            <p className='text-sm text-muted-foreground whitespace-pre-wrap'>
+                                                {contact.notes}
+                                            </p>
+                                        ) : null}
+                                    </div>
+                                    <div className='flex items-center gap-2'>
+                                        <Select
+                                            value={String(contact.contactStatus)}
+                                            onValueChange={(value) =>
+                                                updateStatus.mutate({
+                                                    prospectId,
+                                                    contactId: contact.id,
+                                                    status: parseInt(value, 10),
+                                                })
+                                            }
+                                        >
+                                            <SelectTrigger className='h-8 w-[140px] text-xs'>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {PROSPECT_CONTACT_STATUSES.map((s) => (
+                                                    <SelectItem key={s.value} value={String(s.value)}>
+                                                        {s.label}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button variant='ghost' size='icon'>
+                                                    <MoreVertical className='h-4 w-4' />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align='end'>
+                                                {!contact.isPrimary ? (
+                                                    <DropdownMenuItem
+                                                        onClick={() =>
+                                                            setPrimary.mutate({ prospectId, contactId: contact.id })
+                                                        }
+                                                    >
+                                                        <Star className='mr-2 h-4 w-4' /> Set as primary
+                                                    </DropdownMenuItem>
+                                                ) : null}
+                                                <DropdownMenuItem onClick={() => handleEdit(contact)}>
+                                                    <Edit className='mr-2 h-4 w-4' /> Edit
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    className='text-destructive focus:text-destructive'
+                                                    onClick={() => setContactToDelete(contact)}
+                                                >
+                                                    <Trash2 className='mr-2 h-4 w-4' /> Delete
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            <ProspectContactFormDialog
+                prospectId={prospectId}
+                open={formOpen}
+                onOpenChange={setFormOpen}
+                contact={editingContact}
+                referralCandidates={sortedContacts}
+            />
+
+            <AlertDialog
+                open={!!contactToDelete}
+                onOpenChange={(open) => {
+                    if (!open) setContactToDelete(undefined);
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete this contact?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {contactToDelete?.name
+                                ? `${contactToDelete.name} will be permanently removed.`
+                                : 'This contact will be permanently removed.'}{' '}
+                            If the contact has any activity or outreach history, deletion is blocked — mark them as
+                            "Left Org" or "Wrong Person" instead.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={deleteContact.isPending}>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            disabled={deleteContact.isPending}
+                            onClick={() => {
+                                if (contactToDelete) {
+                                    deleteContact.mutate({
+                                        prospectId,
+                                        contactId: contactToDelete.id,
+                                    });
+                                }
+                            }}
+                        >
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+}

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/$prospectId.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/$prospectId.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import moment from 'moment';
-import { Edit, Plus, Globe, Mail, User, MapPin, Send, ArrowRightLeft } from 'lucide-react';
+import { Edit, Plus, Globe, MapPin, Send, ArrowRightLeft } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -23,7 +23,10 @@ import {
 import { PipelineStageBadge, ACTIVITY_TYPES } from '@/components/prospects/pipeline-stage-badge';
 import { OutreachPreviewDialog } from '@/components/prospects/outreach-preview-dialog';
 import { ConvertToPartnerDialog } from '@/components/prospects/convert-to-partner-dialog';
+import { ProspectContactsCard } from '@/components/prospects/prospect-contacts-card';
 import ProspectActivityData from '@/components/Models/ProspectActivityData';
+
+const NO_CONTACT_VALUE = '__none__';
 
 export const SiteAdminProspectDetail = () => {
     const { prospectId } = useParams<{ prospectId: string }>() as { prospectId: string };
@@ -35,6 +38,7 @@ export const SiteAdminProspectDetail = () => {
     const [activityType, setActivityType] = useState('Note');
     const [activitySubject, setActivitySubject] = useState('');
     const [activityDetails, setActivityDetails] = useState('');
+    const [activityContactId, setActivityContactId] = useState<string>(NO_CONTACT_VALUE);
 
     const { data: prospect } = useQuery({
         queryKey: GetCommunityProspectById({ id: prospectId }).key,
@@ -83,12 +87,23 @@ export const SiteAdminProspectDetail = () => {
             setActivityType('Note');
             setActivitySubject('');
             setActivityDetails('');
+            setActivityContactId(NO_CONTACT_VALUE);
         },
     });
+
+    const prospectContacts = useMemo(() => prospect?.contacts ?? [], [prospect?.contacts]);
+    const activityContactsById = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const c of prospectContacts) {
+            map.set(c.id, c.name);
+        }
+        return map;
+    }, [prospectContacts]);
 
     function handleLogActivity() {
         const body = new ProspectActivityData();
         body.prospectId = prospectId;
+        body.prospectContactId = activityContactId === NO_CONTACT_VALUE ? null : activityContactId;
         body.activityType = activityType;
         body.subject = activitySubject;
         body.details = activityDetails;
@@ -147,23 +162,6 @@ export const SiteAdminProspectDetail = () => {
                             ) : null}
                         </div>
                         <div className='col-span-12 md:col-span-6 space-y-3'>
-                            {prospect.contactName ? (
-                                <div className='flex items-center gap-2 text-sm'>
-                                    <User className='h-4 w-4 text-muted-foreground' />
-                                    {prospect.contactName}
-                                    {prospect.contactTitle ? (
-                                        <span className='text-muted-foreground'>({prospect.contactTitle})</span>
-                                    ) : null}
-                                </div>
-                            ) : null}
-                            {prospect.contactEmail ? (
-                                <div className='flex items-center gap-2 text-sm'>
-                                    <Mail className='h-4 w-4 text-muted-foreground' />
-                                    <a href={`mailto:${prospect.contactEmail}`} className='hover:underline'>
-                                        {prospect.contactEmail}
-                                    </a>
-                                </div>
-                            ) : null}
                             {prospect.website ? (
                                 <div className='flex items-center gap-2 text-sm'>
                                     <Globe className='h-4 w-4 text-muted-foreground' />
@@ -177,6 +175,11 @@ export const SiteAdminProspectDetail = () => {
                                     </a>
                                 </div>
                             ) : null}
+                            <p className='text-sm text-muted-foreground'>
+                                {prospectContacts.length === 0
+                                    ? 'No contacts yet — add one in the Contacts section below.'
+                                    : `${prospectContacts.length} contact${prospectContacts.length === 1 ? '' : 's'} on file.`}
+                            </p>
                         </div>
                         {prospect.notes ? (
                             <div className='col-span-12'>
@@ -187,6 +190,8 @@ export const SiteAdminProspectDetail = () => {
                     </div>
                 </CardContent>
             </Card>
+
+            <ProspectContactsCard prospectId={prospectId} />
 
             {scoreBreakdown ? (
                 <Card>
@@ -272,6 +277,7 @@ export const SiteAdminProspectDetail = () => {
 
             <OutreachPreviewDialog
                 prospectId={prospectId}
+                contacts={prospectContacts}
                 open={outreachDialogOpen}
                 onOpenChange={setOutreachDialogOpen}
             />
@@ -314,6 +320,29 @@ export const SiteAdminProspectDetail = () => {
                                         </SelectContent>
                                     </Select>
                                 </div>
+                                {prospectContacts.length > 0 ? (
+                                    <div>
+                                        <label htmlFor='activity-contact' className='text-sm font-medium'>
+                                            Contact (optional)
+                                        </label>
+                                        <Select value={activityContactId} onValueChange={setActivityContactId}>
+                                            <SelectTrigger id='activity-contact'>
+                                                <SelectValue placeholder='Not tied to a specific contact' />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value={NO_CONTACT_VALUE}>
+                                                    — Not tied to a specific contact —
+                                                </SelectItem>
+                                                {prospectContacts.map((c) => (
+                                                    <SelectItem key={c.id} value={c.id}>
+                                                        {c.name}
+                                                        {c.isPrimary ? ' (primary)' : ''}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
+                                ) : null}
                                 <div>
                                     <label htmlFor='activity-subject' className='text-sm font-medium'>
                                         Subject
@@ -356,8 +385,14 @@ export const SiteAdminProspectDetail = () => {
                         <div className='space-y-4'>
                             {(activities || []).map((activity) => (
                                 <div key={activity.id} className='border-l-2 border-muted pl-4 pb-2'>
-                                    <div className='flex items-center gap-2'>
+                                    <div className='flex items-center gap-2 flex-wrap'>
                                         <Badge variant='outline'>{activity.activityType}</Badge>
+                                        {activity.prospectContactId &&
+                                        activityContactsById.has(activity.prospectContactId) ? (
+                                            <span className='text-xs text-muted-foreground'>
+                                                → {activityContactsById.get(activity.prospectContactId)}
+                                            </span>
+                                        ) : null}
                                         {activity.sentimentScore ? (
                                             <Badge
                                                 className={

--- a/TrashMob/client-app/src/services/community-prospects.ts
+++ b/TrashMob/client-app/src/services/community-prospects.ts
@@ -11,6 +11,7 @@ import OutreachSettingsData from '../components/Models/OutreachSettingsData';
 import PipelineAnalyticsData from '../components/Models/PipelineAnalyticsData';
 import ProspectConversionResultData from '../components/Models/ProspectConversionResultData';
 import ProspectActivityData from '../components/Models/ProspectActivityData';
+import ProspectContactData from '../components/Models/ProspectContactData';
 import ProspectOutreachEmailData from '../components/Models/ProspectOutreachEmailData';
 
 export type GetCommunityProspects_Params = { stage?: number; search?: string };
@@ -191,17 +192,29 @@ export const PreviewOutreach = (params: PreviewOutreach_Params) => ({
         }),
 });
 
-export type SendOutreach_Params = { id: string; subject?: string; htmlBody?: string };
+export type SendOutreach_Params = {
+    id: string;
+    subject?: string;
+    htmlBody?: string;
+    prospectContactId?: string;
+};
 export type SendOutreach_Response = OutreachSendResultData;
 export const SendOutreach = () => ({
     key: ['/communityprospects', 'outreach', 'send'],
-    service: async (params: SendOutreach_Params) =>
-        ApiService('protected').fetchData<SendOutreach_Response>({
+    service: async (params: SendOutreach_Params) => {
+        const hasBody = params.subject || params.htmlBody || params.prospectContactId;
+        return ApiService('protected').fetchData<SendOutreach_Response>({
             url: `/v2/community-prospects/${params.id}/outreach`,
             method: 'post',
-            data:
-                params.subject || params.htmlBody ? { subject: params.subject, htmlBody: params.htmlBody } : undefined,
-        }),
+            data: hasBody
+                ? {
+                      subject: params.subject,
+                      htmlBody: params.htmlBody,
+                      prospectContactId: params.prospectContactId,
+                  }
+                : undefined,
+        });
+    },
 });
 
 export type GetOutreachHistory_Params = { id: string };
@@ -266,5 +279,81 @@ export const ConvertProspectToPartner = () => ({
                 partnerTypeId: params.partnerTypeId ?? 1,
                 sendWelcomeEmail: params.sendWelcomeEmail ?? true,
             },
+        }),
+});
+
+// --- Project 60: Prospect Contacts ---
+
+export type GetProspectContacts_Params = { prospectId: string };
+export type GetProspectContacts_Response = ProspectContactData[];
+export const GetProspectContacts = (params: GetProspectContacts_Params) => ({
+    key: ['/communityprospects', params.prospectId, 'contacts'],
+    service: async () =>
+        ApiService('protected').fetchData<GetProspectContacts_Response>({
+            url: `/v2/community-prospects/${params.prospectId}/contacts`,
+            method: 'get',
+        }),
+});
+
+export type CreateProspectContact_Params = { prospectId: string };
+export type CreateProspectContact_Body = ProspectContactData;
+export type CreateProspectContact_Response = ProspectContactData;
+export const CreateProspectContact = (params: CreateProspectContact_Params) => ({
+    key: ['/communityprospects', params.prospectId, 'contacts', 'create'],
+    service: async (body: CreateProspectContact_Body) =>
+        ApiService('protected').fetchData<CreateProspectContact_Response, CreateProspectContact_Body>({
+            url: `/v2/community-prospects/${params.prospectId}/contacts`,
+            method: 'post',
+            data: body,
+        }),
+});
+
+export type UpdateProspectContact_Params = { prospectId: string; contactId: string };
+export type UpdateProspectContact_Body = ProspectContactData;
+export type UpdateProspectContact_Response = ProspectContactData;
+export const UpdateProspectContact = (params: UpdateProspectContact_Params) => ({
+    key: ['/communityprospects', params.prospectId, 'contacts', params.contactId, 'update'],
+    service: async (body: UpdateProspectContact_Body) =>
+        ApiService('protected').fetchData<UpdateProspectContact_Response, UpdateProspectContact_Body>({
+            url: `/v2/community-prospects/${params.prospectId}/contacts/${params.contactId}`,
+            method: 'put',
+            data: body,
+        }),
+});
+
+export type DeleteProspectContact_Params = { prospectId: string; contactId: string };
+export const DeleteProspectContact = () => ({
+    key: ['/communityprospects', 'contacts', 'delete'],
+    service: async (params: DeleteProspectContact_Params) =>
+        ApiService('protected').fetchData<unknown>({
+            url: `/v2/community-prospects/${params.prospectId}/contacts/${params.contactId}`,
+            method: 'delete',
+        }),
+});
+
+export type SetPrimaryProspectContact_Params = { prospectId: string; contactId: string };
+export type SetPrimaryProspectContact_Response = ProspectContactData;
+export const SetPrimaryProspectContact = () => ({
+    key: ['/communityprospects', 'contacts', 'set-primary'],
+    service: async (params: SetPrimaryProspectContact_Params) =>
+        ApiService('protected').fetchData<SetPrimaryProspectContact_Response>({
+            url: `/v2/community-prospects/${params.prospectId}/contacts/${params.contactId}/set-primary`,
+            method: 'post',
+        }),
+});
+
+export type UpdateProspectContactStatus_Params = {
+    prospectId: string;
+    contactId: string;
+    status: number;
+};
+export type UpdateProspectContactStatus_Response = ProspectContactData;
+export const UpdateProspectContactStatus = () => ({
+    key: ['/communityprospects', 'contacts', 'status'],
+    service: async (params: UpdateProspectContactStatus_Params) =>
+        ApiService('protected').fetchData<UpdateProspectContactStatus_Response>({
+            url: `/v2/community-prospects/${params.prospectId}/contacts/${params.contactId}/status`,
+            method: 'put',
+            data: { status: params.status },
         }),
 });


### PR DESCRIPTION
## Summary
Phase 3 of [Project 60](Planning/Projects/Project_60_Prospect_Contact_Tracking.md). Admin UI for managing multiple contacts per `CommunityProspect`, on top of Phase 2's API.

Site admins can now from the prospect detail page:
- **List** all contacts with name, title, email, phone, role, status, primary marker, and notes
- **Add** a new contact (Zod + React Hook Form dialog) with optional "Referred by" linkage to an existing contact
- **Edit** any contact's details
- **Set Primary** atomically — server demotes any existing primary
- **Change Status** via an inline dropdown on each contact row (Active / Wrong Person / No Response / Left Org / Right Person)
- **Delete** with a confirm-dialog; backend's 409 ("has history") is surfaced in a toast with the recommendation to mark inactive instead

Per-contact attribution is now wired into both interaction surfaces:
- **Log Activity** dialog has a new "Contact (optional)" selector; activity timeline entries show `→ Contact Name` when attributed
- **Outreach Preview** dialog has a "Send to" dropdown listing all Active / RightPerson contacts, defaulting to the primary so the common case is one click; selection flows through `SendOutreach(prospectContactId: ...)` to Phase 2's backend override path

## Components added
| Component | Purpose |
|-----------|---------|
| `ProspectContactStatusBadge` | 5-state lifecycle badge mirroring `PipelineStageBadge` |
| `ProspectContactFormDialog` | Zod + RHF add/edit dialog |
| `ProspectContactsCard` | Detail-page card with list + inline status + actions |
| `ProspectContactData` model | TypeScript mirror of the V2 DTO |

## Frontend changes
- `CommunityProspectData` gains `contacts: ProspectContactData[]` (legacy `contactName/Email/Title/Phone` kept as primary-contact passthrough until Phase 4)
- `ProspectActivityData` gains `prospectContactId`
- `community-prospects.ts` service file extended with six contact service factories + `SendOutreach` now accepts `prospectContactId`
- `OutreachPreviewDialog` accepts a `contacts` prop and renders the "Send to" selector
- Prospect detail page (`$prospectId.tsx`): contacts card inserted, inline single-contact block removed from header (replaced with contact-count summary), activity timeline shows contact attribution

## Out of scope (deferred to Phase 4)
- List-page columns still display the legacy `contactName/contactEmail` (which Phase 1's mapper populates from the primary contact, so they keep working). Replacing them with a dedicated "Primary Contact + Attempts" column is Phase 4 per the project plan.
- Per-user touchpoint tally on the prospect dashboard — Phase 4.

## Verified
- `npm run check` — ESLint + Prettier clean
- `npm test -- --run` — frontend vitest green
- `dotnet build TrashMob.sln` — backend still green

## Test plan
- [ ] Open a prospect detail page; verify the Contacts card lists existing contacts (Phase 1 backfilled the legacy single contact as primary)
- [ ] Add a second contact via "Add Contact"; verify the existing primary stays primary
- [ ] "Set as primary" on the new contact; verify the old primary loses the marker
- [ ] Change status via the inline dropdown to "Wrong Person"; verify the badge updates
- [ ] Try to delete a contact that has outreach history — confirm 409 toast with mark-inactive hint
- [ ] Log an activity with the contact selector pointed at a specific person; confirm the timeline shows "→ Name"
- [ ] Open "Preview & Send" outreach dialog; pick a different contact in the "Send to" dropdown; confirm the email goes to that contact's address (test mode) and the saved outreach row carries the contact id

## Phases
- ✅ Phase 1: backend model + migration (merged #3372)
- ✅ Phase 2: dedicated contacts API + per-contact activity/outreach (merged #3373)
- **Phase 3 (this PR):** admin UI
- Phase 4: reporting tally, days-in-pipeline, attempts column

🤖 Generated with [Claude Code](https://claude.com/claude-code)