### PR TITLE
Add phone call activity types and default name sort to prospects

### DIFF
--- a/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
+++ b/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
@@ -24,6 +24,8 @@
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
     <!-- Override transitive vulnerability in Microsoft.AspNetCore.DataProtection 10.0.0 (GHSA-9mv3-2cwr-p262) -->
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.8" />
+    <!-- Override transitive vulnerability in Microsoft.OpenApi 2.4.1 (GHSA-v5pm-xwqc-g5wc) -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TrashMob/TrashMob.csproj
+++ b/TrashMob/TrashMob.csproj
@@ -61,6 +61,8 @@
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <!-- Override transitive vulnerability in SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q / CVE-2025-6965) -->
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <!-- Override transitive vulnerability in Microsoft.OpenApi 2.4.1 (GHSA-v5pm-xwqc-g5wc) -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
 
   </ItemGroup>
 

--- a/TrashMob/client-app/src/components/prospects/pipeline-stage-badge.tsx
+++ b/TrashMob/client-app/src/components/prospects/pipeline-stage-badge.tsx
@@ -12,7 +12,16 @@ export const PIPELINE_STAGES = [
 
 export const PROSPECT_TYPES = ['Municipality', 'Nonprofit', 'HOA', 'CivicOrg', 'Vendor', 'Other'] as const;
 
-export const ACTIVITY_TYPES = ['EmailSent', 'EmailOpened', 'EmailClicked', 'Reply', 'PhoneCallMade', 'PhoneCallReceived', 'StatusChange', 'Note'] as const;
+export const ACTIVITY_TYPES = [
+    'EmailSent',
+    'EmailOpened',
+    'EmailClicked',
+    'Reply',
+    'PhoneCallMade',
+    'PhoneCallReceived',
+    'StatusChange',
+    'Note',
+] as const;
 
 export function getPipelineStageLabel(stage: number): string {
     return PIPELINE_STAGES.find((s) => s.value === stage)?.label ?? 'Unknown';

--- a/TrashMob/client-app/src/components/prospects/pipeline-stage-badge.tsx
+++ b/TrashMob/client-app/src/components/prospects/pipeline-stage-badge.tsx
@@ -12,7 +12,7 @@ export const PIPELINE_STAGES = [
 
 export const PROSPECT_TYPES = ['Municipality', 'Nonprofit', 'HOA', 'CivicOrg', 'Vendor', 'Other'] as const;
 
-export const ACTIVITY_TYPES = ['EmailSent', 'EmailOpened', 'EmailClicked', 'Reply', 'StatusChange', 'Note'] as const;
+export const ACTIVITY_TYPES = ['EmailSent', 'EmailOpened', 'EmailClicked', 'Reply', 'PhoneCallMade', 'PhoneCallReceived', 'StatusChange', 'Note'] as const;
 
 export function getPipelineStageLabel(stage: number): string {
     return PIPELINE_STAGES.find((s) => s.value === stage)?.label ?? 'Unknown';

--- a/TrashMob/client-app/src/components/ui/data-table.tsx
+++ b/TrashMob/client-app/src/components/ui/data-table.tsx
@@ -50,6 +50,8 @@ interface DataTableProps<TData, TValue> {
     searchPlaceholder?: string;
     /** Columns to search in (by accessorKey). If not provided, searches all columns. */
     searchColumns?: string[];
+    /** Initial sort state applied on first render */
+    initialSorting?: SortingState;
 }
 
 export const DataTable = <TData, TValue>({
@@ -58,8 +60,9 @@ export const DataTable = <TData, TValue>({
     enableSearch = false,
     searchPlaceholder = 'Search...',
     searchColumns,
+    initialSorting = [],
 }: DataTableProps<TData, TValue>) => {
-    const [sorting, setSorting] = useState<SortingState>([]);
+    const [sorting, setSorting] = useState<SortingState>(initialSorting);
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
     const [globalFilter, setGlobalFilter] = useState('');
 

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/page.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/page.tsx
@@ -84,6 +84,7 @@ export const SiteAdminProspects = () => {
                     enableSearch
                     searchPlaceholder='Search prospects...'
                     searchColumns={['name', 'city', 'contactEmail']}
+                    initialSorting={[{ id: 'name', desc: false }]}
                 />
             </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Adds `PhoneCallMade` and `PhoneCallReceived` to the activity type dropdown on the prospect detail page
- Adds an `initialSorting` prop to `DataTable` so callers can set a default sort without touching the component's internal state
- Defaults the prospects list to sort by name ascending on load

## Test plan
- [ ] Open `/siteadmin/prospects` — list should load sorted A→Z by name
- [ ] Click the Name column header to toggle sort direction
- [ ] Open a prospect detail page → Log Activity → verify **Phone Call Made** and **Phone Call Received** appear in the Type dropdown
- [ ] Log an activity with each new type and confirm it saves and displays correctly in the activity timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)