### PR TITLE
Track <MauiVersion> in renovate.json (prevent next workload-skew crash)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,22 @@
       "matchUpdateTypes": ["patch", "minor", "major"],
       "matchCategories": ["security"],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Keep <MauiVersion> in lockstep with Microsoft.Maui.Controls in the same PR",
+      "matchPackageNames": ["Microsoft.Maui.Controls"],
+      "matchManagers": ["custom.regex", "nuget"],
+      "groupName": "Microsoft.Maui.Controls"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track <MauiVersion> MSBuild property in csproj files (mirrors Microsoft.Maui.Controls). Without this, Renovate's nuget manager only bumps the explicit PackageReference entries and leaves the MauiVersion property stale -- the resulting workload/controls skew crashed prod with a MissingMethodException on AccessibilityNodeInfoCompat.set_Checked after MAUI 10.0.50 -> 10.0.70.",
+      "fileMatch": ["\\.csproj$"],
+      "matchStrings": ["<MauiVersion>(?<currentValue>[^<]+)</MauiVersion>"],
+      "datasourceTemplate": "nuget",
+      "depNameTemplate": "Microsoft.Maui.Controls"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a Renovate `customManager` so the next MAUI bump touches both the explicit `Microsoft.Maui.Controls.*` PackageReferences **and** the `<MauiVersion>` MSBuild property in the same PR. The grouping `packageRule` keeps them as one PR rather than two.

## Why

PR #3415 (dotnet monorepo) bumped `Microsoft.Maui.Controls.*` from 10.0.50 → 10.0.70 but left `<MauiVersion>10.0.20</MauiVersion>` in [TrashMobMobile/TrashMobMobile.csproj](TrashMobMobile/TrashMobMobile.csproj#L43). That property drives the implicit versions of the MAUI workload's AndroidX bindings, so the new controls called `AccessibilityNodeInfoCompat.set_Checked(bool)` — a method the older AndroidX bindings didn't expose.

Crash hit prod 17 minutes after merge ([Sentry 820e573932f0483d906c3c0dd2d8a934](https://sentry.io)). Fixed in #3432.

Renovate's built-in nuget manager only matches `<PackageReference>` elements, so arbitrary MSBuild properties like `<MauiVersion>` need an explicit `customManager` regex to be tracked.

## Diff

```jsonc
"customManagers": [
  {
    "customType": "regex",
    "fileMatch": ["\.csproj$"],
    "matchStrings": ["<MauiVersion>(?<currentValue>[^<]+)</MauiVersion>"],
    "datasourceTemplate": "nuget",
    "depNameTemplate": "Microsoft.Maui.Controls"
  }
]
```

Plus a `packageRule` grouping `Microsoft.Maui.Controls` updates from both the `nuget` and `custom.regex` managers under one PR.

## Test plan

- [ ] After merge, watch the Renovate dependency dashboard — the next `Microsoft.Maui.Controls` bump PR should include the `<MauiVersion>` line in its diff
- [ ] No drift in `TrashMobMobile.csproj` versions on the next mobile build

🤖 Generated with [Claude Code](https://claude.com/claude-code)