### PR TITLE
Complete Auth Phase 7 minor protections

### DIFF
--- a/Planning/Projects/Project_01_Auth_Revamp.md
+++ b/Planning/Projects/Project_01_Auth_Revamp.md
@@ -2,7 +2,7 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | In Progress (Phases 0-5a Complete — Production Live; Phase 6 Partial, Phase 7 Remaining) |
+| **Status** | In Progress (Phases 0-5a, 7 Complete — Production Live; Phase 6 mobile app update partial) |
 | **Priority** | Critical |
 | **Risk** | High |
 | **Size** | Large |
@@ -229,12 +229,17 @@ CIAM id_tokens lack the `email` claim because Entra External ID stores sign-up e
 - [ ] Monitor crash-free rate
 - [ ] Decommission B2C (after coexistence period)
 
-### Phase 7 — Minor Protections (→ Project 23 Phase 3)
-- [ ] Communication restrictions for minors
-- [ ] Limited profile visibility (first name + last initial)
-- [ ] Adult presence enforcement at events
-- [ ] Parent notification system
-- [ ] Complete Privo documentation package
+### Phase 7 — Minor Protections (→ Project 23 Phase 3) ✅ Complete (2026-07-01)
+- [x] ~~Communication restrictions for minors~~ **N/A** — TrashMob has no user-to-user 1:1 messaging surface. `MessageRequestV2Controller` is admin-broadcast-only (`[Authorize(Policy = UserIsAdmin)]`); `ContactRequestV2Controller` is a public form. Verified 2026-07-01.
+- [x] Limited profile visibility (first name + last initial) — `UserExtensions.DisplayUserName()` masks `IsMinor` accounts to `"GivenName Surname[0]."` and is wired into `EventAttendeeMappingsV2.ToV2Dto()` and `TeamMemberMappingsV2.ToV2Dto()`. Unit-tested. Landed 2026-07-01.
+- [x] Adult presence enforcement at events — **structural** via the event-lead-required invariant: (a) minors cannot create events (`EventsV2Controller.AddEvent` returns 403 if `creator.IsMinor`), (b) minors cannot be promoted to lead (`EventAttendeeManager.PromoteToLeadAsync` throws), (c) the last remaining lead cannot leave (`EventAttendeeManager.Delete` throws `InvalidOperationException`, controller returns 409). Every live event therefore has at least one adult attendee. Unit-tested. Landed 2026-07-01.
+- [x] Parent notification system — `EventAttendeesV2Controller.NotifyParentWaiverRequiredAsync` and `NotifyParentChildRegisteredAsync` fire on minor RSVP. Gated on `user is { IsMinor: true, DependentId: not null }`; the invariant is enforced by `DependentInvitationManager.LinkInvitationToUser` which sets both fields transactionally. Comment added at the gate line to document this dependency. Verified 2026-07-01.
+- [ ] Complete Privo documentation package — tracked separately as a sponsorship deliverable to Privo (not code work).
+
+**Follow-up hardening (not blockers for Phase 7 completion):**
+- `UsersV2Controller` GET endpoints (`/users`, `/users/{id}`, `/users/getuserbyemail/{email}`, `/users/getbyobjectid/{objectId}`) return the raw `UserDto` (email, DOB, IsMinor, Surname) without a class-level `[Authorize]`. Not caused by Phase 7 but surfaced during the audit — worth opening as a separate bug. Broader than Phase 7 scope.
+- `UserMappingsV2.ToV2Dto()` should also apply `DisplayUserName()` masking if it can ever be returned for a caller other than the profile owner. Currently used by the endpoints above; the fix above resolves it.
+- Consider a DB `CHECK` constraint (`IsMinor = 0 OR DependentId IS NOT NULL`) to hard-enforce the invariant that the parent-notification gate relies on.
 
 ---
 
@@ -550,7 +555,7 @@ For each provider (Google, Microsoft, Apple, Facebook):
 
 ---
 
-**Last Updated:** February 22, 2026
+**Last Updated:** 2026-07-01
 **Owner:** Security Engineer + Product Lead
