### PR TITLE
Fix toggle E2E selectors: radiogroup, not group

### DIFF
--- a/TrashMob/client-app/e2e/tests/home-interactions.spec.ts
+++ b/TrashMob/client-app/e2e/tests/home-interactions.spec.ts
@@ -22,8 +22,8 @@ test.describe('Home Page Interactions', () => {
         test('should toggle between map and list views', async ({ page }) => {
             await page.goto('/');
 
-            // Wait for toggle group
-            const toggleGroup = page.locator('#events [role="group"]');
+            // Wait for toggle group (Radix ToggleGroup with type='single' renders role='radiogroup')
+            const toggleGroup = page.locator('#events [role="radiogroup"]');
             await expect(toggleGroup).toBeVisible({ timeout: 15000 });
 
             const listBtn = toggleGroup.locator('button').first();

--- a/TrashMob/client-app/e2e/tests/litter-reports.spec.ts
+++ b/TrashMob/client-app/e2e/tests/litter-reports.spec.ts
@@ -15,7 +15,8 @@ test.describe('Litter Reports Page Interactions', () => {
 
         await expect(page.locator('h1').first()).toContainText(/litter report/i, { timeout: 15000 });
 
-        const toggleGroup = page.locator('[role="group"]').first();
+        // Radix ToggleGroup with type='single' renders role='radiogroup' (not 'group')
+        const toggleGroup = page.locator('[role="radiogroup"]').first();
         await expect(toggleGroup).toBeVisible({ timeout: 10000 });
 
         const buttons = toggleGroup.locator('button');


### PR DESCRIPTION
## Summary

Both `home-interactions.spec.ts:22` and `litter-reports.spec.ts:13` look for `[role=\"group\"]` on Radix `ToggleGroup` instances. But the project uses `type='single'`, which renders **`role=\"radiogroup\"`** (the single-select variant is semantically a radio group). The `role=\"group\"` selector only matches `type='multiple'` — so the locators were finding zero elements and the assertions timed out with \"element(s) not found\".

The tests had been passing on retries for months, but today's E2E started failing deterministically across all three retries on every run, blocking 4 Renovate PRs (#3430, #3431, #3433, #3434) and making main itself red.

## Verification

The smoking gun is the Playwright failure artifact's page snapshot, which shows the toggle is rendering correctly — just under `radiogroup`, not `group`:

```yaml
- combobox: All time
- checkbox \"Litter Reports\"
- radiogroup:
    - radio
    - radio [checked]
- text: 0 events found in Central Potter
```

## Fix

```diff
-const toggleGroup = page.locator('#events [role=\"group\"]');
+const toggleGroup = page.locator('#events [role=\"radiogroup\"]');
```

Plus the same one-line change in `litter-reports.spec.ts`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, manual E2E rerun on main passes (or the 4 inheritor PRs' next CI run goes green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)