### PR TITLE
Stop recreating the Strapi-blocked Radix tooltip Renovate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,11 @@
       "matchPackageNames": ["Microsoft.Maui.Controls"],
       "matchManagers": ["custom.regex", "nuget"],
       "groupName": "Microsoft.Maui.Controls"
+    },
+    {
+      "description": "Block @radix-ui/react-tooltip bumps: the Strapi admin's @strapi/design-system@2.2.0 peer-pins react-tooltip@1.0.7, so any root-package bump produces an unresolvable ERESOLVE. Renovate had recreated the radix-ui-primitives monorepo PR five times (#3404, #3428, #3436, #3438, #3441) before we added this rule. Re-enable when Strapi ships a design-system with Radix 1.2.x+; other Radix packages can still update normally.",
+      "matchPackageNames": ["@radix-ui/react-tooltip"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Adds a Renovate \`packageRule\` for \`@radix-ui/react-tooltip\` with \`enabled: false\` so the radix-ui-primitives monorepo PR stops recreating every cycle.

## Why

The Strapi admin's \`@strapi/design-system@2.2.0\` (pulled by \`@strapi/admin@5.42.0\`) peer-pins \`@radix-ui/react-tooltip@1.0.7\`. Any root-package bump produces an unresolvable npm ERESOLVE. Renovate had recreated this update **five times** before we added this rule:

- [#3404](https://github.com/TrashMob-eco/TrashMob/pull/3404) (closed)
- [#3428](https://github.com/TrashMob-eco/TrashMob/pull/3428) (closed)
- [#3436](https://github.com/TrashMob-eco/TrashMob/pull/3436) (closed)
- [#3438](https://github.com/TrashMob-eco/TrashMob/pull/3438) (closed)
- [#3441](https://github.com/TrashMob-eco/TrashMob/pull/3441) (closed just now)

Each recurrence burns CI runs, review attention, and adds noise to the dependency dashboard.

## Diff

```jsonc
{
  \"description\": \"Block @radix-ui/react-tooltip bumps: the Strapi admin's @strapi/design-system@2.2.0 peer-pins react-tooltip@1.0.7...\",
  \"matchPackageNames\": [\"@radix-ui/react-tooltip\"],
  \"enabled\": false
}
```

Other Radix packages continue to update normally through the existing monorepo grouping — the rule is scoped narrowly to just \`react-tooltip\`.

## When to re-enable

Flip \`enabled\` back to \`true\` when Strapi ships a design-system whose peer deps allow Radix 1.2.x+. Track upstream at [strapi/design-system](https://github.com/strapi/design-system).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, confirm the radix-ui-primitives monorepo PR does not reappear on the next Renovate scan
- [ ] Confirm other Radix bumps (react-alert-dialog, react-dropdown-menu, etc.) still surface normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)