-**Status:** In Progress (Phases 0-5a Complete — Production Live on Entra External ID; Phase 6 code changes done, mobile testing and store submission remaining; Phase 7 minor protections and Privo API integration remaining)
+**Status:** In Progress (Phases 0-5a, 7 Complete — Production Live on Entra External ID; Phase 6 mobile app update partial — device testing and store submission remaining)
 **Next Review:** After Phase 6 mobile testing and store submission

--- a/TrashMob.Models/Extensions/UserExtensions.cs
+++ b/TrashMob.Models/Extensions/UserExtensions.cs
@@ -1,0 +1,65 @@
+namespace TrashMob.Models.Extensions
+{
+    using System;
+
+    /// <summary>
+    /// Extension methods for the <see cref="User"/> entity that produce
+    /// display-safe representations of user identity.
+    /// </summary>
+    /// <remarks>
+    /// Minors (users with <c>IsMinor == true</c>) must not have their full
+    /// name or contact information rendered to other users. These helpers
+    /// centralise the masking rules so every V2 DTO mapping applies the
+    /// same policy. See Project 23 (Parental Consent).
+    /// </remarks>
+    public static class UserExtensions
+    {
+        /// <summary>
+        /// Returns a display-safe user name for the given user. For minors,
+        /// this is "FirstName L." (first name + last initial). For adults
+        /// and anonymous callers, this is the raw <see cref="User.UserName"/>.
+        /// </summary>
+        /// <param name="user">The user to render. May be <c>null</c>.</param>
+        /// <returns>
+        /// The masked display name for a minor, or the raw user name for an
+        /// adult. Returns <see cref="string.Empty"/> when <paramref name="user"/>
+        /// is <c>null</c>.
+        /// </returns>
+        public static string DisplayUserName(this User user)
+        {
+            if (user == null)
+            {
+                return string.Empty;
+            }
+
+            if (!user.IsMinor)
+            {
+                return user.UserName ?? string.Empty;
+            }
+
+            // Prefer GivenName + Surname initial when we have the structured fields.
+            if (!string.IsNullOrWhiteSpace(user.GivenName))
+            {
+                var lastInitial = !string.IsNullOrWhiteSpace(user.Surname)
+                    ? $" {user.Surname[0]}."
+                    : string.Empty;
+                return $"{user.GivenName}{lastInitial}";
+            }
+
+            // Fall back to splitting the raw UserName on the first space so we can
+            // still mask legacy accounts that never populated GivenName/Surname.
+            if (!string.IsNullOrWhiteSpace(user.UserName))
+            {
+                var parts = user.UserName.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 2)
+                {
+                    return $"{parts[0]} {parts[1][0]}.";
+                }
+
+                return parts[0];
+            }
+
+            return "TrashMob User";
+        }
+    }
+}

