### PR TITLE
Project 64 Phase 2: migrate auth handlers to IUserRoleService, add SalesRep policy

### DIFF
--- a/TrashMob.Shared.Tests/Security/AuthHandlerTestHelper.cs
+++ b/TrashMob.Shared.Tests/Security/AuthHandlerTestHelper.cs
@@ -3,12 +3,40 @@ namespace TrashMob.Shared.Tests.Security
     using System;
     using System.Collections.Generic;
     using System.Security.Claims;
+    using System.Threading;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Moq;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers;
+    using TrashMob.Shared.Managers.Interfaces;
 
     public static class AuthHandlerTestHelper
     {
+        /// <summary>
+        /// Creates a mock <see cref="IUserRoleService"/> whose <c>HasRoleAsync</c> defaults to
+        /// <c>false</c>. Tests that need the caller to hold a role should call
+        /// <see cref="GrantSiteAdmin"/> (or add their own <c>Setup</c> on the returned mock).
+        /// </summary>
+        public static Mock<IUserRoleService> CreateUserRoleService()
+        {
+            var mock = new Mock<IUserRoleService>();
+            mock.Setup(s => s.HasRoleAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            return mock;
+        }
+
+        /// <summary>
+        /// Configures the given <paramref name="mock"/> so that <c>HasRoleAsync</c> returns
+        /// <c>true</c> when queried for the <c>SiteAdmin</c> role with the given
+        /// <paramref name="userId"/>.
+        /// </summary>
+        public static void GrantSiteAdmin(this Mock<IUserRoleService> mock, Guid userId)
+        {
+            mock.Setup(s => s.HasRoleAsync(userId, RoleNames.SiteAdmin, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+        }
+
         public static ClaimsPrincipal CreateClaimsPrincipal(string email)
         {
             var claims = new List<Claim> { new("email", email) };

--- a/TrashMob.Shared.Tests/Security/UserIsAdminAuthHandlerTest.cs
+++ b/TrashMob.Shared.Tests/Security/UserIsAdminAuthHandlerTest.cs
@@ -15,6 +15,7 @@ namespace TrashMob.Shared.Tests.Security
     public class UserIsAdminAuthHandlerTest
     {
         private readonly Mock<IUserManager> _mockUserManager;
+        private readonly Mock<IUserRoleService> _mockUserRoleService;
         private readonly Mock<ILogger<UserIsValidUserAuthHandler>> _mockLogger;
         private readonly UserIsAdminAuthHandler _sut;
         private readonly Mock<Microsoft.AspNetCore.Http.IHttpContextAccessor> _mockHttpContextAccessor;
@@ -22,11 +23,13 @@ namespace TrashMob.Shared.Tests.Security
         public UserIsAdminAuthHandlerTest()
         {
             _mockUserManager = new Mock<IUserManager>();
+            _mockUserRoleService = AuthHandlerTestHelper.CreateUserRoleService();
             _mockLogger = new Mock<ILogger<UserIsValidUserAuthHandler>>();
             _mockHttpContextAccessor = AuthHandlerTestHelper.CreateHttpContextAccessor();
             _sut = new UserIsAdminAuthHandler(
                 _mockHttpContextAccessor.Object,
                 _mockUserManager.Object,
+                _mockUserRoleService.Object,
                 _mockLogger.Object);
         }
 
@@ -36,6 +39,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(user.Id);
 
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");
             var requirement = new UserIsAdminRequirement();
@@ -84,6 +88,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithId(userId).WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(userId);
 
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");
             var requirement = new UserIsAdminRequirement();

--- a/TrashMob.Shared.Tests/Security/UserIsEventLeadOrIsAdminAuthHandlerTest.cs
+++ b/TrashMob.Shared.Tests/Security/UserIsEventLeadOrIsAdminAuthHandlerTest.cs
@@ -16,6 +16,7 @@ namespace TrashMob.Shared.Tests.Security
     {
         private readonly Mock<IUserManager> _mockUserManager;
         private readonly Mock<IEventAttendeeManager> _mockEventAttendeeManager;
+        private readonly Mock<IUserRoleService> _mockUserRoleService;
         private readonly Mock<ILogger<UserIsEventLeadOrIsAdminAuthHandler>> _mockLogger;
         private readonly UserIsEventLeadOrIsAdminAuthHandler _sut;
         private readonly Mock<Microsoft.AspNetCore.Http.IHttpContextAccessor> _mockHttpContextAccessor;
@@ -24,12 +25,14 @@ namespace TrashMob.Shared.Tests.Security
         {
             _mockUserManager = new Mock<IUserManager>();
             _mockEventAttendeeManager = new Mock<IEventAttendeeManager>();
+            _mockUserRoleService = AuthHandlerTestHelper.CreateUserRoleService();
             _mockLogger = new Mock<ILogger<UserIsEventLeadOrIsAdminAuthHandler>>();
             _mockHttpContextAccessor = AuthHandlerTestHelper.CreateHttpContextAccessor();
             _sut = new UserIsEventLeadOrIsAdminAuthHandler(
                 _mockHttpContextAccessor.Object,
                 _mockUserManager.Object,
                 _mockEventAttendeeManager.Object,
+                _mockUserRoleService.Object,
                 _mockLogger.Object);
         }
 
@@ -41,6 +44,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithId(userId).WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(userId);
 
             var resource = new Event { Id = Guid.NewGuid(), CreatedByUserId = otherUserId };
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");
@@ -143,6 +147,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithId(userId).WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(userId);
 
             var resource = new Event { Id = Guid.NewGuid(), CreatedByUserId = Guid.NewGuid() };
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");

--- a/TrashMob.Shared.Tests/Security/UserIsPartnerUserOrIsAdminAuthHandlerTest.cs
+++ b/TrashMob.Shared.Tests/Security/UserIsPartnerUserOrIsAdminAuthHandlerTest.cs
@@ -19,6 +19,7 @@ namespace TrashMob.Shared.Tests.Security
     {
         private readonly Mock<IUserManager> _mockUserManager;
         private readonly Mock<IBaseManager<PartnerAdmin>> _mockPartnerUserManager;
+        private readonly Mock<IUserRoleService> _mockUserRoleService;
         private readonly Mock<ILogger<UserIsValidUserAuthHandler>> _mockLogger;
         private readonly UserIsPartnerUserOrIsAdminAuthHandler _sut;
         private readonly Mock<Microsoft.AspNetCore.Http.IHttpContextAccessor> _mockHttpContextAccessor;
@@ -27,12 +28,14 @@ namespace TrashMob.Shared.Tests.Security
         {
             _mockUserManager = new Mock<IUserManager>();
             _mockPartnerUserManager = new Mock<IBaseManager<PartnerAdmin>>();
+            _mockUserRoleService = AuthHandlerTestHelper.CreateUserRoleService();
             _mockLogger = new Mock<ILogger<UserIsValidUserAuthHandler>>();
             _mockHttpContextAccessor = AuthHandlerTestHelper.CreateHttpContextAccessor();
             _sut = new UserIsPartnerUserOrIsAdminAuthHandler(
                 _mockHttpContextAccessor.Object,
                 _mockUserManager.Object,
                 _mockPartnerUserManager.Object,
+                _mockUserRoleService.Object,
                 _mockLogger.Object);
         }
 
@@ -42,6 +45,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(user.Id);
 
             var resource = new Partner { Id = Guid.NewGuid() };
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");
@@ -124,6 +128,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithId(userId).WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(userId);
 
             var resource = new Partner { Id = Guid.NewGuid() };
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");

--- a/TrashMob.Shared.Tests/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandlerTest.cs
+++ b/TrashMob.Shared.Tests/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandlerTest.cs
@@ -16,6 +16,7 @@ namespace TrashMob.Shared.Tests.Security
     {
         private readonly Mock<IUserManager> _mockUserManager;
         private readonly Mock<IProfessionalCompanyUserManager> _mockCompanyUserManager;
+        private readonly Mock<IUserRoleService> _mockUserRoleService;
         private readonly Mock<ILogger<UserIsProfessionalCompanyUserOrIsAdminAuthHandler>> _mockLogger;
         private readonly UserIsProfessionalCompanyUserOrIsAdminAuthHandler _sut;
         private readonly Mock<Microsoft.AspNetCore.Http.IHttpContextAccessor> _mockHttpContextAccessor;
@@ -24,12 +25,14 @@ namespace TrashMob.Shared.Tests.Security
         {
             _mockUserManager = new Mock<IUserManager>();
             _mockCompanyUserManager = new Mock<IProfessionalCompanyUserManager>();
+            _mockUserRoleService = AuthHandlerTestHelper.CreateUserRoleService();
             _mockLogger = new Mock<ILogger<UserIsProfessionalCompanyUserOrIsAdminAuthHandler>>();
             _mockHttpContextAccessor = AuthHandlerTestHelper.CreateHttpContextAccessor();
             _sut = new UserIsProfessionalCompanyUserOrIsAdminAuthHandler(
                 _mockHttpContextAccessor.Object,
                 _mockUserManager.Object,
                 _mockCompanyUserManager.Object,
+                _mockUserRoleService.Object,
                 _mockLogger.Object);
         }
 
@@ -39,6 +42,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(user.Id);
 
             var resource = new ProfessionalCompany { Id = Guid.NewGuid() };
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");
@@ -117,6 +121,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithId(userId).WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(userId);
 
             var resource = new ProfessionalCompany { Id = Guid.NewGuid() };
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");

--- a/TrashMob.Shared.Tests/Security/UserOwnsEntityOrIsAdminAuthHandlerTest.cs
+++ b/TrashMob.Shared.Tests/Security/UserOwnsEntityOrIsAdminAuthHandlerTest.cs
@@ -15,6 +15,7 @@ namespace TrashMob.Shared.Tests.Security
     public class UserOwnsEntityOrIsAdminAuthHandlerTest
     {
         private readonly Mock<IUserManager> _mockUserManager;
+        private readonly Mock<IUserRoleService> _mockUserRoleService;
         private readonly Mock<ILogger<UserIsValidUserAuthHandler>> _mockLogger;
         private readonly UserOwnsEntityOrIsAdminAuthHandler _sut;
         private readonly Mock<Microsoft.AspNetCore.Http.IHttpContextAccessor> _mockHttpContextAccessor;
@@ -22,11 +23,13 @@ namespace TrashMob.Shared.Tests.Security
         public UserOwnsEntityOrIsAdminAuthHandlerTest()
         {
             _mockUserManager = new Mock<IUserManager>();
+            _mockUserRoleService = AuthHandlerTestHelper.CreateUserRoleService();
             _mockLogger = new Mock<ILogger<UserIsValidUserAuthHandler>>();
             _mockHttpContextAccessor = AuthHandlerTestHelper.CreateHttpContextAccessor();
             _sut = new UserOwnsEntityOrIsAdminAuthHandler(
                 _mockHttpContextAccessor.Object,
                 _mockUserManager.Object,
+                _mockUserRoleService.Object,
                 _mockLogger.Object);
         }
 
@@ -56,6 +59,7 @@ namespace TrashMob.Shared.Tests.Security
             var user = new UserBuilder().WithId(userId).WithEmail("admin@test.com").AsSiteAdmin().Build();
             _mockUserManager.Setup(m => m.GetUserByEmailAsync("admin@test.com", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(user);
+            _mockUserRoleService.GrantSiteAdmin(userId);
 
             var resource = new Event { CreatedByUserId = otherUserId };
             var principal = AuthHandlerTestHelper.CreateClaimsPrincipal("admin@test.com");

--- a/TrashMob/Controllers/V2/CommunityProspectsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunityProspectsV2Controller.cs
@@ -28,7 +28,7 @@ namespace TrashMob.Controllers.V2
     [ApiVersion("2.0")]
     [EnableCors("_myAllowSpecificOrigins")]
     [Route("api/v{version:apiVersion}/community-prospects")]
-    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsSalesRepOrIsAdmin)]
     [RequiredScope(Constants.TrashMobWriteScope)]
     public class CommunityProspectsV2Controller(
         ICommunityProspectManager communityProspectManager,

--- a/TrashMob/Controllers/V2/ProspectContactsV2Controller.cs
+++ b/TrashMob/Controllers/V2/ProspectContactsV2Controller.cs
@@ -21,13 +21,13 @@ namespace TrashMob.Controllers.V2
 
     /// <summary>
     /// V2 controller for managing the contacts associated with a CommunityProspect (Project 60).
-    /// Admin-only — contacts are not exposed publicly.
+    /// Restricted to SalesRep and SiteAdmin roles — contacts are not exposed publicly.
     /// </summary>
     [ApiController]
     [ApiVersion("2.0")]
     [EnableCors("_myAllowSpecificOrigins")]
     [Route("api/v{version:apiVersion}/community-prospects/{prospectId}/contacts")]
-    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsSalesRepOrIsAdmin)]
     [RequiredScope(Constants.TrashMobWriteScope)]
     public class ProspectContactsV2Controller(
         ICommunityProspectManager prospectManager,

--- a/TrashMob/Controllers/V2/UsersV2Controller.cs
+++ b/TrashMob/Controllers/V2/UsersV2Controller.cs
@@ -26,11 +26,14 @@ namespace TrashMob.Controllers.V2
     /// <summary>
     /// V2 controller for users with server-side pagination and filtering.
     /// Returns PII-safe UserDto (no email, identity provider fields, or date of birth).
+    /// All endpoints require an authenticated user (Project 62 audit — no anonymous reads
+    /// of the user directory).
     /// </summary>
     [ApiController]
     [ApiVersion("2.0")]
     [EnableCors("_myAllowSpecificOrigins")]
     [Route("api/v{version:apiVersion}/users")]
+    [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
     public class UsersV2Controller(
         IUserManager userManager,
         IEventAttendeeMetricsManager metricsManager,

--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -180,7 +180,9 @@ public class Program
             .AddPolicy(AuthorizationPolicyConstants.UserIsEventLeadOrIsAdmin,
                 policy => policy.AddRequirements(new UserIsEventLeadOrIsAdminRequirement()))
             .AddPolicy(AuthorizationPolicyConstants.UserIsProfessionalCompanyUserOrIsAdmin,
-                policy => policy.AddRequirements(new UserIsProfessionalCompanyUserOrIsAdminRequirement()));
+                policy => policy.AddRequirements(new UserIsProfessionalCompanyUserOrIsAdminRequirement()))
+            .AddPolicy(AuthorizationPolicyConstants.UserIsSalesRepOrIsAdmin,
+                policy => policy.AddRequirements(new UserIsSalesRepOrIsAdminRequirement()));
 
         // In production, the React files will be served from this directory
         builder.Services.AddSpaStaticFiles(configuration => { configuration.RootPath = "client-app/build"; });
@@ -268,6 +270,7 @@ public class Program
         builder.Services.AddScoped<IAuthorizationHandler, UserIsEventLeadAuthHandler>();
         builder.Services.AddScoped<IAuthorizationHandler, UserIsEventLeadOrIsAdminAuthHandler>();
         builder.Services.AddScoped<IAuthorizationHandler, UserIsProfessionalCompanyUserOrIsAdminAuthHandler>();
+        builder.Services.AddScoped<IAuthorizationHandler, UserIsSalesRepOrIsAdminAuthHandler>();
 
         builder.Services.AddHttpClient("CiamGraph");
         builder.Services.AddSingleton<ICiamGraphService, CiamGraphService>();

--- a/TrashMob/Security/AuthorizationPolicyConstants.cs
+++ b/TrashMob/Security/AuthorizationPolicyConstants.cs
@@ -18,6 +18,13 @@
 
         public const string UserIsProfessionalCompanyUserOrIsAdmin = "UserIsProfessionalCompanyUserOrIsAdmin";
 
+        /// <summary>
+        /// Authorizes users with the SalesRep role (Project 63 — municipal sales
+        /// pipeline access) or the SiteAdmin role. Applied to the prospect and
+        /// sales-report v2 controllers.
+        /// </summary>
+        public const string UserIsSalesRepOrIsAdmin = "UserIsSalesRepOrIsAdmin";
+
         public const string IftttServiceKey = "IftttServiceKey";
     }
 }

--- a/TrashMob/Security/UserIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsAdminAuthHandler.cs
@@ -8,6 +8,7 @@
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
+    using TrashMob.Shared.Managers;
     using TrashMob.Shared.Managers.Interfaces;
 
     public class UserIsAdminAuthHandler : AuthorizationHandler<UserIsAdminRequirement>
@@ -15,12 +16,15 @@
         private readonly IHttpContextAccessor httpContext;
         private readonly ILogger<UserIsValidUserAuthHandler> logger;
         private readonly IUserManager userManager;
+        private readonly IUserRoleService userRoleService;
 
         public UserIsAdminAuthHandler(IHttpContextAccessor httpContext, IUserManager userManager,
+            IUserRoleService userRoleService,
             ILogger<UserIsValidUserAuthHandler> logger)
         {
             this.httpContext = httpContext;
             this.userManager = userManager;
+            this.userRoleService = userRoleService;
             this.logger = logger;
         }
 
@@ -48,7 +52,7 @@
                     httpContext.HttpContext.Items.Add("UserId", user.Id);
                 }
 
-                if (user.IsSiteAdmin)
+                if (await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, CancellationToken.None))
                 {
                     context.Succeed(requirement);
                 }

--- a/TrashMob/Security/UserIsEventLeadOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsEventLeadOrIsAdminAuthHandler.cs
@@ -9,6 +9,7 @@ namespace TrashMob.Security
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using TrashMob.Models;
+    using TrashMob.Shared.Managers;
     using TrashMob.Shared.Managers.Interfaces;
 
     /// <summary>
@@ -20,16 +21,19 @@ namespace TrashMob.Security
         private readonly ILogger<UserIsEventLeadOrIsAdminAuthHandler> logger;
         private readonly IUserManager userManager;
         private readonly IEventAttendeeManager eventAttendeeManager;
+        private readonly IUserRoleService userRoleService;
 
         public UserIsEventLeadOrIsAdminAuthHandler(
             IHttpContextAccessor httpContext,
             IUserManager userManager,
             IEventAttendeeManager eventAttendeeManager,
+            IUserRoleService userRoleService,
             ILogger<UserIsEventLeadOrIsAdminAuthHandler> logger)
         {
             this.httpContext = httpContext;
             this.userManager = userManager;
             this.eventAttendeeManager = eventAttendeeManager;
+            this.userRoleService = userRoleService;
             this.logger = logger;
         }
 
@@ -60,7 +64,7 @@ namespace TrashMob.Security
                 }
 
                 // Site admin can do anything
-                if (user.IsSiteAdmin)
+                if (await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, CancellationToken.None))
                 {
                     context.Succeed(requirement);
                     return;

--- a/TrashMob/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsProfessionalCompanyUserOrIsAdminAuthHandler.cs
@@ -9,6 +9,7 @@ namespace TrashMob.Security
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using TrashMob.Models;
+    using TrashMob.Shared.Managers;
     using TrashMob.Shared.Managers.Interfaces;
 
     public class
@@ -18,16 +19,19 @@ namespace TrashMob.Security
         private readonly ILogger<UserIsProfessionalCompanyUserOrIsAdminAuthHandler> logger;
         private readonly IProfessionalCompanyUserManager companyUserManager;
         private readonly IUserManager userManager;
+        private readonly IUserRoleService userRoleService;
 
         public UserIsProfessionalCompanyUserOrIsAdminAuthHandler(
             IHttpContextAccessor httpContext,
             IUserManager userManager,
             IProfessionalCompanyUserManager companyUserManager,
+            IUserRoleService userRoleService,
             ILogger<UserIsProfessionalCompanyUserOrIsAdminAuthHandler> logger)
         {
             this.httpContext = httpContext;
             this.userManager = userManager;
             this.companyUserManager = companyUserManager;
+            this.userRoleService = userRoleService;
             this.logger = logger;
         }
 
@@ -57,7 +61,7 @@ namespace TrashMob.Security
                     httpContext.HttpContext.Items.Add("UserId", user.Id);
                 }
 
-                if (user.IsSiteAdmin)
+                if (await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, CancellationToken.None))
                 {
                     context.Succeed(requirement);
                 }

--- a/TrashMob/Security/UserIsSalesRepOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserIsSalesRepOrIsAdminAuthHandler.cs
@@ -1,40 +1,42 @@
-﻿namespace TrashMob.Security
+namespace TrashMob.Security
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
-    using TrashMob.Models;
     using TrashMob.Shared.Managers;
     using TrashMob.Shared.Managers.Interfaces;
 
-    public class
-        UserIsPartnerUserOrIsAdminAuthHandler : AuthorizationHandler<UserIsPartnerUserOrIsAdminRequirement, Partner>
+    /// <summary>
+    /// Authorization handler for the <see cref="AuthorizationPolicyConstants.UserIsSalesRepOrIsAdmin"/>
+    /// policy. Succeeds when the calling user is granted the
+    /// <see cref="RoleNames.SalesRep"/> or <see cref="RoleNames.SiteAdmin"/> role.
+    /// </summary>
+    public class UserIsSalesRepOrIsAdminAuthHandler : AuthorizationHandler<UserIsSalesRepOrIsAdminRequirement>
     {
         private readonly IHttpContextAccessor httpContext;
-        private readonly ILogger<UserIsValidUserAuthHandler> logger;
-        private readonly IBaseManager<PartnerAdmin> partnerUserManager;
+        private readonly ILogger<UserIsSalesRepOrIsAdminAuthHandler> logger;
         private readonly IUserManager userManager;
         private readonly IUserRoleService userRoleService;
 
-        public UserIsPartnerUserOrIsAdminAuthHandler(IHttpContextAccessor httpContext, IUserManager userManager,
-            IBaseManager<PartnerAdmin> partnerUserManager, IUserRoleService userRoleService,
-            ILogger<UserIsValidUserAuthHandler> logger)
+        public UserIsSalesRepOrIsAdminAuthHandler(
+            IHttpContextAccessor httpContext,
+            IUserManager userManager,
+            IUserRoleService userRoleService,
+            ILogger<UserIsSalesRepOrIsAdminAuthHandler> logger)
         {
             this.httpContext = httpContext;
             this.userManager = userManager;
-            this.partnerUserManager = partnerUserManager;
             this.userRoleService = userRoleService;
             this.logger = logger;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
-            UserIsPartnerUserOrIsAdminRequirement requirement, Partner resource)
+            UserIsSalesRepOrIsAdminRequirement requirement)
         {
             try
             {
@@ -57,25 +59,15 @@
                     httpContext.HttpContext.Items.Add("UserId", user.Id);
                 }
 
-                if (await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, CancellationToken.None))
+                if (await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, CancellationToken.None)
+                    || await userRoleService.HasRoleAsync(user.Id, RoleNames.SalesRep, CancellationToken.None))
                 {
                     context.Succeed(requirement);
                 }
                 else
                 {
-                    var currentUserPartner =
-                        (await partnerUserManager.GetAsync(pu => pu.PartnerId == resource.Id && pu.UserId == user.Id,
-                            CancellationToken.None)).FirstOrDefault();
-
-                    if (currentUserPartner is not null)
-                    {
-                        context.Succeed(requirement);
-                    }
-                    else
-                    {
-                        AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
-                            { new(this, "User is not a partner user and is not a site admin.") });
-                    }
+                    AuthorizationFailure.Failed(new List<AuthorizationFailureReason>
+                        { new(this, "User is not a sales rep and is not a site admin.") });
                 }
             }
             catch (Exception ex)

--- a/TrashMob/Security/UserIsSalesRepOrIsAdminRequirement.cs
+++ b/TrashMob/Security/UserIsSalesRepOrIsAdminRequirement.cs
@@ -1,0 +1,13 @@
+namespace TrashMob.Security
+{
+    using Microsoft.AspNetCore.Authorization;
+
+    /// <summary>
+    /// Requirement for the <see cref="AuthorizationPolicyConstants.UserIsSalesRepOrIsAdmin"/>
+    /// policy. Satisfied when the caller has the SalesRep or SiteAdmin role
+    /// (see <see cref="TrashMob.Shared.Managers.RoleNames"/>).
+    /// </summary>
+    public class UserIsSalesRepOrIsAdminRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/TrashMob/Security/UserOwnsEntityOrIsAdminAuthHandler.cs
+++ b/TrashMob/Security/UserOwnsEntityOrIsAdminAuthHandler.cs
@@ -9,6 +9,7 @@
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
     using TrashMob.Models;
+    using TrashMob.Shared.Managers;
     using TrashMob.Shared.Managers.Interfaces;
 
     public class
@@ -17,12 +18,15 @@
         private readonly IHttpContextAccessor httpContext;
         private readonly ILogger<UserIsValidUserAuthHandler> logger;
         private readonly IUserManager userManager;
+        private readonly IUserRoleService userRoleService;
 
         public UserOwnsEntityOrIsAdminAuthHandler(IHttpContextAccessor httpContext, IUserManager userManager,
+            IUserRoleService userRoleService,
             ILogger<UserIsValidUserAuthHandler> logger)
         {
             this.httpContext = httpContext;
             this.userManager = userManager;
+            this.userRoleService = userRoleService;
             this.logger = logger;
         }
 
@@ -50,7 +54,8 @@
                     httpContext.HttpContext.Items.Add("UserId", user.Id);
                 }
 
-                if (user.Id == resource.CreatedByUserId || user.IsSiteAdmin)
+                if (user.Id == resource.CreatedByUserId
+                    || await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, CancellationToken.None))
                 {
                     context.Succeed(requirement);
                 }


