### PR TITLE
Project 64 Phase 4a: migrate IsSiteAdmin readers to IUserRoleService

### DIFF
--- a/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
@@ -19,6 +19,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
     public class UsersV2ControllerTests
     {
         private readonly Mock<IUserManager> userManager = new();
+        private readonly Mock<IUserRoleService> userRoleService = new();
         private readonly Mock<IEventAttendeeMetricsManager> metricsManager = new();
         private readonly Mock<IImageManager> imageManager = new();
         private readonly Mock<IUserDataExportManager> exportManager = new();
@@ -28,7 +29,7 @@ namespace TrashMob.Shared.Tests.Controllers.V2
 
         public UsersV2ControllerTests()
         {
-            controller = new UsersV2Controller(userManager.Object, metricsManager.Object, imageManager.Object, exportManager.Object, routeManager.Object, logger.Object);
+            controller = new UsersV2Controller(userManager.Object, userRoleService.Object, metricsManager.Object, imageManager.Object, exportManager.Object, routeManager.Object, logger.Object);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext(),
@@ -242,6 +243,47 @@ namespace TrashMob.Shared.Tests.Controllers.V2
             var result = await controller.GetUserImpact(userId, CancellationToken.None);
 
             Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteUser_ReturnsForbid_WhenCallerIsNotAdminAndNotSelf()
+        {
+            var callerId = Guid.NewGuid();
+            var targetId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = callerId.ToString();
+
+            userManager
+                .Setup(m => m.GetUserByInternalIdAsync(callerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = callerId, UserName = "caller" });
+            // Default userRoleService mock returns false for HasRoleAsync → not a SiteAdmin.
+
+            var result = await controller.DeleteUser(targetId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+            userManager.Verify(m => m.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task DeleteUser_ReturnsNoContent_WhenCallerHoldsSiteAdminRole()
+        {
+            var callerId = Guid.NewGuid();
+            var targetId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = callerId.ToString();
+
+            userManager
+                .Setup(m => m.GetUserByInternalIdAsync(callerId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = callerId, UserName = "admin" });
+            userRoleService
+                .Setup(s => s.HasRoleAsync(callerId, "SiteAdmin", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+            userManager
+                .Setup(m => m.DeleteAsync(targetId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var result = await controller.DeleteUser(targetId, CancellationToken.None);
+
+            Assert.IsType<NoContentResult>(result);
+            userManager.Verify(m => m.DeleteAsync(targetId, It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/TrashMob.Shared/Managers/PhotoModerationManager.cs
+++ b/TrashMob.Shared/Managers/PhotoModerationManager.cs
@@ -19,8 +19,10 @@ namespace TrashMob.Shared.Managers
     /// Manager for photo moderation operations.
     /// Handles moderation for LitterImage, TeamPhoto, EventPhoto, and PartnerPhoto entities.
     /// </summary>
-    public class PhotoModerationManager(MobDbContext dbContext, IEmailManager emailManager)
-        : IPhotoModerationManager
+    public class PhotoModerationManager(
+        MobDbContext dbContext,
+        IEmailManager emailManager,
+        IUserRoleService userRoleService) : IPhotoModerationManager
     {
         private const string LitterImageType = "LitterImage";
         private const string TeamPhotoType = "TeamPhoto";
@@ -560,12 +562,13 @@ namespace TrashMob.Shared.Managers
 
         private async Task SendPhotoFlaggedNotificationAsync(string photoType, Guid photoId, string reason, Guid flaggedByUserId, CancellationToken cancellationToken)
         {
-            // Get admins to notify
-            var admins = await dbContext.Users
-                .Where(u => u.IsSiteAdmin)
-                .ToListAsync(cancellationToken);
+            // Get admins to notify. Routes through IUserRoleService so admin
+            // membership is defined by the SiteAdmin role, not the legacy
+            // User.IsSiteAdmin boolean. The role service's compatibility bridge
+            // still folds any legacy-flag users in during the observation window.
+            var admins = await userRoleService.GetUsersInRoleAsync(RoleNames.SiteAdmin, cancellationToken);
 
-            if (!admins.Any())
+            if (admins.Count == 0)
             {
                 return;
             }

--- a/TrashMob/Controllers/V2/UsersV2Controller.cs
+++ b/TrashMob/Controllers/V2/UsersV2Controller.cs
@@ -20,6 +20,7 @@ namespace TrashMob.Controllers.V2
     using TrashMob.Security;
     using TrashMob.Shared;
     using TrashMob.Shared.Extensions;
+    using TrashMob.Shared.Managers;
     using TrashMob.Shared.Managers.Interfaces;
     using TrashMob.Shared.Poco;
 
@@ -36,6 +37,7 @@ namespace TrashMob.Controllers.V2
     [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
     public class UsersV2Controller(
         IUserManager userManager,
+        IUserRoleService userRoleService,
         IEventAttendeeMetricsManager metricsManager,
         IImageManager imageManager,
         IUserDataExportManager exportManager,
@@ -43,6 +45,9 @@ namespace TrashMob.Controllers.V2
         ILogger<UsersV2Controller> logger) : ControllerBase
     {
         private Guid UserId => Guid.TryParse(HttpContext.Items["UserId"]?.ToString(), out var parsedUserId) ? parsedUserId : Guid.Empty;
+
+        private Task<bool> IsCallerSiteAdminAsync(CancellationToken cancellationToken) =>
+            userRoleService.HasRoleAsync(UserId, RoleNames.SiteAdmin, cancellationToken);
 
         /// <summary>
         /// Gets a paginated list of users with optional filtering.
@@ -137,7 +142,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            if (userDto.Id != UserId && !currentUser.IsSiteAdmin)
+            if (userDto.Id != UserId && !await IsCallerSiteAdminAsync(cancellationToken))
             {
                 return Forbid();
             }
@@ -153,6 +158,8 @@ namespace TrashMob.Controllers.V2
                 }
 
                 user.ObjectId = currentUser.ObjectId;
+                // Preserve the legacy IsSiteAdmin boolean until Phase 4b drops the column.
+                // Actual admin membership is granted / revoked via /api/v2/users/{id}/roles.
                 user.IsSiteAdmin = currentUser.IsSiteAdmin;
                 user.CreatedByUserId = currentUser.CreatedByUserId;
                 user.CreatedDate = currentUser.CreatedDate;
@@ -351,7 +358,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            if (id != UserId && !currentUser.IsSiteAdmin)
+            if (id != UserId && !await IsCallerSiteAdminAsync(cancellationToken))
             {
                 return Forbid();
             }
@@ -403,7 +410,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            if (id != UserId && !currentUser.IsSiteAdmin)
+            if (id != UserId && !await IsCallerSiteAdminAsync(cancellationToken))
             {
                 return Forbid();
             }


### PR DESCRIPTION
## Summary

Fourth phase of the RBAC refactor ([Project 64](Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md)), split into two shippable slices so we can respect the plan's 30-day observation window before dropping the boolean column:

- **Phase 4a (this PR)** — sweep every production caller that reads `User.IsSiteAdmin` and route them through `IUserRoleService.HasRoleAsync` / `GetUsersInRoleAsync`. Additive. No behavior change: the column stays, the boolean stays, the fixture builder still sets it, and the Phase 1 compatibility bridge still folds any legacy-flag users into `SiteAdmin` role lookups.
- **Phase 4b (later PR, 30+ days after 4a stable)** — drop the column, remove the compatibility bridge, migrate the API DTO / fixture / seed data to grant the role instead.

The actual production surface was small once you exclude EF migration snapshot files and planning docs:

### Migrated production callers
- **`UsersV2Controller`** — the three "self or SiteAdmin" checks on `UpdateUser`, `ExportUserData`, and `DeleteUser` now call `HasRoleAsync(SiteAdmin)`. Added a compact `IsCallerSiteAdminAsync` helper to keep the call sites tight.
- **`PhotoModerationManager.SendPhotoFlaggedNotificationAsync`** — replaces the raw `dbContext.Users.Where(u => u.IsSiteAdmin)` LINQ query with `GetUsersInRoleAsync("SiteAdmin", ...)`. The compatibility bridge still folds in legacy-flag users, so the notification recipient list is unchanged during observation.

### Preserved intentionally
- `UsersV2Controller.UpdateUser` still preserves the persisted `IsSiteAdmin` boolean on the server-managed-fields copy. Dropping that path becomes safe in Phase 4b when the column goes.
- `UserManager` still initializes `IsSiteAdmin = false` on new users and preserves the existing value on update — same reasoning.
- `UserBuilder.AsSiteAdmin()` still sets the boolean on the fixture. Migrating fixtures to grant the role happens alongside dropping the column.

### Tests
- Two new tests in `UsersV2ControllerTests` cover the migrated `DeleteUser` path: SiteAdmin (via `HasRoleAsync`) allowed, non-admin forbidden. Existing tests confirm the mock's default `HasRoleAsync = false` matches the pre-migration behavior for non-admin callers.
- Full suite: **1,153 passing** (up from 1,151).

## Test plan
- [x] `dotnet build TrashMob.sln` — clean, 0 warnings, 0 errors
- [x] `dotnet test` — 1,153 passing / 0 failing
- [ ] Deploy to dev, verify existing SiteAdmin can still delete another user (path exercises `HasRoleAsync` + compat bridge)
- [ ] Photo flag on dev triggers admin notification email to existing site admins (compat bridge)
- [ ] Confirm no unexpected 403s in App Insights for `/api/v2/users/{id}` DELETE/PUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)