### PR TITLE
Project 64 Phase 1: Role + UserRole model + IUserRoleService

### DIFF
--- a/TrashMob.Models/Role.cs
+++ b/TrashMob.Models/Role.cs
@@ -1,0 +1,34 @@
+#nullable disable
+
+namespace TrashMob.Models
+{
+    /// <summary>
+    /// Represents an authorization role that can be granted to users.
+    /// </summary>
+    /// <remarks>
+    /// Roles are coarse-grained capability bundles (e.g. <c>SiteAdmin</c>,
+    /// <c>SalesRep</c>). Users are assigned roles via <see cref="UserRole"/>
+    /// records. Authorization policies check for role membership through
+    /// <c>IUserRoleService.HasRoleAsync</c> rather than reading the legacy
+    /// <see cref="User.IsSiteAdmin"/> boolean directly.
+    ///
+    /// New roles are added by seeding a row and adding a corresponding
+    /// authorization handler / policy — never by user action from the UI.
+    /// The admin UI can only grant / revoke existing roles.
+    /// </remarks>
+    public class Role : LookupModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Role"/> class.
+        /// </summary>
+        public Role()
+        {
+            UserRoles = [];
+        }
+
+        /// <summary>
+        /// Gets or sets the collection of assignments of this role to users.
+        /// </summary>
+        public virtual ICollection<UserRole> UserRoles { get; set; }
+    }
+}

--- a/TrashMob.Models/User.cs
+++ b/TrashMob.Models/User.cs
@@ -51,6 +51,7 @@ namespace TrashMob.Models
             ParentalConsentsAsGranter = new HashSet<ParentalConsent>();
             ParentalConsentsCreated = new HashSet<ParentalConsent>();
             ParentalConsentsUpdated = new HashSet<ParentalConsent>();
+            UserRoles = new HashSet<UserRole>();
         }
 
         /// <summary>
@@ -236,6 +237,17 @@ namespace TrashMob.Models
         /// Gets or sets the collection of events last updated by this user.
         /// </summary>
         public virtual ICollection<Event> EventsUpdated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of role assignments for this user.