--- a/TrashMob.Models/Extensions/V2/EventAttendeeMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/EventAttendeeMappingsV2.cs
@@ -9,7 +9,8 @@ namespace TrashMob.Models.Extensions.V2
     {
         /// <summary>
         /// Maps an EventAttendee entity to a V2 EventAttendeeDto, including basic user info.
-        /// Requires the User navigation property to be loaded.
+        /// Requires the User navigation property to be loaded. Minor accounts have their
+        /// UserName masked via <see cref="UserExtensions.DisplayUserName"/>.
         /// </summary>
         /// <param name="entity">The EventAttendee entity to map.</param>
         /// <returns>An EventAttendeeDto with attendee and user info.</returns>
@@ -18,7 +19,7 @@ namespace TrashMob.Models.Extensions.V2
             return new EventAttendeeDto
             {
                 UserId = entity.UserId,
-                UserName = entity.User?.UserName ?? string.Empty,
+                UserName = entity.User.DisplayUserName(),
                 GivenName = entity.User?.GivenName ?? string.Empty,
                 ProfilePhotoUrl = entity.User?.ProfilePhotoUrl ?? string.Empty,
                 SignUpDate = entity.SignUpDate,

--- a/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/TeamMemberMappingsV2.cs
@@ -11,7 +11,8 @@ namespace TrashMob.Models.Extensions.V2
     {
         /// <summary>
         /// Maps a TeamMember entity to a V2 TeamMemberDto.
-        /// Requires the User navigation property to be loaded.
+        /// Requires the User navigation property to be loaded. Minor accounts have their
+        /// UserName masked via <see cref="UserExtensions.DisplayUserName"/>.
         /// </summary>
         public static TeamMemberDto ToV2Dto(this TeamMember entity)
         {
@@ -20,7 +21,7 @@ namespace TrashMob.Models.Extensions.V2
                 Id = entity.Id,
                 TeamId = entity.TeamId,
                 UserId = entity.UserId,
-                UserName = entity.User?.UserName ?? string.Empty,
+                UserName = entity.User.DisplayUserName(),
                 GivenName = entity.User?.GivenName ?? string.Empty,
                 ProfilePhotoUrl = entity.User?.ProfilePhotoUrl ?? string.Empty,
                 IsTeamLead = entity.IsTeamLead,

--- a/TrashMob.Shared.Tests/Builders/UserBuilder.cs
+++ b/TrashMob.Shared.Tests/Builders/UserBuilder.cs
@@ -121,6 +121,19 @@ namespace TrashMob.Shared.Tests.Builders
             return this;
         }
 
+        /// <summary>
+        /// Mark the user as a minor. Sets both IsMinor and DependentId to preserve
+        /// the invariant enforced by DependentInvitationManager.LinkInvitationToUser.
+        /// </summary>
+        public UserBuilder AsMinor(Guid? dependentId = null)
+        {
+            _user.IsMinor = true;
+            _user.DependentId = dependentId ?? Guid.NewGuid();
+            _user.GivenName ??= "Alex";
+            _user.Surname ??= "Martinez";
+            return this;
+        }
+
         public User Build() => _user;
     }
 }

--- a/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
@@ -22,13 +22,14 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         private readonly Mock<IEventManager> eventManager = new();
         private readonly Mock<IEventAttendeeManager> eventAttendeeManager = new();
         private readonly Mock<IEventSummaryManager> eventSummaryManager = new();
+        private readonly Mock<IKeyedManager<User>> userManager = new();
         private readonly Mock<IAuthorizationService> authorizationService = new();
         private readonly Mock<ILogger<EventsV2Controller>> logger = new();
         private readonly EventsV2Controller controller;
 
         public EventsV2ControllerTests()
         {
-            controller = new EventsV2Controller(eventManager.Object, eventAttendeeManager.Object, eventSummaryManager.Object, authorizationService.Object, logger.Object);
+            controller = new EventsV2Controller(eventManager.Object, eventAttendeeManager.Object, eventSummaryManager.Object, userManager.Object, authorizationService.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -188,6 +189,28 @@ namespace TrashMob.Shared.Tests.Controllers.V2
 
             var createdResult = Assert.IsType<CreatedAtActionResult>(result);
             Assert.Equal(nameof(EventsV2Controller.GetEvent), createdResult.ActionName);
+        }
+
+        [Fact]
+        public async Task AddEvent_ReturnsForbid_WhenCreatorIsMinor()
+        {
+            // Project 23 Phase 3 / Auth Phase 7: minor accounts must not be able to
+            // create events, because the creator is auto-assigned as event lead and
+            // event leads must be adults.
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            userManager.Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = userId, IsMinor = true, DependentId = Guid.NewGuid() });
+
+            var eventDto = new EventDto { Id = Guid.NewGuid(), Name = "Minor Attempted Cleanup" };
+
+            var result = await controller.AddEvent(eventDto, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+            eventManager.Verify(
+                m => m.AddAsync(It.IsAny<Event>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]

--- a/TrashMob.Shared.Tests/Extensions/V2/EventAttendeeMappingsV2Tests.cs
+++ b/TrashMob.Shared.Tests/Extensions/V2/EventAttendeeMappingsV2Tests.cs
@@ -51,5 +51,52 @@ namespace TrashMob.Shared.Tests.Extensions.V2
             Assert.Equal(string.Empty, dto.GivenName);
             Assert.Equal(string.Empty, dto.ProfilePhotoUrl);
         }
+
+        [Fact]
+        public void ToV2Dto_MasksMinorUserNameToFirstNameLastInitial()
+        {
+            // COPPA / Project 23 Phase 3: a minor's UserName must not be exposed on the
+            // attendee list. The display name is masked to "GivenName Surname[0]." for
+            // any caller that fetches the DTO.
+            var entity = new EventAttendee
+            {
+                UserId = Guid.NewGuid(),
+                SignUpDate = DateTimeOffset.UtcNow,
+                IsEventLead = false,
+                User = new User
+                {
+                    UserName = "AlexMartinez2011",
+                    GivenName = "Alex",
+                    Surname = "Martinez",
+                    IsMinor = true,
+                },
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal("Alex M.", dto.UserName);
+        }
+
+        [Fact]
+        public void ToV2Dto_UsesRawUserNameForAdultAccounts()
+        {
+            var entity = new EventAttendee
+            {
+                UserId = Guid.NewGuid(),
+                SignUpDate = DateTimeOffset.UtcNow,
+                IsEventLead = false,
+                User = new User
+                {
+                    UserName = "adult_full_name",
+                    GivenName = "Adult",
+                    Surname = "Volunteer",
+                    IsMinor = false,
+                },
+            };
+
+            var dto = entity.ToV2Dto();
+
+            Assert.Equal("adult_full_name", dto.UserName);
+        }
     }
 }

--- a/TrashMob.Shared.Tests/Managers/Events/EventAttendeeManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventAttendeeManagerTests.cs
@@ -584,6 +584,32 @@ namespace TrashMob.Shared.Tests.Managers.Events
         }
 
         [Fact]
