### PR TITLE
Backport: Project 60 migration FK uses NoAction (sync hotfix from release)

### DIFF
--- a/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.Designer.cs
@@ -7757,7 +7757,7 @@ namespace TrashMob.Shared.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectActivities_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")
@@ -7829,7 +7829,7 @@ namespace TrashMob.Shared.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectOutreachEmails_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")

--- a/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.cs
+++ b/TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.cs
@@ -147,13 +147,20 @@ namespace TrashMob.Shared.Migrations
                 table: "ProspectActivities",
                 column: "ProspectContactId");
 
+            // ReferentialAction.NoAction (not SetNull) is required here. SQL Server refuses
+            // FKs that create multiple cascade paths to the same table: ProspectActivities
+            // already has a Cascade FK to CommunityProspects, and ProspectContacts has its own
+            // Cascade FK to CommunityProspects, so a second SetNull path from ProspectContacts
+            // back to ProspectActivities triggers SQL error 1785. The DeleteBehavior on the
+            // EF side is ClientSetNull, which gives the same observable behavior (null'd in
+            // memory when EF loads the entity) without the DB-level cascade.
             migrationBuilder.AddForeignKey(
                 name: "FK_ProspectActivities_ProspectContact",
                 table: "ProspectActivities",
                 column: "ProspectContactId",
                 principalTable: "ProspectContacts",
                 principalColumn: "Id",
-                onDelete: ReferentialAction.SetNull);
+                onDelete: ReferentialAction.NoAction);
 
             migrationBuilder.AddForeignKey(
                 name: "FK_ProspectOutreachEmails_ProspectContact",
@@ -161,7 +168,7 @@ namespace TrashMob.Shared.Migrations
                 column: "ProspectContactId",
                 principalTable: "ProspectContacts",
                 principalColumn: "Id",
-                onDelete: ReferentialAction.SetNull);
+                onDelete: ReferentialAction.NoAction);
         }
 
         /// <inheritdoc />

--- a/TrashMob.Shared/Migrations/MobDbContextModelSnapshot.cs
+++ b/TrashMob.Shared/Migrations/MobDbContextModelSnapshot.cs
@@ -7754,7 +7754,7 @@ namespace TrashMob.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectActivities_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")
@@ -7826,7 +7826,7 @@ namespace TrashMob.Migrations
                     b.HasOne("TrashMob.Models.ProspectContact", "Contact")
                         .WithMany()
                         .HasForeignKey("ProspectContactId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.ClientSetNull)
                         .HasConstraintName("FK_ProspectOutreachEmails_ProspectContact");
 
                     b.HasOne("TrashMob.Models.CommunityProspect", "Prospect")

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -3475,10 +3475,16 @@
                     .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("FK_ProspectActivities_CommunityProspect");
 
+                // ClientSetNull (not SetNull) avoids SQL Server's multi-cascade-path error
+                // 1785: ProspectActivities already cascade-deletes from CommunityProspects, and
+                // ProspectContacts also cascade-deletes from CommunityProspects, so a SetNull
+                // path back to ProspectActivities creates two delete paths to the same table.
+                // ClientSetNull keeps the SetNull semantics in EF's tracker but uses NoAction
+                // in the schema.
                 entity.HasOne(d => d.Contact)
                     .WithMany()
                     .HasForeignKey(d => d.ProspectContactId)
-                    .OnDelete(DeleteBehavior.SetNull)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_ProspectActivities_ProspectContact");
 
                 entity.HasOne(d => d.CreatedByUser)
@@ -3517,10 +3523,11 @@
                     .OnDelete(DeleteBehavior.Cascade)
                     .HasConstraintName("FK_ProspectOutreachEmails_CommunityProspect");
 
+                // ClientSetNull — see FK_ProspectActivities_ProspectContact above for rationale.
                 entity.HasOne(d => d.Contact)
                     .WithMany()
                     .HasForeignKey(d => d.ProspectContactId)
-                    .OnDelete(DeleteBehavior.SetNull)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_ProspectOutreachEmails_ProspectContact");
 
                 entity.HasOne(d => d.CreatedByUser)


### PR DESCRIPTION
## Summary
Backport of [#3379](https://github.com/TrashMob-eco/TrashMob/pull/3379) — the prod hotfix that resolved this morning's incident.

The hotfix landed directly on \`release\` to recover prod fast. This PR brings the same fix back to \`main\` so the next \`main → release\` promotion doesn't reintroduce the broken migration.

## What this contains
Cherry-pick of commit \`e13c7d4d\` from the hotfix branch:
- \`TrashMob.Shared/Persistence/MobDbContext.cs\` — \`DeleteBehavior.SetNull\` → \`DeleteBehavior.ClientSetNull\` on both \`ProspectContactId\` FKs
- \`TrashMob.Shared/Migrations/20260521030318_AddProspectContactsAndDropLegacyContactFields.cs\` — \`ReferentialAction.SetNull\` → \`ReferentialAction.NoAction\`
- \`...Designer.cs\` + \`MobDbContextModelSnapshot.cs\` updated to match

See [#3379](https://github.com/TrashMob-eco/TrashMob/pull/3379) for the full root-cause writeup and SQL Server 1785 error context.

## Verified
- Cherry-pick applied cleanly
- 1,108 backend tests pass
- Build clean

## Note
This migration has already been applied to prod (under the hotfix). Once this merges to main, the next time main is promoted to release, the migration won't re-apply — it's already recorded in \`__EFMigrationsHistory\` with the same migration ID (\`20260521030318_AddProspectContactsAndDropLegacyContactFields\`). EF identifies migrations by name; editing the migration's contents doesn't change its identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)