### PR TITLE
Project 63 Phase 3: monthly sales report + market intelligence notes

### DIFF
--- a/TrashMob.Models/Enums.cs
+++ b/TrashMob.Models/Enums.cs
@@ -709,6 +709,54 @@ namespace TrashMob.Models
     }
 
     /// <summary>
+    /// Represents the 7 tracked metrics for the monthly municipal sales
+    /// pipeline report (Project 63 Phase 3). Numeric values map to
+    /// <c>SalesMonthlyTarget.Metric</c> rows.
+    /// </summary>
+    public enum SalesMetricEnum
+    {
+        /// <summary>
+        /// Count of prospects created in the month.
+        /// </summary>
+        ProspectsResearched = 1,
+
+        /// <summary>
+        /// Count of prospect contacts created in the month.
+        /// </summary>
+        NewContacts = 2,
+
+        /// <summary>
+        /// Count of <see cref="ProspectActivity"/> rows tagged
+        /// <see cref="ProspectActivityTypeEnum.Outreach"/> in the month.
+        /// </summary>
+        OutreachTouches = 3,
+
+        /// <summary>
+        /// Count of <see cref="ProspectActivity"/> rows tagged
+        /// <see cref="ProspectActivityTypeEnum.FollowUp"/> in the month.
+        /// </summary>
+        FollowUpTouches = 4,
+
+        /// <summary>
+        /// Count of <see cref="ProspectActivity"/> rows tagged
+        /// <see cref="ProspectActivityTypeEnum.ResponseReceived"/> in the month.
+        /// </summary>
+        Responses = 5,
+
+        /// <summary>
+        /// Count of <see cref="ProspectActivity"/> rows tagged
+        /// <see cref="ProspectActivityTypeEnum.MeetingRequested"/> in the month.
+        /// </summary>
+        MeetingsRequested = 6,
+
+        /// <summary>
+        /// Count of <see cref="ProspectActivity"/> rows tagged
+        /// <see cref="ProspectActivityTypeEnum.MeetingScheduled"/> in the month.
+        /// </summary>
+        MeetingsScheduled = 7,
+    }
+
+    /// <summary>
     /// Represents the status of a grant in the pipeline.
     /// </summary>
     public enum GrantStatusEnum

