### PR TITLE
Fix: edit/create event forms reject any user-typed number as 'Invalid input'

### DIFF
--- a/TrashMob/client-app/src/pages/events/create.tsx
+++ b/TrashMob/client-app/src/pages/events/create.tsx
@@ -68,9 +68,12 @@ const createEventSchema = z.object({
     region: z.string().optional(),
     country: z.string().optional(),
     postalCode: z.string().optional(),
-    latitude: z.number(),
-    longitude: z.number(),
-    maxNumberOfParticipants: z.number().min(0),
+    // z.coerce.number() (not z.number()) because <Input type='number'> always emits
+    // strings via onChange. With plain z.number(), Zod fails validation as "Invalid input"
+    // on any user-typed value even though the visible field looks correct.
+    latitude: z.coerce.number(),
+    longitude: z.coerce.number(),
+    maxNumberOfParticipants: z.coerce.number().min(0),
     eventVisibilityId: z.string(),
     teamId: z.string().nullable().optional(),
     createdByUserId: z.string(),

--- a/TrashMob/client-app/src/pages/events/edit/index.tsx
+++ b/TrashMob/client-app/src/pages/events/edit/index.tsx
@@ -52,9 +52,12 @@ const updateEventSchema = z.object({
     region: z.string().optional(),
     country: z.string().optional(),
     postalCode: z.string().optional(),
-    latitude: z.number(),
-    longitude: z.number(),
-    maxNumberOfParticipants: z.number().min(0),
+    // z.coerce.number() (not z.number()) because <Input type='number'> always emits
+    // strings via onChange. With plain z.number(), Zod fails validation as "Invalid input"
+    // on any user-typed value even though the visible field looks correct.
+    latitude: z.coerce.number(),
+    longitude: z.coerce.number(),
+    maxNumberOfParticipants: z.coerce.number().min(0),
     eventVisibilityId: z.string(),
     teamId: z.string().nullable().optional(),
     createdByUserId: z.string(),


### PR DESCRIPTION
## Summary
You hit this trying to bump Max Attendees on a dev event to 25 — got an "Invalid input" error despite the value displaying correctly:

![bug screenshot](placeholder — see issue convo)

## Root cause
Both \`edit/index.tsx\` and \`create.tsx\` declare numeric fields with \`z.number()\` but render them as \`<Input type='number' {...field} />\`. Native HTML number inputs emit **strings** via \`event.target.value\` — React Hook Form stores the string in form state. When Zod validates, it sees a string where it expected a number → throws \`ZodError "Invalid input"\` → field shows red "Invalid input."

The forms have been working for fields set programmatically (\`form.reset\` from API data, \`setValue\` from the map picker) because those code paths pass real numbers. Bug only surfaces when the user types.

## Fix
Switch the three user-typeable numeric fields in both forms from \`z.number()\` to \`z.coerce.number()\`. Zod coerces the string to a number before validating. \`.min(0)\` on \`maxNumberOfParticipants\` still applies.

\`\`\`diff
-    latitude: z.number(),
-    longitude: z.number(),
-    maxNumberOfParticipants: z.number().min(0),
+    // <Input type='number'> emits strings via onChange — coerce to number before validating
+    latitude: z.coerce.number(),
+    longitude: z.coerce.number(),
+    maxNumberOfParticipants: z.coerce.number().min(0),
\`\`\`

Applied to both:
- \`pages/events/edit/index.tsx\` (the page where the bug surfaced)
- \`pages/events/create.tsx\` (same pattern — latent bug)

\`eventStatusId\` is left as \`z.number()\` because it's only set programmatically, never user-typed.

## Test plan
- [ ] After deploy to dev, edit the same event (08221c17-6de9-4378-977f-2e0890dbb189), type 25 in Max attendees, click Save — should succeed
- [ ] Verify event details page shows the new max participants
- [ ] Create a new event with hand-typed max attendees — should succeed
- [ ] Confirm vitest still passes (it does, locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)