### PR TITLE
Project 63 Phase 4a: narrative persistence for weekly + monthly reports

### DIFF
--- a/TrashMob.Models/Enums.cs
+++ b/TrashMob.Models/Enums.cs
@@ -709,6 +709,24 @@ namespace TrashMob.Models
     }
 
     /// <summary>
+    /// Discriminates <see cref="SalesReport"/> rows by reporting cadence
+    /// (Project 63 Phase 4). Weekly rows carry <c>NextSteps</c>; monthly
+    /// rows carry <c>NextMonthPriority</c>.
+    /// </summary>
+    public enum SalesReportPeriodTypeEnum
+    {
+        /// <summary>
+        /// Weekly (Monday–Sunday) narrative.
+        /// </summary>
+        Weekly = 1,
+
+        /// <summary>
+        /// Monthly (first-of-month) narrative.
+        /// </summary>
+        Monthly = 2,
+    }
+
+    /// <summary>
     /// Represents the 7 tracked metrics for the monthly municipal sales
     /// pipeline report (Project 63 Phase 3). Numeric values map to
     /// <c>SalesMonthlyTarget.Metric</c> rows.

--- a/TrashMob.Models/Poco/V2/SalesReportNarrativeDto.cs
+++ b/TrashMob.Models/Poco/V2/SalesReportNarrativeDto.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    /// <summary>
+    /// Request body for upserting a weekly or monthly sales report narrative
+    /// (Project 63 Phase 4).
+    /// </summary>
+    public class SalesReportNarrativeDto
+    {
+        /// <summary>
+        /// Gets or sets the free-text "Next Steps" section shown on weekly
+        /// reports. Ignored on monthly upserts.
+        /// </summary>
+        public string? NextSteps { get; set; }
+
+        /// <summary>
+        /// Gets or sets the free-text "Recommended next-month priority"
+        /// section shown on monthly reports. Ignored on weekly upserts.
+        /// </summary>
+        public string? NextMonthPriority { get; set; }
+    }
+}