+        /// </summary>
+        /// <remarks>
+        /// Includes both active and revoked assignments; use
+        /// <c>IUserRoleService.HasRoleAsync</c> or a filter on
+        /// <c>RevokedDate == null &amp;&amp; (ExpiryDate == null || ExpiryDate &gt; now)</c>
+        /// to test effective role membership.
+        /// </remarks>
+        public virtual ICollection<UserRole> UserRoles { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of notifications for this user.

--- a/TrashMob.Models/UserRole.cs
+++ b/TrashMob.Models/UserRole.cs
@@ -1,0 +1,74 @@
+#nullable disable
+
+namespace TrashMob.Models
+{
+    /// <summary>
+    /// Represents a grant of a <see cref="Role"/> to a <see cref="User"/>.
+    /// </summary>
+    /// <remarks>
+    /// A grant is considered active when <see cref="RevokedDate"/> is null
+    /// and either <see cref="ExpiryDate"/> is null or in the future.
+    /// Revocation is soft — the row is retained for audit and never deleted.
+    ///
+    /// The unique index on (<c>UserId</c>, <c>RoleId</c>) is filtered on
+    /// <c>RevokedDate IS NULL</c>, so a user can be granted the same role
+    /// again after a prior revocation without violating the constraint.
+    /// </remarks>
+    public class UserRole : KeyedModel
+    {
+        /// <summary>
+        /// Gets or sets the user this grant applies to.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the role granted to the user.
+        /// </summary>
+        public int RoleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who granted this role.
+        /// </summary>
+        public Guid GrantedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date and time when this grant took effect.
+        /// </summary>
+        public DateTimeOffset GrantedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional expiry date for time-boxed grants
+        /// (contractor trials, incident-response elevation). When set and
+        /// in the past, the grant is treated as inactive without needing
+        /// an explicit revocation.
+        /// </summary>
+        public DateTimeOffset? ExpiryDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date the grant was revoked, or null if the
+        /// grant has never been revoked.
+        /// </summary>
+        public DateTimeOffset? RevokedDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the user who revoked this grant.
+        /// </summary>
+        public Guid? RevokedByUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional free-text reason for revocation, for
+        /// audit / operational context.
+        /// </summary>
+        public string RevokedReason { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user this grant applies to.
+        /// </summary>
+        public virtual User User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the role granted to the user.
+        /// </summary>
+        public virtual Role Role { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/UserRoleServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/UserRoleServiceTests.cs
@@ -1,0 +1,238 @@
+namespace TrashMob.Shared.Tests.Managers
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers;
+    using TrashMob.Shared.Persistence;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="UserRoleService"/>. Cover the four bits of
+    /// non-obvious behaviour: active-grant lookup, revoked / expired filtering,
+    /// the compatibility bridge for the legacy <see cref="User.IsSiteAdmin"/>
+    /// boolean, and the per-request cache.
+    /// </summary>
+    public class UserRoleServiceTests : IDisposable
+    {
+        private readonly MobDbContext db;
+        private readonly UserRoleService sut;
+
+        private static readonly int SiteAdminRoleId = 1;
+        private static readonly int SalesRepRoleId = 2;
+
+        public UserRoleServiceTests()
+        {
+            var options = new DbContextOptionsBuilder<MobDbContext>()
+                .UseInMemoryDatabase(databaseName: $"UserRoleService_{Guid.NewGuid()}")
+                .Options;
+            db = new MobDbContext(options);
+            SeedRoles();
+            sut = new UserRoleService(db);
+        }
+
+        private void SeedRoles()
+        {
+            db.Roles.AddRange(
+                new Role { Id = SiteAdminRoleId, Name = RoleNames.SiteAdmin, IsActive = true },
+                new Role { Id = SalesRepRoleId, Name = RoleNames.SalesRep, IsActive = true });
+            db.SaveChanges();
+        }
+
+        private User AddUser(bool isSiteAdmin = false)
+        {
+            var user = new User
+            {
+                Id = Guid.NewGuid(),
+                UserName = "test",
+                Email = "test@example.com",
+                IsSiteAdmin = isSiteAdmin,
+                MemberSince = DateTimeOffset.UtcNow.AddYears(-1),
+            };
+            db.Users.Add(user);
+            db.SaveChanges();
+            return user;
+        }
+
+        private UserRole AddGrant(Guid userId, int roleId,
+            DateTimeOffset? expiryDate = null, DateTimeOffset? revokedDate = null)
+        {
+            var grant = new UserRole
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                RoleId = roleId,
+                GrantedByUserId = userId,
+                GrantedDate = DateTimeOffset.UtcNow.AddDays(-1),
+                ExpiryDate = expiryDate,
+                RevokedDate = revokedDate,
+            };
+            db.UserRoles.Add(grant);
+            db.SaveChanges();
+            return grant;
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_ReturnsTrue_WhenActiveGrantExists()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SalesRepRoleId);
+
+            Assert.True(await sut.HasRoleAsync(user.Id, RoleNames.SalesRep));
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_ReturnsFalse_WhenGrantIsRevoked()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SalesRepRoleId, revokedDate: DateTimeOffset.UtcNow.AddHours(-1));
+
+            Assert.False(await sut.HasRoleAsync(user.Id, RoleNames.SalesRep));
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_ReturnsFalse_WhenGrantIsExpired()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SalesRepRoleId, expiryDate: DateTimeOffset.UtcNow.AddHours(-1));
+
+            Assert.False(await sut.HasRoleAsync(user.Id, RoleNames.SalesRep));
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_ReturnsTrue_WhenGrantHasFutureExpiry()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SalesRepRoleId, expiryDate: DateTimeOffset.UtcNow.AddDays(30));
+
+            Assert.True(await sut.HasRoleAsync(user.Id, RoleNames.SalesRep));
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_IsCaseInsensitive()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SalesRepRoleId);
+
+            Assert.True(await sut.HasRoleAsync(user.Id, "salesrep"));
+            Assert.True(await sut.HasRoleAsync(user.Id, "SALESREP"));
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_ReturnsFalse_ForEmptyRoleName()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SiteAdminRoleId);
+
+            Assert.False(await sut.HasRoleAsync(user.Id, ""));
+            Assert.False(await sut.HasRoleAsync(user.Id, null!));
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_CompatibilityBridge_HonoursLegacyIsSiteAdminBoolean()
+        {
+            // A user whose IsSiteAdmin=true but no UserRole row (e.g. a state
+            // during deploy where the backfill migration hasn't run yet)
+            // still authorizes as SiteAdmin.
+            var user = AddUser(isSiteAdmin: true);
+
+            Assert.True(await sut.HasRoleAsync(user.Id, RoleNames.SiteAdmin));
+        }
+
+        [Fact]
+        public async Task HasRoleAsync_CompatibilityBridge_DoesNotLeakToOtherRoles()
+        {
+            // The legacy boolean only grants SiteAdmin — it should not
+            // accidentally authorize SalesRep or any future role.
+            var user = AddUser(isSiteAdmin: true);
+
+            Assert.False(await sut.HasRoleAsync(user.Id, RoleNames.SalesRep));
+        }
+
+        [Fact]
+        public async Task GetRoleNamesAsync_ReturnsAllActiveGrants()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SiteAdminRoleId);
+            AddGrant(user.Id, SalesRepRoleId);
+
+            var names = await sut.GetRoleNamesAsync(user.Id);
+
+            Assert.Contains(RoleNames.SiteAdmin, names);
+            Assert.Contains(RoleNames.SalesRep, names);
+            Assert.Equal(2, names.Count);
+        }
+
+        [Fact]
+        public async Task GetRoleNamesAsync_ExcludesRevokedGrants()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SiteAdminRoleId);
+            AddGrant(user.Id, SalesRepRoleId, revokedDate: DateTimeOffset.UtcNow.AddHours(-1));
+
+            var names = await sut.GetRoleNamesAsync(user.Id);
+
+            Assert.Contains(RoleNames.SiteAdmin, names);
+            Assert.DoesNotContain(RoleNames.SalesRep, names);
+        }
+
+        [Fact]
+        public async Task GetUsersInRoleAsync_ReturnsGrantedUsersAndLegacyAdmins()
+        {
+            var granted = AddUser();
+            AddGrant(granted.Id, SiteAdminRoleId);
+            var legacyAdmin = AddUser(isSiteAdmin: true);
+            AddUser(); // control — should not appear
+
+            var users = await sut.GetUsersInRoleAsync(RoleNames.SiteAdmin);
+
+            var ids = System.Linq.Enumerable.ToHashSet(System.Linq.Enumerable.Select(users, u => u.Id));
+            Assert.Contains(granted.Id, ids);
+            Assert.Contains(legacyAdmin.Id, ids);
+            Assert.Equal(2, ids.Count);
+        }
+
+        [Fact]
+        public async Task GetUsersInRoleAsync_NonSiteAdminRole_DoesNotIncludeLegacyAdmins()
+        {
+            var granted = AddUser();
+            AddGrant(granted.Id, SalesRepRoleId);
+            AddUser(isSiteAdmin: true); // must not leak into SalesRep results
+
+            var users = await sut.GetUsersInRoleAsync(RoleNames.SalesRep);
+
+            Assert.Single(users);
+            Assert.Equal(granted.Id, System.Linq.Enumerable.Single(users).Id);
+        }
+
+        [Fact]
+        public async Task GetRoleNamesAsync_CachesPerRequest()
+        {
+            var user = AddUser();
+            AddGrant(user.Id, SalesRepRoleId);
+
+            // Prime the cache
+            _ = await sut.GetRoleNamesAsync(user.Id);
+
+            // Mutate the DB directly — cache should still return the original result
+            var grant = await db.UserRoles.FirstAsync();
+            grant.RevokedDate = DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync();
+
+            var second = await sut.GetRoleNamesAsync(user.Id);
+            Assert.Contains(RoleNames.SalesRep, second);
+
+            // A new service instance (representing a new request) sees the mutation.
+            var freshSut = new UserRoleService(db);
+            var third = await freshSut.GetRoleNamesAsync(user.Id);
+            Assert.DoesNotContain(RoleNames.SalesRep, third);
+        }
+
+        public void Dispose()
+        {
+            db.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/IUserRoleService.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IUserRoleService.cs
@@ -1,0 +1,46 @@
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Read-side accessor for a user's active role membership.
+    /// </summary>
+    /// <remarks>
+    /// Authorization handlers call <see cref="HasRoleAsync"/> instead of reading
+    /// <see cref="User.IsSiteAdmin"/> directly. Grants and revocations flow through
+    /// separate write endpoints; this service is read-only.
+    ///
+    /// A grant is considered active when its <c>RevokedDate</c> is null and
+    /// either <c>ExpiryDate</c> is null or in the future.
+    ///
+    /// During the Project 64 migration window, the implementation includes a
+    /// compatibility bridge: <c>HasRoleAsync(userId, "SiteAdmin")</c> returns
+    /// true if the user has an active <c>SiteAdmin</c> grant OR the legacy
+    /// <see cref="User.IsSiteAdmin"/> boolean is true. That bridge is removed
+    /// when the boolean column is dropped in Phase 4.
+    /// </remarks>
+    public interface IUserRoleService
+    {
+        /// <summary>
+        /// Returns true when the user has an active grant of the named role.
+        /// Role names are compared case-insensitively.
+        /// </summary>
+        Task<bool> HasRoleAsync(Guid userId, string roleName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns the names of every role the user is actively granted.
+        /// </summary>
+        Task<IReadOnlyCollection<string>> GetRoleNamesAsync(Guid userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns every user with an active grant of the named role. Used by
+        /// notification jobs (e.g. photo moderation) that need to fan out to
+        /// role members.
+        /// </summary>
+        Task<IReadOnlyCollection<User>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/RoleNames.cs
+++ b/TrashMob.Shared/Managers/RoleNames.cs
@@ -1,0 +1,23 @@
+namespace TrashMob.Shared.Managers
+{
+    /// <summary>
+    /// Canonical names for the roles seeded in the database. See the
+    /// <see cref="TrashMob.Models.Role"/> HasData block in
+    /// <see cref="Persistence.MobDbContext"/> for the seed rows themselves.
+    /// </summary>
+    public static class RoleNames
+    {
+        /// <summary>
+        /// Full administrative access. Manages users, roles, waivers, events,
+        /// moderation, and every other site-admin surface.
+        /// </summary>
+        public const string SiteAdmin = "SiteAdmin";
+
+        /// <summary>
+        /// Manages the municipal sales pipeline (prospects, contacts,
+        /// activities) and reads sales reports. Cannot administer users,
+        /// waivers, or events. See Project 63.
+        /// </summary>
+        public const string SalesRep = "SalesRep";
+    }
+}

--- a/TrashMob.Shared/Managers/UserRoleService.cs
+++ b/TrashMob.Shared/Managers/UserRoleService.cs
@@ -1,0 +1,115 @@
+namespace TrashMob.Shared.Managers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence;
+
+    /// <summary>
+    /// Read-side accessor for role membership. See <see cref="IUserRoleService"/>
+    /// for the contract, including the compatibility bridge that honours the
+    /// legacy <see cref="User.IsSiteAdmin"/> boolean.
+    /// </summary>
+    /// <remarks>
+    /// Registered as scoped, so the per-instance cache is effectively a
+    /// per-request cache. Concurrent grants / revocations take effect on the
+    /// caller's next request, not mid-request. Acceptable for a coarse-role
+    /// system.
+    /// </remarks>
+    public class UserRoleService(MobDbContext db) : IUserRoleService
+    {
+        private readonly Dictionary<Guid, HashSet<string>> cache = new();
+
+        /// <inheritdoc />
+        public async Task<bool> HasRoleAsync(Guid userId, string roleName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(roleName))
+            {
+                return false;
+            }
+
+            var roles = await GetRoleNamesAsync(userId, cancellationToken);
+            return roles.Contains(roleName);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<string>> GetRoleNamesAsync(Guid userId, CancellationToken cancellationToken = default)
+        {
+            if (cache.TryGetValue(userId, out var cached))
+            {
+                return cached;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+
+            var activeRoles = await db.UserRoles
+                .Where(ur => ur.UserId == userId
+                             && ur.RevokedDate == null
+                             && (ur.ExpiryDate == null || ur.ExpiryDate > now))
+                .Include(ur => ur.Role)
+                .Select(ur => ur.Role.Name)
+                .ToListAsync(cancellationToken);
+
+            var set = new HashSet<string>(activeRoles, StringComparer.OrdinalIgnoreCase);
+
+            // Compatibility bridge: during the Project 64 migration window,
+            // treat the legacy IsSiteAdmin boolean as an implicit SiteAdmin
+            // grant. The backfill migration also inserts real UserRole rows,
+            // so most reads never hit this fallback — but any user promoted
+            // to admin during a partial deploy (backfill pending) still
+            // authorizes correctly. Removed in Phase 4 when the boolean is
+            // dropped.
+            if (!set.Contains(RoleNames.SiteAdmin))
+            {
+                var isLegacyAdmin = await db.Users
+                    .Where(u => u.Id == userId)
+                    .Select(u => u.IsSiteAdmin)
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                if (isLegacyAdmin)
+                {
+                    set.Add(RoleNames.SiteAdmin);
+                }
+            }
+
+            cache[userId] = set;
+            return set;
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<User>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(roleName))
+            {
+                return Array.Empty<User>();
+            }
+
+            var now = DateTimeOffset.UtcNow;
+
+            var usersWithGrant = await db.UserRoles
+                .Where(ur => ur.Role.Name == roleName
+                             && ur.RevokedDate == null
+                             && (ur.ExpiryDate == null || ur.ExpiryDate > now))
+                .Select(ur => ur.User)
+                .ToListAsync(cancellationToken);
+
+            // Compatibility bridge: pull in anyone flagged as legacy SiteAdmin
+            // who hasn't yet been backfilled with a UserRole row.
+            if (roleName.Equals(RoleNames.SiteAdmin, StringComparison.OrdinalIgnoreCase))
+            {
+                var alreadyIncluded = usersWithGrant.Select(u => u.Id).ToHashSet();
+                var legacyAdmins = await db.Users
+                    .Where(u => u.IsSiteAdmin && !alreadyIncluded.Contains(u.Id))
+                    .ToListAsync(cancellationToken);
+                usersWithGrant.AddRange(legacyAdmins);
+            }
+
+            return usersWithGrant;
+        }
+    }
+}

--- a/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using TrashMob.Shared.Persistence;
 
 #nullable disable
 
-namespace TrashMob.Migrations
+namespace TrashMob.Shared.Migrations
 {
     [DbContext(typeof(MobDbContext))]
-    partial class MobDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703202044_AddRolesAndUserRoles")]
+    partial class AddRolesAndUserRoles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.cs
+++ b/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace TrashMob.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRolesAndUserRoles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Roles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(60)", maxLength: 60, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: true),
+                    DisplayOrder = table.Column<int>(type: "int", nullable: true),
+                    IsActive = table.Column<bool>(type: "bit", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Roles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserRoles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoleId = table.Column<int>(type: "int", nullable: false),
+                    GrantedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    GrantedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    ExpiryDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    RevokedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    RevokedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    RevokedReason = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastUpdatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LastUpdatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserRoles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserRoles_Role",
+                        column: x => x.RoleId,
+                        principalTable: "Roles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_UserRoles_User",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_UserRoles_User_CreatedBy",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_UserRoles_User_GrantedBy",
+                        column: x => x.GrantedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_UserRoles_User_LastUpdatedBy",
+                        column: x => x.LastUpdatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.InsertData(
+                table: "Roles",
+                columns: new[] { "Id", "Description", "DisplayOrder", "IsActive", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Full administrative access. Manages users, roles, waivers, events, moderation, and every other site-admin surface.", 1, true, "SiteAdmin" },
+                    { 2, "Manages the municipal sales pipeline (prospects, contacts, activities) and reads the sales reports. Cannot administer users, waivers, or events.", 2, true, "SalesRep" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Roles_Name",
+                table: "Roles",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRoles_CreatedByUserId",
+                table: "UserRoles",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRoles_GrantedByUserId",
+                table: "UserRoles",
+                column: "GrantedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRoles_LastUpdatedByUserId",
+                table: "UserRoles",
+                column: "LastUpdatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRoles_RoleId_Active",
+                table: "UserRoles",
+                column: "RoleId",
+                filter: "[RevokedDate] IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRoles_UserId_Active",
+                table: "UserRoles",
+                column: "UserId",
+                filter: "[RevokedDate] IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_UserRoles_Active",
+                table: "UserRoles",
+                columns: new[] { "UserId", "RoleId" },
+                unique: true,
+                filter: "[RevokedDate] IS NULL");
+
+            // Project 64 Phase 1 backfill: grant every existing IsSiteAdmin=true user
+            // the SiteAdmin role (id=1). GrantedByUserId points at the system user id
+            // used elsewhere for automated writes. Preserves current behavior; the
+            // compatibility bridge in IUserRoleService.HasRoleAsync also honours the
+            // legacy boolean, so no read path breaks between deploy and this backfill.
+            migrationBuilder.Sql(@"
+                DECLARE @SystemUserId UNIQUEIDENTIFIER = '00000000-0000-0000-0000-000000000001';
+                DECLARE @Now DATETIMEOFFSET = SYSDATETIMEOFFSET();
+
+                INSERT INTO UserRoles (Id, UserId, RoleId, GrantedByUserId, GrantedDate,
+                                       CreatedByUserId, CreatedDate,
+                                       LastUpdatedByUserId, LastUpdatedDate)
+                SELECT NEWID(), u.Id, 1, @SystemUserId, @Now,
+                       @SystemUserId, @Now,
+                       @SystemUserId, @Now
+                FROM Users u
+                WHERE u.IsSiteAdmin = 1
+                  AND NOT EXISTS (
+                    SELECT 1 FROM UserRoles ur
+                    WHERE ur.UserId = u.Id AND ur.RoleId = 1 AND ur.RevokedDate IS NULL
+                  );
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserRoles");
+
+            migrationBuilder.DropTable(
+                name: "Roles");
+        }
+    }
+}

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -9,8 +9,9 @@
     /// <summary>
     /// Provides the Entity Framework database context for the TrashMob application.
     /// </summary>
-    public class MobDbContext(IConfiguration configuration) : DbContext
+    public class MobDbContext(DbContextOptions<MobDbContext> options) : DbContext(options)
     {
+
 
         public virtual DbSet<ContactRequest> ContactRequests { get; set; }
 
@@ -156,6 +157,10 @@
 
         public virtual DbSet<UserAchievement> UserAchievements { get; set; }
 
+        public virtual DbSet<Role> Roles { get; set; }
+
+        public virtual DbSet<UserRole> UserRoles { get; set; }
+
         public virtual DbSet<EventPhoto> EventPhotos { get; set; }
 
         public virtual DbSet<CommunityProspect> CommunityProspects { get; set; }
@@ -192,14 +197,6 @@
 
         public virtual DbSet<ParentalConsent> ParentalConsents { get; set; }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer(configuration["TMDBServerConnectionString"], x =>
-            {
-                x.UseNetTopologySuite();
-                x.EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: TimeSpan.FromSeconds(30), errorNumbersToAdd: null);
-            });
-        }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -3344,6 +3341,95 @@
                     .HasForeignKey(d => d.LastUpdatedByUserId)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_UserAchievements_User_LastUpdatedBy");
+            });
+
+            modelBuilder.Entity<Role>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                entity.Property(e => e.Name)
+                    .IsRequired()
+                    .HasMaxLength(60);
+
+                entity.Property(e => e.Description)
+                    .HasMaxLength(300);
+
+                entity.HasIndex(e => e.Name)
+                    .IsUnique()
+                    .HasDatabaseName("IX_Roles_Name");
+
+                // Seed initial roles. New roles are added by follow-up migrations,
+                // never by user action from the UI. See Project 64.
+                entity.HasData(
+                    new Role
+                    {
+                        Id = 1,
+                        Name = "SiteAdmin",
+                        Description = "Full administrative access. Manages users, roles, waivers, events, moderation, and every other site-admin surface.",
+                        DisplayOrder = 1,
+                        IsActive = true,
+                    },
+                    new Role
+                    {
+                        Id = 2,
+                        Name = "SalesRep",
+                        Description = "Manages the municipal sales pipeline (prospects, contacts, activities) and reads the sales reports. Cannot administer users, waivers, or events.",
+                        DisplayOrder = 2,
+                        IsActive = true,
+                    });
+            });
+
+            modelBuilder.Entity<UserRole>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                entity.Property(e => e.RevokedReason)
+                    .HasMaxLength(500);
+
+                // Active-grant unique index (filtered on RevokedDate IS NULL) so a
+                // user can be granted the same role again after a prior revocation.
+                entity.HasIndex(e => new { e.UserId, e.RoleId })
+                    .IsUnique()
+                    .HasFilter("[RevokedDate] IS NULL")
+                    .HasDatabaseName("UX_UserRoles_Active");
+
+                entity.HasIndex(e => e.UserId)
+                    .HasFilter("[RevokedDate] IS NULL")
+                    .HasDatabaseName("IX_UserRoles_UserId_Active");
+
+                entity.HasIndex(e => e.RoleId)
+                    .HasFilter("[RevokedDate] IS NULL")
+                    .HasDatabaseName("IX_UserRoles_RoleId_Active");
+
+                entity.HasOne(d => d.User)
+                    .WithMany(p => p.UserRoles)
+                    .HasForeignKey(d => d.UserId)
+                    .OnDelete(DeleteBehavior.Restrict)
+                    .HasConstraintName("FK_UserRoles_User");
+
+                entity.HasOne(d => d.Role)
+                    .WithMany(p => p.UserRoles)
+                    .HasForeignKey(d => d.RoleId)
+                    .OnDelete(DeleteBehavior.Restrict)
+                    .HasConstraintName("FK_UserRoles_Role");
+
+                entity.HasOne<User>()
+                    .WithMany()
+                    .HasForeignKey(d => d.GrantedByUserId)
+                    .OnDelete(DeleteBehavior.Restrict)
+                    .HasConstraintName("FK_UserRoles_User_GrantedBy");
+
+                entity.HasOne(d => d.CreatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.CreatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_UserRoles_User_CreatedBy");
+
+                entity.HasOne(d => d.LastUpdatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.LastUpdatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_UserRoles_User_LastUpdatedBy");
             });
 
             modelBuilder.Entity<CommunityProspect>(entity =>

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -83,6 +83,7 @@
             services.AddScoped<IPartnerSocialMediaAccountManager, PartnerSocialMediaAccountManager>();
             services.AddScoped<IPickupLocationManager, PickupLocationManager>();
             services.AddScoped<IUserManager, UserManager>();
+            services.AddScoped<IUserRoleService, UserRoleService>();
             services.AddScoped<INonEventUserNotificationManager, NonEventUserNotificationManager>();
             services.AddScoped<IWaiverManager, WaiverManager>();
             services.AddScoped<ILitterImageManager, LitterImageManager>();

--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -248,7 +248,16 @@ public class Program
         builder.Services.Configure<GzipCompressionProviderOptions>(options =>
             options.Level = CompressionLevel.Fastest);
 
-        builder.Services.AddDbContext<MobDbContext>(c => c.UseLazyLoadingProxies());
+        builder.Services.AddDbContext<MobDbContext>((sp, options) =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            options.UseLazyLoadingProxies();
+            options.UseSqlServer(config["TMDBServerConnectionString"], x =>
+            {
+                x.UseNetTopologySuite();
+                x.EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: TimeSpan.FromSeconds(30), errorNumbersToAdd: null);
+            });
+        });
 
         // Security
         builder.Services.AddScoped<IAuthorizationHandler, UserOwnsEntityAuthHandler>();


