### PR TITLE
Move skill mechanics into scripts; cut LLM tokens on routine ops

### DIFF
--- a/.claude/commands/upload-article.md
+++ b/.claude/commands/upload-article.md
@@ -1,88 +1,36 @@
+---
+model: haiku
+---
+
 Upload a news article to the TrashMob Strapi CMS.
 
 ## Arguments
-- `$ARGUMENTS` - Path to the markdown article file (e.g., `Planning/NewsArticles/2026-02-24_article.md`) and target environment (`dev` or `prod`)
 
-## Instructions
+`$ARGUMENTS` — path to the markdown article, followed optionally by an environment (`dev` or `prod`, default `dev`) and/or `--draft` to skip publishing.
 
-1. **Parse the arguments** to get the article file path and environment (default to `dev` if not specified).
+Examples:
+- `/upload-article Planning/NewsArticles/2026-02-24_launch.md`
+- `/upload-article Planning/NewsArticles/2026-02-24_launch.md prod`
+- `/upload-article Planning/NewsArticles/2026-02-24_launch.md dev --draft`
 
-2. **Read the article markdown file**. It should have frontmatter in this format:
-   ```
-   # Title
-   **Slug:** article-slug
-   **Author:** Author Name
-   **Category:** Announcements | Community Stories | Tips & Guides
-   **Tags:** ["tag1", "tag2"]
-   **Featured:** true/false
-   **Estimated Read Time:** N
-   ---
-   ## Excerpt
-   Excerpt text here
-   ---
-   ## Body
-   Article body in markdown...
-   ```
+## What to do
 
-3. **Determine the Strapi URL** based on environment:
-   - `dev`: Get FQDN via `az containerapp show --name ca-strapi-tm-dev-westus2 --resource-group rg-trashmob-dev-westus2 --query "properties.configuration.ingress.fqdn" -o tsv`
-   - `prod`: Get FQDN via `az containerapp show --name ca-strapi-tm-pr-westus2 --resource-group rg-trashmob-pr-westus2 --subscription 5ea21946-8cb1-413f-9005-0ab10bfa839d --query "properties.configuration.ingress.fqdn" -o tsv`
+1. **Run** [`scripts/upload_article.py`](../../scripts/upload_article.py) with the supplied arguments. The script handles frontmatter parsing, markdown→Strapi-blocks conversion, URL discovery via `az`, admin login → API token caching, the POST/PUT publish dance, and verification:
 
-4. **Convert the markdown body to Strapi Blocks format**. The body field uses Strapi's block editor format:
-   - Paragraphs → `{ "type": "paragraph", "children": [{ "type": "text", "text": "..." }] }`
-   - H2 headings → `{ "type": "heading", "level": 2, "children": [{ "type": "text", "text": "..." }] }`
-   - H3 headings → `{ "type": "heading", "level": 3, "children": [{ "type": "text", "text": "..." }] }`
-   - Bold text → `{ "type": "text", "bold": true, "text": "..." }`
-   - Italic text → `{ "type": "text", "italic": true, "text": "..." }`
-   - Links → `{ "type": "link", "url": "https://...", "children": [{ "type": "text", "text": "..." }] }`
-   - Mixed formatting in a paragraph: multiple children in the paragraph's children array
-
-5. **Look up the category ID**. Query `GET /api/news-categories` and find the matching category by name. Default categories (auto-seeded):
-   - ID 1: "Announcements"
-   - ID 2: "Community Stories"
-   - ID 3: "Tips & Guides"
-
-6. **Build the JSON payload**:
-   ```json
-   {
-     "data": {
-       "title": "...",
-       "slug": "...",
-       "excerpt": "...",
-       "author": "...",
-       "isFeatured": true/false,
-       "estimatedReadTime": N,
-       "tags": ["tag1", "tag2"],
-       "category": { "connect": [CATEGORY_ID] },
-       "body": [ ...blocks... ]
-     }
-   }
-   ```
-
-7. **Authenticate with Strapi**:
-   - Try `POST /admin/login` with admin credentials (ask user if not known)
-   - Create or reuse an API token via `POST /admin/api-tokens`
-   - Use `Authorization: Bearer <token>` for the upload
-
-8. **Upload the article**:
    ```bash
-   curl -X POST "$STRAPI_URL/api/news-posts" \
-     -H "Authorization: Bearer $API_TOKEN" \
-     -H "Content-Type: application/json" \
-     -d @article.json
+   python scripts/upload_article.py <markdown> [--env <env>] [--draft]
    ```
 
-9. **Publish the article** (Strapi creates as draft by default in v5):
-   - Get the article ID from the POST response
-   - `PUT /api/news-posts/{id}` with `{ "data": { "publishedAt": "2026-01-01T00:00:00.000Z" } }` to publish
+   Convert the user's plain-language args into the script's flag form. The environment defaults to `dev`; the article path is required.
 
-10. **Save the upload JSON** to `Planning/NewsArticles/` alongside the markdown file for reference (e.g., `strapi-upload.json`).
+2. **Inspect the script's output** and report success or failure to the user. The script prints structured progress (`-> Parsing ...`, `-> POST ...`, etc.) and exits non-zero on errors.
 
-11. **Verify** by hitting `GET /api/news-posts?filters[slug][$eq]=SLUG` and confirming the article appears.
+3. **If the script fails on something it can't handle** — most commonly an article that uses an unsupported markdown construct (code blocks, blockquotes, inline images) — surface the script's error to the user, identify the offending lines in the markdown, and offer to either edit the article into a supported form or extend the script. Don't try to do the upload by hand; the script is the source of truth for the Strapi format.
 
-## Example Usage
-```
-/upload-article Planning/NewsArticles/2026-02-24_trashmob-2026-launch.md prod
-/upload-article Planning/NewsArticles/my-article.md dev
-/upload-article Planning/NewsArticles/my-article.md  (defaults to dev)
-```
+4. **If admin credentials are needed** (first-time use on a machine, or after the cached token expires), the script reads `STRAPI_ADMIN_EMAIL` and `STRAPI_ADMIN_PASSWORD` from the environment or prompts. Tokens are cached under `~/.cache/trashmob-strapi/{env}-token.json` (chmod 600).
+
+## Out of scope for this command
+
+Cover image upload and inline body images require Strapi `/api/upload` calls with binary multipart form data — that flow still lives in `Planning/NewsArticles/CLAUDE.md`. Use that context separately if the article needs a cover image.
+
+Social posts (the trailing `## Social Posts` section) are read by humans only and don't ship to Strapi.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git fetch *)",
+      "Bash(az monitor app-insights *)",
+      "Bash(az monitor log-analytics *)",
+      "Bash(az containerapp logs *)",
+      "Bash(az containerapp revision list *)",
+      "Bash(gh run watch *)"
+    ]
+  }
+}

--- a/Planning/.claude_add_project_command.md
+++ b/Planning/.claude_add_project_command.md
@@ -1,478 +1,144 @@
 # AI Assistant Command: Add New Project to Planning
 
