### PR TITLE
Add Projects 62, 63, 64: engineering health check, sales pipeline, RBAC

### DIFF
--- a/Planning/Projects/Project_60_Prospect_Contact_Tracking.md
+++ b/Planning/Projects/Project_60_Prospect_Contact_Tracking.md
@@ -349,10 +349,11 @@ None.
 - **[Project 40 - AI Community Sales Agent](./Archive/Project_40_AI_Community_Sales_Agent.md)** — The pipeline this project extends
 - **[Project 54 - Community Adoption Outreach](./Project_54_Community_Adoption_Outreach.md)** — Could adopt the same multi-contact pattern in a follow-up
 - **[Project 51 - Contact Management System](./Archive/Project_51_Contact_Management.md)** — Separate nonprofit-donor CRM (different domain; not to be confused with prospect contacts)
+- **[Project 63 - Municipal Sales Pipeline Reporting](./Project_63_Municipal_Sales_Pipeline_Reporting.md)** — Model + API foundation this project extends
 
 ---
 
-**Last Updated:** May 20, 2026
+**Last Updated:** 2026-07-03
 **Owner:** Product & Engineering
 **Status:** Not Started
 **Next Review:** When Project 54 enters development or a salesperson hire is on the calendar — whichever comes first

--- a/Planning/Projects/Project_62_TrashMob_Site_and_Codebase_Reevaluation.md
+++ b/Planning/Projects/Project_62_TrashMob_Site_and_Codebase_Reevaluation.md
@@ -1,0 +1,252 @@
+# Project 62 — TrashMob Site and Codebase Re-evaluation
+
+| Attribute | Value |
+|-----------|-------|
+| **Status** | Planning |
+| **Priority** | High |
+| **Risk** | Low |
+| **Size** | Medium |
+| **Dependencies** | _None_ |
+
+> **Document type:** Principal-engineer-style codebase health check. Answers "what's the engineering state, and what should we work on next?" This document is meant to be updated in place every 6 months as a living quarterly-ish review, not a one-off strategic memo.
+
+---
+
+## Business Rationale
+
+It's been months since the last top-down engineering review. The codebase has grown (92 v2 controllers, 31 active projects, 35 archived, 260+ EF Core migrations). Multiple structural shifts are landing simultaneously: a 1099 sales contractor is starting (see [Project 63](./Project_63_Municipal_Sales_Pipeline_Reporting.md)), and the Renovate auto-merge cadence has surfaced two production-impacting version-skew incidents in the last two weeks — SQLitePCLRaw `CVE-2025-6965`, and the MAUI 10.0.20 vs 10.0.70 `MissingMethodException` that caused a Sentry alert 17 minutes after a merge. Time for a fresh, honest look at where we are.
+
+The goal isn't to find problems to manufacture work — the audit confirms the codebase is healthy. The goal is to make sure Joe's engineering bandwidth (the binding constraint on this entire organization) goes to the work with the highest leverage in light of what's actually next: the first real paid municipal contracts.
+
+---
+
+## Snapshot: Codebase Health
+
+Findings from a fresh principal-engineer audit. Use this as the ground truth for any "where are we?" question for the next 90 days.
+
+### Scale & velocity
+
+| Dimension | Value | Notes |
+|-----------|-------|-------|
+| Active projects | 31 | 13 in-progress simultaneously |
+| Archived projects | 35 | Delivered, in production |
+| v2 controllers | 92 | ~19.5K LOC total, average 212 LOC each — well-distributed, no god-controllers |
+| EF Core migrations | 260+ | Healthy schema evolution; no rollback debt detected |
+| `DbContext` entities | 150+ DbSet properties | Broad but manageable |
+| Playwright E2E tests | 598 | Run against deployed dev environment |
+| Backend xUnit tests | 1,115+ | Healthy ratio |
+| 90-day commit count | ~215 | Joe ~58%, Renovate ~42% |
+| 90-day commits per day | ~2.4 | Healthy cadence |
+| Open PRs (typical) | 4–10 | Mostly Renovate; low WIP |
+
+### Health ratings
+
+| Dimension | Rating | Comment |
+|-----------|--------|---------|
+| Architecture | A- | Clean Manager/Repository/Controller separation; DI consistent; patterns documented in `CLAUDE.md`. Mobile MVVM solid. v2 API well-distributed. |
+| Test coverage | B+ | 598 E2E + 1,115+ unit tests. Some `[Skip]` debt. Mobile nullable issues create future build-warning friction. |
+| Dependency management | A | Renovate cadence high; version skew now actively tracked (post-#3435 `MauiVersion` regex + follow-ups); SQLitePCLRaw 3.50.3 override for `CVE-2025-6965`; no CVE backlog. |
+| Documentation | A | Root + per-area `CLAUDE.md` files excellent. Planning portfolio comprehensive. Code self-documenting via enforced patterns. |
+| Velocity | B+ | 2.4 commits/day. 13 concurrent in-progress projects is a yellow flag — suggests capacity pressure or insufficient prioritization. |
+| Deployment readiness | B | CI/CD partial. Project 5 Phases 4–6 deferred (health dashboards, auto-scaling, security scanning). Docker transition underway. |
+| Production risk | B+ | Known risks (auth migration, mobile testing, COPPA legal — the last of which is now closed via Project 23) all tracked with mitigation. No silent landmines. |
+
+**Maturity level:** early-to-mid-stage growth phase. The codebase has graduated from prototype to production-grade. Debt is strategic (intentional deferment with documented rationale) rather than rot.
+
+### What this means
+
+The instinct after a re-evaluation is to find big problems to attack. **There aren't any.** The platform is in good engineering shape. The real questions are about *prioritization* (too much WIP, not enough finishing) and *readiness for the first paid municipal contracts* (which features would be embarrassing gaps in a city procurement conversation), not about firefighting unknown technical debt.
+
+---
+
+## Where the Real Constraints Are
+
+### 1. Volunteer/founder capacity is the binding constraint
+
+Joe is the only senior engineer doing ~58% of all commits. Volunteers contribute via individual projects but turnover is constant. With 13 projects in-progress and 5+ not started, the organization is taking on more new work than it can reliably finish. This is the single biggest risk to *anything* on the roadmap.
+
+**Recommendation:** Cap in-progress at 6 projects, with a hard requirement that one ships before another starts. Defer or close any in-progress project that hasn't seen a commit in 30 days.
+
+### 2. CI/CD and mobile-test gaps slow every feature
+
+Two specific blockers compound across the portfolio:
+
+- **MAUI + Appium emulator instability in GitHub Actions** ([Project 25 Phase 4](./Project_25_Automated_Testing.md)). Tests exist but don't gate CI. Every mobile feature ships partially blind.
+- **Manual device testing matrix for Mobile Robustness** ([Project 4 Phases 3–5](./Project_04_Mobile_Robustness.md)). Without this, app-store readiness is delayed and crash-rate risk is unmanaged.
+
+Both are *infrastructure* work, not feature work. They unblock every downstream mobile project.
+
+**Recommendation:** Treat these as P0 for Q3 2026. They're prerequisites for everything mobile.
+
+### 3. Auth migration tail risk (mostly resolved)
+
+Project 1 (Azure B2C → Entra External ID) is mostly done. Phases 0–5a, 7 are complete and [Project 23 (Parental Consent / PRIVO)](./Project_23_Parental_Consent.md) went live in production on 2026-05-20 with Flow 3 E2E verification finishing 2026-07-01. **Phase 6 (mobile app update — MSAL config, profile-photo handling, coordinated app-store submission) remains partial.**
+
+**Recommendation:** Finish Phase 6 by end of Q3 2026. It's a known-scope cleanup task. Nothing new is gated on it, but every day it stays partial is a day the mobile app sign-in flow diverges from web.
+
+### 4. Strapi CMS dormancy
+
+[Project 16 (Strapi)](./Archive/Project_16_Strapi_Setup.md) is "complete" but the CMS is lightly used. Its main consumer is the News & Blog feature (Project 50). The infrastructure exists but isn't paying for its complexity.
+
+**Recommendation:** Either commit to deeper Strapi adoption (case studies, partner content, community pages content — would matter for the sales conversation with cities) or sunset it and replace with markdown-in-repo + build-time rendering. Don't leave it in limbo.
+
+### 5. WIP-overload symptom: "deferred phases" accumulating
+
+Several projects have explicitly deferred phases (Project 24 Phase 4 ETags/webhooks, Project 48 Phase 2b density heatmap, Project 51 deadline calendar, Project 57 QR codes). These are *zombies* — neither shipping nor closed. They take planning attention but produce no value.
+
+**Recommendation:** Quarterly "defer-or-cut" pass. If a deferred phase isn't going to ship in the next 6 months, mark the parent project Complete and move the phase to a new tracking list ("Backlog candidates"). Cleanup is a 1-hour exercise; the clarity benefit is large.
+
+### 6. Authorization surface is single-tier
+
+The current `IsSiteAdmin` boolean is a binary — either you have everything or nothing. That was fine for the last five years but breaks the moment the 1099 sales contractor needs an account (see [Project 64](./Project_64_Roles_and_RBAC_Refactor.md)). The refactor is fundamentally straightforward but touches 234 files, so it's real work.
+
+**Recommendation:** Coordinate Project 64 Phase 1 + 2 to land before the salesperson gets a login. If schedule slips, grant them explicit time-boxed `SiteAdmin` and revoke on Project 64 Phase 2 merge.
+
+---
+
+## Top 5 Highest-Leverage Engineering Work
+
+The five items that carry the highest engineering ROI over the next 90 days:
+
+1. **Finish Mobile Robustness ([Project 4](./Project_04_Mobile_Robustness.md) Phases 3–5)** — manual device testing, accessibility audit (TalkBack/VoiceOver), regression suite. Unblocks app-store launch readiness, closes Project 38 parity gaps, reduces crash-rate risk.
+
+2. **Unblock E2E test CI ([Project 25](./Project_25_Automated_Testing.md) Phase 4)** — solve MAUI + Appium emulator stability in GitHub Actions. Alternatives to investigate: Browserstack, AWS Device Farm, self-hosted Mac runner. Unblocks safe CI/CD gating for every mobile change.
+
+3. **Mobile nullable reference types cleanup** (currently deferred inside `TrashMobMobile.csproj`) — resolve CS8618/CS8602 warnings so `TreatWarningsAsErrors=true` can be re-enabled. Mechanical refactor, Claude-assistable.
+
+4. **Auth migration finish ([Project 1](./Project_01_Auth_Revamp.md) Phase 6)** — close out Entra External ID edge cases in the mobile app, finalize canary + rollback runbooks, coordinate app-store push. Removes the last piece of the multi-year auth modernization.
+
+5. **Quarterly "deferred phase" defer-or-cut pass** — go through the active project list, find every deferred phase, and either schedule it within 6 months or move it to a separate backlog file. Clears planning noise; prevents zombie projects.
+
+---
+
+## What "City-Ready" Would Actually Require
+
+The 1099 sales contractor is engaging cities. When one signs, engineering has to be ready. This section catalogues the features that would be *embarrassing gaps* in a real municipal contract conversation, in rough order of pain-if-missing.
+
+- **Multi-tenant *logical* separation** — cities want their event / volunteer / incident data partitioned, even if it's all in the same physical database. We don't need full multi-tenancy infrastructure; we need a `TenantId` (or `CommunityId` extension) on the right entities and consistent filtering. Foundation for everything else.
+- **Waiver workflow polish** ([Project 8](./Project_08_Waivers_V3.md)) — currently legal-pending; needs to land for any city sale.
+- **FOIA-friendly export** — event-scoped record sets (documents, activity logs, attendance histories, photos, incident reports) as a single downloadable bundle. [Project 24 Phase 4 (ETags & bulk export)](./Archive/Project_24_API_v2_Modernization.md) has the plumbing. UX + a filter-driven "give me everything for these events" flow layers on top.
+- **District / zone reporting in admin** — cities ask first for geographic rollups; we have the lat/long data, we don't have a UI for it. Small project, big perception.
+- **Public status page** — cities in procurement want observable uptime. We instrument via App Insights and Sentry, we don't surface it publicly.
+- **Security scanning in CI** — OWASP ZAP, CodeQL, Trivy on every build. Cheap to add, expected by enterprise buyers. Lives in [Project 5 Phase 6](./Project_05_Deployment_Pipelines.md).
+- **SOC 2 Type II initiation** — $30–80K, 6 months. Minimum credibility bar for city procurement > $10K ACV. Its own project when the first paid contract is imminent.
+
+The point isn't to pre-build all of these — it's to know that when the salesperson brings back a "yes if you can also do X" from a city, the answer is likely in this list and roughly costed. Don't try to build them speculatively; wait for the deal.
+
+---
+
+## Scope
+
+### Phase 1 — Codebase audit + this document
+
+- ☐ Engineering audit complete (see Snapshot section above)
+- ☐ Board reads this document at the next scheduled meeting
+
+### Phase 2 — Q3 2026 engineering rebalancing
+
+- ☐ Cap in-progress projects at 6 (close 7 zombies or move to backlog)
+- ☐ Complete Mobile Robustness Phases 3–5
+- ☐ Unblock E2E test CI (Project 25 Phase 4)
+- ☐ Mobile nullable cleanup; re-enable `TreatWarningsAsErrors` in TrashMobMobile.csproj
+- ☐ Strapi commit-or-sunset decision
+
+### Phase 3 — Sales-motion-conditional engineering
+
+Not started speculatively. Triggered when the sales contractor's pipeline reaches a specific milestone (first LOI, first paid pilot, first signed contract — TBD in Project 63):
+
+- ☐ Open new project for SOC 2 Type II preparation
+- ☐ Open new project for multi-tenant logical isolation
+- ☐ Prioritize Project 8 (Waivers) for legal completion
+- ☐ Open new project for event-scoped FOIA-friendly export
+- ☐ Open new project for district/zone reporting in admin
+
+### Phase 4 — Recurring cadence
+
+- ☐ Repeat this audit every 6 months, edited in place — this document is the log
+- ☐ Quarterly defer-or-cut pass on deferred phases
+
+---
+
+## Out-of-Scope
+
+- **Large refactors of the existing v2 controllers, managers, or DbContext.** No architectural rot detected; refactor work is not justified by the audit.
+- **Migrating off Strapi.** That's a decision to be made (commit or sunset), not a refactor to start.
+- **Migrating off any current vendor** (Azure SQL, App Insights, SendGrid, Azure Maps for backend, Google Maps for frontend Android). All are working; replacing them is not on the leverage list.
+- **Adding new domain features that don't ship in Phase 2 or Phase 3.** WIP discipline matters more than feature count.
+
+---
+
+## Success Metrics
+
+### Quantitative
+
+- **In-progress project count:** Drop from 13 to ≤ 6 by end of Q3 2026.
+- **Mobile crash-free sessions:** ≥ 99.5% (Sentry) once Project 4 Phases 3–5 ship.
+- **E2E CI green rate:** ≥ 95% over a rolling 30-day window after Project 25 Phase 4 unblock.
+- **Build warnings in TrashMobMobile:** zero (currently many CS8618/CS8602 deferred under `TreatWarningsAsErrors=false`).
+- **Days from PR open to merge** for low-risk Renovate updates: median ≤ 1 (currently good; track to detect regressions).
+
+### Qualitative
+
+- Engineer (Joe) reports feeling "less pulled in 13 directions" — measurable via gut check at each half-yearly audit.
+- No surprise version-skew or transitive-dependency incidents in 6 months (post-#3435 customManager, post-SQLitePCLRaw, and post-follow-up-hardening).
+- New volunteer engineers (if any join) can onboard from `CLAUDE.md` files alone — re-tested via at least one volunteer onboarding.
+- Salesperson never comes back with a "city asked for X and we can't demo it in the current dev environment" that isn't already on the "What City-Ready Would Actually Require" list.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| **Cutting in-progress projects causes morale drop with volunteer contributors who picked them up** | Medium | Medium | Frame as "completing work we've committed to before starting new things" — not "abandoning your work." Communicate via individual conversations, not bulk announcement. |
+| **Mobile testing infra investment (Browserstack / AWS Device Farm) costs $200–500/mo recurring** | High | Low | Within budget; cheap compared to crash-rate risk. Approve in Q3 2026. |
+| **Sales-motion-conditional engineering (Phase 3) gets pulled forward speculatively and cannibalizes nonprofit roadmap** | Medium | Medium | Hard rule: Phase 3 items don't start until Project 63 hits an explicit milestone. Track engineering-hours-on-city-features as a separate line in the quarterly review. |
+| **Renovate auto-merge keeps surfacing skew incidents we don't anticipate** | Medium | Medium | The #3435 `MauiVersion` customManager is a template — apply to other "implicit version" properties proactively when discovered. Recent skew from `Microsoft.Maui.Controls.Compatibility` bumping independently is a case in point: the customManager needs a wider anchor set. |
+| **A volunteer engineer hits a deferred phase on a "complete" project, gets confused** | Low | Low | The defer-or-cut pass creates a separate `Backlog_Candidates.md` list. Cross-reference from each affected project's footer. |
+
+---
+
+## Open Questions
+
+1. **Cap in-progress projects at 6 — or different number?**
+   **Recommendation:** 6. Heuristic from team size of 1 senior + ~3 active volunteers at any time. Trial for Q3; adjust if obviously wrong.
+   **Owner:** Joe
+   **Due:** 2026-07-15
+
+2. **Strapi: commit or sunset?**
+   **Recommendation:** Commit — case studies and community-content marketing matter for the municipal sales conversation. But acknowledge the CMS hasn't earned its complexity yet and the commit means a concrete content pipeline, not just "keep it running."
+   **Owner:** Joe + Cynthia
+   **Due:** 2026-09-30
+
+3. **Do we hire a second engineer, and when?**
+   **Recommendation:** Not yet. Capacity discipline (cap at 6 in-progress) is the lever, not headcount. Revisit if Project 63 lands the first 5 paying municipal contracts and the sales-motion Phase 3 backlog crosses one engineer's capacity.
+   **Owner:** Board
+   **Due:** Defer to milestone
+
+4. **Should the codebase audit become a recurring quarterly artifact, or only on demand?**
+   **Recommendation:** Every 6 months — quarterly is too often given the codebase's stability, on-demand misses slow-rotting issues. Edit this document in place rather than creating new ones.
+   **Owner:** Joe
+   **Due:** 2027-01-03 (next audit cadence)
+
+5. **What's the trigger to open the Phase 3 (sales-motion-conditional) engineering projects?**
+   **Recommendation:** First signed paid contract, not first LOI. LOIs are cheap to give; a signed contract with revenue attached is the signal that engineering investment is justified.
+   **Owner:** Joe + Cynthia
+   **Due:** As part of Project 63 milestone planning
+
+---
+
+## Related Documents
+
+- **[Project 63 - Municipal Sales Pipeline Reporting](./Project_63_Municipal_Sales_Pipeline_Reporting.md)** — the sales motion whose demands drive Phase 3 engineering priorities
+- **[Project 64 - Roles & RBAC Refactor](./Project_64_Roles_and_RBAC_Refactor.md)** — a real engineering item that surfaced from this audit; unblocks Project 63
+- **[Planning/README.md](../README.md)** — will need quarter section updates after this re-evaluation lands
+- **[Planning/Executive_Summary.md](../Executive_Summary.md)** — roadmap section to reflect WIP cap + sales-motion conditional Phase 3
+
+---
+
+**Last Updated:** 2026-07-03
+**Owner:** Joe (engineering)
+**Status:** Planning
+**Next Review:** 2027-01-03 (half-yearly) or when Project 63 hits Phase 3 trigger — whichever first

--- a/Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md
+++ b/Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md
@@ -1,0 +1,393 @@
+# Project 63 — Municipal Sales Pipeline Reporting
+
+| Attribute | Value |
+|-----------|-------|
+| **Status** | Planning |
+| **Priority** | High |
+| **Risk** | Medium |
+| **Size** | Large |
+| **Dependencies** | [Project 60 — Prospect Multi-Contact Tracking](./Project_60_Prospect_Contact_Tracking.md), [Project 64 — Roles & RBAC Refactor](./Project_64_Roles_and_RBAC_Refactor.md) |
+
+---
+
+## Business Rationale
+
+TrashMob is hiring a **1099 contract salesperson** to sell the existing SaaS platform to US municipalities. This is the first paid revenue channel for the platform and the first operational test of whether cities will actually pay for a volunteer-cleanup coordination + FOIA-friendly reporting product. Board President Cynthia Mitchell has proposed a set of pipeline, weekly, and monthly reporting spreadsheets to run the sales motion. This project translates those spreadsheets into first-class product features inside the existing Site Admin CRM.
+
+The salesperson will use the CRM daily. Cynthia and the Board need weekly and monthly rollups without asking Joe or the salesperson to build them in Excel. And every measurable data point captured here — pipeline conversion rates, common objections, pricing feedback, which departments are most responsive — feeds directly into the strategic question the organization is trying to answer: **is there real, paid demand for TrashMob-as-SaaS to cities?**
+
+Without this reporting infrastructure, we'd land the salesperson with a spreadsheet-based operating rhythm, which lasts about 3 months before the data becomes uneditable in practice.
+
+---
+
+## Snapshot: What Already Exists
+
+Substantial prospect-tracking infrastructure landed in **[Project 60](./Project_60_Prospect_Contact_Tracking.md)** and adjacent work. Reuse first, build second.
+
+### Entities (in `TrashMob.Models/`)
+
+| Entity | Purpose | Fields relevant here |
+|---|---|---|
+| **CommunityProspect** | The prospect record | `Name`, `Type` (free-form string), `City`, `Region`, `Country`, `Population`, `Website`, `PipelineStage` (int), `FitScore`, `Notes`, `LastContactedDate`, `NextFollowUpDate`, `ConvertedPartnerId` |
+| **ProspectContact** | Multi-contact per prospect (from Project 60) | Name, Title, Email, Phone, Role, ContactStatus, IsPrimary, ReferredByContactId |
+| **ProspectActivity** | Touchpoint log | `ProspectId`, `ProspectContactId`, `ActivityType`, `Subject`, `Details`, `SentimentScore`, standard audit fields |
+| **ProspectOutreachEmail** | Structured outreach records | (per-contact via Project 60 Phase 2) |
+
+### UI (in `TrashMob/client-app/src/pages/siteadmin/prospects/`)
+
+- `page.tsx` — list view with `columns.tsx` DataTable
+- `$prospectId.tsx` / `$prospectId.edit.tsx` — detail + edit
+- `create.tsx` — new prospect form
+- `discovery.tsx` — AI-assisted discovery (from Project 40, archived)
+- `import.tsx` — bulk import
+- **`analytics.tsx`** — existing analytics starting point; will be extended for the new reports
+
+### Controllers
+
+- `CommunityProspectsV2Controller`
+- `ProspectContactsV2Controller`
+
+### Gap vs. Cynthia's spreadsheet
+
+| Spreadsheet column | Current state | Gap |
+|---|---|---|
+| Prospect ID (`TM-MUN-001` style) | GUID `Id` only | New: human-readable auto-numbered display id |
+| Municipality | `Name` | none |
+| State | `Region` | none |
+| Municipality Type | `Type` (free-form string) | Constrain to enum (City / Town / County / Regional Agency / Special District / Other) |
+| Department | — | **New field** — critical for "best responding department" analysis |
+| Contact Name / Title / Email / Phone | on `ProspectContact` | none |
+| Website | `Website` | none |
+| **Priority** (High/Med/Low) | — | **New field** |
+| Stage | `PipelineStage` (int) | Expand enum to the 10 stages Cynthia listed |
+| First Contact Date | — | Derived from earliest `ProspectActivity` — computed, not stored |
+| Last Touch Date | `LastContactedDate` | none |
+| Next Follow-Up Date | `NextFollowUpDate` | none |
+| Meeting Requested | — | Modelled as a specific `ProspectActivity.ActivityType = "Meeting Requested"` |
+| Meeting Date | — | Modelled as `"Meeting Scheduled"` activity with the meeting time in `Details` |
+| Pricing Feedback | — | **New field** on prospect (short-text) + also captured per-activity |
+| Key Objection / Question | — | **New field** on prospect (short-text) |
+| Notes | `Notes` | none |
+
+**Verdict:** ~70% of the pipeline sheet is already modelled. Six fields to add, one enum to constrain, one to expand.
+
+---
+
+## Objectives
+
+### Primary Goals
+
+- **Give the salesperson a CRM that mirrors the spreadsheet on day 1** so they never need to open Cynthia's Excel file except for cross-checking.
+- **Auto-generate the Weekly Report** as a screen in the Site Admin — no manual data entry, no double-tracking.
+- **Auto-generate the Monthly Goals report** with actuals rolled up from the CRM against configurable targets.
+- **Surface market-intelligence signal** (best-responding departments, common objections, pricing feedback, messaging that worked) as first-class outputs, not free-text notes trapped in the pipeline entity.
+- **Give Cynthia and the Board weekly and monthly emails** with the reports rendered inline (no logging in to see them).
+
+### Secondary Goals
+
+- Export any report to CSV or PDF for external sharing (grant applications, Board decks).
+- Support one salesperson today; keep the data model general so a second seat can be added without rework.
+- Feed the same underlying queries into a "sales narrative" summary that ties measurable outcomes to Project 61's Option B milestone gate (15 paying cities, $300K ARR, 3 references by mid-2027).
+
+---
+
+## Scope
+
+### Phase 1 — Model + admin form extensions (backend + web) *[Ships first — unblocks the salesperson]*
+
+- ☐ Add `Department` (nullable string) to `CommunityProspect`
+- ☐ Add `Priority` (enum: High / Medium / Low; nullable) to `CommunityProspect`
+- ☐ Add `PricingFeedback` (nvarchar(500), nullable) to `CommunityProspect`
+- ☐ Add `KeyObjection` (nvarchar(500), nullable) to `CommunityProspect`
+- ☐ Introduce `MunicipalityType` enum (City / Town / County / Regional Agency / Special District / Other) and migrate free-form `Type` values to constrained values (data migration + fallback bucket for anything unmapped)
+- ☐ Expand `PipelineStage` enum to the 10 stages: Identified, Researched, Contacted, Follow-up needed, Responded, Discovery in progress, Meeting requested, Meeting scheduled, Not a fit, Future follow-up
+- ☐ Introduce `ProspectActivityType` enum with values that support the weekly-report categorisation: Outreach / Follow-up / Response received / Meeting requested / Meeting scheduled / Meeting held / Note (add lookup rows in `LookupData` seeder)
+- ☐ Migration (`AddMunicipalPipelineFields` or similar) with backfill of existing rows to the new enum values
+- ☐ Update `CommunityProspectDto` + mappings + controller signatures (V2)
+- ☐ Update admin edit form (`$prospectId.edit.tsx`) + create form (`create.tsx`) to expose new fields
+- ☐ Update the list view (`columns.tsx`) to add Priority + Stage columns with badge/pill rendering
+- ☐ Update filters on the prospect list page to include Priority + Municipality Type + Pipeline Stage
+
+### Phase 2 — Weekly Report screen (backend + web)
+
+- ☐ New endpoint `GET /api/v2/reports/weekly?weekEnding=YYYY-MM-DD` returning the following in one payload:
+  - Period start / end (calculated from `weekEnding` — Monday → Sunday by default; make first day of week configurable)
+  - Prospects researched (count of `CommunityProspect` with `CreatedDate` in window)
+  - New contacts added (count of `ProspectContact` created in window)
+  - Outreach touches (count of `ProspectActivity` with type = Outreach in window)
+  - Follow-up touches (count with type = Follow-up)
+  - Responses / conversations (count with type = Response received)
+  - Meetings requested (count with type = Meeting requested)
+  - Meetings scheduled (count with type = Meeting scheduled)
+  - Aggregated "Key Municipal Feedback" — concatenation of non-empty `KeyObjection` fields on prospects touched in the window
+  - Aggregated "Pricing / Business Model Feedback" — concatenation of non-empty `PricingFeedback` fields
+  - Free-text "Next Steps" (see Phase 4)
+- ☐ New page `/siteadmin/prospects/reports/weekly` reading the endpoint, rendered with the same visual layout as Cynthia's spreadsheet so the transition is invisible
+- ☐ Week picker + prev/next navigation
+- ☐ CSV export button
+
+### Phase 3 — Monthly Goals + market intelligence (backend + web)
+
+- ☐ New `SalesMonthlyTarget` entity: `Month` (first-of-month `DateOnly`), `Metric` (enum: ProspectsResearched, NewContacts, OutreachTouches, FollowUpTouches, Responses, MeetingsRequested, MeetingsScheduled), `Target` (int), `Notes` (nvarchar(500))
+- ☐ Seed default targets from Cynthia's baseline: `20, 20, 15, 10, 3, 2, 1`
+- ☐ New endpoint `GET /api/v2/reports/monthly?month=YYYY-MM` returning the same 7 metrics with target + actual + status (`Behind` if actual < 70% of target, `On track` if 70–110%, `Exceeded` if > 110%)
+- ☐ Endpoint `PUT /api/v2/reports/monthly/{month}/targets` to update targets in place
+- ☐ New page `/siteadmin/prospects/reports/monthly` reading the endpoint
+- ☐ **Market Intelligence Notes** section below the metrics — top-N breakdown of:
+  - Best responding departments (group prospects with `type=Response received` activity in the month by `Department`)
+  - Common objections (top-N unique `KeyObjection` values across prospects touched in the month)
+  - Pricing feedback (top-N `PricingFeedback` values)
+  - Messaging that worked (from `ProspectActivity.Details` on `type=Response received` records — long-text summary; may need free-text input to complement)
+  - Recommended next-month priority (free-text field on `MonthlyReport` entity — see Phase 4)
+
+### Phase 4 — Report free-text sections + scheduled email delivery (backend + jobs)
+
+- ☐ New `SalesReport` entity: `PeriodType` (Weekly / Monthly), `PeriodStart`, `PeriodEnd`, `NextSteps` (nvarchar(2000)), `NextMonthPriority` (nvarchar(2000)), `CreatedByUserId`, standard audit fields. One row per period per type — the free-text side of the report that doesn't come from queries.
+- ☐ CRUD endpoints for `SalesReport`
+- ☐ On the weekly / monthly report screens, add a "Save narrative" panel at the bottom for `NextSteps` (weekly) / `NextMonthPriority` (monthly). Auto-saves on blur. Read on page load if a row exists for the period.
+- ☐ New scheduled job in [`TrashMobHourlyJobs`](../../TrashMobHourlyJobs/): every Monday 08:00 America/Los_Angeles, generate the weekly report for the just-ended week and email it to a distribution list. Every 1st of month at 08:00, do the same for the previous month.
+- ☐ Distribution list stored as a `SalesReportSubscriber` mini-entity (User FK + `IncludeWeekly` + `IncludeMonthly`) so Cynthia + Board can opt in/out without an engineering change
+- ☐ Email templates (in `TrashMob.Shared/Engine/EmailCopy/`): `SalesReportWeekly.html`, `SalesReportMonthly.html` — render the same layout as the on-screen reports
+
+### Phase 5 — Nice-to-haves (deferred; open a follow-up if any block progress)
+
+- ☐ Human-readable prospect IDs (`TM-MUN-001` style) as a computed / stored `DisplayId` column
+- ☐ CSV / PDF export of the pipeline itself (not just the reports)
+- ☐ "Cohort" view — how did the salesperson's Month 1 cohort of prospects progress by Month 3 vs Month 2 cohort?
+- ☐ Board dashboard tie-in — surface the monthly metrics on the [Project 56 (Board Metrics Dashboard)](./Project_56_Board_Metrics_Dashboard.md) once that lands
+- ☐ Slack notification on stage changes ("Alameda County moved to Meeting Scheduled")
+
+---
+
+## Out of Scope
+
+- **Full pipeline import from Cynthia's spreadsheet.** Manual first-time entry is fine for ~20 prospects; a one-off import script is available via existing `import.tsx` if she really wants it.
+- **Multi-tenant CRM.** One organisation, one salesperson today. Do not build tenant separation for this project. If [Project 61 (Aegis)](./Project_61_Aegis_Municipal_OS_Spinout_Evaluation.md) triggers Option C spinout, tenant separation lands then, not now.
+- **Deal / opportunity / quote pricing.** We're not doing e-signature contracts or a formal quote workflow in this project. When a city says yes, we convert them to a `Partner` via the existing `ConvertedPartnerId` field and take contract flow into whatever the partner-onboarding project produces.
+- **Automated outreach.** No sending emails on behalf of the salesperson from within TrashMob. All emails still go from a real Gmail/Outlook account; we log them after the fact via `ProspectOutreachEmail`.
+- **Board Metrics Dashboard cross-integration** — deferred to Project 56.
+
+---
+
+## Success Metrics
+
+### Quantitative
+
+- **Zero double-entry:** the salesperson never needs to touch Cynthia's spreadsheet after Phase 1 ships (measured by asking her at 30/60/90 days).
+- **Weekly report is emailed with real data every Monday for 3 consecutive months** before we consider Phase 4 stable.
+- **Monthly report shows metrics on the same grid as the spreadsheet** — matches the layout Cynthia proposed within ±1 column.
+- **All 7 monthly metrics report actuals within 5 minutes of the source touchpoint being logged** (real-time enough that the salesperson can trust the numbers when they check on Friday afternoon).
+- **Time to close a weekly review meeting drops from ~45 minutes to ≤ 15 minutes** once we're on the auto-generated report (baseline: Cynthia and Joe's current dry-run).
+
+### Qualitative
+
+- The salesperson prefers the CRM to their own private spreadsheet after 30 days.
+- Cynthia can walk into a Board meeting with the monthly report as her only slide.
+- The Market Intelligence Notes surface at least one insight per month that changes messaging or target list (i.e. the data is actionable, not just descriptive).
+
+---
+
+## Dependencies
+
+### Blockers (Must be complete before this project starts)
+
+- **[Project 60 — Prospect Multi-Contact Tracking](./Project_60_Prospect_Contact_Tracking.md):** Phase 1 (model) and Phase 2 (API) already shipped; Phase 3 (admin UI) also shipped. This project reuses that infrastructure directly. Nothing to wait for.
+- **[Project 64 — Roles & RBAC Refactor](./Project_64_Roles_and_RBAC_Refactor.md):** the 1099 salesperson needs a scoped `SalesRep` role rather than the sledgehammer of `IsSiteAdmin`. At minimum Project 64 Phase 1 (data model + policy migration) needs to ship before this project's Phase 1 goes live in production; the `SalesRep` role itself is seeded in Project 64.
+
+### Enablers for Other Projects (What this unlocks)
+
+- **[Project 56 — Board Metrics Dashboard](./Project_56_Board_Metrics_Dashboard.md):** the monthly metrics + market intelligence become natural cards on the Board dashboard once both land.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| **Salesperson doesn't log activities consistently → reports look wrong** | High | High | Keep the activity-logging UI dead simple (one click from prospect detail). Include a "days since last touch" chip on the list view so the salesperson sees stale rows and self-corrects. Run a review call at Day 14 with the salesperson to check that the activity types are being applied correctly. |
+| **Spreadsheet vs. app metric definitions drift over time** | Medium | Medium | Metric definitions live in one place — `SalesReportMetrics.cs` (or similar) with a docstring per metric. Any change goes through a code review, not a Slack message. |
+| **Weekly email is noisy and gets muted → nobody reads it** | Medium | Medium | Design the email so the top 3 metrics are the whole thing; details are one click away. Send only if there was at least one activity in the window; skip empty weeks. |
+| **Free-text fields (`KeyObjection`, `PricingFeedback`) get inconsistent phrasing → aggregation is meaningless** | High | Medium | Accept the messiness in Phase 2. In Phase 3, introduce a light auto-suggest / dedupe pass (Levenshtein distance) that hints "did you mean 'budget constraints'?" when typing. Not a strict enum — the salesperson needs freedom. |
+| **`Type` free-form → enum migration collides with existing data** | Medium | Low | Migration includes a lookup table pass; anything unmapped goes to `Other` with the original string preserved in a `TypeRaw` column so nothing is lost. |
+| **Cynthia and the Board treat this as the source of truth *before* the salesperson has trained** | Medium | High | Explicit "beta" banner on the report pages for the first 60 days. Weekly cadence: Cynthia + Joe + salesperson review the numbers *together* for the first 4 weeks before treating them as Board-grade. |
+| **Scope creep — the "sales OS" instinct kicks in and this becomes 6 months of work** | High | High | Phase 1 ships in 2 weeks or the scope is wrong. Phase 5 items don't count as commitments; they are explicitly opened as follow-up projects if pursued. Track WIP against Project 62's cap. |
+| **Salesperson leaves; institutional knowledge disappears** | Medium | Medium | Every prospect has an `Owner` (a User FK we already have via audit fields). Reports work per-owner or org-wide. Handoff to a new salesperson is a matter of reassigning owner, not exporting/importing data. |
+| **Municipal Type migration downcasting existing "Type" values loses metadata** | Low | Low | Preserve original string in `TypeRaw` column during migration; audit logs the mapping decisions. |
+| **Cynthia's monthly targets are wrong for the first hire (too high or too low)** | High | Low | Targets are editable via the UI. Don't hardcode them beyond the initial seed. Revisit at end of Month 1. |
+
+---
+
+## Implementation Plan
+
+### Data Model Changes
+
+```sql
+-- Phase 1 — CommunityProspect extensions
+ALTER TABLE CommunityProspects ADD Department NVARCHAR(120) NULL;
+ALTER TABLE CommunityProspects ADD Priority INT NULL; -- enum: 1=High, 2=Medium, 3=Low
+ALTER TABLE CommunityProspects ADD PricingFeedback NVARCHAR(500) NULL;
+ALTER TABLE CommunityProspects ADD KeyObjection NVARCHAR(500) NULL;
+ALTER TABLE CommunityProspects ADD TypeRaw NVARCHAR(120) NULL; -- preserve original Type string during enum migration
+-- Constrain existing Type to MunicipalityType enum values via data migration
+-- PipelineStage int already exists — expand the enum to 10 values in code, no schema change
+
+-- Phase 3 — Monthly targets
+CREATE TABLE SalesMonthlyTargets (
+    Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    Month DATE NOT NULL,
+    Metric INT NOT NULL, -- enum: ProspectsResearched=1 ... MeetingsScheduled=7
+    Target INT NOT NULL,
+    Notes NVARCHAR(500) NULL,
+    CreatedDate DATETIMEOFFSET NOT NULL,
+    CreatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    LastUpdatedDate DATETIMEOFFSET NOT NULL,
+    LastUpdatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT UQ_SalesMonthlyTargets_MonthMetric UNIQUE (Month, Metric)
+);
+CREATE INDEX IX_SalesMonthlyTargets_Month ON SalesMonthlyTargets(Month);
+
+-- Phase 4 — Free-text sections + subscribers
+CREATE TABLE SalesReports (
+    Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    PeriodType INT NOT NULL, -- 1=Weekly, 2=Monthly
+    PeriodStart DATE NOT NULL,
+    PeriodEnd DATE NOT NULL,
+    NextSteps NVARCHAR(2000) NULL,
+    NextMonthPriority NVARCHAR(2000) NULL,
+    CreatedDate DATETIMEOFFSET NOT NULL,
+    CreatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    LastUpdatedDate DATETIMEOFFSET NOT NULL,
+    LastUpdatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT UQ_SalesReports_PeriodTypeStart UNIQUE (PeriodType, PeriodStart)
+);
+
+CREATE TABLE SalesReportSubscribers (
+    Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    UserId UNIQUEIDENTIFIER NOT NULL,
+    IncludeWeekly BIT NOT NULL DEFAULT 1,
+    IncludeMonthly BIT NOT NULL DEFAULT 1,
+    -- audit fields
+    CONSTRAINT UQ_SalesReportSubscribers_User UNIQUE (UserId)
+);
+```
+
+### API Changes
+
+```csharp
+// Phase 2 — Weekly report
+[HttpGet("api/v2/reports/sales/weekly")]
+[Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+public async Task<ActionResult<WeeklySalesReportDto>> GetWeeklyReport(
+    [FromQuery] DateOnly weekEnding, CancellationToken ct)
+{
+    // Compute period, count activities by type, aggregate feedback strings,
+    // read SalesReport.NextSteps for the period, return as one payload.
+}
+
+// Phase 3 — Monthly report
+[HttpGet("api/v2/reports/sales/monthly")]
+public async Task<ActionResult<MonthlySalesReportDto>> GetMonthlyReport(
+    [FromQuery] DateOnly month, CancellationToken ct);
+
+[HttpPut("api/v2/reports/sales/monthly/{month}/targets")]
+public async Task<IActionResult> UpdateMonthlyTargets(
+    DateOnly month, [FromBody] MonthlyTargetsUpdateDto targets, CancellationToken ct);
+
+// Phase 4 — Free-text sections
+[HttpPut("api/v2/reports/sales/{periodType}/{periodStart}")]
+public async Task<IActionResult> UpsertReportNarrative(
+    string periodType, DateOnly periodStart, [FromBody] SalesReportNarrativeDto body,
+    CancellationToken ct);
+```
+
+### Web UX Changes
+
+- **Prospect list (`/siteadmin/prospects`):** add Priority and Stage columns to `columns.tsx`; add filters to the toolbar
+- **Prospect detail (`/siteadmin/prospects/$prospectId`):** show the new fields prominently (Priority pill in the header, Pricing Feedback + Key Objection in a "Signal" card)
+- **Prospect edit form (`$prospectId.edit.tsx`):** new fields in the same order Cynthia's spreadsheet lists them
+- **`/siteadmin/prospects/reports/weekly`** — grid layout matching Cynthia's spreadsheet exactly, week picker, prev/next arrows, CSV export
+- **`/siteadmin/prospects/reports/monthly`** — grid of the 7 metrics with target vs actual columns, status badges, Market Intelligence Notes below, editable free-text panel at the bottom for `NextMonthPriority`
+- **Subscription toggle** on user settings so anyone can opt in / out of the emails without going through admin
+
+### Mobile App Changes
+
+- **Read-only Weekly Report screen** for Cynthia's phone during Monday morning coffee. No editing needed on mobile — the salesperson lives at a laptop for outreach work.
+- **Push notification** on Monday when the weekly report drops (optional, gated behind Project 12 - In-App Messaging when it lands).
+
+### Background Jobs
+
+- **`WeeklySalesReportEmailJob`** in `TrashMobHourlyJobs`, fires every Monday 08:00 PT
+- **`MonthlySalesReportEmailJob`** fires on the 1st of each month at 08:00 PT
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Model + admin form extensions (~2 weeks, ships first)
+
+Salesperson can start using the CRM immediately after this ships. Everything else is layered on afterwards.
+
+### Phase 2 — Weekly Report screen (~1 week)
+
+Delivers the Board's most-frequently-requested artifact.
+
+### Phase 3 — Monthly Goals + market intelligence (~2 weeks)
+
+Delivers the strategic input Cynthia needs for Board meetings.
+
+### Phase 4 — Scheduled email delivery (~1 week)
+
+Makes the reports show up in inboxes without anyone logging in.
+
+### Phase 5 — Nice-to-haves
+
+Deferred; each item is a candidate follow-up project, not a commitment.
+
+**Note:** Phases are sequential but not time-bound. Volunteers pick up work as available.
+
+---
+
+## Open Questions
+
+1. **`SalesRep` role — tracked separately as [Project 64](./Project_64_Roles_and_RBAC_Refactor.md).**
+   **Recommendation:** The role itself is small. But the current `IsSiteAdmin` boolean on `User` doesn't extend cleanly to a second role, so Project 64 delivers the RBAC infrastructure and this project depends on it. Coordinate so Project 64 Phase 1 (data model + policy migration) lands before Project 63 Phase 1 goes to production.
+   **Owner:** Joe
+   **Due:** Coordinated with Project 64 Phase 1
+
+2. **Does the salesperson want the CRM optimised for one-at-a-time detail work, or bulk day-planning ("show me everyone I owe a follow-up to today")?**
+   **Recommendation:** Both. Phase 1 delivers detail work. Phase 1.5 (added if the salesperson asks in the first 2 weeks) adds a "Today" dashboard on the prospect list that groups by `NextFollowUpDate`.
+   **Owner:** Cynthia (surface the question to the hire) + salesperson
+   **Due:** 30 days after salesperson start
+
+3. **Distribution list for the weekly / monthly emails on Day 1?**
+   **Recommendation:** Cynthia + Joe + salesperson at minimum. Add Board members once we've run 3 weekly cycles cleanly.
+   **Owner:** Cynthia
+   **Due:** Before Phase 4 ships
+
+4. **What happens to the `Type` free-form values that don't map to the new enum?**
+   **Recommendation:** Bucket to `Other`, preserve original in `TypeRaw`. Log the mapping decisions during migration. Rarely-used enough today that the manual review is trivial.
+   **Owner:** Joe
+   **Due:** Before Phase 1 migration runs
+
+5. **Do the weekly / monthly emails need TrashMob branding, or plain-text-first for deliverability into Cynthia's / Board members' inboxes?**
+   **Recommendation:** HTML with a minimal plain-text fallback. Reuse the [existing SendGrid dynamic template pattern](../../TrashMob.Shared/Engine/EmailCopy/) and keep the template deliberately simple.
+   **Owner:** Joe
+   **Due:** Phase 4 kickoff
+
+---
+
+## Related Documents
+
+- **[Project 60 - Prospect Multi-Contact Tracking](./Project_60_Prospect_Contact_Tracking.md)** — the model and API foundation this project extends
+- **[Project 64 - Roles & RBAC Refactor](./Project_64_Roles_and_RBAC_Refactor.md)** — delivers the `SalesRep` role and the underlying RBAC infrastructure
+- **[Project 56 - Board Metrics Dashboard](./Project_56_Board_Metrics_Dashboard.md)** — future dashboard that will surface these same metrics alongside App Insights, GA4, Sentry, Clarity, Azure costs, and QuickBooks
+- **[Project 41 - Sponsored Adoptions](./Project_41_Sponsored_Adoptions.md)** — existing paid-relationship model within the nonprofit; adjacent revenue channel, worth cross-referencing when the salesperson pitches
+- **[Project 46 - Product Support](./Project_46_Product_Support.md)** — the sister function once cities become paying customers
+- **[Project 62 - TrashMob Site and Codebase Re-evaluation](./Project_62_TrashMob_Site_and_Codebase_Reevaluation.md)** — Engineering health check that catalogues sales-readiness gaps
+
+---
+
+**Last Updated:** 2026-07-03
+**Owner:** Joe (engineering) + Cynthia (sales lead + Board) + 1099 salesperson
+**Status:** Planning
+**Next Review:** 2026-07-10 — align on Phase 1 scope before starting model changes

--- a/Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md
+++ b/Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md
@@ -1,0 +1,353 @@
+# Project 64 — Roles and RBAC Refactor
+
+| Attribute | Value |
+|-----------|-------|
+| **Status** | Planning |
+| **Priority** | High |
+| **Risk** | Medium |
+| **Size** | Large |
+| **Dependencies** | _None_ — this project unblocks [Project 63 (Municipal Sales Pipeline Reporting)](./Project_63_Municipal_Sales_Pipeline_Reporting.md) and any future non-admin role |
+
+---
+
+## Business Rationale
+
+Authorization on TrashMob is currently gated by a single `IsSiteAdmin` boolean on the `User` entity. Every non-user-owned operation that isn't public is either "any authenticated user" or "site admin only" — there is no middle tier. This has worked for the last five years because the site had exactly two audiences (volunteers and one small operations team who had full admin rights).
+
+That model breaks the moment a second role shows up:
+
+- The **1099 municipal sales contractor** (see [Project 63](./Project_63_Municipal_Sales_Pipeline_Reporting.md)) needs to see and edit the prospect CRM, view sales reports, and nothing else. They must not see user administration, waivers, event moderation, photo moderation, community management, or site-wide financial data.
+- A **future community manager** at a partner org needs write access to their community's pages but not to other communities.
+- A **content editor** (if we decide to onboard volunteer writers to draft news articles into Strapi) needs Strapi-and-newsletter access but not to touch the API or user data.
+- **A partner admin** who runs adopted-location sponsorships needs to see only their own sponsor org's data.
+
+The `IsSiteAdmin` boolean is a sledgehammer. Handing it to any of the above puts data at risk. Handing them nothing means they can't do their job. We need the roles infrastructure that every other B2B SaaS has, and it's a strict prerequisite before the sales contractor gets a login.
+
+**Scope discipline:** this project delivers **coarse roles**, not fine-grained permissions. A role like `SalesRep` grants a fixed bundle of capabilities. We are not building a permission-per-endpoint policy editor; that lives in a follow-up project (or never — most SaaS at our scale never build one). The line is "which capability tier are you in?", not "can this user perform action X on resource Y?".
+
+---
+
+## What Exists Today
+
+Independent-engineer scan of the auth surface before drafting scope:
+
+- **`User.IsSiteAdmin`** boolean, set/preserved in `UserManager.AddAsync` — new users default to `false`, updates preserve the current value (users cannot self-promote). Direct DB writes are the only way to grant admin today.
+- **234 usages** of `IsSiteAdmin` across [`TrashMob`](../../TrashMob/), [`TrashMob.Shared`](../../TrashMob.Shared/), and [`TrashMob.Models`](../../TrashMob.Models/). Not all of those need to change — many are read-side checks that will keep working once we introduce a role-aware helper.
+- **6 authorization handlers** in [`TrashMob/Security/`](../../TrashMob/Security/) that check `IsSiteAdmin` directly:
+  - `UserIsAdminAuthHandler`
+  - `UserIsEventLeadOrIsAdminAuthHandler`
+  - `UserIsPartnerUserOrIsAdminAuthHandler`
+  - `UserIsProfessionalCompanyUserOrIsAdminAuthHandler`
+  - `UserOwnsEntityOrIsAdminAuthHandler`
+  - `UserIsValidUserAuthHandler` (indirect — via user provisioning)
+- **9 authorization policies** in `AuthorizationPolicyConstants.cs`: `UserIsAdmin`, `UserIsPartnerUserOrIsAdmin`, `UserOwnsEntity`, `UserOwnsEntityOrIsAdmin`, `UserIsEventLead`, `UserIsEventLeadOrIsAdmin`, `ValidUser`, `UserIsProfessionalCompanyUserOrIsAdmin`, `IftttServiceKey`. All work today; new role-scoped policies will layer alongside them.
+- **`UsersV2Controller`** — 4 endpoints touch `IsSiteAdmin` on writes (create + update + admin-only writes to another user). These are the endpoints that need to route through a role-grant/revoke API in Phase 3.
+- **Photo moderation** and other jobs query `IsSiteAdmin` to find moderators for notifications; those queries need to swap to "users with the `PhotoModerator` role or the `SiteAdmin` role" (a small change once the data model lands).
+
+The refactor is entirely additive up to Phase 4 — no existing endpoint changes behavior until we're ready to flip the boolean.
+
+---
+
+## Objectives
+
+### Primary Goals
+
+- **Introduce a `Role` + `UserRole` data model** that supports many-to-many assignment with audit fields (who granted, when, optional expiry).
+- **Preserve existing behavior** during migration: every user with `IsSiteAdmin = true` today gets granted the `SiteAdmin` role, and every authorization handler continues to accept `IsSiteAdmin OR SiteAdmin-role-member` until the boolean is decommissioned.
+- **Ship a `SalesRep` role** as the first non-admin role, with a policy narrow enough that Project 63 can rely on it in production.
+- **Provide an admin UI** to grant / revoke roles with an audit trail.
+- **Deprecate and remove `User.IsSiteAdmin`** once all readers are migrated (last phase).
+
+### Secondary Goals
+
+- Establish the pattern so adding a new role (`PartnerAdmin`, `CommunityManager`, `ContentEditor`) is a one-migration + one-policy exercise, not a codebase-wide refactor.
+- Give role assignments an optional `ExpiryDate` so we can grant temporary access without back-and-forth (contractor onboarding trials, security incident response).
+- Support role-membership queries efficiently — the `PhotoModerationManager` and any future "notify all Xs" job needs a fast lookup.
+
+---
+
+## Scope
+
+### Phase 1 — Data model + read-side layering (~1 week; ships first, no behavior change)
+
+- ☐ Add `Role` entity: `Id (Guid)`, `Name (nvarchar(60), unique)`, `Description (nvarchar(300))`, standard audit fields
+- ☐ Add `UserRole` entity: `Id`, `UserId (FK)`, `RoleId (FK)`, `GrantedByUserId`, `GrantedDate`, `ExpiryDate (nullable)`, `RevokedDate (nullable)`, `RevokedByUserId (nullable)`, audit fields. Unique constraint on (UserId, RoleId) where `RevokedDate IS NULL`
+- ☐ Seed default roles: `SiteAdmin`, `SalesRep`. (More roles land as needed; do not pre-seed speculative ones.)
+- ☐ Backfill migration: for every `User` with `IsSiteAdmin = true`, insert a `UserRole` row granting `SiteAdmin`. GrantedByUserId = a well-known system user id documented in `Constants.cs`.
+- ☐ New `IUserRoleService` in `TrashMob.Shared.Managers.Interfaces`:
+  - `Task<bool> HasRoleAsync(Guid userId, string roleName, CancellationToken ct)`
+  - `Task<IReadOnlyCollection<string>> GetRoleNamesAsync(Guid userId, CancellationToken ct)`
+  - `Task<IReadOnlyCollection<User>> GetUsersInRoleAsync(string roleName, CancellationToken ct)`
+- ☐ Implementation in `UserRoleManager` with in-memory caching per-request via `IHttpContextAccessor` (so authorization handlers don't do a DB round trip per policy check)
+- ☐ **Compatibility bridge:** `HasRoleAsync("SiteAdmin", ...)` returns `true` if the user has an active `UserRole` for SiteAdmin **OR** `IsSiteAdmin = true`. This keeps the pre-migration state working.
+- ☐ Unit tests for the manager covering: active grant, revoked grant, expired grant, boolean-only fallback, role-mixed users
+- ☐ Wire into DI in [`ServiceBuilder.cs`](../../TrashMob.Shared/ServiceBuilder.cs)
+
+### Phase 2 — Authorization handler migration (~1 week; enables SalesRep role in production)
+
+- ☐ Update the 6 auth handlers to check `HasRoleAsync("SiteAdmin", ...)` instead of `user.IsSiteAdmin`. The compatibility bridge above means no behavior change for existing SiteAdmins.
+- ☐ New `AuthorizationPolicyConstants` entries: `UserIsSalesRepOrIsAdmin` and any others required by [Project 63](./Project_63_Municipal_Sales_Pipeline_Reporting.md)
+- ☐ New handler `UserIsSalesRepOrIsAdminAuthHandler` following the existing pattern
+- ☐ Update [`Program.cs`](../../TrashMob/Program.cs) DI: register the new handler
+- ☐ Apply `[Authorize(Policy = UserIsSalesRepOrIsAdmin)]` to the Prospect-related v2 controllers (`CommunityProspectsV2Controller`, `ProspectContactsV2Controller`, and the new sales-report controllers from Project 63)
+- ☐ Update integration tests in [`TrashMob.Shared.Tests/Controllers/V2/`](../../TrashMob.Shared.Tests/Controllers/V2/) — one covering a SalesRep hitting a prospect endpoint (allowed), another covering a SalesRep hitting a user-admin endpoint (forbidden)
+- ☐ [Project 62](./Project_62_TrashMob_Site_and_Codebase_Reevaluation.md) also called out the `UsersV2Controller` missing class-level `[Authorize]` — take that fix in this project's PR to eliminate a real anonymous-read leak while we're editing the file
+
+### Phase 3 — Admin UI for role management (~1 week)
+
+- ☐ New v2 controller `RolesV2Controller`:
+  - `GET /api/v2/roles` — list all roles
+  - `GET /api/v2/roles/{roleName}/members` — users with the role
+  - `POST /api/v2/users/{userId}/roles` — grant a role (body: `{ roleName, expiryDate? }`)
+  - `DELETE /api/v2/users/{userId}/roles/{roleName}` — revoke
+  - All gated on `UserIsAdmin` policy — only SiteAdmins can grant/revoke roles
+- ☐ New admin page `/siteadmin/roles`: table of roles with member counts + click to see members
+- ☐ New admin page `/siteadmin/users/{userId}/roles`: shows current roles for the user, add/remove buttons, expiry date picker
+- ☐ Extend `/siteadmin/users` list view with a "Roles" column (comma-separated pill list)
+- ☐ Email templates: `RoleGranted.html`, `RoleRevoked.html` — notify the affected user with a plain "Your account has been granted the SalesRep role by {actor}" message
+
+### Phase 4 — Deprecate `IsSiteAdmin` boolean (~1 week; ships when Phase 2+3 are stable)
+
+- ☐ Rewrite the 234 direct `IsSiteAdmin` references to go through the role-aware helper (`await userRoleService.HasRoleAsync(user.Id, "SiteAdmin", ct)` where an async call is possible; a synchronous fallback via cached user context where it isn't)
+- ☐ Update `UsersV2Controller` write endpoints to route SiteAdmin promotion through the role-grant API rather than setting the boolean directly
+- ☐ Add a computed property `User.IsSiteAdmin => Roles.Any(r => r.Name == "SiteAdmin")` (backed by the navigation property) so any callers we missed continue to work as read-only
+- ☐ Remove the persisted `IsSiteAdmin` column via a migration after a 30-day observation window with no regressions
+- ☐ Update the seed data + fixture builders to grant `SiteAdmin` role rather than set the boolean
+
+### Phase 5 — Deferred (open a follow-up project if pursued)
+
+- ☐ Fine-grained permissions (per-endpoint capability model)
+- ☐ Delegated admin — an org admin who can grant roles within their org only
+- ☐ Just-in-time role elevation with 2FA re-prompt
+- ☐ Role change audit report / dashboard tie-in with [Project 56 (Board Metrics Dashboard)](./Project_56_Board_Metrics_Dashboard.md)
+
+---
+
+## Out of Scope
+
+- **Fine-grained per-endpoint or per-resource permissions.** Roles are coarse bundles by design.
+- **Multi-tenant role isolation.** If we ever ship a spinout that needs tenant-scoped roles, that's a bigger effort.
+- **External identity provider role sync** (SSO groups → TrashMob roles). Later, if needed.
+- **Retroactive role assignment audit** for the 5-year `IsSiteAdmin` history. The backfill grants happen once; no attempt to reconstruct who granted admin to whom in the past.
+- **UI to create new roles.** Roles are seeded from code and require a migration. This is intentional — accidental role creation shouldn't be a UI action.
+
+---
+
+## Success Metrics
+
+### Quantitative
+
+- **Zero regressions in existing SiteAdmin capability** verified by full test-suite pass at each phase boundary, including the 1,115 existing tests
+- **SalesRep role gates production access** — after Phase 2 ships, a user with only `SalesRep` role gets HTTP 200 on prospect endpoints and HTTP 403 on user-admin endpoints, verified by an xUnit integration test
+- **All 234 direct `IsSiteAdmin` references migrated** to the role-aware helper by end of Phase 4
+- **Median policy-check latency stays under 5 ms** (target — the per-request cache should make this trivial, but it's worth tracking to prevent a regression sneaking in)
+
+### Qualitative
+
+- Adding the next new role (`PartnerAdmin` or similar) requires only a migration + a policy + a handler — no touching auth infrastructure
+- The salesperson from Project 63 onboards without needing to be granted `IsSiteAdmin` "temporarily to unblock them"
+- Admin UI makes it obvious who can do what across the small team without needing to open the database
+
+---
+
+## Dependencies
+
+### Blockers (Must be complete before this project starts)
+
+- _None._ This project can start immediately. It depends only on the current auth infrastructure, all of which exists.
+
+### Enablers for Other Projects (What this unlocks)
+
+- **[Project 63 — Municipal Sales Pipeline Reporting](./Project_63_Municipal_Sales_Pipeline_Reporting.md):** requires the `SalesRep` role from Phase 2 before the 1099 sales contractor is given a login
+- **Future partner-admin, community-manager, content-editor roles** — the pattern established here makes each of these a small, well-scoped addition
+- **[Project 62 — TrashMob Site & Codebase Re-evaluation](./Project_62_TrashMob_Site_and_Codebase_Reevaluation.md)** — one of the follow-up hardening items surfaced there was the `UsersV2Controller` missing class-level `[Authorize]`. Phase 2 of this project closes that gap while touching the same file.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| **A missed `IsSiteAdmin` read in Phase 4 silently downgrades a SiteAdmin's capability** | High | High | Grep-based inventory of all 234 usages *before* starting Phase 4. Land the boolean → role-helper migration in slices (one handler at a time) with tests. Keep the computed property fallback so anything we miss reads correctly. |
+| **The per-request role cache stales incorrectly and a just-revoked user still has access for the rest of the request** | Low | Medium | The cache is per-request only, scoped to the single `HttpContext`. Revocation takes effect on the next request. Explicitly documented. Acceptable for a coarse-role system. |
+| **Backfill migration incorrectly grants SiteAdmin to a user who had `IsSiteAdmin=true` due to an old testing artifact** | Medium | Medium | Manually review the seed backfill output before running in prod. Currently ~5 users have the flag; individually verify. |
+| **A malicious admin grants SiteAdmin to themselves and covers tracks by revoking the auditor** | Low | High | Every role change writes an immutable audit row. Grant/revoke of SiteAdmin sends an email to *all* existing SiteAdmins (not just the affected user). Acceptable defense-in-depth for a small team. |
+| **The 6 auth handlers get updated inconsistently — Handler A checks role, Handler B still checks boolean, and a user with the role but not the boolean sees inconsistent behavior** | Medium | High | Handle the migration in Phase 2 as a **single PR** touching all 6 handlers together, not one at a time. Compatibility bridge (Phase 1) means the transition is safe in either direction. |
+| **The new admin UI is a persistent target — a SiteAdmin grants access accidentally** | Medium | Medium | Grant/revoke are two-step (select role + confirm modal with explicit consequences shown). Every action is audited and emailed. |
+| **Existing tests reference `.IsSiteAdmin` extensively in fixtures — updating them is tedious and error-prone** | High | Low | Keep the boolean as a computed property (Phase 4). Fixtures continue to set `IsSiteAdmin = true` and the property reflects role membership on read. No test rewrites needed for the read path. |
+| **Deprecation of the `IsSiteAdmin` column happens before all readers are migrated → runtime NRE** | Low | High | The column stays until an explicit greenlight after Phase 4 stabilises. Don't run the drop migration for at least 30 days after all readers move to the helper. |
+| **Project 63 timing pressure — the salesperson is starting soon** | High | Medium | Phase 1 + Phase 2 can ship in a 2-week window. If schedule tight, Project 63 Phase 1 (data model + admin forms) can ship *without* the SalesRep role and the salesperson can be granted temporary `SiteAdmin` for the transition — with the caveat that this is explicitly time-boxed and revoked once Project 64 Phase 2 lands. |
+
+---
+
+## Implementation Plan
+
+### Data Model Changes
+
+```sql
+-- Phase 1
+CREATE TABLE Roles (
+    Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    Name NVARCHAR(60) NOT NULL,
+    Description NVARCHAR(300) NULL,
+    CreatedDate DATETIMEOFFSET NOT NULL,
+    CreatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    LastUpdatedDate DATETIMEOFFSET NOT NULL,
+    LastUpdatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT UQ_Roles_Name UNIQUE (Name)
+);
+
+CREATE TABLE UserRoles (
+    Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    UserId UNIQUEIDENTIFIER NOT NULL,
+    RoleId UNIQUEIDENTIFIER NOT NULL,
+    GrantedByUserId UNIQUEIDENTIFIER NOT NULL,
+    GrantedDate DATETIMEOFFSET NOT NULL,
+    ExpiryDate DATETIMEOFFSET NULL,
+    RevokedDate DATETIMEOFFSET NULL,
+    RevokedByUserId UNIQUEIDENTIFIER NULL,
+    RevokedReason NVARCHAR(500) NULL,
+    -- standard audit
+    CreatedDate DATETIMEOFFSET NOT NULL,
+    CreatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    LastUpdatedDate DATETIMEOFFSET NOT NULL,
+    LastUpdatedByUserId UNIQUEIDENTIFIER NOT NULL,
+    CONSTRAINT FK_UserRoles_User FOREIGN KEY (UserId) REFERENCES Users(Id),
+    CONSTRAINT FK_UserRoles_Role FOREIGN KEY (RoleId) REFERENCES Roles(Id)
+);
+-- Unique constraint on active grants (partial index; SQL Server supports filtered indexes)
+CREATE UNIQUE INDEX UX_UserRoles_Active
+    ON UserRoles(UserId, RoleId)
+    WHERE RevokedDate IS NULL;
+CREATE INDEX IX_UserRoles_RoleId ON UserRoles(RoleId) WHERE RevokedDate IS NULL;
+CREATE INDEX IX_UserRoles_UserId ON UserRoles(UserId) WHERE RevokedDate IS NULL;
+
+-- Backfill: existing SiteAdmins
+INSERT INTO UserRoles (Id, UserId, RoleId, GrantedByUserId, GrantedDate, CreatedDate, CreatedByUserId, LastUpdatedDate, LastUpdatedByUserId)
+SELECT NEWID(), u.Id, r.Id, '<system-user-guid>', SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), '<system-user-guid>', SYSDATETIMEOFFSET(), '<system-user-guid>'
+FROM Users u
+CROSS JOIN Roles r
+WHERE u.IsSiteAdmin = 1 AND r.Name = 'SiteAdmin';
+
+-- Phase 4 (30 days after Phase 2 stable)
+ALTER TABLE Users DROP COLUMN IsSiteAdmin;
+```
+
+### API Changes
+
+```csharp
+// Phase 1 — service surface
+public interface IUserRoleService
+{
+    Task<bool> HasRoleAsync(Guid userId, string roleName, CancellationToken ct);
+    Task<IReadOnlyCollection<string>> GetRoleNamesAsync(Guid userId, CancellationToken ct);
+    Task<IReadOnlyCollection<User>> GetUsersInRoleAsync(string roleName, CancellationToken ct);
+}
+
+// Phase 2 — authorization handler shape
+public class UserIsAdminAuthHandler(IUserRoleService roles) : AuthorizationHandler<UserIsAdminRequirement>
+{
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext ctx, UserIsAdminRequirement req)
+    {
+        var user = await ResolveUser(ctx);
+        if (user is null) return;
+        if (await roles.HasRoleAsync(user.Id, RoleNames.SiteAdmin, ctx.HttpContext.RequestAborted))
+        {
+            ctx.Succeed(req);
+        }
+    }
+}
+
+// Phase 3 — role admin endpoints
+[Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+public class RolesV2Controller(...) : ControllerBase
+{
+    [HttpGet] public Task<ActionResult<IEnumerable<RoleDto>>> ListRoles(...);
+    [HttpGet("{roleName}/members")] public Task<...> ListMembers(...);
+    [HttpPost("~/api/v2/users/{userId}/roles")] public Task<...> GrantRole(Guid userId, [FromBody] GrantRoleRequest req, ...);
+    [HttpDelete("~/api/v2/users/{userId}/roles/{roleName}")] public Task<...> RevokeRole(Guid userId, string roleName, ...);
+}
+```
+
+### Web UX Changes
+
+- **`/siteadmin/roles`** — DataTable of roles, columns: name, description, member count, actions
+- **`/siteadmin/roles/{roleName}`** — role detail with member list
+- **`/siteadmin/users/{userId}/roles`** — per-user roles with grant/revoke controls
+- **`/siteadmin/users`** list — add a "Roles" column so the current tier of every user is visible at a glance
+
+### Mobile App Changes
+
+None. Roles gate site-admin surface only; the mobile app doesn't expose any of the affected endpoints.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Data model + read-side layering (~1 week)
+
+Ships first with **no behavior change** for anyone. Once merged and running for a few days, we know the read path is stable.
+
+### Phase 2 — Handler migration + SalesRep role (~1 week)
+
+Ships when Phase 1 has soaked. Unblocks Project 63 immediately.
+
+### Phase 3 — Admin UI (~1 week)
+
+Ships alongside or shortly after Phase 2. Not strictly required for Project 63 (roles can be granted via SQL script if the UI slips), but strongly preferred.
+
+### Phase 4 — Deprecate the boolean (~1 week, ships 30+ days after Phase 2 stable)
+
+Sweep the codebase, drop the column, close the loop.
+
+**Note:** Phases are sequential but not time-bound.
+
+---
+
+## Open Questions
+
+1. **What roles do we seed on day 1?**
+   **Recommendation:** Just `SiteAdmin` and `SalesRep`. Don't pre-seed speculative roles — they'll rot before they're used. Every new role is a migration; that's a good friction.
+   **Owner:** Joe + Cynthia
+   **Due:** Phase 1 kickoff
+
+2. **Should role grants be self-service revocable, or admin-only?**
+   **Recommendation:** Admin-only for grant *and* revoke. A user can't revoke their own SiteAdmin role (fat-finger prevention). If someone truly needs to step down, they ask another admin.
+   **Owner:** Joe
+   **Due:** Phase 3 kickoff
+
+3. **Do we need role hierarchy (SiteAdmin implicitly has SalesRep capabilities)?**
+   **Recommendation:** No — the auth policies already handle this via the "SalesRep OR SiteAdmin" pattern (`UserIsSalesRepOrIsAdmin`). Explicit hierarchy adds accidental-privilege risk. Stick with policy composition.
+   **Owner:** Joe
+   **Due:** Phase 2 kickoff
+
+4. **How do we handle the system user id for the backfill grant?**
+   **Recommendation:** There's a well-known "System" user id used elsewhere for automated writes; use the same one. Document it in `Constants.cs` if not already.
+   **Owner:** Joe
+   **Due:** Phase 1 migration
+
+5. **Which policies does the new `SalesRep` role satisfy?**
+   **Recommendation:** Introduce two policies specifically for prospect/report access: `UserIsSalesRepOrIsAdmin` (read + write on prospect and sales-report endpoints only) and reuse `ValidUser` for anything a normal authenticated user can do. The salesperson should not implicitly gain any other capability.
+   **Owner:** Joe + salesperson (once hired) via a scope-check exercise
+   **Due:** Phase 2 kickoff
+
+6. **Do role changes trigger a re-issue of the caller's token, or does the change take effect on the next request only?**
+   **Recommendation:** Next request only. Re-issuing tokens is a bigger surface (and would need Entra External ID coordination). Documented so the admin UI shows a "changes take effect on next login or next API call" note.
+   **Owner:** Joe
+   **Due:** Phase 3
+
+---
+
+## Related Documents
+
+- **[Project 63 - Municipal Sales Pipeline Reporting](./Project_63_Municipal_Sales_Pipeline_Reporting.md)** — primary consumer of the `SalesRep` role
+- **[Project 62 - TrashMob Site & Codebase Re-evaluation](./Project_62_TrashMob_Site_and_Codebase_Reevaluation.md)** — the `UsersV2Controller` anonymous-read leak flagged in the audit gets fixed here as a side-effect
+- **[Project 1 - Auth Revamp](./Project_01_Auth_Revamp.md)** — modernized *authentication* (Entra External ID); this project modernizes *authorization*. Adjacent, not blocking.
+
+---
+
+**Last Updated:** 2026-07-03
+**Owner:** Joe (engineering)
+**Status:** Planning
+**Next Review:** 2026-07-10 — coordinate Phase 1 kickoff with Project 63 timeline

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -198,12 +198,12 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 | ✅ **Complete** (production live, in-place) | 1 | Project 23 (PRIVO live 2026-05-20, testing complete 2026-07-01) |
 | ✅ **Complete** (pending external) | 1 | Project 8 (minor waiver text pending legal review) |
 | **In Progress** | 13 | Projects 1, 4, 5, 6, 15, 25, 30, 36, 41, 45, 46, 49, 57 |
-| **Planning** | 2 | Projects 56, 58 |
+| **Planning** | 5 | Projects 56, 58, 62, 63, 64 |
 | **Ready for Review** | 1 | Project 2 |
 | **Not Started** | 5 | Projects 12, 31, 43, 52, 54, 55 |
 | **Deprioritized** | 1 | Project 33 |
 
-**Total:** 59 project specifications documented
+**Total:** 62 project specifications documented
 
 ---
 
@@ -241,6 +241,9 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 |---------|-------------|
 | [Project 56 - Board Metrics Dashboard](./Projects/Project_56_Board_Metrics_Dashboard.md) | Unified admin dashboard pulling from App Insights, GA4, Sentry, Clarity, Azure Cost Management, and QuickBooks for monthly board meetings |
 | [Project 58 - Community Event Seeding](./Projects/Project_58_Community_Event_Seeding.md) | Admin-seeded public cleanup events with organizer claim workflow to solve cold-start growth |
+| [Project 62 - TrashMob Site & Codebase Re-evaluation](./Projects/Project_62_TrashMob_Site_and_Codebase_Reevaluation.md) | **Engineering health check.** Codebase is in solid shape (A- architecture, no surprise debt); real constraint is WIP overload. Recommends capping in-progress at 6, finishing Mobile Robustness Phases 3–5 and unblocking E2E CI as P0 for Q3 2026. Living doc, updated every 6 months. |
+| [Project 63 - Municipal Sales Pipeline Reporting](./Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md) | Extends the existing prospect CRM (from Project 60) with municipal-specific fields, a weekly report screen matching Cynthia's spreadsheet, monthly goals with target-vs-actual rollups, and market-intelligence aggregation. Supports the 1099 sales contractor selling TrashMob SaaS to cities. |
+| [Project 64 - Roles & RBAC Refactor](./Projects/Project_64_Roles_and_RBAC_Refactor.md) | Replaces the single `IsSiteAdmin` boolean with a proper Role + UserRole model. Ships `SiteAdmin` and `SalesRep` on day 1; establishes the pattern for future roles (`PartnerAdmin`, `ContentEditor`, etc.). Prerequisite for Project 63 to give the sales contractor a scoped login. |
 
 ### Not Started
 


### PR DESCRIPTION
## Summary

Three planning documents that frame the next quarter of work.

- **[Project 62](Planning/Projects/Project_62_TrashMob_Site_and_Codebase_Reevaluation.md)** — engineering health check. Living document updated in place every 6 months. Codebase is in solid shape; real constraint is WIP overload.
- **[Project 63](Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md)** — extends the existing prospect CRM with municipal-specific fields, weekly/monthly reports, and market-intelligence aggregation to support the 1099 sales contractor. ~70% of the spreadsheet already modelled by [Project 60](Planning/Projects/Project_60_Prospect_Contact_Tracking.md).
- **[Project 64](Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md)** — replaces `User.IsSiteAdmin` (234 references, 6 auth handlers) with a proper Role + UserRole model. Delivers the \`SalesRep\` role that Project 63 depends on for a scoped contractor login.

## Dependencies between the three

```
Project 60 ─── shipped ──▶ Project 63 ──▶ Project 64 (RBAC / SalesRep role)
                              │
                              └──▶ Project 62 (audit that catalogues what
                                              would matter to city buyers)
```

## Board / stakeholder note

Project 62's Snapshot section is intentionally usable as a Board update on \"how healthy is the platform?\" without needing engineering translation. Project 63 mirrors the layout of the Board President's spreadsheet directly, so the transition from Excel to app should be invisible.

## Notes on scope

- **Project 63 Phase 1** ships first and unblocks the salesperson (assuming Project 64 Phase 2 lands in parallel to grant the \`SalesRep\` role). If Project 64 slips, contingency is documented in Project 63 Risks: grant time-boxed \`SiteAdmin\` and revoke on Project 64 Phase 2 merge.
- **Project 62 Phase 3** (sales-motion-conditional engineering — SOC 2, multi-tenancy, FOIA export, etc.) is explicitly gated on a real signed municipal contract, not speculative buildout.
- **Project 64 Phase 4** (dropping the \`IsSiteAdmin\` column) sits 30+ days after Phase 2 stabilises. Not part of the initial delivery window.

## Test plan

- [ ] CI green on this PR
- [ ] Cynthia + Joe walk through the three docs together before starting execution
- [ ] Establish Project 63 Phase 1 kickoff date once the 1099 sales contractor's start date is confirmed
- [ ] Coordinate Project 63 Phase 1 and Project 64 Phase 1+2 timelines so the contractor gets a scoped role at go-live, not \`SiteAdmin\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)