### PR TITLE
Hotfix: Project 60 migration — use NoAction on ProspectContact FKs (prod incident)

### DIFF
--- a/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.Designer.cs
@@ -7757,7 +7757,7 @@ namespace TrashMob.Shared.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectActivities_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")
@@ -7829,7 +7829,7 @@ namespace TrashMob.Shared.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectOutreachEmails_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")

--- a/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.cs
+++ b/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.cs
@@ -147,13 +147,20 @@ namespace TrashMob.Shared.Migrations
                 table: "ProspectActivities",
                 column: "ProspectContactId");
 
+            // ReferentialAction.NoAction (not SetNull) is required here. SQL Server refuses
+            // FKs that create multiple cascade paths to the same table: ProspectActivities
+            // already has a Cascade FK to CommunityProspects, and ProspectContacts has its own
+            // Cascade FK to CommunityProspects, so a second SetNull path from ProspectContacts
+            // back to ProspectActivities triggers SQL error 1785. The DeleteBehavior on the
+            // EF side is ClientSetNull, which gives the same observable behavior (null'd in
+            // memory when EF loads the entity) without the DB-level cascade.
             migrationBuilder.AddForeignKey(
                 name: "FK_ProspectActivities_ProspectContact",
                 table: "ProspectActivities",
                 column: "ProspectContactId",
                 principalTable: "ProspectContacts",
                 principalColumn: "Id",
-                onDelete: ReferentialAction.SetNull);
+                onDelete: ReferentialAction.NoAction);
 
             migrationBuilder.AddForeignKey(
                 name: "FK_ProspectOutreachEmails_ProspectContact",
@@ -161,7 +168,7 @@ namespace TrashMob.Shared.Migrations
                 column: "ProspectContactId",
                 principalTable: "ProspectContacts",
                 principalColumn: "Id",
-                onDelete: ReferentialAction.SetNull);
+                onDelete: ReferentialAction.NoAction);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Migrations/MobDbContextModelSnapshot.cs
+++ b/TrashMob.Shared/Migrations/MobDbContextModelSnapshot.cs
@@ -7754,7 +7754,7 @@ namespace TrashMob.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectActivities_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")
@@ -7826,7 +7826,7 @@ namespace TrashMob.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectOutreachEmails_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -3475,10 +3475,16 @@
                     .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("FK_ProspectActivities_CommunityProspect");
 
+                // ClientSetNull (not SetNull) avoids SQL Server's multi-cascade-path error
+                // 1785: ProspectActivities already cascade-deletes from CommunityProspects, and
+                // ProspectContacts also cascade-deletes from CommunityProspects, so a SetNull
+                // path back to ProspectActivities creates two delete paths to the same table.
+                // ClientSetNull keeps the SetNull semantics in EF's tracker but uses NoAction
+                // in the schema.
                 entity.HasOne(d => d.Contact)
                     .WithMany()
                     .HasForeignKey(d => d.ProspectContactId)
-                    .OnDelete(DeleteBehavior.SetNull)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_ProspectActivities_ProspectContact");
 
                 entity.HasOne(d => d.CreatedByUser)
@@ -3517,10 +3523,11 @@
                     .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("FK_ProspectOutreachEmails_CommunityProspect");
 
+                // ClientSetNull — see FK_ProspectActivities_ProspectContact above for rationale.
                 entity.HasOne(d => d.Contact)
                     .WithMany()
                     .HasForeignKey(d => d.ProspectContactId)
-                    .OnDelete(DeleteBehavior.SetNull)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_ProspectOutreachEmails_ProspectContact");
 
                 entity.HasOne(d => d.CreatedByUser)


### PR DESCRIPTION
## Summary
**Active prod incident.** The Phase 1 migration on PR #3378 (merged earlier today) failed when applying to prod DB with SQL Server error 1785:

\`\`\`
Introducing FOREIGN KEY constraint 'FK_ProspectActivities_ProspectContact' on table
'ProspectActivities' may cause cycles or multiple cascade paths. Specify ON DELETE
NO ACTION or ON UPDATE NO ACTION, or modify other FOREIGN KEY constraints.
\`\`\`

EF Core rolled the migration back, but the **container app deploy ran in parallel and succeeded** — so prod is now running new Project 60 code against the old (pre-migration) schema. App Insights confirms the impact:

\`\`\`
[14:02:46Z, 14:01:14Z, 13:02:46Z, 13:01:14Z]  Unhandled exception.
Microsoft.Data.SqlClient.SqlException: Invalid object name 'ProspectContacts'.
\`\`\`

Hourly + daily background jobs are throwing every cycle. User-facing prospect admin pages will also fail.

## Root cause
The Phase 1 migration used \`DeleteBehavior.SetNull\` on the two new \`ProspectContactId\` FKs in \`ProspectActivities\` and \`ProspectOutreachEmails\`. SQL Server static-analyzes the cascade graph and finds two paths from \`CommunityProspects\`:
- Direct: \`ProspectActivities.ProspectId → CommunityProspects\` (Cascade)
- Indirect: \`ProspectActivities.ProspectContactId → ProspectContacts → CommunityProspects\` (where the link to CP is also Cascade)

Two delete paths to the same table = SQL Server says no, even though the second one ends in \`SetNull\`. This was missed in PR #3372 review because EF Core's logical model allows the config; the error only surfaces when SQL Server actually applies the FK.

## Fix
Switch both FKs to \`DeleteBehavior.ClientSetNull\` (DB level: \`ReferentialAction.NoAction\`). EF still tracks SetNull semantics in memory (loaded entities work the same), but no schema-level cascade conflict.

Functionally equivalent for our scenarios:
- **CommunityProspect delete** still cascade-deletes Activities and ProspectContacts atomically — the activity rows go away in the same transaction, so the ProspectContactId never needs to be nulled-out
- **Direct ProspectContact delete** is already blocked by \`ProspectContactsV2Controller\` when any Activity / OutreachEmail references the contact (returns 409 with a "mark inactive" hint)

## Changes
- \`TrashMob.Shared/Persistence/MobDbContext.cs\` — both FK configs use \`ClientSetNull\` with an inline comment explaining the rationale
- The Phase 1 migration's \`Up()\` uses \`ReferentialAction.NoAction\`
- Migration \`Designer.cs\` and \`MobDbContextModelSnapshot.cs\` updated to keep snapshots in sync
- Hand-edited the original migration file rather than adding a new "fix" migration, since the original has never successfully applied anywhere

## What happens on merge
1. Path filter on \`TrashMob.Shared/Migrations/**\` triggers \`TrashMobProd - Database Migrations\` workflow again
2. EF sees \`AddProspectContactsAndDropLegacyContactFields\` as still pending (no row in \`__EFMigrationsHistory\`), runs it against the rolled-back prod DB
3. Migration applies cleanly (this time)
4. Hourly background jobs stop throwing \`Invalid object name 'ProspectContacts'\`

## Verified
- \`dotnet build TrashMob.sln\` — clean
- \`dotnet test TrashMob.Shared.Tests\` — 1,108 passing, 0 failing

## Follow-up
- Backport this same fix to \`main\` as a separate PR so \`main\` and \`release\` stay in sync — opening immediately after this lands
- The path-filter-driven workflow design means migrations and container deploys can race. Worth a follow-up to make container deploy depend on migration success (separate ticket — not blocking this hotfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)