-**Purpose:** This file provides step-by-step instructions for AI assistants (Claude, GitHub Copilot, etc.) to help add a new project to the TrashMob 2026 planning documentation.
+Purpose: scaffold a new project plan in `Planning/Projects/` and update the surrounding planning docs.
+
+## TL;DR
+
+```bash
+python scripts/new_project.py "Email Digest System" \
+    --priority High --size Medium --risk Low \
+    --owner "Engineering" \
+    --dependencies "Project 11, Project 19"
+```
+
+That writes `Planning/Projects/Project_NN_Email_Digest_System.md` (with header fields filled, today's date, next review +30 days), prints a checklist of follow-up edits, and exits. **Do that first.** The rest of this guide is for the judgment work the script can't do.
 
 ---
 
-## Command Format
+## Step 1: Run the script
 
-When a user requests to add a new project, follow this structured process:
+`scripts/new_project.py` handles the mechanical parts of the original "Step 1" through "Step 3":
 
-### User Request Pattern
-- "Add a new project for [feature/initiative]"
-- "Create a project spec for [feature]"
-- "Document a new project: [description]"
+- Find the next available project number across `Planning/Projects/` and `Planning/Projects/Archive/`
+- Build the filename (`Project_NN_Title_With_Underscores.md`)
+- Copy the template (`_Project_Template.md`) and fill the Status / Priority / Risk / Size / Dependencies / Owner / Last Updated / Next Review fields
+- Normalise encoding to utf-8
 
----
+CLI flags:
 
-## Step 1: Gather Project Information
+| Flag | Default | Choices |
+|------|---------|---------|
+| `--priority` | `Medium` | Low / Medium / High / Critical |
+| `--size` | `Medium` | Very Small / Small / Medium / Large / Very Large (dashes also OK) |
+| `--risk` | `Low` | Low / Medium / High / Very High |
+| `--status` | `Not Started` | Not Started / Planning |
+| `--owner` | `TBD` | any string |
+| `--dependencies` | `""` | any string |
+| `--archive` | off | write to Archive/ instead (for retroactive docs) |
+| `--dry-run` | off | print to stdout instead of writing |
+| `--no-followups` | off | suppress the printed checklist |
 
-Ask the user for the following information (use defaults if not provided):
-
-### Required Information
-1. **Project Title** (e.g., "Email Digest System")
-2. **Business Rationale** (Why is this needed?)
-3. **Priority** (Low / Medium / High / Critical)
-4. **Estimated Size** (Very Small / Small / Medium / Large / Very Large)
-5. **Risk Level** (Low / Medium / High / Very High)
-
-### Optional Information
-6. Dependencies on other projects
-7. Key objectives (3-5 bullet points)
-8. Success metrics
-9. Known risks
-10. Technical approach (if known)
+If the user supplies a title only (no flags), accept the defaults. Don't interrogate them for every field — pick reasonable defaults and surface them in the summary.
 
 ---
 
-## Step 2: Determine Project Number
+## Step 2: Fill in the judgement-heavy sections
 
-1. Check existing projects in `Planning/Projects/` folder
-2. Find the highest project number (currently 25)
-3. Assign next sequential number (e.g., 26)
+The script only fills the header table and footer. The body sections — Business Rationale, Objectives, Scope, Out-of-Scope, Success Metrics, Risks & Mitigations, Implementation Plan, Open Questions, Related Documents — still need your judgement.
 
-**Command to check:**
-```powershell
-Get-ChildItem -Path Planning/Projects/ -Filter "Project_*.md" | 
-    Sort-Object Name | 
-    Select-Object -Last 5 Name
-```
+Style guide:
 
----
-
-## Step 3: Create Project File
-
-### File Naming Convention
-`Planning/Projects/Project_[NUMBER]_[TITLE_WITH_UNDERSCORES].md`
-
-Example: `Planning/Projects/Project_26_Email_Digest_System.md`
-
-### Use Template
-Copy structure from `Planning/Projects/_Project_Template.md`
-
-### Fill in Sections
-
-#### Header Table
-```markdown
-| Attribute | Value |
-|-----------|-------|
-| **Status** | Not Started (or Planning if requirements are clear) |
-| **Priority** | [From user input] |
-| **Risk** | [From user input] |
-| **Size** | [From user input] |
-| **Dependencies** | [List project numbers and names] |
-```
-
-#### Business Rationale
-- Explain the "why" in 2-4 paragraphs
-- Connect to TrashMob's mission and strategic objectives
-- Describe problem being solved or value being delivered
-
-#### Objectives
-Split into:
-- **Primary Goals** (3-5 must-have outcomes)
-- **Secondary Goals** (2-3 nice-to-have outcomes)
-
-#### Scope
-Organize into phases:
-- **Phase 1 - [Name]** ([Timeline]): List of deliverables with checkboxes
-- **Phase 2 - [Name]** ([Timeline]): Continue as needed
-
-#### Out-of-Scope
-- List 3-5 things explicitly NOT included
-- Helps set boundaries and manage expectations
-
-#### Success Metrics
-- **Quantitative:** Specific numbers, percentages, targets
-- **Qualitative:** Outcomes that can't be measured numerically
-
-#### Dependencies
-- **Blockers:** What must be done first
-- **Enablers:** What this project unlocks
-
-#### Risks & Mitigations
-Table format:
-```markdown
-| Risk | Likelihood | Impact | Mitigation |
-|------|------------|--------|------------|
-| [Risk 1] | [L/M/H] | [L/M/H/Critical] | [How to handle] |
-```
-
-#### Implementation Plan
-Include:
-- Data model changes (SQL if applicable)
-- API changes (C# examples if applicable)
-- Web UX changes
-- Mobile changes (if applicable)
-
-#### Rollout Plan
-Week-by-week or phase-by-phase timeline
-
-#### Open Questions
-Format:
-```markdown
-1. **[Question]**
-   **Recommendation:** [Suggestion]
-   **Owner:** [Who should decide]
-   **Due:** [When needed]
-```
-
-#### Related Documents
-Cross-reference to:
-- Other project files
-- Technical designs
-- PRD sections
-
-#### Footer
-```markdown
-**Last Updated:** [Today's date]
-**Owner:** [Team/person responsible]
-**Status:** [Not Started/Planning]
-**Next Review:** [Date]
-```
+- **Business Rationale**: 2–4 paragraphs. Connect to TrashMob's mission. State the user problem first, then the value delivered. Concrete examples beat abstractions.
+- **Objectives**: split Primary Goals (3–5 must-have) and Secondary Goals (2–3 nice-to-have).
+- **Scope**: organize into phases (`### Phase 1 — Name`) with checkbox deliverables. Phases are sequential but not time-bound.
+- **Out-of-Scope**: 3–5 explicit non-goals. Sets boundaries.
+- **Success Metrics**: split Quantitative (numbers, percentages, targets) and Qualitative.
+- **Risks & Mitigations**: table format (Risk | Likelihood | Impact | Mitigation). At least 3 rows.
+- **Implementation Plan**: data model changes, API changes, web UX, mobile if applicable. Include C# / TypeScript snippets where helpful.
+- **Open Questions**: each with **Recommendation**, **Owner**, **Due** lines.
 
 ---
 
-## Step 4: Update README.md
+## Step 3: Update neighbour docs
 
-Add project to appropriate section in `Planning/README.md`:
+These cross-file updates need LLM judgment about where the project fits. The script prints this same list on exit:
 
-### 4.1 Add to Navigation Section
+1. **`Planning/README.md`**
+   - Add to the appropriate quarter section
+   - Add to the appropriate theme section (Trust & Safety, Community Features, Impact Tracking, Platform Quality, Engagement & Growth, or create a new theme if needed)
+   - Bump the count in the status table (`Not Started`, etc.)
 
-Based on timeline:
-- **Q1 2026:** Add to Q1 section
-- **Q2 2026:** Add to Q2 section
-- **Q3 2026:** Add to Q3 section
-- **Q4 2026:** Add to Q4 section
-- **TBD:** Add to "Ongoing/TBD" section
+2. **`Planning/Executive_Summary.md`** — only if the project is High priority or Large+. Add to the roadmap quarter and the priority matrix.
 
-**Format:**
-```markdown
-- **[Project [NUMBER] - [TITLE]](./Projects/Project_[NUMBER]_[FILENAME].md)** � [Brief description]
-```
+3. **`Planning/Risks_and_Mitigations.md`** — only if Risk is High or Very High. Add a `PR-N` entry with Category, Likelihood, Impact, Priority, Affected Project, Mitigations, Owner, Timeline.
 
-### 4.2 Add to Quick Links by Theme
+4. **`Planning/TODO_Project_Extraction.md`** — add to the appropriate priority section.
 
-Determine appropriate category:
-- Trust & Safety
-- Community Features
-- Impact Tracking
-- Platform Quality
-- Engagement & Growth
-- Other (create new if needed)
-
-### 4.3 Update Status Table
-
-Add row to status overview table:
-```markdown
-| Status | Count | Projects |
-|--------|-------|----------|
-| ? **Not Started** | [N+1] | Projects X, Y, Z, [NEW] |
-```
+5. **Pre-existing related projects** — open each one and add the new project to its `## Related Documents` section.
 
 ---
 
-## Step 5: Update Executive Summary (if major project)
+## Step 4: Sanity check before you stop
 
-For high-priority or large projects, update `Planning/Executive_Summary.md`:
+Quick checklist before declaring done:
 
-### 5.1 Add to Roadmap Overview
-If the project has a defined quarter, add to the appropriate section:
-
-```markdown
-### Q[X] ([Month-Month])
-- **Project [NUMBER]:** [Title] ([brief description])
-```
-
-### 5.2 Update Priority Matrix (if applicable)
-Add to the priority table:
-
-```markdown
-| **High** | ..., [NUMBER] ([Title]), ... |
-```
-
----
-
-## Step 6: Update TODO List
-
-Update `Planning/TODO_Project_Extraction.md`:
-
-Add to appropriate priority section:
-
-```markdown
-- [ ] **Project [NUMBER]** - [Title]
-  - File: `Project_[NUMBER]_[Title].md`
-  - Source: New project (not in original 2026 plan)
-  - Status: [Status]
-  - Timeline: [Timeline]
-```
-
----
-
-## Step 7: Update Risks Document (if high risk)
-
-If Risk level is High or Very High, add to `Planning/Risks_and_Mitigations.md`:
-
-### 7.1 Add Project-Specific Risk Section
-
-```markdown
-### PR-[N]: [Risk Title]
-
-**Category:** [Technical/Organizational/External]
-**Likelihood:** [Low/Medium/High]
-**Impact:** [Low/Medium/High/Critical]
-**Priority:** [Based on matrix]
-
-**Affected Project:** Project [NUMBER] ([Title])
-
-**Mitigations:**
-- [Mitigation 1]
-- [Mitigation 2]
-- [Mitigation 3]
-
-**Owner:** [Team/person]
-**Timeline:** [When applicable]
-```
-
-### 7.2 Update Risk Dashboard Table
-
-Add row:
-```markdown
-| PR-[N] | [Risk Title] | [Priority] | [Status] | [Date] |
-```
-
----
-
-## Step 8: Quality Checks
-
-Before completing, verify:
-
-### ? File Checks
-- [ ] Project file exists in `Planning/Projects/`
-- [ ] Filename follows naming convention
-- [ ] All template sections are present
-- [ ] No `[PLACEHOLDER]` text remaining
-
-### ? Content Checks
-- [ ] Business rationale is clear and compelling
-- [ ] Objectives are specific and actionable
-- [ ] Success metrics are measurable
+- [ ] File exists with the right number + filename
+- [ ] All header table fields filled (no `[Low / Medium / ...]` placeholders left)
+- [ ] No `[PLACEHOLDER]` text remaining in body
 - [ ] At least 3 risks identified with mitigations
-- [ ] Dependencies are listed (if any)
-- [ ] Footer is complete with all 4 fields
-
-### ? Cross-Reference Checks
-- [ ] Project added to README.md navigation
-- [ ] Project added to README.md status table
-- [ ] Project added to TODO list
-- [ ] Executive Summary updated (if major project)
-- [ ] Risks document updated (if high risk)
-- [ ] Related projects link to this new project (if applicable)
-
-### ? Formatting Checks
-- [ ] Markdown tables render correctly
-- [ ] All links work (no broken references)
-- [ ] Code blocks have language specified
-- [ ] Consistent heading levels (# ? ## ? ###)
+- [ ] Quantitative success metrics include numbers, not just "improve X"
+- [ ] Dependencies list any project numbers the new project relies on
+- [ ] Cross-references added in both directions (this project lists related projects; related projects list this one)
+- [ ] README.md status table count is consistent
+- [ ] Markdown renders correctly (tables, code blocks with language tags, no broken links)
 
 ---
 
-## Step 9: Summary for User
+## Step 5: Report to the user
 
-Provide a summary message:
+```
+Project NN — Title has been added.
 
-```markdown
-? **Project [NUMBER] - [TITLE] has been added to the planning documentation!**
+Files created:
+  Planning/Projects/Project_NN_Title.md
 
-**Files Created:**
-- `Planning/Projects/Project_[NUMBER]_[Title].md`
+Files updated:
+  Planning/README.md  (added to <quarter>/<theme>, status table)
+  Planning/TODO_Project_Extraction.md  (added to <priority>)
+  [+ Executive_Summary.md if applicable]
+  [+ Risks_and_Mitigations.md if High/Very High risk]
 
-**Files Updated:**
-- `Planning/README.md` (navigation + status table)
-- `Planning/TODO_Project_Extraction.md` (checklist)
-[- `Planning/Executive_Summary.md` (roadmap) - if applicable]
-[- `Planning/Risks_and_Mitigations.md` (risks) - if applicable]
-
-**Next Steps:**
-1. Review the project file for accuracy
-2. Fill in any missing details (marked with TODO comments)
-3. Get stakeholder approval before starting work
-4. Update status as project progresses
-
-**Quick Links:**
-- [View Project File](./Projects/Project_[NUMBER]_[Title].md)
-- [View All Projects](./README.md)
-- [View Template](./Projects/_Project_Template.md)
+Next:
+  - Review the project file for accuracy
+  - Fill in any remaining placeholders
+  - Get stakeholder approval before starting work
 ```
 
 ---
 
-## Example: Complete Workflow
+## Project shape cheat-sheet
 
-### User Request
-> "Add a new project for implementing an email digest system that sends weekly summaries of nearby events to users"
+| Type | Typical Size | Typical Risk |
+|------|--------------|--------------|
+| Feature enhancement (improving existing functionality) | Small–Medium | Low–Medium |
+| Technical infrastructure (platform, tooling, DevOps) | Medium–Large | Medium–High |
+| New feature (net-new capability) | Large–Very Large | Medium–Very High |
+| Maintenance / debt (refactor, upgrade, cleanup) | Variable | Low–Medium |
 
-### AI Response
-
-**Step 1: Gathering Information**
-Let me collect the details for this project:
-
-- **Project Title:** Email Digest System
-- **Business Rationale:** Increase user engagement by proactively notifying users about nearby events via weekly email digests
-- **Priority:** High (drives engagement)
-- **Size:** Medium (email template, scheduling, personalization)
-- **Risk:** Low (leveraging existing SendGrid infrastructure)
-- **Dependencies:** None
-
-**Step 2: Project Number**
-Next available: Project 26
-
-**Step 3-8: [AI executes all steps, creating files and updating documentation]**
-
-**Step 9: Summary**
-? **Project 26 - Email Digest System has been added!**
-
-[Full summary as shown in Step 9 template]
-
----
-
-## Advanced: Integration with Existing Projects
-
-If the new project relates to existing projects:
-
-### Update Related Project Files
-
-For each related project, add cross-reference:
-
-```markdown
-## Related Documents
-
-- **[Project 26 - Email Digest](./Project_26_Email_Digest.md)** - Complements notification strategy
-```
-
-### Update Dependency Chains
-
-If new project depends on others or others depend on it:
-
-1. Update Dependencies section in all affected projects
-2. Update Executive Summary dependency graph (if complex)
-3. Note in README if critical path changes
-
----
-
-## Quality Standards
-
-### Code Examples
-- Use C# for backend (.NET 10)
-- Use TypeScript for frontend (React 18)
-- Include XML documentation comments
-- Show complete, runnable examples
-
-### Documentation Style
-- Clear, concise language
-- Active voice preferred
-- Bullet points for lists
-- Tables for structured data
-- Code blocks with language tags
-
-### Cross-References
-- Use relative paths for links
-- Link to related projects by name and number
-- Include PRD references if applicable
-- Link to technical designs when they exist
+Use as a sanity check on user-provided Size / Risk values — push back if they look mismatched.
 
 ---
 
 ## Troubleshooting
 
-### Issue: Project number conflicts
-**Solution:** Use `Get-ChildItem` to check highest number, add 1
-
-### Issue: Unclear business rationale
-**Solution:** Ask user for more context, connect to strategic objectives
-
-### Issue: Too many dependencies
-**Solution:** Consider breaking into smaller projects
-
-### Issue: Scope too large
-**Solution:** Suggest phasing or splitting into multiple projects
-
-### Issue: Duplicate functionality
-**Solution:** Check if existing project covers this, suggest enhancement instead
+| Issue | Action |
+|-------|--------|
+| Project number conflict | The script picks max-of-existing + 1 across both `Projects/` and `Archive/`. If you hit a real collision, something else wrote the file in between — re-run. |
+| Unclear business rationale | Ask the user for more context. Anchor to strategic objectives in `Planning/Executive_Summary.md`. |
+| Scope too large | Suggest phasing or splitting into multiple projects (the script can scaffold a second one). |
+| Duplicate functionality | Check `Planning/Projects/` and `Archive/` for an existing project. If found, suggest extending it instead of creating a new one. |
+| Template encoding error | `_Project_Template.md` historically used cp1252. The script handles this; if you're reading the template manually, use `iconv` or open with cp1252 fallback. |
 
 ---
 
-## Templates for Common Project Types
-
-### Feature Enhancement Project
-- Focus: Improving existing functionality
-- Size: Usually Small to Medium
-- Risk: Usually Low to Medium
-- Timeline: 1-2 quarters
-
-### Technical Infrastructure Project
-- Focus: Platform improvements, tooling, DevOps
-- Size: Usually Medium to Large
-- Risk: Usually Medium to High
-- Timeline: 2-3 quarters
-
-### New Feature Project
-- Focus: Net-new capability
-- Size: Usually Large to Very Large
-- Risk: Usually Medium to Very High
-- Timeline: 2-4 quarters
-
-### Maintenance/Debt Project
-- Focus: Code quality, upgrades, refactoring
-- Size: Variable
-- Risk: Usually Low to Medium
-- Timeline: Ongoing or 1 quarter
-
----
-
-## Quick Reference
-
-### Essential Commands
-
-**Check existing projects:**
-```powershell
-Get-ChildItem Planning/Projects/Project_*.md | Sort-Object Name
-```
-
-**Count projects:**
-```powershell
-(Get-ChildItem Planning/Projects/Project_*.md).Count
-```
-
-**Find template:**
-```powershell
-Get-Content Planning/Projects/_Project_Template.md
-```
-
-**Validate links:**
-```powershell
-# Check if all referenced projects exist
-Select-String -Path Planning/README.md -Pattern "Project_\d{2}_" | 
-    ForEach-Object { $_.Matches.Value } | 
-    ForEach-Object { Test-Path "Planning/Projects/$_.md" }
-```
-
----
-
-## Change Log
-
-**v1.0 (2026-01-24):** Initial command file created
-
----
-
-**This is a living document.** Update as new patterns emerge or process improvements are identified.
+**Last updated:** When the script in `scripts/new_project.py` last changed.

--- a/Planning/.claude_common_commands.md
+++ b/Planning/.claude_common_commands.md
@@ -1,429 +1,115 @@
 # AI Assistant Commands: Common Planning Operations
 
-This file provides quick commands for AI assistants to help with common planning documentation tasks.
+Quick reference for AI assistants performing common planning-doc tasks. The deterministic operations are handled by [`scripts/project_ops.py`](../scripts/project_ops.py); the judgement-heavy ones still live below as prose.
 
 ---
 
-## Command: Update Project Status
+## Scripted operations (run the script — don't hand-edit)
 
-**User says:** "Update project [NUMBER] status to [STATUS]"
+[`scripts/project_ops.py`](../scripts/project_ops.py) handles the mechanical operations: editing the header table, footer fields, Last Updated date, Related Documents section, and Risks & Mitigations table. Always prefer the script to hand-editing — it preserves CRLF line endings, only touches the intended fields, and won't accidentally reformat the surrounding markdown.
 
-### Steps:
-1. **Update project file** (`Planning/Projects/Project_XX_*.md`)
-   - Change `| **Status** | [OLD]` to `| **Status** | [NEW]`
-   - Update footer: `**Status:** [NEW]`
-   - Update `**Last Updated:** [Today's date]`
-
-2. **Update README.md**
-   - Move project to correct status section
-   - Update status overview table counts
-
-3. **Update TODO list** (if completing project)
-   - Change `[ ]` to `[x]` in TODO_Project_Extraction.md
-
-**Status Options:** Not Started, Planning, Ready for Review, In Progress, Developers Engaged, Complete
-
----
-
-## Command: Add Dependency Between Projects
-
-**User says:** "Project [X] depends on project [Y]"
-
-### Steps:
-1. **Update dependent project** (Project X)
-   ```markdown
-   ## Dependencies
-   
-   ### Blockers
-   - **[Project Y - Title](./Project_YY_Title.md):** [Reason why]
-   ```
-
-2. **Update enabling project** (Project Y)
-   ```markdown
-   ## Dependencies
-   
-   ### Enablers for Other Projects
-   - **[Project X - Title](./Project_XX_Title.md):** [What it unlocks]
-   ```
-
-3. **Update Executive Summary** (if critical path)
-   - Add to dependencies section
-
----
-
-## Command: Change Project Priority
-
-**User says:** "Change project [NUMBER] priority to [PRIORITY]"
-
-### Steps:
-1. **Update project file**
-   - Change `| **Priority** | [OLD]` to `| **Priority** | [NEW]`
-   - Update footer date
-
-2. **Update Executive Summary**
-   - Move project in Priority Matrix table
-
-3. **Update README.md** (if affects quarterly ordering)
-
-**Priority Options:** Low, Medium, High, Critical
-
----
-
-## Command: Reschedule Project
-
-**User says:** "Move project [NUMBER] to [QUARTER]"
-
-### Steps:
-1. **Update project file**
-   - Change `| **Timeline** | [OLD]` to `| **Timeline** | [NEW]`
-   - Update footer date
-
-2. **Update README.md**
-   - Move project from old quarter section to new quarter section
-
-3. **Update Executive Summary**
-   - Move in roadmap overview
-
-4. **Update TODO list**
-   - Move to appropriate priority section
-
----
-
-## Command: Add Risk to Project
-
-**User says:** "Add risk [DESCRIPTION] to project [NUMBER]"
-
-### Steps:
-1. **Update project file** - Add to Risks table:
-   ```markdown
-   | **[Risk Title]** | [Likelihood] | [Impact] | [Mitigation] |
-   ```
-
-2. **If High/Very High priority**, update Risks_and_Mitigations.md:
-   - Add project-specific risk section
-   - Update risk dashboard table
-
----
-
-## Command: Mark Project Complete
-
-**User says:** "Mark project [NUMBER] as complete"
-
-### Steps:
-1. **Update project file**
-   - Change status to "Complete"
-   - Add completion date
-   - Document outcomes vs. targets
-
-2. **Update README.md**
-   - Move to ? Completed section
-   - Update status table
-
-3. **Update TODO list**
-   - Mark as `[x]` complete
-
-4. **Update Executive Summary**
-   - Move to completed projects (if tracked)
-
-5. **Document lessons learned** (in project file)
-
----
-
-## Command: Split Project into Multiple Projects
-
-**User says:** "Split project [NUMBER] into [N] smaller projects"
-
-### Steps:
-1. **Identify split points**
-   - Usually by phase or major component
-   - Ask user for confirmation
-
-2. **Create new project files** for each split
-   - Use "Add Project" command for each
-   - Number sequentially (26, 27, 28...)
-
-3. **Update original project**
-   - Mark as "Superseded by Projects X, Y, Z"
-   - Archive or mark as historical
-
-4. **Update dependencies**
-   - Any project depending on original now depends on split projects
-
-5. **Update README and other docs**
-
----
-
-## Command: Merge Projects
-
-**User says:** "Merge projects [X] and [Y] into one"
-
-### Steps:
-1. **Create new combined project**
-   - Determine which number to use (or new number)
-   - Combine objectives, scope, risks
-
-2. **Mark old projects as superseded**
-   - "Merged into Project Z"
-
-3. **Update all cross-references**
-   - Projects that linked to X or Y now link to Z
-
-4. **Update README and navigation**
-
----
-
-## Command: Add Code Example to Project
-
-**User says:** "Add code example for [FEATURE] to project [NUMBER]"
-
-### Steps:
-1. **Locate Implementation Plan section**
-
-2. **Add code block with language tag**
-   ```csharp
-   // Example implementation
-   public class Example
-   {
-       // Code here
-   }
-   ```
-
-3. **Add explanation** before and after code
-
-4. **Update footer date**
-
----
-
-## Command: Cross-Reference Projects
-
-**User says:** "Link project [X] to project [Y]"
-
-### Steps:
-1. **Update Project X** - Add to Related Documents:
-   ```markdown
-   - **[Project Y - Title](./Project_YY_Title.md)** - [How it relates]
-   ```
-
-2. **Update Project Y** - Add reciprocal link:
-   ```markdown
-   - **[Project X - Title](./Project_XX_Title.md)** - [How it relates]
-   ```
-
-3. **Determine dependency** (if applicable)
-   - If X blocks Y or Y enables X, update Dependencies sections
-
----
-
-## Command: Add Success Metric
-
-**User says:** "Add metric [METRIC] to project [NUMBER]"
-
-### Steps:
-1. **Locate Success Metrics section**
-
-2. **Add to appropriate subsection**:
-   - **Quantitative:** If measurable with numbers
-   - **Qualitative:** If not directly measurable
-
-3. **Include target and baseline** (if quantitative)
-   ```markdown
-   - **[Metric Name]:** Target [VALUE] (currently [BASELINE])
-   ```
-
-4. **Update footer date**
-
----
-
-## Command: Document Risk Materialization
-
-**User says:** "Risk [DESCRIPTION] occurred in project [NUMBER]"
-
-### Steps:
-1. **Update project file** - Add note to risk:
-   ```markdown
-   | **[Risk]** | ~~[Likelihood]~~ **OCCURRED** | [Impact] | [Actual mitigation used] |
-   ```
-
-2. **Document in Rollout Plan**:
-   - What happened
-   - How it was handled
-   - Lessons learned
-
-3. **Update Risks_and_Mitigations.md**:
-   - Update risk status
-   - Document in appropriate section
-
-4. **Consider creating post-mortem** (if significant)
-
----
-
-## Command: Generate Project Status Report
-
-**User says:** "Generate status report for project [NUMBER]" or "Status report for [QUARTER]"
-
-### For Single Project:
-1. **Extract from project file**:
-   - Current status
-   - Progress vs. plan
-   - Open questions
-   - Risks
-   - Next milestones
-
-2. **Format as summary markdown**
-
-### For Quarter:
-1. **List all projects in quarter**
-2. **For each**: Status, completion %, blockers
-3. **Overall quarter health**
-
----
-
-## Command: Add Open Question
-
-**User says:** "Add question [QUESTION] to project [NUMBER]"
-
-### Steps:
-1. **Locate Open Questions section**
-
-2. **Add new question**:
-   ```markdown
-   [N]. **[Question text]**
-      **Recommendation:** [If known, or "To be determined"]
-      **Owner:** [Who should decide]
-      **Due:** [When decision needed]
-   ```
-
-3. **Update footer date**
-
----
-
-## Command: Close Open Question
-
-**User says:** "Answer question [NUMBER] in project [X]: [ANSWER]"
-
-### Steps:
-1. **Update Open Questions section**:
-   - ~~Strike through question~~
-   - Add **Decision:** and date
-   ```markdown
-   1. ~~**[Question]**~~
-      **Decision:** [Answer] (Decided: [Date])
-      **Owner:** [Who decided]
-   ```
-
-2. **If decision affects scope/timeline**:
-   - Update appropriate sections
-   - Note in Implementation or Rollout Plan
-
-3. **Update footer date**
-
----
-
-## Command: Add Phase to Project
-
-**User says:** "Add new phase [NAME] to project [NUMBER]"
-
-### Steps:
-1. **Locate Scope section**
-
-2. **Add new phase**:
-   ```markdown
-   ### Phase [N] - [Phase Name] ([Timeline])
-   - ? Deliverable 1
-   - ? Deliverable 2
-   ```
-
-3. **Update Out-of-Scope** if needed
-   - Move items from out-of-scope if now in-scope
-
-4. **Update Rollout Plan** with new phase
-
-5. **Update footer date**
-
----
-
-## Command: Update Completion Percentage
-
-**User says:** "Project [NUMBER] is [X]% complete"
-
-### Steps:
-1. **Add progress indicator** (at top of file):
-   ```markdown
-   **Completion:** [X]% complete
-   ```
-
-2. **Update Scope section** with checkmarks:
-   ```markdown
-   - ? Completed deliverable
-   - ?? In progress
-   - ? Not started
-   ```
-
-3. **Update README.md** if status changed (e.g., 0% ? 50%)
-
----
-
-## Common Snippets
-
-### Risk Table Row
-```markdown
-| **[Risk Name]** | [Low/Medium/High] | [Low/Medium/High/Critical] | [Mitigation strategy] |
-```
-
-### Dependency Block
-```markdown
-### Blockers
-- **[Project X - Title](./Project_XX_Title.md):** [Why required]
-
-### Enablers
-- **[Project Y - Title](./Project_YY_Title.md):** [What it unlocks]
-```
-
-### Open Question
-```markdown
-[N]. **[Question]**
-     **Recommendation:** [Suggestion]
-     **Owner:** [Decider]
-     **Due:** [Date]
-```
-
-### Success Metric
-```markdown
-- **[Metric]:** Target [VALUE] (current: [BASELINE])
-```
-
-### Phase
-```markdown
-### Phase [N] - [Name] ([Timeline])
-- ? [Deliverable 1]
-- ? [Deliverable 2]
-```
-
----
-
-## Quick Commands Reference
-
-| User Says | Command |
+| Operation | Command |
 |-----------|---------|
-| "Update status" | Update Project Status |
-| "Add dependency" | Add Dependency Between Projects |
-| "Change priority" | Change Project Priority |
-| "Reschedule" / "Move to Q#" | Reschedule Project |
-| "Add risk" | Add Risk to Project |
-| "Mark complete" | Mark Project Complete |
-| "Split project" | Split Project |
-| "Merge projects" | Merge Projects |
-| "Add code example" | Add Code Example |
-| "Link projects" | Cross-Reference Projects |
-| "Add metric" | Add Success Metric |
-| "Risk occurred" | Document Risk Materialization |
-| "Status report" | Generate Project Status Report |
-| "Add question" | Add Open Question |
-| "Answer question" | Close Open Question |
-| "Add phase" | Add Phase to Project |
-| "[X]% complete" | Update Completion Percentage |
+| Update status | `python scripts/project_ops.py status <N> "<Status>"` |
+| Change priority | `python scripts/project_ops.py priority <N> <Priority>` |
+| Mark complete | `python scripts/project_ops.py complete <N>` |
+| Cross-reference two projects | `python scripts/project_ops.py link <X> <Y> --x-note "..." --y-note "..."` |
+| Add a risk row | `python scripts/project_ops.py risk <N> --title "..." --likelihood <Low/Med/High> --impact <Low/Med/High/Critical> --mitigation "..."` |
+
+Valid status values: `Not Started`, `Planning`, `Ready for Review`, `In Progress`, `Developers Engaged`, `Complete`.
+Valid priorities: `Low`, `Medium`, `High`, `Critical`.
+
+**What the script does NOT do** (still your job after running it):
+
+- `status` and `complete` — bump the Planning/README.md status table counts and move the project to the right status section.
+- `complete` — flip the box in `TODO_Project_Extraction.md` from `[ ]` to `[x]`.
+- `link` — write a meaningful note. The script just inserts the bullets; the `--x-note` / `--y-note` text is the explanation a reader needs.
+- `risk` — judgement on Likelihood / Impact classifications; the script just appends the row.
 
 ---
 
-**Last Updated:** January 24, 2026  
-**For detailed "Add New Project" workflow, see:** `.claude_add_project_command.md`
+## Operations that still need LLM judgement
+
+These operations are not scripted because they require either content generation, multi-file judgement, or classification that an LLM does better than a regex.
+
+### Add a Dependency Between Projects
+
+User says: "Project X depends on project Y"
+
+Add to Project X's "Dependencies" section under `### Blockers`:
+
+```markdown
+- **[Project Y - Title](./Project_YY_Title.md):** [Why X needs Y first]
+```
+
+Add to Project Y's "Dependencies" section under `### Enablers for Other Projects`:
+
+```markdown
+- **[Project X - Title](./Project_XX_Title.md):** [What completing Y unlocks for X]
+```
+
+Update `Executive_Summary.md` if the dependency is on the critical path.
+
+### Document Risk Materialization
+
+When a risk actually happens, append an `**Update YYYY-MM-DD:**` block to the existing risk row's Mitigation cell describing what happened and how it was resolved. Don't change the original Likelihood / Impact — they're a record of what we thought beforehand.
+
+### Generate a Project Status Report
+
+Walk `Planning/README.md` and project files; produce a synthesis with: completed projects this period, in-progress projects with % completion, blocked projects with the reason, new risks identified, and "watch list" items. This is multi-source synthesis — needs an LLM.
+
+### Add a Phase to a Project
+
+Append a new `### Phase N — Name` section under `## Scope`. Phase name needs judgement; checkbox deliverables need judgement. Bump the Last Updated date afterwards (manually, or use a future `project_ops.py touch` subcommand if one is added).
+
+### Add a Code Example
+
+Insert into "Implementation Plan". Always include the language tag on the fence. Use C# for backend, TypeScript for frontend, XAML / C# for mobile. Keep snippets focused — show the pattern, not a complete file.
+
+### Split or Merge Projects
+
+Multi-file impact. Splitting: create new project(s) with `scripts/new_project.py`, move scope items, update Dependencies on the original to reference the new ones, update `Planning/README.md` counts and theme assignments. Merging: pick the "winning" project, move scope items into it, archive the loser with a header note pointing at the winner, update all cross-references.
+
+### Reschedule a Project
+
+Update target quarter in `Planning/Executive_Summary.md`, the quarter section in `Planning/README.md`, and any cross-referenced timeline in dependent projects. Bump the Last Updated date.
+
+### Add a Success Metric
+
+Identify whether the metric is quantitative (has a number / percentage / threshold) or qualitative (descriptive). Insert into the corresponding subsection under `## Success Metrics`. Bump Last Updated.
+
+### Add or Close an Open Question
+
+Open questions need a recommendation, owner, and due date. Closing one needs the actual decision and a strikethrough of the question. Both involve content generation, not just structure.
+
+### Update Completion Percentage
+
+If the project doesn't have a `**Completion:**` top-of-file marker, decide whether one is worth adding (usually yes for projects > 25% done with multiple phases). Choose a phase-weighted percentage, not a "feels right" number.
+
+---
+
+## Sanity check before declaring done
+
+After any change to a project file:
+
+- [ ] Header table fields make sense together (Risk vs. Size, Status vs. Completion %)
+- [ ] Last Updated reflects today's date
+- [ ] Cross-references are bidirectional
+- [ ] `Planning/README.md` status table counts still sum to the project file count
+- [ ] No `[PLACEHOLDER]` text was left behind by the script
+
+---
+
+## Where each operation lives
+
+| Operation | Owner |
+|-----------|-------|
+| Update status / priority / mark complete | [`scripts/project_ops.py`](../scripts/project_ops.py) |
+| Cross-reference two projects | [`scripts/project_ops.py`](../scripts/project_ops.py) |
+| Add a risk row | [`scripts/project_ops.py`](../scripts/project_ops.py) |
+| Add a new project | [`scripts/new_project.py`](../scripts/new_project.py) — see [`.claude_add_project_command.md`](.claude_add_project_command.md) |
+| Everything in "needs LLM judgement" above | This document |
+
+---
+
+**Last Updated:** When `scripts/project_ops.py` last changed.

--- a/scripts/new_project.py
+++ b/scripts/new_project.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Scaffold a new project plan in Planning/Projects/.
+
+Replaces the deterministic prefix of the LLM "add a new project" workflow
+(find next number, build the filename, copy the template, fill in trivial
+header fields, set today's date). The creative work — Business Rationale,
+Scope, Risks, Open Questions — is left to the human or LLM as a follow-up.
+
+Usage:
+    python scripts/new_project.py "Title of the project" \\
+        [--priority Low|Medium|High|Critical] \\
+        [--size  Very-Small|Small|Medium|Large|Very-Large] \\
+        [--risk  Low|Medium|High|Very-High] \\
+        [--status Not-Started|Planning] \\
+        [--owner "Team or person"] \\
+        [--dependencies "Project 5, Project 11"] \\
+        [--archive] \\
+        [--print-followups]
+
+`--archive` writes to Planning/Projects/Archive/ instead. Useful for
+projects that are already complete on day one (e.g. retroactive docs).
+
+`--print-followups` lists the non-mechanical updates a human needs to
+make after this script runs: README.md status table, Executive_Summary,
+TODO list, Risks_and_Mitigations entry if risk is High+, etc. Defaults
+to on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+from pathlib import Path
+
+PLANNING = Path(__file__).resolve().parents[1] / "Planning"
+PROJECTS = PLANNING / "Projects"
+ARCHIVE = PROJECTS / "Archive"
+TEMPLATE = PROJECTS / "_Project_Template.md"
+
+
+def next_project_number() -> int:
+    nums: list[int] = []
+    for src in (PROJECTS, ARCHIVE):
+        for path in src.glob("Project_*.md"):
+            m = re.match(r"Project_(\d+)_", path.name)
+            if m:
+                nums.append(int(m.group(1)))
+    return (max(nums) + 1) if nums else 1
+
+
+def title_to_filename_segment(title: str) -> str:
+    """Convert 'My Cool Project!' → 'My_Cool_Project'."""
+    cleaned = re.sub(r"[^\w\s-]", "", title)        # drop punctuation
+    cleaned = re.sub(r"[\s-]+", "_", cleaned).strip("_")
+    return cleaned or "Untitled"
+
+
+def _read_template() -> str:
+    """Read the template tolerant of the historical cp1252 file encoding.
+
+    Project templates have been around since pre-utf8-everywhere; we accept
+    the legacy encoding on input and normalise to utf-8 on output.
+    """
+    raw = TEMPLATE.read_bytes()
+    for encoding in ("utf-8", "utf-8-sig", "cp1252"):
+        try:
+            return raw.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    raise UnicodeDecodeError(
+        "utf-8", raw, 0, 1,
+        f"could not decode {TEMPLATE} as utf-8 / utf-8-sig / cp1252",
+    )
+
+
+def render_project(
+    number: int,
+    title: str,
+    priority: str,
+    size: str,
+    risk: str,
+    status: str,
+    owner: str,
+    dependencies: str,
+) -> str:
+    today = datetime.date.today().isoformat()
+    template = _read_template()
+
+    # The template's first line is "# Project Template — [PROJECT TITLE]".
+    # Swap to "# Project N — Title".
+    template = re.sub(
+        r"^# Project Template.*$",
+        f"# Project {number} — {title}",
+        template,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    # Header table values — only the bracketed placeholders we know how to fill.
+    template = re.sub(
+        r"^\| \*\*Status\*\* \| \[Not Started.*?\] \|",
+        f"| **Status** | {status} |",
+        template,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    template = re.sub(
+        r"^\| \*\*Priority\*\* \| \[Low.*?\] \|",
+        f"| **Priority** | {priority} |",
+        template,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    template = re.sub(
+        r"^\| \*\*Risk\*\* \| \[Low.*?\] \|",
+        f"| **Risk** | {risk} |",
+        template,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    template = re.sub(
+        r"^\| \*\*Size\*\* \| \[Very Small.*?\] \|",
+        f"| **Size** | {size} |",
+        template,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    template = re.sub(
+        r"^\| \*\*Dependencies\*\* \| \[List of dependent projects\] \|",
+        f"| **Dependencies** | {dependencies or '_None_'} |",
+        template,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    # Footer trailer.
+    template = re.sub(r"\*\*Last Updated:\*\* \[Date\]", f"**Last Updated:** {today}", template)
+    template = re.sub(r"\*\*Owner:\*\* \[Team/Person responsible\]", f"**Owner:** {owner}", template)
+    template = re.sub(r"\*\*Status:\*\* \[Current status\]", f"**Status:** {status}", template)
+    template = re.sub(
+        r"\*\*Next Review:\*\* \[When to review again\]",
+        f"**Next Review:** {(datetime.date.today() + datetime.timedelta(days=30)).isoformat()}",
+        template,
+    )
+    return template
+
+
+FOLLOWUPS = """
+After scaffolding, the human (or follow-up LLM pass) still needs to:
+
+  1. Fill in Business Rationale, Objectives, Scope (phases), Out-of-Scope,
+     Success Metrics, Risks & Mitigations, Implementation Plan, Open Questions.
+
+  2. Update Planning/README.md
+     - Add the project to the appropriate quarter/theme section
+     - Bump the "Not Started" count in the status table
+
+  3. Update Planning/.claude_commands_index.md if a new common operation
+     was introduced.
+
+  4. Update Planning/Executive_Summary.md if the project is high-priority
+     or large.
+
+  5. If Risk is High or Very High, add a PR-{N} entry to
+     Planning/Risks_and_Mitigations.md.
+
+  6. Link this project from any pre-existing related projects'
+     "Related Documents" sections.
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument("title", help="Project title, e.g. 'Email Digest System'")
+    parser.add_argument("--priority", default="Medium",
+                        choices=["Low", "Medium", "High", "Critical"])
+    parser.add_argument("--size", default="Medium",
+                        choices=["Very Small", "Small", "Medium", "Large", "Very Large",
+                                 "Very-Small", "Very-Large"])  # dash form for CLI ergonomics
+    parser.add_argument("--risk", default="Low",
+                        choices=["Low", "Medium", "High", "Very High", "Very-High"])
+    parser.add_argument("--status", default="Not Started",
+                        choices=["Not Started", "Not-Started", "Planning"])
+    parser.add_argument("--owner", default="TBD")
+    parser.add_argument("--dependencies", default="",
+                        help="Free-text dependencies list, e.g. 'Project 11, Project 23'")
+    parser.add_argument("--archive", action="store_true",
+                        help="Write to Planning/Projects/Archive/ instead of Projects/")
+    parser.add_argument("--no-followups", action="store_true",
+                        help="Don't print the follow-up checklist after scaffolding")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the proposed filename + content; don't write")
+    args = parser.parse_args()
+
+    # Normalise the dashed CLI variants back to space form.
+    size = args.size.replace("-", " ")
+    risk = args.risk.replace("-", " ")
+    status = args.status.replace("-", " ")
+
+    if not TEMPLATE.exists():
+        print(f"error: template not found at {TEMPLATE}", file=sys.stderr)
+        return 2
+
+    number = next_project_number()
+    filename_segment = title_to_filename_segment(args.title)
+    filename = f"Project_{number}_{filename_segment}.md"
+    target_dir = ARCHIVE if args.archive else PROJECTS
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / filename
+
+    if target.exists():
+        print(f"error: {target} already exists", file=sys.stderr)
+        return 1
+
+    rendered = render_project(
+        number=number,
+        title=args.title,
+        priority=args.priority,
+        size=size,
+        risk=risk,
+        status=status,
+        owner=args.owner,
+        dependencies=args.dependencies,
+    )
+
+    if args.dry_run:
+        print(f"# Would write: {target}")
+        print(rendered)
+        return 0
+
+    target.write_text(rendered, encoding="utf-8")
+    print(f"Created {target}")
+    print(f"  Project number: {number}")
+    print(f"  Title:          {args.title}")
+    print(f"  Priority/Size/Risk: {args.priority} / {size} / {risk}")
+    print(f"  Status:         {status}")
+    if args.dependencies:
+        print(f"  Dependencies:   {args.dependencies}")
+
+    if not args.no_followups:
+        print(FOLLOWUPS)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/project_ops.py
+++ b/scripts/project_ops.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""
+Deterministic operations on Planning/Projects/*.md files.
+
+Pulls the mechanical operations out of `.claude_common_commands.md` so they
+can run without spending LLM tokens on string editing. The judgment-heavy
+operations (split, merge, document a materialised risk, generate a status
+report, add a code example) stay in the prose guide.
+
+Subcommands:
+    status     Set Status field on a project (table header + footer + date)
+    priority   Set Priority field on a project
+    complete   Mark a project complete (status + completion-date stamp)
+    link       Add reciprocal `Related Documents` cross-references between
+               two projects (judgment-free: just inserts links)
+    risk       Append a row to the Risks & Mitigations table
+
+Each subcommand finds the target project by its number; it scans both
+`Planning/Projects/` and `Planning/Projects/Archive/`.
+
+Usage examples:
+    python scripts/project_ops.py status 60 Complete
+    python scripts/project_ops.py priority 41 High
+    python scripts/project_ops.py complete 60
+    python scripts/project_ops.py link 41 60 \
+        --x-note "Sponsored adoption pipeline feeds prospect contacts" \
+        --y-note "Multi-contact tracking supports sponsorship outreach"
+    python scripts/project_ops.py risk 41 \
+        --title "Payment provider lock-in" --likelihood Medium \
+        --impact High --mitigation "Abstract payment via Strategy pattern"
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+from pathlib import Path
+
+PROJECTS = Path(__file__).resolve().parents[1] / "Planning" / "Projects"
+ARCHIVE = PROJECTS / "Archive"
+
+
+STATUS_CHOICES = [
+    "Not Started", "Planning", "Ready for Review",
+    "In Progress", "Developers Engaged", "Complete",
+]
+PRIORITY_CHOICES = ["Low", "Medium", "High", "Critical"]
+LIKELIHOOD_CHOICES = ["Low", "Medium", "High"]
+IMPACT_CHOICES = ["Low", "Medium", "High", "Critical"]
+
+
+# ---------------------------------------------------------------------------
+# File lookup
+# ---------------------------------------------------------------------------
+
+def find_project(number: int) -> Path:
+    """Return the path to Project_{number}_*.md (active or archived)."""
+    for root in (PROJECTS, ARCHIVE):
+        matches = list(root.glob(f"Project_{number}_*.md"))
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise FileNotFoundError(
+                f"Multiple matches for project {number} in {root}: "
+                + ", ".join(p.name for p in matches)
+            )
+    raise FileNotFoundError(
+        f"No project file for number {number} in {PROJECTS} or {ARCHIVE}"
+    )
+
+
+def read_project(path: Path) -> str:
+    """Read a project file with cp1252 fallback (legacy templates)."""
+    raw = path.read_bytes()
+    for enc in ("utf-8", "utf-8-sig", "cp1252"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    raise UnicodeDecodeError(
+        "utf-8", raw, 0, 1, f"could not decode {path}"
+    )
+
+
+def write_project(path: Path, content: str) -> None:
+    # Write bytes (not write_text) so we preserve whatever line endings the
+    # file already had. write_text with newline=None translates "\n" to the
+    # platform separator, which silently corrupts CRLF-on-Windows files into
+    # CRCRLF since our reader keeps \r in the buffer.
+    path.write_bytes(content.encode("utf-8"))
+
+
+def project_title(text: str) -> str:
+    """Pull the human title out of an opening `# Project N — Title` line."""
+    m = re.search(r"^#\s+Project\s+\d+\s*[—-]\s*(.+?)\s*$", text, re.MULTILINE)
+    return m.group(1).strip() if m else "(unknown)"
+
+
+def relative_link_to(target: Path, source: Path) -> str:
+    """Return a `./...md` relative link between two project files (sibling-aware)."""
+    try:
+        rel = target.relative_to(source.parent).as_posix()
+    except ValueError:
+        # Different folders (Projects vs Archive). Walk relative.
+        import os.path
+        rel = os.path.relpath(target, source.parent).replace("\\", "/")
+    if not rel.startswith(("./", "../")):
+        rel = "./" + rel
+    return rel
+
+
+# ---------------------------------------------------------------------------
+# Header table + footer field setters
+# ---------------------------------------------------------------------------
+
+_TODAY = datetime.date.today().isoformat()
+
+
+def _set_header_field(text: str, field: str, value: str) -> tuple[str, bool]:
+    """Replace `| **Field** | ... |` row; returns (new_text, did_replace).
+
+    The trailing `\r?` tolerates CRLF line endings — Python's `$` in MULTILINE
+    mode anchors before `\n` only, so files written with CRLF would otherwise
+    leave a stray `\r` between the final `|` and `$` and miss the match.
+    """
+    pattern = rf"^\| \*\*{re.escape(field)}\*\* \| .*? \|\r?$"
+    new = re.subn(
+        pattern,
+        f"| **{field}** | {value} |",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    return new[0], (new[1] > 0)
+
+
+def _set_footer_field(text: str, field: str, value: str) -> tuple[str, bool]:
+    """Replace `**Field:** value` footer line."""
+    pattern = rf"^\*\*{re.escape(field)}:\*\*\s+.+?\r?$"
+    new = re.subn(
+        pattern,
+        f"**{field}:** {value}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    return new[0], (new[1] > 0)
+
+
+def _bump_last_updated(text: str) -> str:
+    """Set the footer's Last Updated to today; tolerant of missing field."""
+    text, replaced = _set_footer_field(text, "Last Updated", _TODAY)
+    if replaced:
+        return text
+    # Insert near the end if missing entirely.
+    return text.rstrip() + f"\n\n**Last Updated:** {_TODAY}\n"
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+def cmd_status(args: argparse.Namespace) -> int:
+    path = find_project(args.number)
+    text = read_project(path)
+    text, ok_h = _set_header_field(text, "Status", args.status)
+    text, _ = _set_footer_field(text, "Status", args.status)
+    text = _bump_last_updated(text)
+    if not ok_h:
+        print(f"warning: no Status row found in header table of {path.name}",
+              file=sys.stderr)
+    write_project(path, text)
+    print(f"{path.name}: Status -> {args.status}")
+    return 0
+
+
+def cmd_priority(args: argparse.Namespace) -> int:
+    path = find_project(args.number)
+    text = read_project(path)
+    text, ok = _set_header_field(text, "Priority", args.priority)
+    text = _bump_last_updated(text)
+    if not ok:
+        print(f"warning: no Priority row found in {path.name}", file=sys.stderr)
+    write_project(path, text)
+    print(f"{path.name}: Priority -> {args.priority}")
+    return 0
+
+
+def cmd_complete(args: argparse.Namespace) -> int:
+    """Convenience: Status ->Complete, stamps a completion date if missing."""
+    path = find_project(args.number)
+    text = read_project(path)
+    text, _ = _set_header_field(text, "Status", "Complete")
+    text, _ = _set_footer_field(text, "Status", "Complete")
+    # Append a "Completed:" footer line if not already present.
+    if not re.search(r"^\*\*Completed:\*\*", text, re.MULTILINE):
+        # Insert right after Last Updated, or at end.
+        completed_line = f"**Completed:** {_TODAY}"
+        m = re.search(r"^\*\*Last Updated:\*\*.*$", text, re.MULTILINE)
+        if m:
+            insert_pos = m.end()
+            text = text[:insert_pos] + "\n" + completed_line + text[insert_pos:]
+        else:
+            text = text.rstrip() + "\n\n" + completed_line + "\n"
+    text = _bump_last_updated(text)
+    write_project(path, text)
+    print(f"{path.name}: marked Complete (date stamped {_TODAY})")
+    print("Reminder: also update Planning/README.md status table count "
+          "and TODO_Project_Extraction.md.")
+    return 0
+
+
+def cmd_link(args: argparse.Namespace) -> int:
+    """Add reciprocal `## Related Documents` entries between two projects."""
+    px = find_project(args.x)
+    py = find_project(args.y)
+    tx = read_project(px)
+    ty = read_project(py)
+    tx_title = project_title(tx)
+    ty_title = project_title(ty)
+    # link_in_x points from px's file to py; link_in_y points from py's file to px.
+    link_in_x = relative_link_to(py, px)
+    link_in_y = relative_link_to(px, py)
+
+    def add_related(content: str, other_num: int, other_title: str,
+                    other_link: str, note: str) -> tuple[str, bool]:
+        entry_body = f"- **[Project {other_num} - {other_title}]({other_link})**"
+        entry = f"{entry_body} — {note}" if note else entry_body
+
+        lines = content.splitlines(keepends=True)
+        for i, line in enumerate(lines):
+            if re.match(r"^## Related Documents\s*$", line.rstrip("\r\n")):
+                # Find the last `- ` bullet that belongs to this section.
+                last_bullet = i
+                j = i + 1
+                while j < len(lines):
+                    stripped = lines[j].rstrip("\r\n")
+                    if stripped.startswith("## ") or stripped == "---":
+                        break
+                    if stripped.startswith("- "):
+                        if other_link in stripped:
+                            return content, False  # already linked
+                        last_bullet = j
+                    j += 1
+                line_ending = "\r\n" if lines[last_bullet].endswith("\r\n") else "\n"
+                # If no bullets exist yet, ensure a blank line separates header & entry.
+                insert_at = last_bullet + 1
+                if last_bullet == i:
+                    lines.insert(insert_at, line_ending)
+                    insert_at += 1
+                lines.insert(insert_at, entry + line_ending)
+                return "".join(lines), True
+
+        # No section found — append a new one near the file end.
+        line_ending = "\r\n" if content.endswith("\r\n") else "\n"
+        suffix = (
+            f"{line_ending}{line_ending}## Related Documents{line_ending}"
+            f"{line_ending}{entry}{line_ending}"
+        )
+        return content.rstrip() + suffix, True
+
+    tx_new, added_x = add_related(tx, args.y, ty_title, link_in_x, args.x_note or "")
+    ty_new, added_y = add_related(ty, args.x, tx_title, link_in_y, args.y_note or "")
+
+    tx_new = _bump_last_updated(tx_new) if added_x else tx_new
+    ty_new = _bump_last_updated(ty_new) if added_y else ty_new
+
+    write_project(px, tx_new)
+    write_project(py, ty_new)
+
+    print(f"{px.name}: {'added' if added_x else 'already had'} link to {py.name}")
+    print(f"{py.name}: {'added' if added_y else 'already had'} link to {px.name}")
+    return 0
+
+
+def cmd_risk(args: argparse.Namespace) -> int:
+    """Append a row to the Risks & Mitigations table."""
+    path = find_project(args.number)
+    text = read_project(path)
+
+    lines = text.splitlines(keepends=True)
+    in_section = False
+    table_started = False
+    last_table_idx = -1
+    for i, raw in enumerate(lines):
+        stripped = raw.rstrip("\r\n")
+        if re.match(r"^## Risks & Mitigations\s*$", stripped):
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            break  # left the section
+        if stripped.startswith("|"):
+            table_started = True
+            last_table_idx = i
+        elif table_started and not stripped:
+            break  # blank line after table ends the rows
+
+    if last_table_idx < 0:
+        print(f"error: no Risks & Mitigations table in {path.name}",
+              file=sys.stderr)
+        return 1
+
+    line_ending = "\r\n" if lines[last_table_idx].endswith("\r\n") else "\n"
+    new_row = (
+        f"| **{args.title}** | {args.likelihood} | {args.impact} "
+        f"| {args.mitigation} |{line_ending}"
+    )
+    lines.insert(last_table_idx + 1, new_row)
+    text = "".join(lines)
+    text = _bump_last_updated(text)
+    write_project(path, text)
+    print(f"{path.name}: added risk row {args.title!r}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_status = sub.add_parser("status", help="Set Status field")
+    p_status.add_argument("number", type=int)
+    p_status.add_argument("status", choices=STATUS_CHOICES)
+    p_status.set_defaults(func=cmd_status)
+
+    p_priority = sub.add_parser("priority", help="Set Priority field")
+    p_priority.add_argument("number", type=int)
+    p_priority.add_argument("priority", choices=PRIORITY_CHOICES)
+    p_priority.set_defaults(func=cmd_priority)
+
+    p_complete = sub.add_parser("complete", help="Mark project Complete")
+    p_complete.add_argument("number", type=int)
+    p_complete.set_defaults(func=cmd_complete)
+
+    p_link = sub.add_parser("link", help="Cross-reference two projects")
+    p_link.add_argument("x", type=int, help="First project number")
+    p_link.add_argument("y", type=int, help="Second project number")
+    p_link.add_argument("--x-note", default="", help="Why X relates to Y")
+    p_link.add_argument("--y-note", default="", help="Why Y relates to X")
+    p_link.set_defaults(func=cmd_link)
+
+    p_risk = sub.add_parser("risk", help="Add a Risks & Mitigations row")
+    p_risk.add_argument("number", type=int)
+    p_risk.add_argument("--title", required=True)
+    p_risk.add_argument("--likelihood", required=True, choices=LIKELIHOOD_CHOICES)
+    p_risk.add_argument("--impact", required=True, choices=IMPACT_CHOICES)
+    p_risk.add_argument("--mitigation", required=True)
+    p_risk.set_defaults(func=cmd_risk)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/upload_article.py
+++ b/scripts/upload_article.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""
+Upload a news article markdown file to TrashMob's Strapi v5 CMS.
+
+Replaces the LLM-driven upload-article slash command with a deterministic
+script. Handles frontmatter parsing, markdown -> Strapi v5 Blocks
+conversion, Strapi URL discovery via az CLI, admin login, API-token
+caching, POST/PUT/GET-verify.
+
+Usage:
+    python scripts/upload_article.py <markdown-path> [--env dev|prod] [--draft]
+
+Environment variables:
+    STRAPI_ADMIN_EMAIL     admin email (prompted if missing)
+    STRAPI_ADMIN_PASSWORD  admin password (prompted if missing, NEVER echoed)
+    STRAPI_URL             override URL discovery (skip az lookup)
+
+Cached state:
+    ~/.cache/trashmob-strapi/{env}-token.json  API token (chmod 600)
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+CACHE_DIR = Path.home() / ".cache" / "trashmob-strapi"
+
+# --- Category cache (mirrors Planning/NewsArticles/CLAUDE.md "Categories (Dev)") ---
+KNOWN_CATEGORIES = {
+    "announcements": 1,
+    "community stories": 2,
+    "tips & guides": 3,
+    "tips and guides": 3,
+    "features": 4,
+}
+
+
+# ---------------------------------------------------------------------------
+# Article parsing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Article:
+    title: str
+    slug: str
+    author: str
+    category: str
+    tags: list[str]
+    featured: bool
+    estimated_read_time: int
+    excerpt: str
+    body_markdown: str
+    body_blocks: list[dict[str, Any]] = field(default_factory=list)
+
+
+def parse_article(path: Path) -> Article:
+    """Parse a TrashMob news-article markdown file into an Article."""
+    text = path.read_text(encoding="utf-8")
+
+    # Title: first H1
+    m = re.search(r"^#\s+(.+?)\s*$", text, re.MULTILINE)
+    if not m:
+        raise ValueError(f"{path}: no H1 title found")
+    title = m.group(1).strip()
+
+    # Bold key:value frontmatter lines, e.g. **Slug:** foo
+    def field_value(name: str) -> str | None:
+        rx = rf"\*\*{re.escape(name)}:\*\*\s*(.*?)\s*$"
+        mm = re.search(rx, text, re.MULTILINE)
+        return mm.group(1).strip() if mm else None
+
+    slug = field_value("Slug") or ""
+    author = field_value("Author") or ""
+    category = field_value("Category") or ""
+    featured_raw = (field_value("Featured") or "false").strip().lower()
+    estimated_raw = field_value("Estimated Read Time") or "0"
+    tags_raw = field_value("Tags") or "[]"
+
+    # Tags: JSON array literal
+    try:
+        tags = json.loads(tags_raw)
+        if not isinstance(tags, list):
+            raise ValueError("Tags must be a JSON array")
+    except json.JSONDecodeError as e:
+        raise ValueError(f"{path}: invalid Tags JSON {tags_raw!r}: {e}") from e
+
+    # Excerpt: between ## Excerpt and the next ---
+    excerpt = _extract_section(text, "Excerpt")
+    if not excerpt:
+        raise ValueError(f"{path}: no ## Excerpt section found")
+
+    # Body: between ## Body and the next ## (e.g. ## Social Posts) or end-of-file
+    body_md = _extract_section(text, "Body", stop_at_h2=True)
+    if not body_md:
+        raise ValueError(f"{path}: no ## Body section found")
+
+    article = Article(
+        title=title,
+        slug=slug,
+        author=author,
+        category=category,
+        tags=tags,
+        featured=featured_raw in ("true", "1", "yes"),
+        estimated_read_time=int(estimated_raw),
+        excerpt=excerpt,
+        body_markdown=body_md,
+    )
+    article.body_blocks = markdown_to_blocks(body_md)
+    return article
+
+
+def _extract_section(text: str, name: str, stop_at_h2: bool = False) -> str:
+    """Return the contents of a ## Name section, trimmed."""
+    # Find "## Name" then capture until next "---" or "## " or EOF.
+    rx = rf"^##\s+{re.escape(name)}\s*$\n(.*?)(?=^---|\Z|^## )" if stop_at_h2 \
+        else rf"^##\s+{re.escape(name)}\s*$\n(.*?)(?=^---|\Z)"
+    m = re.search(rx, text, re.MULTILINE | re.DOTALL)
+    return m.group(1).strip() if m else ""
+
+
+# ---------------------------------------------------------------------------
+# Markdown -> Strapi v5 Blocks
+# ---------------------------------------------------------------------------
+#
+# Supports the subset used in TrashMob news articles per
+# Planning/NewsArticles/CLAUDE.md:
+#   - Paragraphs
+#   - H2 / H3 headings
+#   - Bold (**text**)
+#   - Italic (*text* or _text_)
+#   - Inline links [text](url)
+#   - Unordered lists (- item / * item)
+#   - Ordered lists (1. item / 2. item)
+#   - Mixed inline formatting within paragraphs and list items
+#
+# Out of scope: code blocks, blockquotes, tables, images. If the article
+# uses one of those, the script errors out so a human handles it.
+
+_INLINE_PATTERN = re.compile(
+    r"(\*\*([^*]+)\*\*)"            # 1,2 bold
+    r"|(\*([^*]+)\*)"               # 3,4 italic with *
+    r"|(_([^_]+)_)"                 # 5,6 italic with _
+    r"|(\[([^\]]+)\]\(([^)]+)\))"   # 7,8,9 link [text](url)
+)
+
+# For parsing inside a bold/italic span — same as _INLINE_PATTERN but excluding
+# the outer wrapper. Used by _inline_to_children for nested formatting.
+_LINK_PATTERN = re.compile(r"(\[([^\]]+)\]\(([^)]+)\))")
+
+
+def markdown_to_blocks(md: str) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = []
+    lines = md.splitlines()
+    i = 0
+    while i < len(lines):
+        raw = lines[i]
+        line = raw.rstrip()
+
+        if not line.strip():
+            i += 1
+            continue
+
+        # Reject unsupported block types early.
+        if line.startswith("```"):
+            raise ValueError(
+                "Code blocks aren't supported by the converter — handle "
+                "manually or extend the script.")
+        if line.startswith(">"):
+            raise ValueError(
+                "Blockquotes aren't supported by the converter — handle "
+                "manually or extend the script.")
+        if line.startswith("![") or line.startswith("<img"):
+            raise ValueError(
+                "Inline images need full Strapi upload metadata — handle "
+                "manually via the existing upload flow.")
+
+        # Headings
+        m = re.match(r"^(#{2,3})\s+(.*)$", line)
+        if m:
+            level = len(m.group(1))
+            blocks.append({
+                "type": "heading",
+                "level": level,
+                "children": _inline_to_children(m.group(2)),
+            })
+            i += 1
+            continue
+
+        # Unordered list
+        if re.match(r"^[-*]\s+\S", line):
+            items: list[dict[str, Any]] = []
+            while i < len(lines) and re.match(r"^[-*]\s+\S", lines[i].rstrip()):
+                text = re.sub(r"^[-*]\s+", "", lines[i].rstrip())
+                items.append({
+                    "type": "list-item",
+                    "children": _inline_to_children(text),
+                })
+                i += 1
+            blocks.append({
+                "type": "list",
+                "format": "unordered",
+                "children": items,
+            })
+            continue
+
+        # Ordered list
+        if re.match(r"^\d+\.\s+\S", line):
+            items = []
+            while i < len(lines) and re.match(r"^\d+\.\s+\S", lines[i].rstrip()):
+                text = re.sub(r"^\d+\.\s+", "", lines[i].rstrip())
+                items.append({
+                    "type": "list-item",
+                    "children": _inline_to_children(text),
+                })
+                i += 1
+            blocks.append({
+                "type": "list",
+                "format": "ordered",
+                "children": items,
+            })
+            continue
+
+        # Paragraph: combine consecutive non-empty non-block lines
+        para_lines = [line]
+        i += 1
+        while i < len(lines):
+            nxt = lines[i].rstrip()
+            if not nxt.strip():
+                break
+            if re.match(r"^(#{1,6}\s|[-*]\s|\d+\.\s|>|```|!\[)", nxt):
+                break
+            para_lines.append(nxt)
+            i += 1
+        para = " ".join(para_lines)
+        blocks.append({
+            "type": "paragraph",
+            "children": _inline_to_children(para),
+        })
+
+    return blocks
+
+
+def _inline_to_children(text: str) -> list[dict[str, Any]]:
+    """Parse inline markdown into Strapi children array.
+
+    Handles nesting: a link inside a bold span becomes a link child whose
+    inner text node carries the bold flag (Strapi treats links as siblings
+    of text at the inline level, not as wrappers).
+    """
+    children: list[dict[str, Any]] = []
+    pos = 0
+    for m in _INLINE_PATTERN.finditer(text):
+        if m.start() > pos:
+            children.append({"type": "text", "text": text[pos:m.start()]})
+        if m.group(1):  # bold
+            children.extend(_styled_children(m.group(2), bold=True))
+        elif m.group(3):  # italic *
+            children.extend(_styled_children(m.group(4), italic=True))
+        elif m.group(5):  # italic _
+            children.extend(_styled_children(m.group(6), italic=True))
+        elif m.group(7):  # link
+            children.append({
+                "type": "link",
+                "url": m.group(9),
+                "children": [{"type": "text", "text": m.group(8)}],
+            })
+        pos = m.end()
+    if pos < len(text):
+        children.append({"type": "text", "text": text[pos:]})
+    if not children:
+        children.append({"type": "text", "text": ""})
+    return children
+
+
+def _styled_children(
+    inner: str, *, bold: bool = False, italic: bool = False,
+) -> list[dict[str, Any]]:
+    """Render the inside of a bold/italic span, surfacing nested links."""
+    out: list[dict[str, Any]] = []
+    pos = 0
+    for m in _LINK_PATTERN.finditer(inner):
+        if m.start() > pos:
+            out.append(_text_node(inner[pos:m.start()], bold, italic))
+        out.append({
+            "type": "link",
+            "url": m.group(3),
+            "children": [_text_node(m.group(2), bold, italic)],
+        })
+        pos = m.end()
+    if pos < len(inner):
+        out.append(_text_node(inner[pos:], bold, italic))
+    return out
+
+
+def _text_node(text: str, bold: bool, italic: bool) -> dict[str, Any]:
+    node: dict[str, Any] = {"type": "text", "text": text}
+    if bold:
+        node["bold"] = True
+    if italic:
+        node["italic"] = True
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Strapi URL + auth
+# ---------------------------------------------------------------------------
+
+def resolve_strapi_url(env: str) -> str:
+    if override := os.environ.get("STRAPI_URL"):
+        return override.rstrip("/")
+    if env == "dev":
+        cmd = [
+            "az", "containerapp", "show",
+            "--name", "ca-strapi-tm-dev-westus2",
+            "--resource-group", "rg-trashmob-dev-westus2",
+            "--query", "properties.configuration.ingress.fqdn", "-o", "tsv",
+        ]
+    elif env == "prod":
+        cmd = [
+            "az", "containerapp", "show",
+            "--name", "ca-strapi-tm-pr-westus2",
+            "--resource-group", "rg-trashmob-pr-westus2",
+            "--subscription", "5ea21946-8cb1-413f-9005-0ab10bfa839d",
+            "--query", "properties.configuration.ingress.fqdn", "-o", "tsv",
+        ]
+    else:
+        raise ValueError(f"Unknown env: {env}")
+    res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    fqdn = res.stdout.strip()
+    return f"https://{fqdn}"
+
+
+def get_admin_credentials() -> tuple[str, str]:
+    email = os.environ.get("STRAPI_ADMIN_EMAIL")
+    password = os.environ.get("STRAPI_ADMIN_PASSWORD")
+    if not email:
+        email = input("Strapi admin email: ").strip()
+    if not password:
+        password = getpass.getpass("Strapi admin password: ")
+    return email, password
+
+
+def get_api_token(strapi_url: str, env: str) -> str:
+    """Get a Strapi API token, caching it under ~/.cache/trashmob-strapi/."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_file = CACHE_DIR / f"{env}-token.json"
+
+    if cache_file.exists():
+        try:
+            cached = json.loads(cache_file.read_text())
+            token = cached.get("token")
+            if token and _ping_with_token(strapi_url, token):
+                return token
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    email, password = get_admin_credentials()
+    print(f"-> Admin login as {email}")
+    login = _post_json(f"{strapi_url}/admin/login",
+                       {"email": email, "password": password})
+    jwt = login["data"]["token"]
+
+    print("-> Creating API token")
+    token_res = _post_json(
+        f"{strapi_url}/admin/api-tokens",
+        {
+            "name": f"upload-article-{env}-{os.getpid()}",
+            "description": "Created by scripts/upload_article.py",
+            "type": "full-access",
+            "lifespan": None,
+        },
+        bearer=jwt,
+    )
+    token = token_res["data"]["accessKey"]
+    cache_file.write_text(json.dumps({"token": token}))
+    try:
+        cache_file.chmod(0o600)
+    except OSError:
+        pass
+    return token
+
+
+def _ping_with_token(strapi_url: str, token: str) -> bool:
+    """Return True if the token can read /api/news-categories."""
+    try:
+        _get_json(f"{strapi_url}/api/news-categories", bearer=token)
+        return True
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (urllib — CLAUDE.md mandates not using curl due to shell escapes)
+# ---------------------------------------------------------------------------
+
+def _request(method: str, url: str, body: Any = None, bearer: str | None = None) -> Any:
+    headers = {"Accept": "application/json"}
+    data: bytes | None = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req) as resp:  # noqa: S310 — trusted Strapi URL
+        raw = resp.read().decode("utf-8")
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def _post_json(url: str, body: Any, bearer: str | None = None) -> Any:
+    return _request("POST", url, body, bearer)
+
+
+def _put_json(url: str, body: Any, bearer: str | None = None) -> Any:
+    return _request("PUT", url, body, bearer)
+
+
+def _get_json(url: str, bearer: str | None = None) -> Any:
+    return _request("GET", url, None, bearer)
+
+
+# ---------------------------------------------------------------------------
+# Strapi operations
+# ---------------------------------------------------------------------------
+
+def resolve_category_id(strapi_url: str, token: str, name: str) -> int:
+    # Try cache first
+    if (cid := KNOWN_CATEGORIES.get(name.lower())) is not None:
+        return cid
+    res = _get_json(f"{strapi_url}/api/news-categories", bearer=token)
+    for row in res.get("data", []):
+        attrs = row.get("attributes", row)
+        if attrs.get("name", "").lower() == name.lower():
+            return row["id"]
+    raise ValueError(f"No category named {name!r} on Strapi")
+
+
+def post_article(strapi_url: str, token: str, article: Article,
+                 category_id: int) -> dict[str, Any]:
+    payload = {
+        "data": {
+            "title": article.title,
+            "slug": article.slug,
+            "excerpt": article.excerpt,
+            "author": article.author,
+            "isFeatured": article.featured,
+            "estimatedReadTime": article.estimated_read_time,
+            "tags": article.tags,
+            "category": {"connect": [category_id]},
+            "body": article.body_blocks,
+        }
+    }
+    res = _post_json(f"{strapi_url}/api/news-posts", payload, bearer=token)
+    return res["data"]
+
+
+def publish_article(strapi_url: str, token: str, document_id: str) -> None:
+    # Strapi v5: use documentId, not numeric id.
+    import datetime
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    _put_json(
+        f"{strapi_url}/api/news-posts/{document_id}",
+        {"data": {"publishedAt": now}},
+        bearer=token,
+    )
+
+
+def verify_slug(strapi_url: str, token: str, slug: str) -> bool:
+    q = urllib.parse.urlencode({"filters[slug][$eq]": slug})
+    res = _get_json(f"{strapi_url}/api/news-posts?{q}", bearer=token)
+    return bool(res.get("data"))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.add_argument("markdown", type=Path, help="Path to the article .md file")
+    parser.add_argument("--env", choices=["dev", "prod"], default="dev",
+                        help="Strapi environment (default: dev)")
+    parser.add_argument("--draft", action="store_true",
+                        help="Skip the publish step; leave the article as a draft")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Parse + convert + print the JSON payload, do not upload")
+    args = parser.parse_args()
+
+    if not args.markdown.exists():
+        print(f"error: {args.markdown} not found", file=sys.stderr)
+        return 2
+
+    print(f"-> Parsing {args.markdown}")
+    article = parse_article(args.markdown)
+    print(f"   title={article.title!r} slug={article.slug!r} category={article.category!r}")
+    print(f"   {len(article.body_blocks)} block(s) generated")
+
+    if args.dry_run:
+        payload = {
+            "data": {
+                "title": article.title,
+                "slug": article.slug,
+                "excerpt": article.excerpt,
+                "author": article.author,
+                "isFeatured": article.featured,
+                "estimatedReadTime": article.estimated_read_time,
+                "tags": article.tags,
+                "category": "RESOLVED-AT-UPLOAD-TIME",
+                "body": article.body_blocks,
+            }
+        }
+        json.dump(payload, sys.stdout, indent=2)
+        print()
+        return 0
+
+    print(f"-> Resolving Strapi URL ({args.env})")
+    strapi_url = resolve_strapi_url(args.env)
+    print(f"   {strapi_url}")
+
+    token = get_api_token(strapi_url, args.env)
+
+    print(f"-> Resolving category id for {article.category!r}")
+    category_id = resolve_category_id(strapi_url, token, article.category)
+    print(f"   id={category_id}")
+
+    print("-> POST /api/news-posts (creates draft)")
+    created = post_article(strapi_url, token, article, category_id)
+    document_id = created.get("documentId") or created.get("attributes", {}).get("documentId")
+    if not document_id:
+        print("error: created article missing documentId", file=sys.stderr)
+        json.dump(created, sys.stderr, indent=2)
+        return 1
+    print(f"   documentId={document_id}")
+
+    if not args.draft:
+        print(f"-> PUT /api/news-posts/{document_id} (publish)")
+        publish_article(strapi_url, token, document_id)
+
+    print(f"-> Verifying slug={article.slug!r} is queryable")
+    if not verify_slug(strapi_url, token, article.slug):
+        print("warning: slug not found via GET — Strapi may need a moment", file=sys.stderr)
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Lifts the deterministic work out of three LLM-driven Claude skills into Python scripts so the model isn't burning tokens on string editing.
- Sets the `/upload-article` slash command to run on `haiku` since after this change it's just argument shuffling and error reporting.
- Thins `Planning/.claude_add_project_command.md` (478 → 145 lines) and `Planning/.claude_common_commands.md` (429 → 100 lines) to delegate mechanical work to the scripts; keeps the genuinely judgement-heavy ops (split / merge / rationale / status report / risk classification) as LLM workflows.

## New scripts

| Script | Purpose |
|--------|---------|
| `scripts/upload_article.py` | Parse frontmatter, convert markdown → Strapi v5 Blocks (nested bold + link supported), `az`-discover the Strapi URL, login + cache API token under `~/.cache/trashmob-strapi/{env}-token.json` (chmod 600), POST + publish via `documentId`, verify |
| `scripts/new_project.py` | Pick next project number across `Planning/Projects/` and `Archive/`, copy template (cp1252-tolerant), fill header / footer / dates, print human follow-up checklist |
| `scripts/project_ops.py` | `status` / `priority` / `complete` / `link` / `risk` subcommands — handle the mechanical operations from `.claude_common_commands.md`. CRLF-tolerant. Writes via `path.write_bytes` to preserve existing line endings. ASCII output (no Unicode arrows that crash Windows `cp1252` consoles). |

## Why

The previous skills had the LLM doing string surgery on markdown files — token-expensive, error-prone with CRLF / mixed-encoding files, and easy to get wrong (e.g., self-referencing link URLs, regex matching the wrong row, footer mangling). Pulling the deterministic parts into Python:

1. Cuts tokens — the upload-article skill in particular went from ~89 lines of step-by-step prose to a thin wrapper that just calls the script.
2. Eliminates whole classes of bugs (cross-encoding, line-ending preservation, bidirectional cross-references).
3. Keeps judgement work where it belongs — the LLM still writes business rationale, classifies risks, decides how to split a project.

## Test plan

- [x] `scripts/upload_article.py --dry-run` against `Planning/NewsArticles/2026-02-24_trashmob-2026-launch.md` — 21 blocks generated, nested bold + link spans preserved
- [x] `scripts/new_project.py "Demo" --dry-run` — picks Project_61 (next after current max 60), template rendered with utf-8 normalisation from cp1252 source
- [x] `scripts/project_ops.py status 60 Planning` — diff shows only the Status row + footer Status + Last Updated
- [x] `scripts/project_ops.py priority 60 High` — diff shows only the Priority row + Last Updated
- [x] `scripts/project_ops.py link 41 60 --x-note "..." --y-note "..."` — bidirectional, correct URLs (no self-reference), inserted inside the Related Documents section
- [x] `scripts/project_ops.py risk 60 ...` — risk row appended below the existing last data row, before the closing blank/divider
- [ ] Run one real `/upload-article` end-to-end after merge to confirm the `haiku`-backed wrapper still does the right error reporting

## Not in this PR

- `.claude/settings.local.json` cleanup (will run `/fewer-permission-prompts` in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)