--- a/TrashMob.Models/Poco/V2/MonthlySalesReportDto.cs
+++ b/TrashMob.Models/Poco/V2/MonthlySalesReportDto.cs
@@ -1,0 +1,142 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Monthly municipal sales pipeline report (Project 63 Phase 3). Mirrors
+    /// the layout of Cynthia's Monthly Goals worksheet — the salesperson
+    /// consumes it on <c>/siteadmin/prospects/reports/monthly</c>.
+    /// </summary>
+    public class MonthlySalesReportDto
+    {
+        /// <summary>
+        /// First day of the reporting month (UTC).
+        /// </summary>
+        public DateTimeOffset PeriodStart { get; set; }
+
+        /// <summary>
+        /// Last day of the reporting month (UTC, end-of-day).
+        /// </summary>
+        public DateTimeOffset PeriodEnd { get; set; }
+
+        /// <summary>
+        /// One row per metric — target vs. actual with a color-coded status.
+        /// </summary>
+        public List<MonthlySalesMetricDto> Metrics { get; set; } = [];
+
+        /// <summary>
+        /// Best-responding departments derived from prospects with a
+        /// <c>ResponseReceived</c> activity in the month.
+        /// </summary>
+        public List<MarketIntelligenceCountDto> BestRespondingDepartments { get; set; } = [];
+
+        /// <summary>
+        /// Top objection / open-question snippets from prospects touched in
+        /// the month, ordered by frequency.
+        /// </summary>
+        public List<MarketIntelligenceCountDto> CommonObjections { get; set; } = [];
+
+        /// <summary>
+        /// Top pricing / business-model feedback snippets from prospects
+        /// touched in the month, ordered by frequency.
+        /// </summary>
+        public List<MarketIntelligenceCountDto> PricingFeedback { get; set; } = [];
+
+        /// <summary>
+        /// Free-text "Recommended next-month priority" section captured by
+        /// the salesperson. Persisted via the Phase 4 <c>SalesReport</c>
+        /// entity; null until Phase 4 ships.
+        /// </summary>
+        public string? NextMonthPriority { get; set; }
+    }
+
+    /// <summary>
+    /// Row on the monthly report — one tracked metric with its target,
+    /// actual, and a status label.
+    /// </summary>
+    public class MonthlySalesMetricDto
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="SalesMetricEnum"/> numeric value.
+        /// </summary>
+        public int Metric { get; set; }
+
+        /// <summary>
+        /// Gets or sets the machine-friendly metric name
+        /// (e.g. <c>OutreachTouches</c>).
+        /// </summary>
+        public string MetricName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the human-readable metric label
+        /// (e.g. <c>Outreach touches</c>).
+        /// </summary>
+        public string Label { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the numeric target for the month.
+        /// </summary>
+        public int Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets the observed actual for the month.
+        /// </summary>
+        public int Actual { get; set; }
+
+        /// <summary>
+        /// Gets or sets a status label: <c>Behind</c> (actual &lt; 70% of
+        /// target), <c>OnTrack</c> (70–110%), <c>Exceeded</c> (&gt; 110%).
+        /// When target = 0, status is <c>NoTarget</c>.
+        /// </summary>
+        public string Status { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// A single Market Intelligence Notes entry: a label plus the number of
+    /// prospects that expressed it.
+    /// </summary>
+    public class MarketIntelligenceCountDto
+    {
+        /// <summary>
+        /// Gets or sets the aggregated label (department, objection, or
+        /// pricing snippet).
+        /// </summary>
+        public string Label { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the number of prospects mentioning it.
+        /// </summary>
+        public int Count { get; set; }
+    }
+
+    /// <summary>
+    /// Request body for updating monthly targets. Any metric omitted is left
+    /// untouched.
+    /// </summary>
+    public class UpdateMonthlyTargetsRequest
+    {
+        /// <summary>
+        /// Gets or sets the per-metric target updates.
+        /// </summary>
+        public List<MonthlyTargetUpdateDto> Targets { get; set; } = [];
+    }
+
+    /// <summary>
+    /// One target row in an <see cref="UpdateMonthlyTargetsRequest"/>.
+    /// </summary>
+    public class MonthlyTargetUpdateDto
+    {
+        /// <summary>
+        /// Gets or sets the metric identifier (see <see cref="SalesMetricEnum"/>).
+        /// </summary>
+        public int Metric { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new target value.
+        /// </summary>
+        public int Target { get; set; }
+    }
+}

--- a/TrashMob.Models/SalesMonthlyTarget.cs
+++ b/TrashMob.Models/SalesMonthlyTarget.cs
@@ -1,0 +1,36 @@
+#nullable disable
+
+namespace TrashMob.Models
+{
+    using System;
+
+    /// <summary>
+    /// Per-month, per-metric target for the municipal sales pipeline
+    /// (Project 63 Phase 3). One row per <c>(Month, Metric)</c> pair;
+    /// the salesperson (or Cynthia) edits these via the Monthly Report screen.
+    /// </summary>
+    public class SalesMonthlyTarget : KeyedModel
+    {
+        /// <summary>
+        /// Gets or sets the first day of the reporting month (day = 1) in UTC.
+        /// Uses <see cref="DateTime"/> instead of <c>DateOnly</c> for cleaner
+        /// EF6-era mapping alongside the rest of the schema.
+        /// </summary>
+        public DateTime Month { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tracked metric (see <see cref="SalesMetricEnum"/>).
+        /// </summary>
+        public int Metric { get; set; }
+
+        /// <summary>
+        /// Gets or sets the numeric target the salesperson is aiming for.
+        /// </summary>
+        public int Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional free-text note (e.g. "revised after Q1 pipeline review").
+        /// </summary>
+        public string Notes { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/MonthlySalesReportServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/MonthlySalesReportServiceTests.cs
@@ -1,0 +1,268 @@
+namespace TrashMob.Shared.Tests.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Prospects;
+    using TrashMob.Shared.Persistence;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="MonthlySalesReportService"/> — Project 63 Phase 3.
+    /// Covers default-target fallback, override behavior, status thresholds,
+    /// market intelligence aggregation, and window boundaries.
+    /// </summary>
+    public class MonthlySalesReportServiceTests : IDisposable
+    {
+        private readonly MobDbContext db;
+        private readonly MonthlySalesReportService sut;
+        private readonly DateOnly reportMonth = new DateOnly(2026, 7, 15); // July 2026
+        private readonly DateTimeOffset inMonthEarly = new DateTimeOffset(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+        private readonly DateTimeOffset inMonthLate = new DateTimeOffset(2026, 7, 31, 23, 0, 0, TimeSpan.Zero);
+        private readonly DateTimeOffset outOfMonthBefore = new DateTimeOffset(2026, 6, 30, 23, 0, 0, TimeSpan.Zero);
+        private readonly DateTimeOffset outOfMonthAfter = new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public MonthlySalesReportServiceTests()
+        {
+            var options = new DbContextOptionsBuilder<MobDbContext>()
+                .UseInMemoryDatabase(databaseName: $"MonthlySalesReport_{Guid.NewGuid()}")
+                .Options;
+            db = new MobDbContext(options);
+            sut = new MonthlySalesReportService(db);
+        }
+
+        private CommunityProspect AddProspect(
+            DateTimeOffset createdDate,
+            string department = null,
+            string keyObjection = null,
+            string pricingFeedback = null)
+        {
+            var prospect = new CommunityProspect
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test City",
+                CreatedDate = createdDate,
+                LastUpdatedDate = createdDate,
+                Department = department,
+                KeyObjection = keyObjection,
+                PricingFeedback = pricingFeedback,
+            };
+            db.CommunityProspects.Add(prospect);
+            db.SaveChanges();
+            return prospect;
+        }
+
+        private void AddActivity(Guid prospectId, string activityType, DateTimeOffset createdDate)
+        {
+            db.ProspectActivities.Add(new ProspectActivity
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = prospectId,
+                ActivityType = activityType,
+                Subject = "test",
+                CreatedDate = createdDate,
+                LastUpdatedDate = createdDate,
+            });
+            db.SaveChanges();
+        }
+
+        [Fact]
+        public async Task Generate_EmptyDatabase_UsesDefaultTargets()
+        {
+            var report = await sut.GenerateAsync(reportMonth);
+
+            Assert.Equal(7, report.Metrics.Count);
+            Assert.Equal(20, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.ProspectsResearched).Target);
+            Assert.Equal(20, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.NewContacts).Target);
+            Assert.Equal(15, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.OutreachTouches).Target);
+            Assert.Equal(10, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.FollowUpTouches).Target);
+            Assert.Equal(3, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.Responses).Target);
+            Assert.Equal(2, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.MeetingsRequested).Target);
+            Assert.Equal(1, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.MeetingsScheduled).Target);
+        }
+
+        [Fact]
+        public async Task Generate_EmptyDatabase_AllMetricsShowZeroActualAndBehindStatus()
+        {
+            var report = await sut.GenerateAsync(reportMonth);
+
+            Assert.All(report.Metrics, m =>
+            {
+                Assert.Equal(0, m.Actual);
+                Assert.Equal("Behind", m.Status);
+            });
+        }
+
+        [Fact]
+        public async Task Generate_ProspectAndContactCounts_RespectMonthBoundaries()
+        {
+            AddProspect(inMonthEarly);
+            AddProspect(inMonthLate);
+            AddProspect(outOfMonthBefore);
+            AddProspect(outOfMonthAfter);
+            db.ProspectContacts.Add(new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = Guid.NewGuid(),
+                Name = "Contact",
+                CreatedDate = inMonthEarly,
+                LastUpdatedDate = inMonthEarly,
+            });
+            db.ProspectContacts.Add(new ProspectContact
+            {
+                Id = Guid.NewGuid(),
+                ProspectId = Guid.NewGuid(),
+                Name = "Contact",
+                CreatedDate = outOfMonthBefore,
+                LastUpdatedDate = outOfMonthBefore,
+            });
+            db.SaveChanges();
+
+            var report = await sut.GenerateAsync(reportMonth);
+
+            Assert.Equal(2, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.ProspectsResearched).Actual);
+            Assert.Equal(1, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.NewContacts).Actual);
+        }
+
+        [Fact]
+        public async Task Generate_ActivityCategoriesAreCountedIndependently()
+        {
+            var prospect = AddProspect(outOfMonthBefore);
+            AddActivity(prospect.Id, "Outreach", inMonthEarly);
+            AddActivity(prospect.Id, "Outreach", inMonthEarly);
+            AddActivity(prospect.Id, "FollowUp", inMonthEarly);
+            AddActivity(prospect.Id, "ResponseReceived", inMonthEarly);
+            AddActivity(prospect.Id, "MeetingRequested", inMonthEarly);
+            AddActivity(prospect.Id, "MeetingScheduled", inMonthEarly);
+            AddActivity(prospect.Id, "Outreach", outOfMonthAfter); // outside — ignored
+
+            var report = await sut.GenerateAsync(reportMonth);
+
+            Assert.Equal(2, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.OutreachTouches).Actual);
+            Assert.Equal(1, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.FollowUpTouches).Actual);
+            Assert.Equal(1, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.Responses).Actual);
+            Assert.Equal(1, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.MeetingsRequested).Actual);
+            Assert.Equal(1, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.MeetingsScheduled).Actual);
+        }
+
+        [Fact]
+        public async Task Generate_StatusThresholds_BehindOnTrackExceeded()
+        {
+            var prospect = AddProspect(outOfMonthBefore);
+            // Target 15 (OutreachTouches). Add 10 → 10/15 = 0.67 → Behind.
+            for (var i = 0; i < 10; i++)
+            {
+                AddActivity(prospect.Id, "Outreach", inMonthEarly);
+            }
+
+            // Target 10 (FollowUpTouches). Add 8 → 8/10 = 0.80 → OnTrack.
+            for (var i = 0; i < 8; i++)
+            {
+                AddActivity(prospect.Id, "FollowUp", inMonthEarly);
+            }
+
+            // Target 3 (Responses). Add 5 → 5/3 = 1.67 → Exceeded.
+            for (var i = 0; i < 5; i++)
+            {
+                AddActivity(prospect.Id, "ResponseReceived", inMonthEarly);
+            }
+
+            var report = await sut.GenerateAsync(reportMonth);
+
+            Assert.Equal("Behind", report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.OutreachTouches).Status);
+            Assert.Equal("OnTrack", report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.FollowUpTouches).Status);
+            Assert.Equal("Exceeded", report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.Responses).Status);
+        }
+
+        [Fact]
+        public async Task Generate_StoredTarget_OverridesDefault()
+        {
+            var actor = Guid.NewGuid();
+            await sut.UpdateTargetsAsync(reportMonth, new[]
+            {
+                new MonthlyTargetUpdateDto { Metric = (int)SalesMetricEnum.OutreachTouches, Target = 50 },
+            }, actor);
+
+            var report = await sut.GenerateAsync(reportMonth);
+
+            var row = report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.OutreachTouches);
+            Assert.Equal(50, row.Target);
+            // Other metrics still fall back to Cynthia's defaults.
+            Assert.Equal(20, report.Metrics.Single(m => m.Metric == (int)SalesMetricEnum.ProspectsResearched).Target);
+        }
+
+        [Fact]
+        public async Task UpdateTargets_IsIdempotent_ExistingRowsAreUpdatedNotDuplicated()
+        {
+            var actor = Guid.NewGuid();
+            await sut.UpdateTargetsAsync(reportMonth, new[]
+            {
+                new MonthlyTargetUpdateDto { Metric = (int)SalesMetricEnum.OutreachTouches, Target = 50 },
+            }, actor);
+            await sut.UpdateTargetsAsync(reportMonth, new[]
+            {
+                new MonthlyTargetUpdateDto { Metric = (int)SalesMetricEnum.OutreachTouches, Target = 60 },
+            }, actor);
+
+            var rows = await db.SalesMonthlyTargets
+                .Where(t => t.Metric == (int)SalesMetricEnum.OutreachTouches)
+                .ToListAsync();
+
+            Assert.Single(rows);
+            Assert.Equal(60, rows[0].Target);
+        }
+
+        [Fact]
+        public async Task Generate_MarketIntelligence_BestRespondingDepartmentsCountsOnlyRespondedProspects()
+        {
+            var responder = AddProspect(outOfMonthBefore, department: "Public Works");
+            var alsoResponder = AddProspect(outOfMonthBefore, department: "Public Works");
+            var justTouched = AddProspect(outOfMonthBefore, department: "Sustainability");
+            var noDepartment = AddProspect(outOfMonthBefore, department: null);
+
+            AddActivity(responder.Id, "ResponseReceived", inMonthEarly);
+            AddActivity(alsoResponder.Id, "ResponseReceived", inMonthEarly);
+            AddActivity(justTouched.Id, "Outreach", inMonthEarly); // touched but did not respond
+            AddActivity(noDepartment.Id, "ResponseReceived", inMonthEarly);
+
+            var report = await sut.GenerateAsync(reportMonth);
+
+            Assert.Single(report.BestRespondingDepartments);
+            var pw = report.BestRespondingDepartments.First();
+            Assert.Equal("Public Works", pw.Label);
+            Assert.Equal(2, pw.Count);
+        }
+
+        [Fact]
+        public async Task Generate_MarketIntelligence_ObjectionsAndPricingAreDedupedAndOrdered()
+        {
+            var p1 = AddProspect(outOfMonthBefore, keyObjection: "Budget cycle", pricingFeedback: "Prefer usage-based");
+            var p2 = AddProspect(outOfMonthBefore, keyObjection: "budget cycle", pricingFeedback: "Council review");
+            var p3 = AddProspect(outOfMonthBefore, keyObjection: "Waivers concern", pricingFeedback: "Prefer usage-based");
+            AddActivity(p1.Id, "Outreach", inMonthEarly);
+            AddActivity(p2.Id, "Outreach", inMonthEarly);
+            AddActivity(p3.Id, "Outreach", inMonthEarly);
+
+            var report = await sut.GenerateAsync(reportMonth);
+
+            Assert.Equal(2, report.CommonObjections.Count); // "Budget cycle" and "Waivers concern"
+            Assert.Equal("Budget cycle", report.CommonObjections[0].Label);
+            Assert.Equal(2, report.CommonObjections[0].Count);
+            Assert.Equal(1, report.CommonObjections[1].Count);
+
+            Assert.Equal(2, report.PricingFeedback.Count);
+            Assert.Equal("Prefer usage-based", report.PricingFeedback[0].Label);
+            Assert.Equal(2, report.PricingFeedback[0].Count);
+        }
+
+        public void Dispose()
+        {
+            db.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/IMonthlySalesReportService.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IMonthlySalesReportService.cs
@@ -1,0 +1,35 @@
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// Aggregates a single calendar month of municipal sales pipeline activity
+    /// against configurable per-metric targets, and layers on Market Intelligence
+    /// Notes (best-responding departments, common objections, pricing feedback)
+    /// derived from the same window (Project 63 Phase 3).
+    /// </summary>
+    public interface IMonthlySalesReportService
+    {
+        /// <summary>
+        /// Builds the monthly report for the calendar month containing
+        /// <paramref name="anyDateInMonth"/>. Targets fall back to Cynthia's
+        /// baseline (20 / 20 / 15 / 10 / 3 / 2 / 1) when no <c>SalesMonthlyTarget</c>
+        /// row exists yet for the month.
+        /// </summary>
+        Task<MonthlySalesReportDto> GenerateAsync(DateOnly anyDateInMonth, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Upserts targets for the given month. Any metric omitted from
+        /// <paramref name="targets"/> is left untouched.
+        /// </summary>
+        Task UpdateTargetsAsync(
+            DateOnly month,
+            IReadOnlyCollection<MonthlyTargetUpdateDto> targets,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/MonthlySalesReportService.cs
+++ b/TrashMob.Shared/Managers/Prospects/MonthlySalesReportService.cs
@@ -1,0 +1,250 @@
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence;
+
+    /// <summary>
+    /// EF-backed implementation of the Monthly Municipal Sales Pipeline Report
+    /// (Project 63 Phase 3). One DB pass for the base metrics, one for market
+    /// intelligence aggregation.
+    /// </summary>
+    public class MonthlySalesReportService(MobDbContext db) : IMonthlySalesReportService
+    {
+        /// <summary>
+        /// Cynthia's baseline targets per Project 63 (20 / 20 / 15 / 10 / 3 / 2 / 1).
+        /// Used as fallback when the salesperson has not yet edited targets
+        /// for the month.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<SalesMetricEnum, int> DefaultTargets = new Dictionary<SalesMetricEnum, int>
+        {
+            [SalesMetricEnum.ProspectsResearched] = 20,
+            [SalesMetricEnum.NewContacts] = 20,
+            [SalesMetricEnum.OutreachTouches] = 15,
+            [SalesMetricEnum.FollowUpTouches] = 10,
+            [SalesMetricEnum.Responses] = 3,
+            [SalesMetricEnum.MeetingsRequested] = 2,
+            [SalesMetricEnum.MeetingsScheduled] = 1,
+        };
+
+        private static readonly IReadOnlyDictionary<SalesMetricEnum, string> MetricLabels = new Dictionary<SalesMetricEnum, string>
+        {
+            [SalesMetricEnum.ProspectsResearched] = "Prospects researched",
+            [SalesMetricEnum.NewContacts] = "New contacts added",
+            [SalesMetricEnum.OutreachTouches] = "Outreach touches",
+            [SalesMetricEnum.FollowUpTouches] = "Follow-up touches",
+            [SalesMetricEnum.Responses] = "Responses",
+            [SalesMetricEnum.MeetingsRequested] = "Meetings requested",
+            [SalesMetricEnum.MeetingsScheduled] = "Meetings scheduled",
+        };
+
+        /// <inheritdoc />
+        public async Task<MonthlySalesReportDto> GenerateAsync(DateOnly anyDateInMonth, CancellationToken cancellationToken = default)
+        {
+            var monthStart = new DateOnly(anyDateInMonth.Year, anyDateInMonth.Month, 1);
+            var monthStartUtc = new DateTimeOffset(monthStart.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+            var nextMonthUtc = monthStartUtc.AddMonths(1);
+            var monthEndUtc = nextMonthUtc.AddTicks(-1);
+
+            var prospectsResearched = await db.CommunityProspects
+                .Where(p => p.CreatedDate >= monthStartUtc && p.CreatedDate < nextMonthUtc)
+                .CountAsync(cancellationToken);
+
+            var newContacts = await db.ProspectContacts
+                .Where(c => c.CreatedDate >= monthStartUtc && c.CreatedDate < nextMonthUtc)
+                .CountAsync(cancellationToken);
+
+            var activities = await db.ProspectActivities
+                .Where(a => a.CreatedDate >= monthStartUtc && a.CreatedDate < nextMonthUtc)
+                .Select(a => new { a.ActivityType, a.ProspectId })
+                .ToListAsync(cancellationToken);
+
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var respondedProspectIds = new HashSet<Guid>();
+            var touchedProspectIds = new HashSet<Guid>();
+            foreach (var a in activities)
+            {
+                touchedProspectIds.Add(a.ProspectId);
+                if (string.IsNullOrWhiteSpace(a.ActivityType))
+                {
+                    continue;
+                }
+
+                counts.TryGetValue(a.ActivityType, out var current);
+                counts[a.ActivityType] = current + 1;
+
+                if (string.Equals(a.ActivityType, ProspectActivityTypeEnum.ResponseReceived.ToString(), StringComparison.OrdinalIgnoreCase))
+                {
+                    respondedProspectIds.Add(a.ProspectId);
+                }
+            }
+
+            int CountOf(ProspectActivityTypeEnum type) =>
+                counts.TryGetValue(type.ToString(), out var n) ? n : 0;
+
+            var actuals = new Dictionary<SalesMetricEnum, int>
+            {
+                [SalesMetricEnum.ProspectsResearched] = prospectsResearched,
+                [SalesMetricEnum.NewContacts] = newContacts,
+                [SalesMetricEnum.OutreachTouches] = CountOf(ProspectActivityTypeEnum.Outreach),
+                [SalesMetricEnum.FollowUpTouches] = CountOf(ProspectActivityTypeEnum.FollowUp),
+                [SalesMetricEnum.Responses] = CountOf(ProspectActivityTypeEnum.ResponseReceived),
+                [SalesMetricEnum.MeetingsRequested] = CountOf(ProspectActivityTypeEnum.MeetingRequested),
+                [SalesMetricEnum.MeetingsScheduled] = CountOf(ProspectActivityTypeEnum.MeetingScheduled),
+            };
+
+            var storedTargets = await db.SalesMonthlyTargets
+                .Where(t => t.Month == monthStart.ToDateTime(TimeOnly.MinValue))
+                .Select(t => new { t.Metric, t.Target })
+                .ToListAsync(cancellationToken);
+
+            var targetLookup = storedTargets.ToDictionary(t => (SalesMetricEnum)t.Metric, t => t.Target);
+
+            var metricRows = new List<MonthlySalesMetricDto>();
+            foreach (var metric in DefaultTargets.Keys)
+            {
+                var target = targetLookup.TryGetValue(metric, out var stored) ? stored : DefaultTargets[metric];
+                var actual = actuals.TryGetValue(metric, out var a) ? a : 0;
+                metricRows.Add(new MonthlySalesMetricDto
+                {
+                    Metric = (int)metric,
+                    MetricName = metric.ToString(),
+                    Label = MetricLabels[metric],
+                    Target = target,
+                    Actual = actual,
+                    Status = ComputeStatus(target, actual),
+                });
+            }
+
+            // Market intelligence: pull the touched-prospect universe once and
+            // derive the three top-N breakdowns from the same rows.
+            var touchedIdList = touchedProspectIds.ToList();
+            var respondedIdList = respondedProspectIds.ToList();
+
+            var touchedProspects = touchedIdList.Count == 0
+                ? []
+                : await db.CommunityProspects
+                    .Where(p => touchedIdList.Contains(p.Id))
+                    .Select(p => new { p.Id, p.Department, p.KeyObjection, p.PricingFeedback })
+                    .ToListAsync(cancellationToken);
+
+            var bestRespondingDepartments = touchedProspects
+                .Where(p => respondedIdList.Contains(p.Id))
+                .Select(p => (p.Department ?? string.Empty).Trim())
+                .Where(d => !string.IsNullOrWhiteSpace(d))
+                .GroupBy(d => d, StringComparer.OrdinalIgnoreCase)
+                .Select(g => new MarketIntelligenceCountDto { Label = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ThenBy(x => x.Label)
+                .Take(5)
+                .ToList();
+
+            var commonObjections = touchedProspects
+                .Select(p => (p.KeyObjection ?? string.Empty).Trim())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .GroupBy(s => s, StringComparer.OrdinalIgnoreCase)
+                .Select(g => new MarketIntelligenceCountDto { Label = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ThenBy(x => x.Label)
+                .Take(5)
+                .ToList();
+
+            var pricingFeedback = touchedProspects
+                .Select(p => (p.PricingFeedback ?? string.Empty).Trim())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .GroupBy(s => s, StringComparer.OrdinalIgnoreCase)
+                .Select(g => new MarketIntelligenceCountDto { Label = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ThenBy(x => x.Label)
+                .Take(5)
+                .ToList();
+
+            return new MonthlySalesReportDto
+            {
+                PeriodStart = monthStartUtc,
+                PeriodEnd = monthEndUtc,
+                Metrics = metricRows,
+                BestRespondingDepartments = bestRespondingDepartments,
+                CommonObjections = commonObjections,
+                PricingFeedback = pricingFeedback,
+                NextMonthPriority = null,
+            };
+        }
+
+        /// <inheritdoc />
+        public async Task UpdateTargetsAsync(
+            DateOnly month,
+            IReadOnlyCollection<MonthlyTargetUpdateDto> targets,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default)
+        {
+            if (targets == null || targets.Count == 0)
+            {
+                return;
+            }
+
+            var monthStart = new DateOnly(month.Year, month.Month, 1);
+            var monthDateTime = monthStart.ToDateTime(TimeOnly.MinValue);
+            var now = DateTimeOffset.UtcNow;
+
+            var existing = await db.SalesMonthlyTargets
+                .Where(t => t.Month == monthDateTime)
+                .ToListAsync(cancellationToken);
+
+            foreach (var update in targets)
+            {
+                var match = existing.FirstOrDefault(t => t.Metric == update.Metric);
+                if (match == null)
+                {
+                    db.SalesMonthlyTargets.Add(new SalesMonthlyTarget
+                    {
+                        Id = Guid.NewGuid(),
+                        Month = monthDateTime,
+                        Metric = update.Metric,
+                        Target = update.Target,
+                        CreatedByUserId = actingUserId,
+                        CreatedDate = now,
+                        LastUpdatedByUserId = actingUserId,
+                        LastUpdatedDate = now,
+                    });
+                }
+                else if (match.Target != update.Target)
+                {
+                    match.Target = update.Target;
+                    match.LastUpdatedByUserId = actingUserId;
+                    match.LastUpdatedDate = now;
+                }
+            }
+
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Applies the plan's status thresholds: &lt; 70% target = Behind,
+        /// 70–110% = OnTrack, &gt; 110% = Exceeded. When target is 0,
+        /// returns <c>NoTarget</c> so the UI can render an unmarked row.
+        /// </summary>
+        private static string ComputeStatus(int target, int actual)
+        {
+            if (target <= 0)
+            {
+                return "NoTarget";
+            }
+
+            var ratio = (double)actual / target;
+            return ratio switch
+            {
+                < 0.70 => "Behind",
+                > 1.10 => "Exceeded",
+                _ => "OnTrack",
+            };
+        }
+    }
+}

--- a/TrashMob.Shared/Migrations/20260704195153_AddSalesMonthlyTargets.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260704195153_AddSalesMonthlyTargets.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using TrashMob.Shared.Persistence;
 
 #nullable disable
 
-namespace TrashMob.Migrations
+namespace TrashMob.Shared.Migrations
 {
     [DbContext(typeof(MobDbContext))]
-    partial class MobDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704195153_AddSalesMonthlyTargets")]
+    partial class AddSalesMonthlyTargets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TrashMob.Shared/Migrations/20260704195153_AddSalesMonthlyTargets.cs
+++ b/TrashMob.Shared/Migrations/20260704195153_AddSalesMonthlyTargets.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrashMob.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSalesMonthlyTargets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SalesMonthlyTargets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Month = table.Column<DateTime>(type: "date", nullable: false),
+                    Metric = table.Column<int>(type: "int", nullable: false),
+                    Target = table.Column<int>(type: "int", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastUpdatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LastUpdatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SalesMonthlyTargets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SalesMonthlyTargets_User_CreatedBy",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_SalesMonthlyTargets_User_LastUpdatedBy",
+                        column: x => x.LastUpdatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SalesMonthlyTargets_CreatedByUserId",
+                table: "SalesMonthlyTargets",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SalesMonthlyTargets_LastUpdatedByUserId",
+                table: "SalesMonthlyTargets",
+                column: "LastUpdatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SalesMonthlyTargets_Month",
+                table: "SalesMonthlyTargets",
+                column: "Month");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_SalesMonthlyTargets_MonthMetric",
+                table: "SalesMonthlyTargets",
+                columns: new[] { "Month", "Metric" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SalesMonthlyTargets");
+        }
+    }
+}

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -171,6 +171,8 @@
 
         public virtual DbSet<ProspectOutreachEmail> ProspectOutreachEmails { get; set; }
 
+        public virtual DbSet<SalesMonthlyTarget> SalesMonthlyTargets { get; set; }
+
         public virtual DbSet<Contact> Contacts { get; set; }
 
         public virtual DbSet<Donation> Donations { get; set; }
@@ -3639,6 +3641,37 @@
                     .HasForeignKey(d => d.LastUpdatedByUserId)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_ProspectOutreachEmails_User_LastUpdatedBy");
+            });
+
+            modelBuilder.Entity<SalesMonthlyTarget>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                entity.Property(e => e.Month).HasColumnType("date");
+
+                entity.Property(e => e.Notes).HasMaxLength(500);
+
+                // One target per (Month, Metric) pair. The Monthly Report UI
+                // upserts through this constraint so callers never need to
+                // check for a pre-existing row.
+                entity.HasIndex(e => new { e.Month, e.Metric })
+                    .IsUnique()
+                    .HasDatabaseName("UX_SalesMonthlyTargets_MonthMetric");
+
+                entity.HasIndex(e => e.Month)
+                    .HasDatabaseName("IX_SalesMonthlyTargets_Month");
+
+                entity.HasOne(d => d.CreatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.CreatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_SalesMonthlyTargets_User_CreatedBy");
+
+                entity.HasOne(d => d.LastUpdatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.LastUpdatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_SalesMonthlyTargets_User_LastUpdatedBy");
             });
 
             // ===== Contact Management System (Project 51) =====

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -173,6 +173,7 @@
             services.AddScoped<ISentimentAnalysisService, SentimentAnalysisService>();
             services.AddScoped<IProspectConversionManager, ProspectConversionManager>();
             services.AddScoped<IWeeklySalesReportService, WeeklySalesReportService>();
+            services.AddScoped<IMonthlySalesReportService, MonthlySalesReportService>();
 
             // Contact Management
             services.AddScoped<IContactManager, ContactManager>();

--- a/TrashMob/Controllers/V2/SalesReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/SalesReportsV2Controller.cs
@@ -27,8 +27,13 @@ namespace TrashMob.Controllers.V2
     [RequiredScope(Constants.TrashMobWriteScope)]
     public class SalesReportsV2Controller(
         IWeeklySalesReportService weeklyReportService,
+        IMonthlySalesReportService monthlyReportService,
         ILogger<SalesReportsV2Controller> logger) : ControllerBase
     {
+        private Guid UserId => Guid.TryParse(HttpContext.Items["UserId"]?.ToString(), out var parsedUserId)
+            ? parsedUserId
+            : Guid.Empty;
+
         /// <summary>
         /// Gets the weekly sales report for the seven-day window ending on
         /// <paramref name="weekEnding"/>. Defaults to today when the parameter
@@ -49,6 +54,60 @@ namespace TrashMob.Controllers.V2
 
             var report = await weeklyReportService.GenerateAsync(effectiveWeekEnding, cancellationToken);
             return Ok(report);
+        }
+
+        /// <summary>
+        /// Gets the monthly sales report for the calendar month containing
+        /// <paramref name="month"/>. Defaults to the current month when the
+        /// parameter is omitted.
+        /// </summary>
+        /// <param name="month">Any day in the desired month in
+        /// <c>yyyy-MM-dd</c> format. Parsed as UTC.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the monthly report payload.</response>
+        [HttpGet("monthly")]
+        [ProducesResponseType(typeof(MonthlySalesReportDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMonthly(
+            [FromQuery] DateOnly? month,
+            CancellationToken cancellationToken)
+        {
+            var effectiveMonth = month ?? DateOnly.FromDateTime(DateTime.UtcNow);
+            logger.LogInformation("V2 GetMonthlySalesReport Month={Month}", effectiveMonth);
+
+            var report = await monthlyReportService.GenerateAsync(effectiveMonth, cancellationToken);
+            return Ok(report);
+        }
+
+        /// <summary>
+        /// Updates per-metric monthly targets. Metrics omitted from the body
+        /// are left untouched. The URL <paramref name="month"/> is normalized
+        /// to the first day of its calendar month.
+        /// </summary>
+        /// <param name="month">Any day in the target month in
+        /// <c>yyyy-MM-dd</c> format.</param>
+        /// <param name="request">Per-metric targets to upsert.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Targets applied.</response>
+        /// <response code="400">Empty request body.</response>
+        [HttpPut("monthly/{month}/targets")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> UpdateMonthlyTargets(
+            DateOnly month,
+            [FromBody] UpdateMonthlyTargetsRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (request?.Targets == null || request.Targets.Count == 0)
+            {
+                return Problem("At least one target update is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            logger.LogInformation(
+                "V2 UpdateMonthlyTargets Month={Month} UpdateCount={Count} User={UserId}",
+                month, request.Targets.Count, UserId);
+
+            await monthlyReportService.UpdateTargetsAsync(month, request.Targets, UserId, cancellationToken);
+            return NoContent();
         }
     }
 }

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -424,6 +424,11 @@ const SiteAdminProspectWeeklyReport = lazy(() =>
         default: m.SiteAdminProspectWeeklyReport,
     })),
 );
+const SiteAdminProspectMonthlyReport = lazy(() =>
+    import('./pages/siteadmin/prospects/reports/monthly').then((m) => ({
+        default: m.SiteAdminProspectMonthlyReport,
+    })),
+);
 const SiteAdminDocuments = lazy(() =>
     import('./pages/siteadmin/documents/page').then((m) => ({ default: m.SiteAdminDocuments })),
 );
@@ -751,6 +756,7 @@ const AppContent: FC = () => {
                                 <Route path='prospects/import' element={<SiteAdminProspectImport />} />
                                 <Route path='prospects/analytics' element={<SiteAdminProspectAnalytics />} />
                                 <Route path='prospects/reports/weekly' element={<SiteAdminProspectWeeklyReport />} />
+                                <Route path='prospects/reports/monthly' element={<SiteAdminProspectMonthlyReport />} />
                                 <Route path='prospects/:prospectId' element={<SiteAdminProspectDetail />} />
                                 <Route path='prospects/:prospectId/edit' element={<SiteAdminProspectEdit />} />
                                 <Route path='contacts' element={<SiteAdminContacts />} />

--- a/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
@@ -31,6 +31,7 @@ import {
     TrendingUp,
     Shield,
     CalendarClock,
+    CalendarDays,
 } from 'lucide-react';
 import { SidebarNav, NavGroup } from '@/components/ui/sidebar-nav';
 
@@ -58,6 +59,7 @@ const navGroups: NavGroup[] = [
             { name: 'Import CSV', href: `${pathPrefix}/prospects/import`, icon: Upload },
             { name: 'Pipeline Analytics', href: `${pathPrefix}/prospects/analytics`, icon: BarChart3 },
             { name: 'Weekly Report', href: `${pathPrefix}/prospects/reports/weekly`, icon: CalendarClock },
+            { name: 'Monthly Report', href: `${pathPrefix}/prospects/reports/monthly`, icon: CalendarDays },
         ],
     },
     {

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/reports/monthly.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/reports/monthly.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import moment, { type Moment } from 'moment';
+import { CalendarClock, ChevronLeft, ChevronRight, Check, Save } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { getErrorMessage } from '@/lib/api-errors';
+import {
+    GetMonthlySalesReport,
+    UpdateMonthlyTargets,
+    type MonthlySalesMetricDto,
+    type MarketIntelligenceCountDto,
+} from '@/services/sales-reports';
+
+/**
+ * Monthly Municipal Sales Pipeline Report (Project 63 Phase 3).
+ *
+ * Renders the 7 tracked metrics with per-month targets, target-vs-actual
+ * status pills, an inline "edit targets" mode, and a Market Intelligence
+ * Notes section below (best-responding departments, common objections,
+ * pricing feedback). NextMonthPriority persistence lands in Phase 4.
+ *
+ * Route: /siteadmin/prospects/reports/monthly
+ * SalesRep or SiteAdmin only.
+ */
+
+function toMonthString(m: Moment): string {
+    return m.format('YYYY-MM-01');
+}
+
+function StatusBadge({ status }: { status: MonthlySalesMetricDto['status'] }) {
+    switch (status) {
+        case 'Exceeded':
+            return <Badge variant='success'>Exceeded</Badge>;
+        case 'OnTrack':
+            return <Badge>On track</Badge>;
+        case 'Behind':
+            return <Badge variant='destructive'>Behind</Badge>;
+        default:
+            return <Badge variant='outline'>No target</Badge>;
+    }
+}
+
+function MarketIntelligenceCard({
+    title,
+    description,
+    rows,
+    emptyMessage,
+}: {
+    title: string;
+    description: string;
+    rows: MarketIntelligenceCountDto[];
+    emptyMessage: string;
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                {rows.length === 0 ? (
+                    <p className='text-sm text-muted-foreground'>{emptyMessage}</p>
+                ) : (
+                    <ul className='divide-y'>
+                        {rows.map((row) => (
+                            <li key={row.label} className='flex items-center justify-between py-2 text-sm'>
+                                <span>{row.label}</span>
+                                <Badge variant='outline'>{row.count}</Badge>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+export const SiteAdminProspectMonthlyReport = () => {
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+    const [monthAnchor, setMonthAnchor] = useState<Moment>(() => moment().startOf('month'));
+    const [editing, setEditing] = useState(false);
+    const [draftTargets, setDraftTargets] = useState<Record<number, string>>({});
+
+    const monthStr = useMemo(() => toMonthString(monthAnchor), [monthAnchor]);
+    const isThisMonth = monthAnchor.isSame(moment().startOf('month'), 'day');
+
+    const { data: report, isLoading } = useQuery({
+        queryKey: GetMonthlySalesReport({ month: monthStr }).key,
+        queryFn: GetMonthlySalesReport({ month: monthStr }).service,
+        select: (res) => res.data,
+    });
+
+    useEffect(() => {
+        // Reset the draft whenever the loaded report changes (new month or refetch).
+        if (report) {
+            const initial: Record<number, string> = {};
+            for (const m of report.metrics) {
+                initial[m.metric] = String(m.target);
+            }
+            setDraftTargets(initial);
+            setEditing(false);
+        }
+    }, [report]);
+
+    const saveTargets = useMutation({
+        mutationKey: UpdateMonthlyTargets({ month: monthStr }).key,
+        mutationFn: UpdateMonthlyTargets({ month: monthStr }).service,
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Targets saved' });
+            queryClient.invalidateQueries({ queryKey: GetMonthlySalesReport({ month: monthStr }).key });
+            setEditing(false);
+        },
+        onError: (error: Error) => {
+            toast({ variant: 'destructive', title: 'Save failed', description: getErrorMessage(error) });
+        },
+    });
+
+    const handleSave = () => {
+        if (!report) return;
+        const updates = report.metrics
+            .map((m) => {
+                const draft = draftTargets[m.metric];
+                const parsed = parseInt(draft ?? '', 10);
+                if (Number.isNaN(parsed) || parsed < 0) return null;
+                if (parsed === m.target) return null;
+                return { metric: m.metric, target: parsed };
+            })
+            .filter((u): u is { metric: number; target: number } => u !== null);
+
+        if (updates.length === 0) {
+            toast({ title: 'No changes to save' });
+            setEditing(false);
+            return;
+        }
+
+        saveTargets.mutate({ targets: updates });
+    };
+
+    return (
+        <div className='space-y-6'>
+            <Card>
+                <CardHeader className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
+                    <div>
+                        <CardTitle>Monthly Sales Report</CardTitle>
+                        <CardDescription>{monthAnchor.format('MMMM YYYY')}</CardDescription>
+                    </div>
+                    <div className='flex flex-wrap items-center gap-2'>
+                        <Button
+                            variant='outline'
+                            size='icon'
+                            onClick={() => setMonthAnchor((m) => m.clone().subtract(1, 'month'))}
+                            aria-label='Previous month'
+                        >
+                            <ChevronLeft className='h-4 w-4' />
+                        </Button>
+                        <Input
+                            type='month'
+                            value={monthAnchor.format('YYYY-MM')}
+                            onChange={(e) => {
+                                const v = e.target.value;
+                                if (!v) return;
+                                setMonthAnchor(moment(`${v}-01`, 'YYYY-MM-DD'));
+                            }}
+                            className='w-40'
+                        />
+                        <Button
+                            variant='outline'
+                            size='icon'
+                            onClick={() => setMonthAnchor((m) => m.clone().add(1, 'month'))}
+                            disabled={isThisMonth}
+                            aria-label='Next month'
+                        >
+                            <ChevronRight className='h-4 w-4' />
+                        </Button>
+                        <Button
+                            variant='outline'
+                            size='sm'
+                            onClick={() => setMonthAnchor(moment().startOf('month'))}
+                            disabled={isThisMonth}
+                        >
+                            <CalendarClock className='mr-1 h-4 w-4' />
+                            This month
+                        </Button>
+                    </div>
+                </CardHeader>
+            </Card>
+
+            <Card>
+                <CardHeader className='flex flex-row items-center justify-between'>
+                    <div>
+                        <CardTitle>Goals</CardTitle>
+                        <CardDescription>
+                            Defaults come from Cynthia's baseline (20 / 20 / 15 / 10 / 3 / 2 / 1). Edit any row to
+                            override for this month; other months are unaffected.
+                        </CardDescription>
+                    </div>
+                    {editing ? (
+                        <div className='flex items-center gap-2'>
+                            <Button variant='ghost' size='sm' onClick={() => setEditing(false)}>
+                                Cancel
+                            </Button>
+                            <Button size='sm' onClick={handleSave} disabled={saveTargets.isPending}>
+                                <Save className='mr-1 h-4 w-4' />
+                                Save targets
+                            </Button>
+                        </div>
+                    ) : (
+                        <Button variant='outline' size='sm' onClick={() => setEditing(true)} disabled={!report}>
+                            <Check className='mr-1 h-4 w-4' />
+                            Edit targets
+                        </Button>
+                    )}
+                </CardHeader>
+                <CardContent>
+                    {isLoading && !report ? (
+                        <p className='text-sm text-muted-foreground'>Loading report…</p>
+                    ) : (
+                        <div className='overflow-x-auto'>
+                            <table className='min-w-full text-sm'>
+                                <thead>
+                                    <tr className='border-b text-left text-muted-foreground'>
+                                        <th className='py-2 pr-4 font-medium'>Metric</th>
+                                        <th className='py-2 pr-4 font-medium'>Target</th>
+                                        <th className='py-2 pr-4 font-medium'>Actual</th>
+                                        <th className='py-2 pr-4 font-medium'>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {report?.metrics.map((m) => (
+                                        <tr key={m.metric} className='border-b last:border-b-0'>
+                                            <td className='py-2 pr-4 font-medium'>{m.label}</td>
+                                            <td className='py-2 pr-4 tabular-nums'>
+                                                {editing ? (
+                                                    <Input
+                                                        type='number'
+                                                        min={0}
+                                                        value={draftTargets[m.metric] ?? ''}
+                                                        onChange={(e) =>
+                                                            setDraftTargets((prev) => ({
+                                                                ...prev,
+                                                                [m.metric]: e.target.value,
+                                                            }))
+                                                        }
+                                                        className='h-8 w-20'
+                                                    />
+                                                ) : (
+                                                    m.target
+                                                )}
+                                            </td>
+                                            <td className='py-2 pr-4 tabular-nums'>{m.actual}</td>
+                                            <td className='py-2 pr-4'>
+                                                <StatusBadge status={m.status} />
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            <div className='grid gap-4 md:grid-cols-3'>
+                <MarketIntelligenceCard
+                    title='Best responding departments'
+                    description='Departments whose prospects responded this month.'
+                    rows={report?.bestRespondingDepartments ?? []}
+                    emptyMessage='No responses recorded this month.'
+                />
+                <MarketIntelligenceCard
+                    title='Common objections'
+                    description='Top objections captured across touched prospects.'
+                    rows={report?.commonObjections ?? []}
+                    emptyMessage='No objections captured yet.'
+                />
+                <MarketIntelligenceCard
+                    title='Pricing feedback'
+                    description='Budget, pricing, and procurement signals.'
+                    rows={report?.pricingFeedback ?? []}
+                    emptyMessage='No pricing feedback captured yet.'
+                />
+            </div>
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/services/sales-reports.ts
+++ b/TrashMob/client-app/src/services/sales-reports.ts
@@ -31,3 +31,61 @@ export const GetWeeklySalesReport = (params: GetWeeklySalesReport_Params = {}) =
             method: 'get',
         }),
 });
+
+// ---------- Monthly report (Project 63 Phase 3) ----------
+
+export interface MonthlySalesMetricDto {
+    metric: number;
+    metricName: string;
+    label: string;
+    target: number;
+    actual: number;
+    status: 'Behind' | 'OnTrack' | 'Exceeded' | 'NoTarget';
+}
+
+export interface MarketIntelligenceCountDto {
+    label: string;
+    count: number;
+}
+
+export interface MonthlySalesReportDto {
+    periodStart: string;
+    periodEnd: string;
+    metrics: MonthlySalesMetricDto[];
+    bestRespondingDepartments: MarketIntelligenceCountDto[];
+    commonObjections: MarketIntelligenceCountDto[];
+    pricingFeedback: MarketIntelligenceCountDto[];
+    nextMonthPriority: string | null;
+}
+
+export type GetMonthlySalesReport_Params = { month?: string };
+
+export const GetMonthlySalesReport = (params: GetMonthlySalesReport_Params = {}) => ({
+    key: ['/reports/sales/monthly', params.month ?? 'this-month'],
+    service: async () =>
+        ApiService('protected').fetchData<MonthlySalesReportDto>({
+            url: `/v2/reports/sales/monthly${params.month ? `?month=${params.month}` : ''}`,
+            method: 'get',
+        }),
+});
+
+export interface MonthlyTargetUpdate {
+    metric: number;
+    target: number;
+}
+
+export interface UpdateMonthlyTargetsBody {
+    targets: MonthlyTargetUpdate[];
+}
+
+export type UpdateMonthlyTargets_Params = { month: string };
+
+export const UpdateMonthlyTargets = (params: UpdateMonthlyTargets_Params) => ({
+    key: ['/reports/sales/monthly', params.month, 'targets'],
+    service: async (body: UpdateMonthlyTargetsBody) =>
+        ApiService('protected').fetchData<unknown, UpdateMonthlyTargetsBody>({
+            url: `/v2/reports/sales/monthly/${params.month}/targets`,
+            method: 'put',
+            data: body,
+        }),
+});


### PR DESCRIPTION
## Summary

Third phase of [Project 63 (Municipal Sales Pipeline Reporting)](Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md). The Board-facing side of the pipeline reports — the salesperson gets a monthly view of Cynthia's 7 tracked metrics with target-vs-actual, editable per-month targets, and a Market Intelligence Notes section that surfaces best-responding departments, common objections, and pricing feedback.

### Backend
- **`SalesMetricEnum`** covers the 7 tracked metrics (`ProspectsResearched`, `NewContacts`, `OutreachTouches`, `FollowUpTouches`, `Responses`, `MeetingsRequested`, `MeetingsScheduled`).
- **`SalesMonthlyTarget`** entity + `AddSalesMonthlyTargets` migration. Unique index on `(Month, Metric)` so upserts don't need read-before-write.
- **`MonthlySalesReportDto`** with per-metric target / actual / status rows plus three Market Intelligence lists (departments, objections, pricing).
- **`IMonthlySalesReportService.GenerateAsync` / `UpdateTargetsAsync`** — one DB pass for base counts, one for market intelligence.
- Cynthia's baseline (`20 / 20 / 15 / 10 / 3 / 2 / 1`) applied as a **service-side fallback** so day 1 works with no seeded data. Storing a target overrides just that metric for just that month; other months are unaffected.
- Status thresholds match the plan: `<70%` target = `Behind`, `70–110%` = `OnTrack`, `>110%` = `Exceeded`, zero target = `NoTarget`.
- `SalesReportsV2Controller` grows `GET /api/v2/reports/sales/monthly` and `PUT /api/v2/reports/sales/monthly/{month}/targets` (SalesRep or SiteAdmin only).
- **9 new unit tests** — default targets, boundary counts, per-category counting, status thresholds, override behavior, idempotent upsert, department fan-out for responders, objection/pricing dedupe. Suite: **1,169 passing**.

### Frontend
- **`/siteadmin/prospects/reports/monthly`** page:
  - Month picker + prev/next arrows + "This month" reset
  - Metrics table with inline **Edit targets** mode (only changed rows are sent on save)
  - Status badges: `Behind` (red), `On track` (green), `Exceeded` (success), `No target` (outline)
  - Market Intelligence Notes — three cards for departments, objections, pricing feedback with count badges
- `services/sales-reports.ts` extended with monthly types + PUT targets
- **"Monthly Report"** nav entry directly under "Weekly Report"

### Not in this PR
Phase 4 (scheduled email delivery + `NextMonthPriority` persistence) closes out Project 63.

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 warnings, 0 errors
- [x] `dotnet test` — 1,169 passing / 0 failing
- [x] `npm run check` — 0 errors (14 pre-existing warnings unchanged)
- [x] `npm run build` — production build succeeds
- [ ] Deploy to dev, verify `/siteadmin/prospects/reports/monthly` renders for a SalesRep-role account
- [ ] Edit `OutreachTouches` target to a non-default number, refresh — value persists; other metrics still show defaults
- [ ] Log a `ResponseReceived` activity on a prospect with a Department set — confirm the department appears in **Best responding departments** with count = 1
- [ ] Log two prospects with slightly different capitalizations of the same objection — confirm they dedupe

🤖 Generated with [Claude Code](https://claude.com/claude-code)