+        public async Task PromoteToLeadAsync_WhenUserIsMinor_ThrowsInvalidOperationException()
+        {
+            // Project 23 Phase 3 / Auth Phase 7: minors cannot be event leads. Event leads
+            // are the responsible adult on record; allowing a minor to be promoted would
+            // let the last-lead check pass with no adult supervision on the event.
+            var userId = Guid.NewGuid();
+            var promoterUserId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var minor = new UserBuilder().WithId(userId).AsMinor().Build();
+            var attendee = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(minor)
+                .AsRegularAttendee()
+                .Build();
+
+            var attendees = new List<EventAttendee> { attendee };
+            _attendeeRepository.SetupGetWithFilter(attendees);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.PromoteToLeadAsync(eventId, userId, promoterUserId));
+
+            Assert.Contains("Minors cannot be promoted", ex.Message);
+        }
+
+        [Fact]
         public async Task PromoteToLeadAsync_SendsNotificationEmail()
         {
             // Arrange
@@ -730,6 +756,106 @@ namespace TrashMob.Shared.Tests.Managers.Events
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => _sut.DemoteFromLeadAsync(eventId, userId, demoterUserId));
+        }
+
+        #endregion
+
+        #region Delete Tests
+
+        [Fact]
+        public async Task Delete_WhenLeavingUserIsLastLead_ThrowsInvalidOperationException()
+        {
+            // Project 23 Phase 3 / Auth Phase 7: mirrors the last-lead guardrail on
+            // DemoteFromLeadAsync. A lead must not be able to leave the event via the
+            // "unregister" path if they are the only remaining organiser — otherwise
+            // any minor still on the event has no adult supervision and there is no
+            // attendee left with authority to promote a replacement.
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var lastLead = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsEventLead()
+                .Build();
+
+            // Repository returns this attendee for both the "find me" lookup and the
+            // "count of leads" query — since predicate-based filtering is what SetupGetWithFilter
+            // wires up, both paths see this single lead.
+            _attendeeRepository.SetupGetWithFilter(new List<EventAttendee> { lastLead });
+            _eventDependentRepository.SetupGetWithFilter(new List<EventDependent>());
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.Delete(eventId, userId, CancellationToken.None));
+
+            Assert.Contains("only event lead", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+            // Should not have deleted anything.
+            _attendeeRepository.Verify(
+                r => r.DeleteAsync(It.IsAny<EventAttendee>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Delete_WhenLeavingUserIsCoLead_Succeeds()
+        {
+            // Two leads on the event; either one can leave and the other remains.
+            var userId = Guid.NewGuid();
+            var otherLeadId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+
+            var leavingLead = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsEventLead()
+                .Build();
+
+            var coLead = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(otherLeadId)
+                .AsEventLead()
+                .Build();
+
+            _attendeeRepository.SetupGetWithFilter(new List<EventAttendee> { leavingLead, coLead });
+            _eventDependentRepository.SetupGetWithFilter(new List<EventDependent>());
+            _attendeeRepository.Setup(r => r.DeleteAsync(It.IsAny<EventAttendee>()))
+                .ReturnsAsync(1);
+
+            var affected = await _sut.Delete(eventId, userId, CancellationToken.None);
+
+            Assert.Equal(1, affected);
+            _attendeeRepository.Verify(
+                r => r.DeleteAsync(It.Is<EventAttendee>(ea => ea.UserId == userId)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Delete_WhenLeavingUserIsNonLeadAttendee_Succeeds()
+        {
+            // Baseline: a regular attendee leaving does not touch the lead guardrail.
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var leadId = Guid.NewGuid();
+
+            var leaving = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(userId)
+                .AsRegularAttendee()
+                .Build();
+
+            var lead = new EventAttendeeBuilder()
+                .ForEvent(eventId)
+                .ForUser(leadId)
+                .AsEventLead()
+                .Build();
+
+            _attendeeRepository.SetupGetWithFilter(new List<EventAttendee> { leaving, lead });
+            _eventDependentRepository.SetupGetWithFilter(new List<EventDependent>());
+            _attendeeRepository.Setup(r => r.DeleteAsync(It.IsAny<EventAttendee>()))
+                .ReturnsAsync(1);
+
+            var affected = await _sut.Delete(eventId, userId, CancellationToken.None);
+
+            Assert.Equal(1, affected);
         }
 
         #endregion

--- a/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventAttendeeManager.cs
@@ -55,9 +55,31 @@ namespace TrashMob.Shared.Managers.Events
         /// <inheritdoc />
         public override async Task<int> Delete(Guid parentId, Guid secondId, CancellationToken cancellationToken)
         {
+            var eventAttendee = await Repository.Get(ea => ea.EventId == parentId && ea.UserId == secondId)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            // Enforce the same last-lead guardrail as DemoteFromLeadAsync — an event lead
+            // cannot leave the event if they are the only remaining lead. Otherwise a minor
+            // registered on the event could end up with no adult organiser, and no attendee
+            // has the authority to promote a replacement (PromoteToLeadAsync requires the
+            // caller to already be a lead).
+            if (eventAttendee is { IsEventLead: true })
+            {
+                var currentLeadCount = await Repository
+                    .Get(ea => ea.EventId == parentId && ea.IsEventLead)
+                    .CountAsync(cancellationToken);
+
+                if (currentLeadCount <= 1)
+                {
+                    throw new InvalidOperationException(
+                        "You are the only event lead. Promote another attendee to co-lead before leaving the event.");
+                }
+            }
+
             // Auto-unregister under-13 dependents when parent cancels (they have no account
             // and cannot attend without the parent). 13-17 minors with their own accounts
-            // are NOT auto-unregistered — another adult may be supervising.
+            // are NOT auto-unregistered — the last-lead guardrail above ensures at least one
+            // adult organiser remains on the event.
             var dependentRegistrations = await eventDependentRepository
                 .Get(ed => ed.EventId == parentId && ed.ParentUserId == secondId)
                 .Include(ed => ed.Dependent)
@@ -71,9 +93,6 @@ namespace TrashMob.Shared.Managers.Events
                     await eventDependentRepository.DeleteAsync(registration);
                 }
             }
-
-            var eventAttendee = await Repository.Get(ea => ea.EventId == parentId && ea.UserId == secondId)
-                .FirstOrDefaultAsync(cancellationToken);
 
             return await Repository.DeleteAsync(eventAttendee);
         }
@@ -187,6 +206,14 @@ namespace TrashMob.Shared.Managers.Events
             if (attendee.IsEventLead)
             {
                 throw new InvalidOperationException("User is already an event lead.");
+            }
+
+            // Minors cannot be event leads. Event leads are the responsible adult on record —
+            // they organise the event, sign the liability waiver, and are the last-lead check
+            // in Delete/Demote. See Project 23 Phase 3 (Auth Phase 7) minor protections.
+            if (attendee.User is { IsMinor: true })
+            {
+                throw new InvalidOperationException("Minors cannot be promoted to event lead.");
             }
 
             attendee.IsEventLead = true;

--- a/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventAttendeesV2Controller.cs
@@ -118,6 +118,12 @@ namespace TrashMob.Controllers.V2
             // Check if user is a minor — minors cannot sign their own waivers
             var user = await userManager.GetAsync(dto.UserId, cancellationToken);
 
+            // Invariant: a minor account is always created via DependentInvitationManager.LinkInvitationToUser(),
+            // which sets IsMinor and DependentId in the same transaction. So we can rely on
+            // "IsMinor implies DependentId != null" here. If that ever changes (e.g. a future signup path
+            // creates a minor without linking to a Dependent), the else branch will silently treat the minor
+            // as an adult — waiver enforcement and parent notifications will be skipped. Guard the invariant
+            // in tests or add a DB CHECK constraint if that flow gets more entry points.
             if (user is { IsMinor: true, DependentId: not null })
             {
                 // Minor path: check DependentWaivers signed by parent
@@ -210,7 +216,16 @@ namespace TrashMob.Controllers.V2
         {
             logger.LogInformation("V2 DeleteEventAttendee Event={EventId}, User={UserId}", eventId, userId);
 
-            await eventAttendeeManager.Delete(eventId, userId, cancellationToken);
+            try
+            {
+                await eventAttendeeManager.Delete(eventId, userId, cancellationToken);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Last-lead guardrail: the only remaining event lead cannot leave the event.
+                return Conflict(ex.Message);
+            }
+
             return NoContent();
         }
 

--- a/TrashMob/Controllers/V2/EventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventsV2Controller.cs
@@ -34,6 +34,7 @@ namespace TrashMob.Controllers.V2
         IEventManager eventManager,
         IEventAttendeeManager eventAttendeeManager,
         IEventSummaryManager eventSummaryManager,
+        IKeyedManager<User> userManager,
         IAuthorizationService authorizationService,
         ILogger<EventsV2Controller> logger) : ControllerBase
     {
@@ -319,6 +320,16 @@ namespace TrashMob.Controllers.V2
         public async Task<IActionResult> AddEvent(EventDto eventDto, CancellationToken cancellationToken)
         {
             logger.LogInformation("V2 AddEvent Name={Name}", eventDto.Name);
+
+            // Minors cannot create events. Event creators are auto-assigned as event lead,
+            // and event leads must be adults (see EventAttendeeManager.PromoteToLeadAsync).
+            // Defence-in-depth against a UI regression that could expose the create button
+            // to a minor account. Project 23 Phase 3 / Auth Phase 7.
+            var creator = await userManager.GetAsync(UserId, cancellationToken);
+            if (creator is { IsMinor: true })
+            {
+                return Forbid();
+            }
 
             var mobEvent = eventDto.ToEntity();
             var newEvent = await eventManager.AddAsync(mobEvent, UserId, cancellationToken);


### PR DESCRIPTION
## Summary

Closes out Auth Phase 7 (Project 23 Phase 3) by wiring up the four minor-protection guardrails that were partly implemented and partly missing. Discovered when reconciling Project 23's status doc (which said Phase 3 was done) against Project 1's Phase 7 checkboxes (which were all unchecked). Code audit found real gaps.

### Findings from the audit

| Guardrail | State before | Fix |
|---|---|---|
| Communication restrictions | N/A — no user-to-user messaging surface exists | Documented and closed |
| Limited profile visibility | Masking function existed but was never called by the V2 attendee/team-member mappings — minor names leaked on attendee lists and team member lists | New `UserExtensions.DisplayUserName()` helper, wired into both mappings |
| Adult presence at events | Assumed but not verified — minor could create events, be promoted to lead, or leave as the only remaining lead (bypassed the guardrail on `DemoteFromLeadAsync`) | 3 new checks: create-event, promote-to-lead, and last-lead-leave |
| Parent notifications | Wired correctly, but the gate `IsMinor: true, DependentId: not null` silently depends on an invariant enforced only by `DependentInvitationManager` | Documentation comment at the gate line |

### Code changes

- **New:** [`TrashMob.Models/Extensions/UserExtensions.cs`](TrashMob.Models/Extensions/UserExtensions.cs) — `DisplayUserName(this User)` centralises \"FirstName L.\" masking in the same assembly the V2 DTO mappers live in, so mappings no longer have to reach across into `TrashMob.Shared.Poco`.
- **Fixed:** `EventAttendeeMappingsV2.ToV2Dto` and `TeamMemberMappingsV2.ToV2Dto` now call `DisplayUserName()` instead of passing raw `UserName`.
- **Fixed:** `EventAttendeeManager.Delete` mirrors the last-lead guardrail from `DemoteFromLeadAsync` — a lead cannot leave the event if they are the only remaining lead. `EventAttendeesV2Controller.DeleteEventAttendee` catches `InvalidOperationException` → 409 Conflict.
- **Fixed:** `EventAttendeeManager.PromoteToLeadAsync` rejects minor promotions. Existing controller error handler translates → 400.
- **Fixed:** `EventsV2Controller.AddEvent` returns 403 Forbid if creator is a minor. Injects `IKeyedManager<User>`.
- **Added:** invariant comment on the parent-notification gate in `EventAttendeesV2Controller`.

### Tests

- 5 new unit tests: masking on `EventAttendeeMappingsV2`, last-lead / co-lead / non-lead paths on `EventAttendeeManager.Delete`, minor promotion, minor event creation.
- New `UserBuilder.AsMinor()` helper preserves the `IsMinor ⇒ DependentId != null` invariant.
- Full suite: **1,115 passed / 0 failed / 0 skipped**.

### Documented follow-ups (out of scope for this PR)

- `UsersV2Controller` GET endpoints (`/users`, `/users/{id}`, `/users/getuserbyemail/{email}`, `/users/getbyobjectid/{objectId}`) lack a class-level `[Authorize]` and return raw `UserDto` including email, DOB, IsMinor, Surname. Broader than Phase 7. Recommend opening as a separate bug.
- `UserMappingsV2.ToV2Dto()` should apply the same masking if it can ever be returned for a caller other than the profile owner.
- A DB `CHECK` constraint (`IsMinor = 0 OR DependentId IS NOT NULL`) would hard-enforce the invariant the parent-notification gate relies on.

### Planning docs

- [Project 1 (Auth Revamp)](Planning/Projects/Project_01_Auth_Revamp.md) Phase 7 checkboxes flipped to ✅ with explanatory notes and follow-up hardening section. Status line at top and footer updated.

## Test plan

- [ ] CI green
- [ ] Manual spot check post-merge: browse an event attendee list and a team members list as any non-minor account; confirm any minor's UserName renders as \"First L.\" and the leaderboard likewise masks
- [ ] Manual spot check: as an event lead (with no co-lead), attempt to leave the event via the \"unregister\" button on web and mobile — expect a 409 with the guardrail message

🤖 Generated with [Claude Code](https://claude.com/claude-code)