--- a/TrashMob.Models/SalesReport.cs
+++ b/TrashMob.Models/SalesReport.cs
@@ -1,0 +1,51 @@
+#nullable disable
+
+namespace TrashMob.Models
+{
+    using System;
+
+    /// <summary>
+    /// Persistent narrative sidecar for a weekly or monthly sales pipeline
+    /// report (Project 63 Phase 4). One row per <c>(PeriodType, PeriodStart)</c>
+    /// pair. Numeric aggregations still come from live queries; only the
+    /// free-text sections that the salesperson types live here.
+    /// </summary>
+    public class SalesReport : KeyedModel
+    {
+        /// <summary>
+        /// Gets or sets the reporting cadence (see <see cref="SalesReportPeriodTypeEnum"/>).
+        /// </summary>
+        public int PeriodType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the first day of the reporting window (UTC). Weekly rows use
+        /// the Monday of the window; monthly rows use the first day of the month.
+        /// Stored as a <see cref="DateTime"/> for cleaner SQL Server DATE mapping.
+        /// </summary>
+        public DateTime PeriodStart { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last day of the reporting window (UTC).
+        /// </summary>
+        public DateTime PeriodEnd { get; set; }
+
+        /// <summary>
+        /// Gets or sets the free-text "Next Steps" section shown on weekly reports.
+        /// Persisted from the report screen; null on monthly rows.
+        /// </summary>
+        public string NextSteps { get; set; }
+
+        /// <summary>
+        /// Gets or sets the free-text "Recommended next-month priority" section
+        /// shown on monthly reports. Null on weekly rows.
+        /// </summary>
+        public string NextMonthPriority { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp the scheduled email job dispatched this report.
+        /// Null until sent. Populated in Phase 4b so the hourly job can skip
+        /// duplicate sends.
+        /// </summary>
+        public DateTimeOffset? EmailSentDate { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/MonthlySalesReportServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/MonthlySalesReportServiceTests.cs
@@ -32,7 +32,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
                 .UseInMemoryDatabase(databaseName: $"MonthlySalesReport_{Guid.NewGuid()}")
                 .Options;
             db = new MobDbContext(options);
-            sut = new MonthlySalesReportService(db);
+            sut = new MonthlySalesReportService(db, new SalesReportNarrativeService(db));
         }
 
         private CommunityProspect AddProspect(

--- a/TrashMob.Shared.Tests/Managers/Prospects/SalesReportNarrativeServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/SalesReportNarrativeServiceTests.cs
@@ -1,0 +1,138 @@
+namespace TrashMob.Shared.Tests.Managers.Prospects
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Prospects;
+    using TrashMob.Shared.Persistence;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="SalesReportNarrativeService"/> — the Project 63
+    /// Phase 4 free-text sidecar for weekly and monthly reports.
+    /// </summary>
+    public class SalesReportNarrativeServiceTests : IDisposable
+    {
+        private readonly MobDbContext db;
+        private readonly SalesReportNarrativeService sut;
+        private readonly Guid userId = Guid.NewGuid();
+        private readonly DateOnly weekStart = new DateOnly(2026, 7, 13);
+        private readonly DateOnly weekEnd = new DateOnly(2026, 7, 19);
+        private readonly DateOnly monthStart = new DateOnly(2026, 7, 1);
+        private readonly DateOnly monthEnd = new DateOnly(2026, 7, 31);
+
+        public SalesReportNarrativeServiceTests()
+        {
+            var options = new DbContextOptionsBuilder<MobDbContext>()
+                .UseInMemoryDatabase(databaseName: $"SalesReportNarrative_{Guid.NewGuid()}")
+                .Options;
+            db = new MobDbContext(options);
+            sut = new SalesReportNarrativeService(db);
+        }
+
+        [Fact]
+        public async Task Get_ReturnsNull_WhenNoRowExists()
+        {
+            var result = await sut.GetAsync(SalesReportPeriodTypeEnum.Weekly, weekStart);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task UpsertWeekly_CreatesRowWithNextStepsAndIgnoresPriority()
+        {
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Weekly,
+                weekStart,
+                weekEnd,
+                nextSteps: "Follow up on 3 warm cities",
+                nextMonthPriority: "should be ignored on weekly",
+                userId);
+
+            var row = await sut.GetAsync(SalesReportPeriodTypeEnum.Weekly, weekStart);
+
+            Assert.NotNull(row);
+            Assert.Equal("Follow up on 3 warm cities", row!.NextSteps);
+            Assert.Null(row.NextMonthPriority);
+        }
+
+        [Fact]
+        public async Task UpsertMonthly_CreatesRowWithPriorityAndIgnoresNextSteps()
+        {
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Monthly,
+                monthStart,
+                monthEnd,
+                nextSteps: "should be ignored on monthly",
+                nextMonthPriority: "Focus on Contra Costa County",
+                userId);
+
+            var row = await sut.GetAsync(SalesReportPeriodTypeEnum.Monthly, monthStart);
+
+            Assert.NotNull(row);
+            Assert.Equal("Focus on Contra Costa County", row!.NextMonthPriority);
+            Assert.Null(row.NextSteps);
+        }
+
+        [Fact]
+        public async Task Upsert_UpdatesExistingRowRatherThanDuplicating()
+        {
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnd,
+                nextSteps: "v1", nextMonthPriority: null, userId);
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnd,
+                nextSteps: "v2 revised", nextMonthPriority: null, userId);
+
+            var rows = await db.SalesReports
+                .Where(r => r.PeriodType == (int)SalesReportPeriodTypeEnum.Weekly)
+                .ToListAsync();
+
+            Assert.Single(rows);
+            Assert.Equal("v2 revised", rows[0].NextSteps);
+        }
+
+        [Fact]
+        public async Task Upsert_NullNextSteps_ClearsExistingText()
+        {
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnd,
+                nextSteps: "will be cleared", nextMonthPriority: null, userId);
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnd,
+                nextSteps: null, nextMonthPriority: null, userId);
+
+            var row = await sut.GetAsync(SalesReportPeriodTypeEnum.Weekly, weekStart);
+
+            Assert.NotNull(row);
+            Assert.Null(row!.NextSteps);
+        }
+
+        [Fact]
+        public async Task Upsert_WeeklyAndMonthlyForSameStartDate_AreDistinctRows()
+        {
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Weekly, monthStart, monthStart.AddDays(6),
+                nextSteps: "weekly text", nextMonthPriority: null, userId);
+            await sut.UpsertAsync(
+                SalesReportPeriodTypeEnum.Monthly, monthStart, monthEnd,
+                nextSteps: null, nextMonthPriority: "monthly text", userId);
+
+            var weekly = await sut.GetAsync(SalesReportPeriodTypeEnum.Weekly, monthStart);
+            var monthly = await sut.GetAsync(SalesReportPeriodTypeEnum.Monthly, monthStart);
+
+            Assert.NotNull(weekly);
+            Assert.NotNull(monthly);
+            Assert.NotEqual(weekly!.Id, monthly!.Id);
+            Assert.Equal("weekly text", weekly.NextSteps);
+            Assert.Equal("monthly text", monthly.NextMonthPriority);
+        }
+
+        public void Dispose()
+        {
+            db.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/WeeklySalesReportServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/WeeklySalesReportServiceTests.cs
@@ -29,7 +29,7 @@ namespace TrashMob.Shared.Tests.Managers.Prospects
                 .UseInMemoryDatabase(databaseName: $"WeeklySalesReport_{Guid.NewGuid()}")
                 .Options;
             db = new MobDbContext(options);
-            sut = new WeeklySalesReportService(db);
+            sut = new WeeklySalesReportService(db, new SalesReportNarrativeService(db));
         }
 
         private CommunityProspect AddProspect(

--- a/TrashMob.Shared/Managers/Interfaces/ISalesReportNarrativeService.cs
+++ b/TrashMob.Shared/Managers/Interfaces/ISalesReportNarrativeService.cs
@@ -1,0 +1,41 @@
+#nullable enable
+
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Persists the free-text sections of the weekly and monthly sales
+    /// pipeline reports (Project 63 Phase 4). Numeric aggregations remain in
+    /// <c>IWeeklySalesReportService</c> / <c>IMonthlySalesReportService</c>
+    /// and are computed live at read time.
+    /// </summary>
+    public interface ISalesReportNarrativeService
+    {
+        /// <summary>
+        /// Returns the persisted <see cref="SalesReport"/> row for the given
+        /// period, or null when the salesperson has not yet typed a narrative.
+        /// </summary>
+        Task<SalesReport?> GetAsync(
+            SalesReportPeriodTypeEnum periodType,
+            DateOnly periodStart,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Upserts the narrative sections for the given period. On weekly
+        /// upserts <c>NextMonthPriority</c> is ignored; on monthly upserts
+        /// <c>NextSteps</c> is ignored. Null values clear existing text.
+        /// </summary>
+        Task<SalesReport> UpsertAsync(
+            SalesReportPeriodTypeEnum periodType,
+            DateOnly periodStart,
+            DateOnly periodEnd,
+            string? nextSteps,
+            string? nextMonthPriority,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/MonthlySalesReportService.cs
+++ b/TrashMob.Shared/Managers/Prospects/MonthlySalesReportService.cs
@@ -16,7 +16,9 @@ namespace TrashMob.Shared.Managers.Prospects
     /// (Project 63 Phase 3). One DB pass for the base metrics, one for market
     /// intelligence aggregation.
     /// </summary>
-    public class MonthlySalesReportService(MobDbContext db) : IMonthlySalesReportService
+    public class MonthlySalesReportService(
+        MobDbContext db,
+        ISalesReportNarrativeService narrativeService) : IMonthlySalesReportService
     {
         /// <summary>
         /// Cynthia's baseline targets per Project 63 (20 / 20 / 15 / 10 / 3 / 2 / 1).
@@ -166,6 +168,9 @@ namespace TrashMob.Shared.Managers.Prospects
                 .Take(5)
                 .ToList();
 
+            var narrative = await narrativeService.GetAsync(
+                SalesReportPeriodTypeEnum.Monthly, monthStart, cancellationToken);
+
             return new MonthlySalesReportDto
             {
                 PeriodStart = monthStartUtc,
@@ -174,7 +179,7 @@ namespace TrashMob.Shared.Managers.Prospects
                 BestRespondingDepartments = bestRespondingDepartments,
                 CommonObjections = commonObjections,
                 PricingFeedback = pricingFeedback,
-                NextMonthPriority = null,
+                NextMonthPriority = narrative?.NextMonthPriority,
             };
         }
 

--- a/TrashMob.Shared/Managers/Prospects/SalesReportNarrativeService.cs
+++ b/TrashMob.Shared/Managers/Prospects/SalesReportNarrativeService.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence;
+
+    /// <summary>
+    /// EF-backed narrative sidecar for weekly and monthly sales pipeline
+    /// reports (Project 63 Phase 4).
+    /// </summary>
+    public class SalesReportNarrativeService(MobDbContext db) : ISalesReportNarrativeService
+    {
+        /// <inheritdoc />
+        public async Task<SalesReport?> GetAsync(
+            SalesReportPeriodTypeEnum periodType,
+            DateOnly periodStart,
+            CancellationToken cancellationToken = default)
+        {
+            var start = periodStart.ToDateTime(TimeOnly.MinValue);
+            return await db.SalesReports
+                .FirstOrDefaultAsync(
+                    r => r.PeriodType == (int)periodType && r.PeriodStart == start,
+                    cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<SalesReport> UpsertAsync(
+            SalesReportPeriodTypeEnum periodType,
+            DateOnly periodStart,
+            DateOnly periodEnd,
+            string? nextSteps,
+            string? nextMonthPriority,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default)
+        {
+            var start = periodStart.ToDateTime(TimeOnly.MinValue);
+            var end = periodEnd.ToDateTime(TimeOnly.MinValue);
+            var now = DateTimeOffset.UtcNow;
+
+            var existing = await db.SalesReports
+                .FirstOrDefaultAsync(
+                    r => r.PeriodType == (int)periodType && r.PeriodStart == start,
+                    cancellationToken);
+
+            if (existing == null)
+            {
+                var row = new SalesReport
+                {
+                    Id = Guid.NewGuid(),
+                    PeriodType = (int)periodType,
+                    PeriodStart = start,
+                    PeriodEnd = end,
+                    NextSteps = periodType == SalesReportPeriodTypeEnum.Weekly ? nextSteps : null,
+                    NextMonthPriority = periodType == SalesReportPeriodTypeEnum.Monthly ? nextMonthPriority : null,
+                    CreatedByUserId = actingUserId,
+                    CreatedDate = now,
+                    LastUpdatedByUserId = actingUserId,
+                    LastUpdatedDate = now,
+                };
+                db.SalesReports.Add(row);
+                await db.SaveChangesAsync(cancellationToken);
+                return row;
+            }
+
+            // Only the field relevant to this period type is written — a
+            // caller mistakenly passing the wrong field name does not clobber
+            // the good one.
+            if (periodType == SalesReportPeriodTypeEnum.Weekly)
+            {
+                existing.NextSteps = nextSteps;
+            }
+            else
+            {
+                existing.NextMonthPriority = nextMonthPriority;
+            }
+
+            existing.PeriodEnd = end;
+            existing.LastUpdatedByUserId = actingUserId;
+            existing.LastUpdatedDate = now;
+            await db.SaveChangesAsync(cancellationToken);
+            return existing;
+        }
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/WeeklySalesReportService.cs
+++ b/TrashMob.Shared/Managers/Prospects/WeeklySalesReportService.cs
@@ -15,13 +15,16 @@ namespace TrashMob.Shared.Managers.Prospects
     /// EF-backed implementation of the weekly municipal sales pipeline report
     /// (Project 63 Phase 2). All counts are computed in a single scoped DB pass.
     /// </summary>
-    public class WeeklySalesReportService(MobDbContext db) : IWeeklySalesReportService
+    public class WeeklySalesReportService(
+        MobDbContext db,
+        ISalesReportNarrativeService narrativeService) : IWeeklySalesReportService
     {
         /// <inheritdoc />
         public async Task<WeeklySalesReportDto> GenerateAsync(DateOnly weekEnding, CancellationToken cancellationToken = default)
         {
             var end = new DateTimeOffset(weekEnding.ToDateTime(new TimeOnly(23, 59, 59, 999)), TimeSpan.Zero);
             var start = new DateTimeOffset(weekEnding.AddDays(-6).ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+            var periodStart = DateOnly.FromDateTime(start.UtcDateTime);
 
             var prospectsResearched = await db.CommunityProspects
                 .Where(p => p.CreatedDate >= start && p.CreatedDate <= end)
@@ -97,7 +100,8 @@ namespace TrashMob.Shared.Managers.Prospects
                 MeetingsHeld = meetingsHeld,
                 KeyMunicipalFeedback = keyMunicipalFeedback,
                 PricingFeedback = pricingFeedback,
-                NextSteps = null,
+                NextSteps = (await narrativeService.GetAsync(
+                    SalesReportPeriodTypeEnum.Weekly, periodStart, cancellationToken))?.NextSteps,
             };
         }
 

--- a/TrashMob.Shared/Migrations/20260704222938_AddSalesReports.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260704222938_AddSalesReports.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using TrashMob.Shared.Persistence;
 
 #nullable disable
 
-namespace TrashMob.Migrations
+namespace TrashMob.Shared.Migrations
 {
     [DbContext(typeof(MobDbContext))]
-    partial class MobDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704222938_AddSalesReports")]
+    partial class AddSalesReports
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TrashMob.Shared/Migrations/20260704222938_AddSalesReports.cs
+++ b/TrashMob.Shared/Migrations/20260704222938_AddSalesReports.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrashMob.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSalesReports : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SalesReports",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PeriodType = table.Column<int>(type: "int", nullable: false),
+                    PeriodStart = table.Column<DateTime>(type: "date", nullable: false),
+                    PeriodEnd = table.Column<DateTime>(type: "date", nullable: false),
+                    NextSteps = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    NextMonthPriority = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    EmailSentDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CreatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastUpdatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LastUpdatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SalesReports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SalesReports_User_CreatedBy",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_SalesReports_User_LastUpdatedBy",
+                        column: x => x.LastUpdatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SalesReports_CreatedByUserId",
+                table: "SalesReports",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SalesReports_LastUpdatedByUserId",
+                table: "SalesReports",
+                column: "LastUpdatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_SalesReports_PeriodTypeStart",
+                table: "SalesReports",
+                columns: new[] { "PeriodType", "PeriodStart" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SalesReports");
+        }
+    }
+}

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -173,6 +173,8 @@
 
         public virtual DbSet<SalesMonthlyTarget> SalesMonthlyTargets { get; set; }
 
+        public virtual DbSet<SalesReport> SalesReports { get; set; }
+
         public virtual DbSet<Contact> Contacts { get; set; }
 
         public virtual DbSet<Donation> Donations { get; set; }
@@ -3672,6 +3674,36 @@
                     .HasForeignKey(d => d.LastUpdatedByUserId)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_SalesMonthlyTargets_User_LastUpdatedBy");
+            });
+
+            modelBuilder.Entity<SalesReport>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                entity.Property(e => e.PeriodStart).HasColumnType("date");
+                entity.Property(e => e.PeriodEnd).HasColumnType("date");
+
+                entity.Property(e => e.NextSteps).HasMaxLength(2000);
+                entity.Property(e => e.NextMonthPriority).HasMaxLength(2000);
+
+                // One narrative per (PeriodType, PeriodStart) — the report screen
+                // upserts through this constraint so callers never need a
+                // read-before-write dance.
+                entity.HasIndex(e => new { e.PeriodType, e.PeriodStart })
+                    .IsUnique()
+                    .HasDatabaseName("UX_SalesReports_PeriodTypeStart");
+
+                entity.HasOne(d => d.CreatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.CreatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_SalesReports_User_CreatedBy");
+
+                entity.HasOne(d => d.LastUpdatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.LastUpdatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_SalesReports_User_LastUpdatedBy");
             });
 
             // ===== Contact Management System (Project 51) =====

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -174,6 +174,7 @@
             services.AddScoped<IProspectConversionManager, ProspectConversionManager>();
             services.AddScoped<IWeeklySalesReportService, WeeklySalesReportService>();
             services.AddScoped<IMonthlySalesReportService, MonthlySalesReportService>();
+            services.AddScoped<ISalesReportNarrativeService, SalesReportNarrativeService>();
 
             // Contact Management
             services.AddScoped<IContactManager, ContactManager>();

--- a/TrashMob/Controllers/V2/SalesReportsV2Controller.cs
+++ b/TrashMob/Controllers/V2/SalesReportsV2Controller.cs
@@ -10,6 +10,7 @@ namespace TrashMob.Controllers.V2
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models;
     using TrashMob.Models.Poco.V2;
     using TrashMob.Security;
     using TrashMob.Shared;
@@ -28,6 +29,7 @@ namespace TrashMob.Controllers.V2
     public class SalesReportsV2Controller(
         IWeeklySalesReportService weeklyReportService,
         IMonthlySalesReportService monthlyReportService,
+        ISalesReportNarrativeService narrativeService,
         ILogger<SalesReportsV2Controller> logger) : ControllerBase
     {
         private Guid UserId => Guid.TryParse(HttpContext.Items["UserId"]?.ToString(), out var parsedUserId)
@@ -107,6 +109,75 @@ namespace TrashMob.Controllers.V2
                 month, request.Targets.Count, UserId);
 
             await monthlyReportService.UpdateTargetsAsync(month, request.Targets, UserId, cancellationToken);
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Upserts the free-text "Next Steps" section on a weekly report.
+        /// </summary>
+        /// <param name="weekEnding">Last day of the week (Sunday) in
+        /// <c>yyyy-MM-dd</c> format. The narrative row keys off the derived
+        /// <c>weekEnding - 6 days</c> start-of-week date.</param>
+        /// <param name="body">Narrative body — <c>NextSteps</c> is written;
+        /// other fields are ignored on weekly upserts.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Narrative saved.</response>
+        [HttpPut("weekly/{weekEnding}/narrative")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UpsertWeeklyNarrative(
+            DateOnly weekEnding,
+            [FromBody] SalesReportNarrativeDto body,
+            CancellationToken cancellationToken)
+        {
+            var periodStart = weekEnding.AddDays(-6);
+            logger.LogInformation(
+                "V2 UpsertWeeklyNarrative WeekEnding={WeekEnding} PeriodStart={PeriodStart} User={UserId}",
+                weekEnding, periodStart, UserId);
+
+            await narrativeService.UpsertAsync(
+                SalesReportPeriodTypeEnum.Weekly,
+                periodStart,
+                weekEnding,
+                body?.NextSteps,
+                nextMonthPriority: null,
+                UserId,
+                cancellationToken);
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Upserts the free-text "Recommended next-month priority" section on
+        /// a monthly report.
+        /// </summary>
+        /// <param name="month">Any day in the target month in
+        /// <c>yyyy-MM-dd</c> format.</param>
+        /// <param name="body">Narrative body — <c>NextMonthPriority</c> is
+        /// written; other fields are ignored on monthly upserts.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Narrative saved.</response>
+        [HttpPut("monthly/{month}/narrative")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UpsertMonthlyNarrative(
+            DateOnly month,
+            [FromBody] SalesReportNarrativeDto body,
+            CancellationToken cancellationToken)
+        {
+            var periodStart = new DateOnly(month.Year, month.Month, 1);
+            var periodEnd = periodStart.AddMonths(1).AddDays(-1);
+            logger.LogInformation(
+                "V2 UpsertMonthlyNarrative Month={Month} User={UserId}",
+                periodStart, UserId);
+
+            await narrativeService.UpsertAsync(
+                SalesReportPeriodTypeEnum.Monthly,
+                periodStart,
+                periodEnd,
+                nextSteps: null,
+                body?.NextMonthPriority,
+                UserId,
+                cancellationToken);
+
             return NoContent();
         }
     }

--- a/TrashMob/client-app/src/components/prospects/sales-report-narrative-panel.tsx
+++ b/TrashMob/client-app/src/components/prospects/sales-report-narrative-panel.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Check, Loader2 } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { getErrorMessage } from '@/lib/api-errors';
+
+/**
+ * Autosave-on-blur narrative panel used by both the Weekly and Monthly report
+ * screens (Project 63 Phase 4a). The parent supplies the current on-disk value
+ * plus a mutation hook that persists it; this component owns the local draft
+ * and fires the mutation when the textarea loses focus, if the draft actually
+ * changed.
+ *
+ * The parent also owns the query invalidation strategy — this component only
+ * cares about the current value + save function.
+ */
+interface SalesReportNarrativePanelProps {
+    title: string;
+    description: string;
+    placeholder: string;
+    persistedValue: string | null | undefined;
+    mutationKey: readonly unknown[];
+    save: (value: string | null) => Promise<unknown>;
+    invalidateQueryKey: readonly unknown[];
+}
+
+export const SalesReportNarrativePanel = ({
+    title,
+    description,
+    placeholder,
+    persistedValue,
+    mutationKey,
+    save,
+    invalidateQueryKey,
+}: SalesReportNarrativePanelProps) => {
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+    const [draft, setDraft] = useState<string>(persistedValue ?? '');
+    // Track the last committed value so we can detect real changes on blur
+    // regardless of intermediate keystrokes.
+    const lastCommitted = useRef<string>(persistedValue ?? '');
+
+    useEffect(() => {
+        // When the parent's persisted value updates (new period selected, refetch),
+        // reset both the draft and the committed marker so the next blur only
+        // fires when the salesperson actually edits.
+        setDraft(persistedValue ?? '');
+        lastCommitted.current = persistedValue ?? '';
+    }, [persistedValue]);
+
+    const mutation = useMutation({
+        mutationKey: [...mutationKey],
+        mutationFn: (value: string | null) => save(value),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: [...invalidateQueryKey] });
+        },
+        onError: (error: Error) => {
+            toast({ variant: 'destructive', title: 'Save failed', description: getErrorMessage(error) });
+        },
+    });
+
+    const commitIfChanged = () => {
+        const trimmed = draft.trim();
+        const currentValue = trimmed.length === 0 ? null : trimmed;
+        const lastValue = lastCommitted.current.trim().length === 0 ? null : lastCommitted.current.trim();
+        if (currentValue === lastValue) return;
+        lastCommitted.current = trimmed;
+        mutation.mutate(currentValue);
+    };
+
+    return (
+        <Card>
+            <CardHeader className='flex flex-row items-center justify-between'>
+                <div>
+                    <CardTitle>{title}</CardTitle>
+                    <CardDescription>{description}</CardDescription>
+                </div>
+                <span className='flex items-center gap-1 text-xs text-muted-foreground'>
+                    {mutation.isPending ? (
+                        <>
+                            <Loader2 className='h-3 w-3 animate-spin' /> Saving…
+                        </>
+                    ) : mutation.isSuccess || (persistedValue ?? '').trim().length > 0 ? (
+                        <>
+                            <Check className='h-3 w-3 text-green-600' /> Saved
+                        </>
+                    ) : null}
+                </span>
+            </CardHeader>
+            <CardContent>
+                <Textarea
+                    rows={4}
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onBlur={commitIfChanged}
+                    placeholder={placeholder}
+                    maxLength={2000}
+                />
+                <p className='mt-1 text-right text-xs text-muted-foreground'>{draft.length} / 2000</p>
+            </CardContent>
+        </Card>
+    );
+};

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/reports/monthly.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/reports/monthly.tsx
@@ -11,9 +11,11 @@ import { getErrorMessage } from '@/lib/api-errors';
 import {
     GetMonthlySalesReport,
     UpdateMonthlyTargets,
+    UpsertMonthlyNarrative,
     type MonthlySalesMetricDto,
     type MarketIntelligenceCountDto,
 } from '@/services/sales-reports';
+import { SalesReportNarrativePanel } from '@/components/prospects/sales-report-narrative-panel';
 
 /**
  * Monthly Municipal Sales Pipeline Report (Project 63 Phase 3).
@@ -285,6 +287,16 @@ export const SiteAdminProspectMonthlyReport = () => {
                     emptyMessage='No pricing feedback captured yet.'
                 />
             </div>
+
+            <SalesReportNarrativePanel
+                title='Recommended next-month priority'
+                description='What the salesperson recommends focusing on next month. Auto-saves when you click away.'
+                placeholder='e.g. Move all Bay Area meetings into scheduled; open a NorCal region tier.'
+                persistedValue={report?.nextMonthPriority ?? null}
+                mutationKey={UpsertMonthlyNarrative({ month: monthStr }).key}
+                save={(value) => UpsertMonthlyNarrative({ month: monthStr }).service({ nextMonthPriority: value })}
+                invalidateQueryKey={GetMonthlySalesReport({ month: monthStr }).key}
+            />
         </div>
     );
 };

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/reports/weekly.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/reports/weekly.tsx
@@ -5,7 +5,8 @@ import { CalendarClock, ChevronLeft, ChevronRight, Download } from 'lucide-react
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { GetWeeklySalesReport, type WeeklySalesReportDto } from '@/services/sales-reports';
+import { GetWeeklySalesReport, UpsertWeeklyNarrative, type WeeklySalesReportDto } from '@/services/sales-reports';
+import { SalesReportNarrativePanel } from '@/components/prospects/sales-report-narrative-panel';
 
 /**
  * Weekly Municipal Sales Pipeline Report (Project 63 Phase 2).
@@ -222,6 +223,18 @@ export const SiteAdminProspectWeeklyReport = () => {
                             </CardContent>
                         </Card>
                     </div>
+
+                    <SalesReportNarrativePanel
+                        title='Next Steps'
+                        description='What the salesperson plans to do next week. Auto-saves when you click away.'
+                        placeholder='e.g. Push follow-ups on the 3 warm California cities; nail down Alameda County meeting time.'
+                        persistedValue={report?.nextSteps ?? null}
+                        mutationKey={UpsertWeeklyNarrative({ weekEnding: weekEndingStr }).key}
+                        save={(value) =>
+                            UpsertWeeklyNarrative({ weekEnding: weekEndingStr }).service({ nextSteps: value })
+                        }
+                        invalidateQueryKey={GetWeeklySalesReport({ weekEnding: weekEndingStr }).key}
+                    />
                 </>
             )}
         </div>

--- a/TrashMob/client-app/src/services/sales-reports.ts
+++ b/TrashMob/client-app/src/services/sales-reports.ts
@@ -89,3 +89,34 @@ export const UpdateMonthlyTargets = (params: UpdateMonthlyTargets_Params) => ({
             data: body,
         }),
 });
+
+// ---------- Narrative persistence (Project 63 Phase 4a) ----------
+
+export interface SalesReportNarrativeBody {
+    nextSteps?: string | null;
+    nextMonthPriority?: string | null;
+}
+
+export type UpsertWeeklyNarrative_Params = { weekEnding: string };
+
+export const UpsertWeeklyNarrative = (params: UpsertWeeklyNarrative_Params) => ({
+    key: ['/reports/sales/weekly', params.weekEnding, 'narrative'],
+    service: async (body: SalesReportNarrativeBody) =>
+        ApiService('protected').fetchData<unknown, SalesReportNarrativeBody>({
+            url: `/v2/reports/sales/weekly/${params.weekEnding}/narrative`,
+            method: 'put',
+            data: body,
+        }),
+});
+
+export type UpsertMonthlyNarrative_Params = { month: string };
+
+export const UpsertMonthlyNarrative = (params: UpsertMonthlyNarrative_Params) => ({
+    key: ['/reports/sales/monthly', params.month, 'narrative'],
+    service: async (body: SalesReportNarrativeBody) =>
+        ApiService('protected').fetchData<unknown, SalesReportNarrativeBody>({
+            url: `/v2/reports/sales/monthly/${params.month}/narrative`,
+            method: 'put',
+            data: body,
+        }),
+});


### PR DESCRIPTION
## Summary

Splits the plan's Phase 4 into two shippable slices so the scheduled email work gets its own review. This PR is the low-risk half — narrative persistence + auto-save UX. **Phase 4b** will add subscribers and the hourly email job that actually sends the reports.

### Backend
- **`SalesReport` entity** — one row per `(PeriodType, PeriodStart)` with `NextSteps` (weekly) and `NextMonthPriority` (monthly). Includes an `EmailSentDate` column reserved for Phase 4b so the hourly job can skip duplicate sends.
- **`AddSalesReports` migration** + unique index on `(PeriodType, PeriodStart)` so upserts don't need a read-before-write.
- **`ISalesReportNarrativeService.GetAsync` / `UpsertAsync`** — writes only the field relevant to the period type (a caller mistakenly passing the wrong field name cannot clobber the good one).
- **`WeeklySalesReportService` and `MonthlySalesReportService`** now populate the DTO's `NextSteps` / `NextMonthPriority` from the narrative row (null when the salesperson has not yet typed one).
- **`SalesReportsV2Controller`** gains `PUT /weekly/{weekEnding}/narrative` and `PUT /monthly/{month}/narrative` (SalesRep or SiteAdmin).
- **6 new service tests** cover create, weekly/monthly field isolation, idempotent update, null-clearing, and `(Weekly, Monthly)` with the same start-date being distinct rows. Suite: **1,175 passing**.

### Frontend
- New reusable **`SalesReportNarrativePanel`** — controlled textarea with **autosave-on-blur** (only fires the mutation when the trimmed value actually changed), a saving/saved status indicator, and a 2000-char counter matching the backend column length.
- Weekly report gets a **Next Steps** panel; monthly report gets a **Recommended next-month priority** panel.
- `services/sales-reports.ts` extended with `UpsertWeeklyNarrative` + `UpsertMonthlyNarrative` factories.

### Not in this PR (queued as Phase 4b)
- `SalesReportSubscriber` entity + CRUD
- `SalesReportWeekly.html` / `SalesReportMonthly.html` email templates
- Scheduled hourly job that fires the emails on Monday 08:00 PT (weekly) and 1st-of-month 08:00 PT (monthly)
- Admin UI for managing the distribution list

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 warnings, 0 errors
- [x] `dotnet test` — 1,175 passing / 0 failing
- [x] `npm run check` — 0 errors (14 pre-existing warnings unchanged)
- [x] `npm run build` — production build succeeds
- [ ] Deploy to dev, verify the migration lands cleanly
- [ ] Type a Next Steps note on the current week, click away — confirm the "Saving…" → "Saved" indicator, then hard-refresh and confirm persistence
- [ ] Do the same for Next-month priority on the monthly report
- [ ] Confirm null-clearing: delete all text and click away — text stays cleared after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)