### PR DESCRIPTION
## Summary

Delivers Phase 1 of [Project 64 (Roles & RBAC Refactor)](Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md): the Role + UserRole data model and a read-side service that Phase 2's authorization handlers will consume. **No behavior changes** — every existing \`IsSiteAdmin\` check keeps working unmodified.

Enables:
- Phase 2 to migrate the 6 auth handlers to consume the new service
- [Project 63](Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md) to eventually grant a scoped \`SalesRep\` role to the 1099 sales contractor

## Data model

- **\`Role\`** (LookupModel-based): int Id, unique Name, Description, DisplayOrder, IsActive
- **\`UserRole\`** (KeyedModel-based): grants a Role to a User with GrantedBy, GrantedDate, optional ExpiryDate, and soft-delete RevokedDate / RevokedByUserId / RevokedReason
- Unique index on \`(UserId, RoleId)\` filtered on \`RevokedDate IS NULL\` — so a role can be re-granted after prior revocation
- Migration \`AddRolesAndUserRoles\` seeds \`SiteAdmin\` (id=1) and \`SalesRep\` (id=2), and backfills a UserRole grant for every existing user with \`IsSiteAdmin=true\`

## Service surface

\`IUserRoleService\` is scoped, so the in-memory cache is effectively per-request.

- \`HasRoleAsync(userId, roleName, ct)\` — case-insensitive
- \`GetRoleNamesAsync(userId, ct)\` — currently-active role names
- \`GetUsersInRoleAsync(roleName, ct)\` — every user with an active grant

## Compatibility bridge

\`HasRoleAsync(userId, \"SiteAdmin\")\` returns true if the user has an active SiteAdmin grant **OR** \`User.IsSiteAdmin == true\`. Same for \`GetUsersInRoleAsync(\"SiteAdmin\")\`. This keeps existing authorization checks (still reading the boolean today) and the new service (used in Phase 2 handlers) both correct during the migration window. Bridge is removed in Phase 4 when the column is dropped.

## MobDbContext refactor (ancillary)

Consolidated to a single \`(DbContextOptions<MobDbContext>)\` primary constructor and moved SqlServer wiring into \`Program.cs\`'s \`AddDbContext\` lambda. Enables in-memory testing (the tests in this PR wouldn't work without it). Standard EF Core pattern; behaviour identical.

## Mobile confirmation

Zero \`IsSiteAdmin\` references in \`TrashMobMobile/\`. \`UserContext\` only has \`EmailAddress\` / \`IsLoggedOn\` / \`AccessToken\`. Mobile is volunteer-facing and needs no changes across any Project 64 phase.

## Test coverage

13 new tests + 1,115 pre-existing = **1,128 passing / 0 failed / 0 skipped**.

Tests cover: active grants, revoked grants, expired grants, future-expiry grants, case-insensitivity, null/empty role name, legacy bridge for SiteAdmin, legacy bridge does NOT leak to SalesRep, GetRoleNamesAsync completeness, GetRoleNamesAsync excludes revoked, GetUsersInRoleAsync merges granted+legacy for SiteAdmin, GetUsersInRoleAsync excludes legacy for non-SiteAdmin, per-request cache correctness.

## Test plan

- [ ] CI green
- [ ] Migration runs cleanly on dev (backfill grants SiteAdmin to the ~5 existing admins)
- [ ] Spot-check: sign in as a SiteAdmin, confirm every existing admin surface still authorizes
- [ ] Spot-check: DB inspection confirms the backfill wrote a UserRole row per legacy admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)