### PR TITLE
Bump MauiVersion to 10.0.70 to match Maui.Controls (crashfix)

### DIFF
--- a/TrashMobMobile/TrashMobMobile.csproj
+++ b/TrashMobMobile/TrashMobMobile.csproj
@@ -40,7 +40,7 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 		<UserSecretsId>0a8c5383-6f9f-4b4e-a3f3-f8ac8cc4d258</UserSecretsId>
-		<MauiVersion>10.0.20</MauiVersion>
+		<MauiVersion>10.0.70</MauiVersion>
 	</PropertyGroup>
 
 


### PR DESCRIPTION
## Summary

Hotfix for [Sentry 820e573932f0483d906c3c0dd2d8a934](https://sentry.io) — `MissingMethodException` on `AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat.set_Checked(bool)` triggered by MAUI's accessibility delegate.

PR #3415 bumped `Microsoft.Maui.Controls.*` PackageReferences from 10.0.50 → 10.0.70 but left the `<MauiVersion>` MSBuild property at 10.0.20. That property drives the implicit versions of the MAUI workload's AndroidX bindings, so the controls and the workload ended up out of sync — controls call accessibility APIs the workload's bindings don't have.

Renovate doesn't track arbitrary MSBuild properties, so it missed this when bumping the explicit references.

## Crash trace

```
System.MissingMethodException: Method not found: void
AndroidX.Core.View.Accessibility.AccessibilityNodeInfoCompat.set_Checked(bool)
  at MauiAccessibilityDelegateCompat.OnInitializeAccessibilityNodeInfo
```

Caught 17 minutes after #3415 landed on an Android 11 OnePlus 8 Pro. Will fire on any user with accessibility services on, focus events, or routine view rebinding.

## Diff

```diff
- <MauiVersion>10.0.20</MauiVersion>
+ <MauiVersion>10.0.70</MauiVersion>
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge, deploy a new Android build and confirm the Sentry issue stops reproducing
- [ ] Open a follow-up to add a Renovate manager (or custom regex) for the `<MauiVersion>` property so future MAUI bumps catch this automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)