### PR DESCRIPTION
## Summary

Second phase of the RBAC refactor ([Project 64](Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md)). Migrates every admin-checking authorization handler off the legacy `user.IsSiteAdmin` boolean and onto `IUserRoleService.HasRoleAsync(...)`. The compatibility bridge shipped in [Phase 1 (#3468)](https://github.com/TrashMob-eco/TrashMob/pull/3468) still honors legacy grants, so existing admins keep their access with no data migration required.

### Handler migrations
- `UserIsAdminAuthHandler`
- `UserOwnsEntityOrIsAdminAuthHandler`
- `UserIsEventLeadOrIsAdminAuthHandler`
- `UserIsPartnerUserOrIsAdminAuthHandler`
- `UserIsProfessionalCompanyUserOrIsAdminAuthHandler`

Each now takes `IUserRoleService` and replaces the direct `user.IsSiteAdmin` check with `await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, ct)`.

### New SalesRep policy
- `AuthorizationPolicyConstants.UserIsSalesRepOrIsAdmin`
- `UserIsSalesRepOrIsAdminRequirement` + `UserIsSalesRepOrIsAdminAuthHandler`
- Applied to `CommunityProspectsV2Controller` and `ProspectContactsV2Controller` (was `UserIsAdmin`)

This lets the 1099 municipal sales contractor (starting 2026-07-13) work the prospect CRM without holding site-admin rights.

### UsersV2Controller anon-read fix
Added class-level `[Authorize(Policy = ValidUser)]` — closes the anonymous-read leak flagged in the [Project 62 audit](Planning/Projects/Project_62_TrashMob_Site_and_Codebase_Reevaluation.md). All frontend callers already use `ApiService('protected')`, so no client changes needed.

### Test infrastructure
- `AuthHandlerTestHelper.CreateUserRoleService()` returns a default-`false` mock
- `.GrantSiteAdmin(userId)` extension configures per-test SiteAdmin grants
- 6 handler test files updated to inject the new dependency

## Test plan
- [x] `dotnet build TrashMob.sln` — clean, 0 warnings, 0 errors
- [x] `dotnet test TrashMob.Shared.Tests` — 1,128 passing / 0 failing
- [ ] Deploy to dev — verify existing SiteAdmin users still hit `/siteadmin/*` pages
- [ ] Grant `SalesRep` role to a test user via seeded data — verify prospect CRM access without site-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)