### PR TITLE
Bump OpenTelemetry.Extensions.Hosting to 1.15.3

### DIFF
--- a/TrashMob/TrashMob.csproj
+++ b/TrashMob/TrashMob.csproj
@@ -53,7 +53,7 @@
 
     <!-- OpenTelemetry packages for observability -->
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />

--- a/TrashMobDailyJobs/TrashMobDailyJobs.csproj
+++ b/TrashMobDailyJobs/TrashMobDailyJobs.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />

--- a/TrashMobHourlyJobs/TrashMobHourlyJobs.csproj
+++ b/TrashMobHourlyJobs/TrashMobHourlyJobs.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Unblocks Renovate PR #3407 (azure azure-sdk-for-net monorepo). Three projects pin `OpenTelemetry.Extensions.Hosting` 1.15.2 directly, but the Azure SDK bump pulls `Azure.Monitor.OpenTelemetry.Exporter` 1.8.1 which transitively requires `>= 1.15.3` — NU1605 (warning-as-error package downgrade) currently fails the build on #3407.

`OpenTelemetry.Api` is already pinned to 1.15.3 in all three projects (override for GHSA-g94r-2vxg-569j), so this just aligns the Hosting bump.

After this lands, Renovate will rebase #3407 against the new main and it should pass.

## Test plan

- [ ] CI green (build + tests) on this PR
- [ ] Renovate rebases #3407; #3407 CI goes green; merge #3407

🤖 Generated with [Claude Code](https://claude.com/claude-code)