### PR TITLE
Project 63 Phase 2: weekly municipal sales pipeline report

### DIFF
--- a/TrashMob.Models/Poco/V2/WeeklySalesReportDto.cs
+++ b/TrashMob.Models/Poco/V2/WeeklySalesReportDto.cs
@@ -1,0 +1,91 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// One-payload weekly sales report (Project 63 Phase 2). Mirrors the layout
+    /// of Cynthia's Weekly Report spreadsheet — the salesperson consumes it on
+    /// <c>/siteadmin/prospects/reports/weekly</c>, and Phase 4 emails the same
+    /// shape to Cynthia and the Board.
+    /// </summary>
+    public class WeeklySalesReportDto
+    {
+        /// <summary>
+        /// First day of the reporting window (inclusive), typically Monday.
+        /// </summary>
+        public DateTimeOffset PeriodStart { get; set; }
+
+        /// <summary>
+        /// Last day of the reporting window (inclusive), typically Sunday.
+        /// </summary>
+        public DateTimeOffset PeriodEnd { get; set; }
+
+        /// <summary>
+        /// Count of <see cref="CommunityProspect"/> rows created in the window.
+        /// </summary>
+        public int ProspectsResearched { get; set; }
+
+        /// <summary>
+        /// Count of <see cref="ProspectContact"/> rows created in the window.
+        /// </summary>
+        public int NewContactsAdded { get; set; }
+
+        /// <summary>
+        /// <see cref="ProspectActivity"/> rows where <c>ActivityType</c> matches
+        /// <see cref="ProspectActivityTypeEnum.Outreach"/> (case-insensitive).
+        /// </summary>
+        public int OutreachTouches { get; set; }
+
+        /// <summary>
+        /// <see cref="ProspectActivity"/> rows matching
+        /// <see cref="ProspectActivityTypeEnum.FollowUp"/>.
+        /// </summary>
+        public int FollowUpTouches { get; set; }
+
+        /// <summary>
+        /// <see cref="ProspectActivity"/> rows matching
+        /// <see cref="ProspectActivityTypeEnum.ResponseReceived"/>.
+        /// </summary>
+        public int Responses { get; set; }
+
+        /// <summary>
+        /// <see cref="ProspectActivity"/> rows matching
+        /// <see cref="ProspectActivityTypeEnum.MeetingRequested"/>.
+        /// </summary>
+        public int MeetingsRequested { get; set; }
+
+        /// <summary>
+        /// <see cref="ProspectActivity"/> rows matching
+        /// <see cref="ProspectActivityTypeEnum.MeetingScheduled"/>.
+        /// </summary>
+        public int MeetingsScheduled { get; set; }
+
+        /// <summary>
+        /// <see cref="ProspectActivity"/> rows matching
+        /// <see cref="ProspectActivityTypeEnum.MeetingHeld"/>.
+        /// </summary>
+        public int MeetingsHeld { get; set; }
+
+        /// <summary>
+        /// De-duplicated key-objection snippets from prospects touched in the
+        /// window. Rendered under "Key Municipal Feedback" on the report.
+        /// </summary>
+        public List<string> KeyMunicipalFeedback { get; set; } = [];
+
+        /// <summary>
+        /// De-duplicated pricing-feedback snippets from prospects touched in
+        /// the window. Rendered under "Pricing / Business Model Feedback".
+        /// </summary>
+        public List<string> PricingFeedback { get; set; } = [];
+
+        /// <summary>
+        /// Free-text "Next Steps" section captured by the salesperson. Persisted
+        /// via the Phase 4 <see cref="SalesReport"/> entity; null on read until
+        /// Phase 4 ships.
+        /// </summary>
+        public string? NextSteps { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/WeeklySalesReportServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/WeeklySalesReportServiceTests.cs
@@ -1,0 +1,205 @@
+namespace TrashMob.Shared.Tests.Managers.Prospects
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Prospects;
+    using TrashMob.Shared.Persistence;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="WeeklySalesReportService"/> — the Project 63 Phase 2
+    /// aggregation. Covers window boundaries, activity-type case-insensitivity,
+    /// touched-prospect feedback fan-out, and the empty-window path.
+    /// </summary>
+    public class WeeklySalesReportServiceTests : IDisposable
+    {
+        private readonly MobDbContext db;
+        private readonly WeeklySalesReportService sut;
+        private readonly DateOnly weekEnding = new DateOnly(2026, 7, 12); // Sunday
+        private readonly DateTimeOffset windowStart = new DateTimeOffset(2026, 7, 6, 0, 0, 0, TimeSpan.Zero);
+        private readonly DateTimeOffset windowMid = new DateTimeOffset(2026, 7, 9, 12, 0, 0, TimeSpan.Zero);
+        private readonly DateTimeOffset windowEnd = new DateTimeOffset(2026, 7, 12, 23, 0, 0, TimeSpan.Zero);
+        private readonly DateTimeOffset outsideWindow = new DateTimeOffset(2026, 7, 5, 12, 0, 0, TimeSpan.Zero);
+
+        public WeeklySalesReportServiceTests()
+        {
+            var options = new DbContextOptionsBuilder<MobDbContext>()
+                .UseInMemoryDatabase(databaseName: $"WeeklySalesReport_{Guid.NewGuid()}")
+                .Options;
+            db = new MobDbContext(options);
+            sut = new WeeklySalesReportService(db);
+        }
+
+        private CommunityProspect AddProspect(
+            DateTimeOffset createdDate,
+            string keyObjection = null,
+            string pricingFeedback = null)
+        {
+            var prospect = new CommunityProspect
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test City",
+                CreatedDate = createdDate,
+                LastUpdatedDate = createdDate,
+                KeyObjection = keyObjection,
+                PricingFeedback = pricingFeedback,
+            };
+            db.CommunityProspects.Add(prospect);
+            db.SaveChanges();
+            return prospect;
+        }
+
+        private void AddActivity(Guid prospectId, string activityType, DateTimeOffset createdDate)
+        {
+            db.ProspectActivities.Add(new ProspectActivity
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospectId,
+                ActivityType = activityType,
+                Subject = "test",
+                CreatedDate = createdDate,
+                LastUpdatedDate = createdDate,
+            });
+            db.SaveChanges();
+        }
+
+        private void AddContact(Guid prospectId, DateTimeOffset createdDate)
+        {
+            db.ProspectContacts.Add(new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospectId,
+                Name = "Test Contact",
+                CreatedDate = createdDate,
+                LastUpdatedDate = createdDate,
+            });
+            db.SaveChanges();
+        }
+
+        [Fact]
+        public async Task Generate_EmptyDatabase_ReturnsZeroCounts()
+        {
+            var report = await sut.GenerateAsync(weekEnding);
+
+            Assert.Equal(0, report.ProspectsResearched);
+            Assert.Equal(0, report.NewContactsAdded);
+            Assert.Equal(0, report.OutreachTouches);
+            Assert.Equal(0, report.FollowUpTouches);
+            Assert.Equal(0, report.Responses);
+            Assert.Equal(0, report.MeetingsRequested);
+            Assert.Equal(0, report.MeetingsScheduled);
+            Assert.Equal(0, report.MeetingsHeld);
+            Assert.Empty(report.KeyMunicipalFeedback);
+            Assert.Empty(report.PricingFeedback);
+        }
+
+        [Fact]
+        public async Task Generate_CountsProspectsCreatedInWindow_ExcludesOutside()
+        {
+            AddProspect(windowMid);
+            AddProspect(windowStart);
+            AddProspect(windowEnd);
+            AddProspect(outsideWindow);
+
+            var report = await sut.GenerateAsync(weekEnding);
+
+            Assert.Equal(3, report.ProspectsResearched);
+        }
+
+        [Fact]
+        public async Task Generate_CountsContactsCreatedInWindow()
+        {
+            var prospect = AddProspect(outsideWindow);
+            AddContact(prospect.Id, windowMid);
+            AddContact(prospect.Id, windowStart);
+            AddContact(prospect.Id, outsideWindow);
+
+            var report = await sut.GenerateAsync(weekEnding);
+
+            Assert.Equal(2, report.NewContactsAdded);
+        }
+
+        [Fact]
+        public async Task Generate_ActivityTypeMatchesAreCaseInsensitive()
+        {
+            var prospect = AddProspect(outsideWindow);
+            AddActivity(prospect.Id, "Outreach", windowMid);
+            AddActivity(prospect.Id, "OUTREACH", windowMid);
+            AddActivity(prospect.Id, "outreach", windowMid);
+            AddActivity(prospect.Id, "outreach", outsideWindow); // outside window — ignored
+
+            var report = await sut.GenerateAsync(weekEnding);
+
+            Assert.Equal(3, report.OutreachTouches);
+        }
+
+        [Fact]
+        public async Task Generate_CountsEachActivityCategoryIndependently()
+        {
+            var prospect = AddProspect(outsideWindow);
+            AddActivity(prospect.Id, "Outreach", windowMid);
+            AddActivity(prospect.Id, "FollowUp", windowMid);
+            AddActivity(prospect.Id, "FollowUp", windowMid);
+            AddActivity(prospect.Id, "ResponseReceived", windowMid);
+            AddActivity(prospect.Id, "MeetingRequested", windowMid);
+            AddActivity(prospect.Id, "MeetingScheduled", windowMid);
+            AddActivity(prospect.Id, "MeetingHeld", windowMid);
+            AddActivity(prospect.Id, "EmailSent", windowMid); // legacy — unrecognised, not counted
+
+            var report = await sut.GenerateAsync(weekEnding);
+
+            Assert.Equal(1, report.OutreachTouches);
+            Assert.Equal(2, report.FollowUpTouches);
+            Assert.Equal(1, report.Responses);
+            Assert.Equal(1, report.MeetingsRequested);
+            Assert.Equal(1, report.MeetingsScheduled);
+            Assert.Equal(1, report.MeetingsHeld);
+        }
+
+        [Fact]
+        public async Task Generate_FeedbackAggregation_TouchedProspectsOnly_DedupedCaseInsensitive()
+        {
+            var touched = AddProspect(outsideWindow, keyObjection: "Budget cycle", pricingFeedback: "Prefer usage-based");
+            var alsoTouched = AddProspect(outsideWindow, keyObjection: "budget cycle", pricingFeedback: "Council review");
+            var untouched = AddProspect(outsideWindow, keyObjection: "Should not appear", pricingFeedback: "Should not appear");
+
+            AddActivity(touched.Id, "Outreach", windowMid);
+            AddActivity(alsoTouched.Id, "FollowUp", windowMid);
+            // untouched has no activity in the window
+
+            var report = await sut.GenerateAsync(weekEnding);
+
+            Assert.Single(report.KeyMunicipalFeedback); // "Budget cycle" and "budget cycle" dedup case-insensitively
+            Assert.Equal(2, report.PricingFeedback.Count); // "Prefer usage-based" and "Council review"
+            Assert.DoesNotContain("Should not appear", report.KeyMunicipalFeedback);
+            Assert.DoesNotContain("Should not appear", report.PricingFeedback);
+        }
+
+        [Fact]
+        public async Task Generate_WindowBoundaries_AreInclusive()
+        {
+            AddProspect(new DateTimeOffset(2026, 7, 6, 0, 0, 0, TimeSpan.Zero)); // start-of-window, inclusive
+            AddProspect(new DateTimeOffset(2026, 7, 12, 23, 59, 59, TimeSpan.Zero)); // end-of-window, inclusive
+            AddProspect(new DateTimeOffset(2026, 7, 5, 23, 59, 59, TimeSpan.Zero)); // one second before start — excluded
+
+            var report = await sut.GenerateAsync(weekEnding);
+
+            Assert.Equal(2, report.ProspectsResearched);
+            Assert.Equal(
+                new DateTimeOffset(2026, 7, 6, 0, 0, 0, TimeSpan.Zero),
+                report.PeriodStart);
+            // PeriodEnd is inclusive-end-of-day (23:59:59.999)
+            Assert.Equal(2026, report.PeriodEnd.Year);
+            Assert.Equal(7, report.PeriodEnd.Month);
+            Assert.Equal(12, report.PeriodEnd.Day);
+        }
+
+        public void Dispose()
+        {
+            db.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/IWeeklySalesReportService.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IWeeklySalesReportService.cs
@@ -1,0 +1,23 @@
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Aggregates a single week of municipal sales pipeline activity into the
+    /// <see cref="WeeklySalesReportDto"/> shape shown to the salesperson and
+    /// emailed to Cynthia + the Board (Project 63).
+    /// </summary>
+    public interface IWeeklySalesReportService
+    {
+        /// <summary>
+        /// Builds the weekly report for the seven-day window ending on
+        /// <paramref name="weekEnding"/> (inclusive). The window is
+        /// <c>weekEnding - 6 days</c> at 00:00 UTC through <c>weekEnding</c>
+        /// at 23:59:59.999 UTC.
+        /// </summary>
+        Task<WeeklySalesReportDto> GenerateAsync(DateOnly weekEnding, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/WeeklySalesReportService.cs
+++ b/TrashMob.Shared/Managers/Prospects/WeeklySalesReportService.cs
@@ -1,0 +1,105 @@
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence;
+
+    /// <summary>
+    /// EF-backed implementation of the weekly municipal sales pipeline report
+    /// (Project 63 Phase 2). All counts are computed in a single scoped DB pass.
+    /// </summary>
+    public class WeeklySalesReportService(MobDbContext db) : IWeeklySalesReportService
+    {
+        /// <inheritdoc />
+        public async Task<WeeklySalesReportDto> GenerateAsync(DateOnly weekEnding, CancellationToken cancellationToken = default)
+        {
+            var end = new DateTimeOffset(weekEnding.ToDateTime(new TimeOnly(23, 59, 59, 999)), TimeSpan.Zero);
+            var start = new DateTimeOffset(weekEnding.AddDays(-6).ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+
+            var prospectsResearched = await db.CommunityProspects
+                .Where(p => p.CreatedDate >= start && p.CreatedDate <= end)
+                .CountAsync(cancellationToken);
+
+            var newContactsAdded = await db.ProspectContacts
+                .Where(c => c.CreatedDate >= start && c.CreatedDate <= end)
+                .CountAsync(cancellationToken);
+
+            // Load activities for the window once — the same rows drive the
+            // counts, the touched-prospect fan-out, and the feedback aggregation.
+            var activities = await db.ProspectActivities
+                .Where(a => a.CreatedDate >= start && a.CreatedDate <= end)
+                .Select(a => new { a.ActivityType, a.ProspectId })
+                .ToListAsync(cancellationToken);
+
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var touchedProspectIds = new HashSet<Guid>();
+            foreach (var a in activities)
+            {
+                if (!string.IsNullOrWhiteSpace(a.ActivityType))
+                {
+                    counts.TryGetValue(a.ActivityType, out var current);
+                    counts[a.ActivityType] = current + 1;
+                }
+
+                touchedProspectIds.Add(a.ProspectId);
+            }
+
+            int CountOf(ProspectActivityTypeEnum type) =>
+                counts.TryGetValue(type.ToString(), out var n) ? n : 0;
+
+            var outreach = CountOf(ProspectActivityTypeEnum.Outreach);
+            var followUp = CountOf(ProspectActivityTypeEnum.FollowUp);
+            var responses = CountOf(ProspectActivityTypeEnum.ResponseReceived);
+            var meetingsRequested = CountOf(ProspectActivityTypeEnum.MeetingRequested);
+            var meetingsScheduled = CountOf(ProspectActivityTypeEnum.MeetingScheduled);
+            var meetingsHeld = CountOf(ProspectActivityTypeEnum.MeetingHeld);
+
+            var touchedIdList = touchedProspectIds.ToList();
+            var feedback = touchedIdList.Count == 0
+                ? []
+                : await db.CommunityProspects
+                    .Where(p => touchedIdList.Contains(p.Id))
+                    .Select(p => new { p.KeyObjection, p.PricingFeedback })
+                    .ToListAsync(cancellationToken);
+
+            var keyMunicipalFeedback = feedback
+                .Select(f => (f.KeyObjection ?? string.Empty).Trim())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(s => s)
+                .ToList();
+
+            var pricingFeedback = feedback
+                .Select(f => (f.PricingFeedback ?? string.Empty).Trim())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(s => s)
+                .ToList();
+
+            return new WeeklySalesReportDto
+            {
+                PeriodStart = start,
+                PeriodEnd = end,
+                ProspectsResearched = prospectsResearched,
+                NewContactsAdded = newContactsAdded,
+                OutreachTouches = outreach,
+                FollowUpTouches = followUp,
+                Responses = responses,
+                MeetingsRequested = meetingsRequested,
+                MeetingsScheduled = meetingsScheduled,
+                MeetingsHeld = meetingsHeld,
+                KeyMunicipalFeedback = keyMunicipalFeedback,
+                PricingFeedback = pricingFeedback,
+                NextSteps = null,
+            };
+        }
+
+    }
+}

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -172,6 +172,7 @@
             services.AddScoped<IPipelineAnalyticsManager, PipelineAnalyticsManager>();
             services.AddScoped<ISentimentAnalysisService, SentimentAnalysisService>();
             services.AddScoped<IProspectConversionManager, ProspectConversionManager>();
+            services.AddScoped<IWeeklySalesReportService, WeeklySalesReportService>();
 
             // Contact Management
             services.AddScoped<IContactManager, ContactManager>();

--- a/TrashMob/Controllers/V2/SalesReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/SalesReportsV2Controller.cs
@@ -1,0 +1,54 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for the municipal sales pipeline reports (Project 63).
+    /// Restricted to SalesRep and SiteAdmin roles.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/reports/sales")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsSalesRepOrIsAdmin)]
+    [RequiredScope(Constants.TrashMobWriteScope)]
+    public class SalesReportsV2Controller(
+        IWeeklySalesReportService weeklyReportService,
+        ILogger<SalesReportsV2Controller> logger) : ControllerBase
+    {
+        /// <summary>
+        /// Gets the weekly sales report for the seven-day window ending on
+        /// <paramref name="weekEnding"/>. Defaults to today when the parameter
+        /// is omitted.
+        /// </summary>
+        /// <param name="weekEnding">Last day of the week (inclusive) in
+        /// <c>yyyy-MM-dd</c> format.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the weekly report payload.</response>
+        [HttpGet("weekly")]
+        [ProducesResponseType(typeof(WeeklySalesReportDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetWeekly(
+            [FromQuery] DateOnly? weekEnding,
+            CancellationToken cancellationToken)
+        {
+            var effectiveWeekEnding = weekEnding ?? DateOnly.FromDateTime(DateTime.UtcNow);
+            logger.LogInformation("V2 GetWeeklySalesReport WeekEnding={WeekEnding}", effectiveWeekEnding);
+
+            var report = await weeklyReportService.GenerateAsync(effectiveWeekEnding, cancellationToken);
+            return Ok(report);
+        }
+    }
+}

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -419,6 +419,11 @@ const SiteAdminProspectImport = lazy(() =>
 const SiteAdminProspectAnalytics = lazy(() =>
     import('./pages/siteadmin/prospects/analytics').then((m) => ({ default: m.SiteAdminProspectAnalytics })),
 );
+const SiteAdminProspectWeeklyReport = lazy(() =>
+    import('./pages/siteadmin/prospects/reports/weekly').then((m) => ({
+        default: m.SiteAdminProspectWeeklyReport,
+    })),
+);
 const SiteAdminDocuments = lazy(() =>
     import('./pages/siteadmin/documents/page').then((m) => ({ default: m.SiteAdminDocuments })),
 );
@@ -745,6 +750,7 @@ const AppContent: FC = () => {
                                 <Route path='prospects/discovery' element={<SiteAdminProspectDiscovery />} />
                                 <Route path='prospects/import' element={<SiteAdminProspectImport />} />
                                 <Route path='prospects/analytics' element={<SiteAdminProspectAnalytics />} />
+                                <Route path='prospects/reports/weekly' element={<SiteAdminProspectWeeklyReport />} />
                                 <Route path='prospects/:prospectId' element={<SiteAdminProspectDetail />} />
                                 <Route path='prospects/:prospectId/edit' element={<SiteAdminProspectEdit />} />
                                 <Route path='contacts' element={<SiteAdminContacts />} />

--- a/TrashMob/client-app/src/components/prospects/pipeline-stage-badge.tsx
+++ b/TrashMob/client-app/src/components/prospects/pipeline-stage-badge.tsx
@@ -34,14 +34,22 @@ export const PROSPECT_PRIORITIES = [
     { value: 3, label: 'Low' },
 ] as const;
 
+/**
+ * Activity-type strings the Weekly Report categorizes (Project 63 Phase 2).
+ * Match `ProspectActivityTypeEnum` names on the backend — case-insensitive on
+ * read, but new activities should log with these exact strings.
+ *
+ * Legacy strings like `EmailSent` / `Reply` are still accepted on write (the
+ * ActivityType column is free-form), but they won't be counted in the weekly
+ * report categories.
+ */
 export const ACTIVITY_TYPES = [
-    'EmailSent',
-    'EmailOpened',
-    'EmailClicked',
-    'Reply',
-    'PhoneCallMade',
-    'PhoneCallReceived',
-    'StatusChange',
+    'Outreach',
+    'FollowUp',
+    'ResponseReceived',
+    'MeetingRequested',
+    'MeetingScheduled',
+    'MeetingHeld',
     'Note',
 ] as const;
 

--- a/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
@@ -30,6 +30,7 @@ import {
     Sparkles,
     TrendingUp,
     Shield,
+    CalendarClock,
 } from 'lucide-react';
 import { SidebarNav, NavGroup } from '@/components/ui/sidebar-nav';
 
@@ -56,6 +57,7 @@ const navGroups: NavGroup[] = [
             { name: 'Discovery', href: `${pathPrefix}/prospects/discovery`, icon: Search },
             { name: 'Import CSV', href: `${pathPrefix}/prospects/import`, icon: Upload },
             { name: 'Pipeline Analytics', href: `${pathPrefix}/prospects/analytics`, icon: BarChart3 },
+            { name: 'Weekly Report', href: `${pathPrefix}/prospects/reports/weekly`, icon: CalendarClock },
         ],
     },
     {

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/reports/weekly.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/reports/weekly.tsx
@@ -1,0 +1,229 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import moment, { type Moment } from 'moment';
+import { CalendarClock, ChevronLeft, ChevronRight, Download } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { GetWeeklySalesReport, type WeeklySalesReportDto } from '@/services/sales-reports';
+
+/**
+ * Weekly Municipal Sales Pipeline Report (Project 63 Phase 2).
+ *
+ * Renders the same numbers Cynthia tracks in her spreadsheet — auto-generated
+ * from the CRM so the salesperson never double-enters. Free-text "Next Steps"
+ * lands in Phase 4.
+ *
+ * Route: /siteadmin/prospects/reports/weekly
+ * SalesRep or SiteAdmin only.
+ */
+
+/** Weeks end on Sunday per Cynthia's spreadsheet convention. */
+function endOfSalesWeek(anchor: Moment): Moment {
+    return anchor.clone().endOf('isoWeek'); // isoWeek ends on Sunday
+}
+
+function toDateOnlyString(m: Moment): string {
+    return m.format('YYYY-MM-DD');
+}
+
+interface MetricCardProps {
+    label: string;
+    value: number | undefined;
+    hint?: string;
+}
+
+const MetricCard = ({ label, value, hint }: MetricCardProps) => (
+    <Card>
+        <CardHeader className='pb-1'>
+            <CardTitle className='text-sm font-medium text-muted-foreground'>{label}</CardTitle>
+        </CardHeader>
+        <CardContent>
+            <div className='text-2xl font-bold tabular-nums'>{value ?? '—'}</div>
+            {hint ? <p className='text-xs text-muted-foreground'>{hint}</p> : null}
+        </CardContent>
+    </Card>
+);
+
+const FEEDBACK_EMPTY = 'No feedback captured for this window.';
+
+function buildCsv(report: WeeklySalesReportDto): string {
+    const rows: string[][] = [
+        ['Metric', 'Value'],
+        ['Period start', report.periodStart],
+        ['Period end', report.periodEnd],
+        ['Prospects researched', String(report.prospectsResearched)],
+        ['New contacts added', String(report.newContactsAdded)],
+        ['Outreach touches', String(report.outreachTouches)],
+        ['Follow-up touches', String(report.followUpTouches)],
+        ['Responses', String(report.responses)],
+        ['Meetings requested', String(report.meetingsRequested)],
+        ['Meetings scheduled', String(report.meetingsScheduled)],
+        ['Meetings held', String(report.meetingsHeld)],
+        [],
+        ['Key Municipal Feedback'],
+        ...(report.keyMunicipalFeedback.length ? report.keyMunicipalFeedback.map((f) => [f]) : [[FEEDBACK_EMPTY]]),
+        [],
+        ['Pricing / Business Model Feedback'],
+        ...(report.pricingFeedback.length ? report.pricingFeedback.map((f) => [f]) : [[FEEDBACK_EMPTY]]),
+    ];
+
+    const escape = (cell: string) => {
+        // Wrap in quotes and double any embedded quotes so Excel round-trips cleanly.
+        const needsQuoting = /[,"\r\n]/.test(cell);
+        const escaped = cell.replace(/"/g, '""');
+        return needsQuoting ? `"${escaped}"` : escaped;
+    };
+
+    return rows.map((r) => r.map(escape).join(',')).join('\r\n');
+}
+
+function downloadCsv(report: WeeklySalesReportDto) {
+    const csv = buildCsv(report);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `weekly-sales-report-${report.periodEnd.substring(0, 10)}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+export const SiteAdminProspectWeeklyReport = () => {
+    const [weekEnding, setWeekEnding] = useState<Moment>(() => endOfSalesWeek(moment()));
+
+    const weekEndingStr = useMemo(() => toDateOnlyString(weekEnding), [weekEnding]);
+
+    const { data: report, isLoading } = useQuery({
+        queryKey: GetWeeklySalesReport({ weekEnding: weekEndingStr }).key,
+        queryFn: GetWeeklySalesReport({ weekEnding: weekEndingStr }).service,
+        select: (res) => res.data,
+    });
+
+    const isThisWeek = weekEnding.isSame(endOfSalesWeek(moment()), 'day');
+
+    return (
+        <div className='space-y-6'>
+            <Card>
+                <CardHeader className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
+                    <div>
+                        <CardTitle>Weekly Sales Report</CardTitle>
+                        <CardDescription>
+                            Week of {weekEnding.clone().startOf('isoWeek').format('MMM D')} –{' '}
+                            {weekEnding.format('MMM D, YYYY')}
+                        </CardDescription>
+                    </div>
+                    <div className='flex flex-wrap items-center gap-2'>
+                        <Button
+                            variant='outline'
+                            size='icon'
+                            onClick={() => setWeekEnding((w) => w.clone().subtract(7, 'days'))}
+                            aria-label='Previous week'
+                        >
+                            <ChevronLeft className='h-4 w-4' />
+                        </Button>
+                        <Input
+                            type='date'
+                            value={weekEndingStr}
+                            onChange={(e) => {
+                                const v = e.target.value;
+                                if (!v) return;
+                                setWeekEnding(endOfSalesWeek(moment(v, 'YYYY-MM-DD')));
+                            }}
+                            className='w-40'
+                        />
+                        <Button
+                            variant='outline'
+                            size='icon'
+                            onClick={() => setWeekEnding((w) => w.clone().add(7, 'days'))}
+                            disabled={isThisWeek}
+                            aria-label='Next week'
+                        >
+                            <ChevronRight className='h-4 w-4' />
+                        </Button>
+                        <Button
+                            variant='outline'
+                            size='sm'
+                            onClick={() => setWeekEnding(endOfSalesWeek(moment()))}
+                            disabled={isThisWeek}
+                        >
+                            <CalendarClock className='mr-1 h-4 w-4' />
+                            This week
+                        </Button>
+                        <Button
+                            variant='outline'
+                            size='sm'
+                            onClick={() => report && downloadCsv(report)}
+                            disabled={!report}
+                        >
+                            <Download className='mr-1 h-4 w-4' />
+                            Export CSV
+                        </Button>
+                    </div>
+                </CardHeader>
+            </Card>
+
+            {isLoading && !report ? (
+                <Card>
+                    <CardContent className='py-8 text-sm text-muted-foreground'>Loading report…</CardContent>
+                </Card>
+            ) : (
+                <>
+                    <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+                        <MetricCard label='Prospects researched' value={report?.prospectsResearched} />
+                        <MetricCard label='New contacts added' value={report?.newContactsAdded} />
+                        <MetricCard label='Outreach touches' value={report?.outreachTouches} />
+                        <MetricCard label='Follow-up touches' value={report?.followUpTouches} />
+                        <MetricCard label='Responses' value={report?.responses} />
+                        <MetricCard label='Meetings requested' value={report?.meetingsRequested} />
+                        <MetricCard label='Meetings scheduled' value={report?.meetingsScheduled} />
+                        <MetricCard label='Meetings held' value={report?.meetingsHeld} />
+                    </div>
+
+                    <div className='grid gap-4 md:grid-cols-2'>
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Key Municipal Feedback</CardTitle>
+                                <CardDescription>
+                                    Objections and questions captured on prospects touched this week.
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent>
+                                {(report?.keyMunicipalFeedback ?? []).length === 0 ? (
+                                    <p className='text-sm text-muted-foreground'>{FEEDBACK_EMPTY}</p>
+                                ) : (
+                                    <ul className='list-disc space-y-1 pl-5 text-sm'>
+                                        {report!.keyMunicipalFeedback.map((f) => (
+                                            <li key={f}>{f}</li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </CardContent>
+                        </Card>
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Pricing / Business Model Feedback</CardTitle>
+                                <CardDescription>
+                                    What the salesperson heard about budget, pricing, or procurement.
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent>
+                                {(report?.pricingFeedback ?? []).length === 0 ? (
+                                    <p className='text-sm text-muted-foreground'>{FEEDBACK_EMPTY}</p>
+                                ) : (
+                                    <ul className='list-disc space-y-1 pl-5 text-sm'>
+                                        {report!.pricingFeedback.map((f) => (
+                                            <li key={f}>{f}</li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </CardContent>
+                        </Card>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/services/sales-reports.ts
+++ b/TrashMob/client-app/src/services/sales-reports.ts
@@ -1,0 +1,33 @@
+import { ApiService } from '.';
+
+/**
+ * V2 API service factories for the municipal sales pipeline reports (Project 63).
+ * SalesRep and SiteAdmin roles can consume these; anonymous callers are rejected.
+ */
+
+export interface WeeklySalesReportDto {
+    periodStart: string;
+    periodEnd: string;
+    prospectsResearched: number;
+    newContactsAdded: number;
+    outreachTouches: number;
+    followUpTouches: number;
+    responses: number;
+    meetingsRequested: number;
+    meetingsScheduled: number;
+    meetingsHeld: number;
+    keyMunicipalFeedback: string[];
+    pricingFeedback: string[];
+    nextSteps: string | null;
+}
+
+export type GetWeeklySalesReport_Params = { weekEnding?: string };
+
+export const GetWeeklySalesReport = (params: GetWeeklySalesReport_Params = {}) => ({
+    key: ['/reports/sales/weekly', params.weekEnding ?? 'today'],
+    service: async () =>
+        ApiService('protected').fetchData<WeeklySalesReportDto>({
+            url: `/v2/reports/sales/weekly${params.weekEnding ? `?weekEnding=${params.weekEnding}` : ''}`,
+            method: 'get',
+        }),
+});


### PR DESCRIPTION
## Summary

Second phase of [Project 63 (Municipal Sales Pipeline Reporting)](Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md). Auto-generates Cynthia's Weekly Report from the CRM's prospect + activity + contact logs so the salesperson never double-enters.

### Backend
- **`WeeklySalesReportDto`** — 8 numeric metrics (`ProspectsResearched`, `NewContactsAdded`, `OutreachTouches`, `FollowUpTouches`, `Responses`, `MeetingsRequested`, `MeetingsScheduled`, `MeetingsHeld`) plus two de-duped feedback lists and a Phase 4 `NextSteps` placeholder
- **`IWeeklySalesReportService.GenerateAsync(weekEnding)`** — one-DB-pass aggregation over a Monday-Sunday (`isoWeek`) window with inclusive boundaries
- **`SalesReportsV2Controller`** (SalesRep or SiteAdmin only) exposes `GET /api/v2/reports/sales/weekly?weekEnding=YYYY-MM-DD`. Defaults to today when the parameter is omitted.
- Activity-type matching is case-insensitive against `ProspectActivityTypeEnum` names; legacy free-form strings (`EmailSent`, `Reply`) pass through cleanly but don't hit any counted category.
- **7 new unit tests** — empty DB, window boundaries, case-insensitive match, per-category counting, touched-prospect feedback fan-out. Suite: **1,160 passing**.

### Frontend
- **`/siteadmin/prospects/reports/weekly`** page:
  - Week picker (defaults to current `isoWeek`), prev / next arrows, "This week" reset
  - 8 metric cards laid out to match Cynthia's spreadsheet
  - Two-column **Key Municipal Feedback** and **Pricing Feedback** lists
  - **CSV export** button — client-side, Excel-safe quoting so the file round-trips
- `services/sales-reports.ts` factory
- **"Weekly Report"** nav item under the Prospects section
- `ACTIVITY_TYPES` updated to the enum-aligned categories (`Outreach`, `FollowUp`, `ResponseReceived`, `MeetingRequested`, `MeetingScheduled`, `MeetingHeld`, `Note`) so newly logged activities feed the report. Legacy activities from before this change won't be captured — the salesperson starts fresh 2026-07-13.

### Not in this PR (queued)
- **Phase 3** — Monthly Goals + Market Intelligence Notes
- **Phase 4** — Scheduled email delivery via `TrashMobHourlyJobs` + persisted `NextSteps` free-text

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 warnings, 0 errors
- [x] `dotnet test` — 1,160 passing / 0 failing
- [x] `npm run check` — 0 errors, 14 pre-existing warnings unchanged
- [x] `npm run build` — production build succeeds
- [ ] Deploy to dev, verify `/siteadmin/prospects/reports/weekly` renders for a SalesRep-role account
- [ ] Log a `MeetingRequested` activity on a real prospect, confirm the count shows on the current week's report within seconds
- [ ] Populate `KeyObjection` on two touched prospects with slightly different capitalizations — confirm they dedupe case-insensitively
- [ ] Click **Export CSV** and open in Excel — confirm the layout matches the on-screen grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)