### PR TITLE
Override SQLitePCLRaw.lib.e_sqlite3 to 3.50.3 (CVE-2025-6965)

### DIFF
--- a/TrashMob.Shared/TrashMob.Shared.csproj
+++ b/TrashMob.Shared/TrashMob.Shared.csproj
@@ -128,6 +128,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Override transitive vulnerability in SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q / CVE-2025-6965) -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="NetTopologySuite.IO.Esri.Shapefile" Version="1.2.0" />
     <PackageReference Include="QuestPDF" Version="2026.2.4" />

--- a/TrashMob/TrashMob.csproj
+++ b/TrashMob/TrashMob.csproj
@@ -59,6 +59,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
     <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <!-- Override transitive vulnerability in SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q / CVE-2025-6965) -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 
   </ItemGroup>
 

--- a/TrashMobDailyJobs/TrashMobDailyJobs.csproj
+++ b/TrashMobDailyJobs/TrashMobDailyJobs.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <!-- Override transitive vulnerability in SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q / CVE-2025-6965) -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
   </ItemGroup>
   <ItemGroup>

--- a/TrashMobHourlyJobs/TrashMobHourlyJobs.csproj
+++ b/TrashMobHourlyJobs/TrashMobHourlyJobs.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- Override transitive vulnerability in OpenTelemetry.Api 1.15.0 (GHSA-g94r-2vxg-569j) -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <!-- Override transitive vulnerability in SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q / CVE-2025-6965) -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TrashMob.Shared\TrashMob.Shared.csproj" />

--- a/TrashMobMCP/TrashMobMCP.csproj
+++ b/TrashMobMCP/TrashMobMCP.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
+    <!-- Override transitive vulnerability in SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q / CVE-2025-6965) -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Unblocks main + every open Renovate PR. GitHub flagged GHSA-2m69-gcr7-jv3q on `SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11`, the transitive native lib pulled in by `Microsoft.EntityFrameworkCore.Sqlite`. With `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` on the leaf executables, NU1903 is fatal — main is currently failing the dev container deploy on this, and so are #3415 and #3417.

Adds a `<PackageReference>` override on the four leaf executables that hit NU1903, following the existing OpenTelemetry.Api / NuGet.Packaging security-override pattern in the repo.

## Why 3.50.3

SQLite < 3.50.2 has a memory-corruption vulnerability (CVE-2025-6965). The SQLitePCLRaw maintainers switched version scheme to mirror SQLite's upstream version — there is no `2.1.12`; the next release after `2.1.11` is `3.50.3`, which bundles SQLite 3.50.3.

```xml
<!-- Override transitive vulnerability in SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q / CVE-2025-6965) -->
<PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
```

## Out of scope

`SQLitePCLRaw.bundle_green` (used by `TrashMobMobile` and `TrashMobMobile.Tests`) only goes up to `2.1.11` — no 3.x yet. Mobile builds don't currently fail NU1903 (different transitive resolution), so deferring that override to a follow-up once `bundle_green` ships 3.x.

## Test plan

- [ ] CI green on this PR (build + tests, no NU1903)
- [ ] After merge, main's dev container deploy goes green
- [ ] After merge, #3415 (dotnet monorepo) and #3417 (vitest) rebase clean and CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)