### PR TITLE
Project 63 Phase 4b: subscribers + scheduled sales report emails

### DIFF
--- a/TrashMob.Models/Extensions/V2/SalesReportSubscriberMappingsV2.cs
+++ b/TrashMob.Models/Extensions/V2/SalesReportSubscriberMappingsV2.cs
@@ -1,0 +1,25 @@
+namespace TrashMob.Models.Extensions.V2
+{
+    using TrashMob.Models.Poco.V2;
+
+    /// <summary>
+    /// V2 DTO mappings for the sales report subscribers list (Project 63 Phase 4b).
+    /// </summary>
+    public static class SalesReportSubscriberMappingsV2
+    {
+        /// <summary>
+        /// Maps a <see cref="SalesReportSubscriber"/> to a <see cref="SalesReportSubscriberDto"/>.
+        /// Assumes the caller has eager-loaded the <see cref="SalesReportSubscriber.User"/>
+        /// navigation.
+        /// </summary>
+        public static SalesReportSubscriberDto ToV2Dto(this SalesReportSubscriber entity) => new()
+        {
+            Id = entity.Id,
+            UserId = entity.UserId,
+            UserName = entity.User?.UserName,
+            Email = entity.User?.Email,
+            IncludeWeekly = entity.IncludeWeekly,
+            IncludeMonthly = entity.IncludeMonthly,
+        };
+    }
+}

--- a/TrashMob.Models/Poco/V2/SalesReportSubscriberDto.cs
+++ b/TrashMob.Models/Poco/V2/SalesReportSubscriberDto.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2
+{
+    using System;
+
+    /// <summary>
+    /// V2 API representation of a distribution-list entry for the weekly and
+    /// monthly sales pipeline emails (Project 63 Phase 4b).
+    /// </summary>
+    public class SalesReportSubscriberDto
+    {
+        /// <summary>
+        /// Gets or sets the subscription identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subscribed user id.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subscribed user's display name (populated on read).
+        /// </summary>
+        public string? UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subscribed user's email (populated on read).
+        /// </summary>
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives the weekly email.
+        /// </summary>
+        public bool IncludeWeekly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives the monthly email.
+        /// </summary>
+        public bool IncludeMonthly { get; set; }
+    }
+
+    /// <summary>
+    /// Request body for adding a subscriber.
+    /// </summary>
+    public class AddSalesReportSubscriberRequest
+    {
+        /// <summary>
+        /// Gets or sets the user id to subscribe.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives the weekly email.
+        /// </summary>
+        public bool IncludeWeekly { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives the monthly email.
+        /// </summary>
+        public bool IncludeMonthly { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Request body for updating an existing subscription's cadence flags.
+    /// </summary>
+    public class UpdateSalesReportSubscriberRequest
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives the weekly email.
+        /// </summary>
+        public bool IncludeWeekly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives the monthly email.
+        /// </summary>
+        public bool IncludeMonthly { get; set; }
+    }
+}

--- a/TrashMob.Models/SalesReportSubscriber.cs
+++ b/TrashMob.Models/SalesReportSubscriber.cs
@@ -1,0 +1,36 @@
+#nullable disable
+
+namespace TrashMob.Models
+{
+    using System;
+
+    /// <summary>
+    /// Distribution-list entry for the weekly and monthly municipal sales
+    /// pipeline emails (Project 63 Phase 4b). One row per user; per-cadence
+    /// opt-in flags let a subscriber take only weekly or only monthly.
+    /// </summary>
+    public class SalesReportSubscriber : KeyedModel
+    {
+        /// <summary>
+        /// Gets or sets the subscribed <see cref="User"/> id.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives
+        /// the weekly email. Defaults to true.
+        /// </summary>
+        public bool IncludeWeekly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the subscriber receives
+        /// the monthly email. Defaults to true.
+        /// </summary>
+        public bool IncludeMonthly { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subscribed user (navigation).
+        /// </summary>
+        public virtual User User { get; set; }
+    }
+}

--- a/TrashMob.Shared.Tests/Managers/Prospects/SalesReportEmailServiceTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Prospects/SalesReportEmailServiceTests.cs
@@ -1,0 +1,293 @@
+namespace TrashMob.Shared.Tests.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Managers.Prospects;
+    using TrashMob.Shared.Persistence;
+    using TrashMob.Shared.Poco;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="SalesReportEmailService"/> — Project 63 Phase 4b.
+    /// Focuses on the day-of-week / day-of-month gate, empty-window skip,
+    /// subscriber-count skip, and the EmailSentDate dedupe path so re-running
+    /// the daily job on the same day is a no-op.
+    /// </summary>
+    public class SalesReportEmailServiceTests : IDisposable
+    {
+        private readonly MobDbContext db;
+        private readonly Mock<IWeeklySalesReportService> weekly = new();
+        private readonly Mock<IMonthlySalesReportService> monthly = new();
+        private readonly Mock<ISalesReportSubscriberService> subscribers = new();
+        private readonly Mock<IEmailManager> emailManager = new();
+        private readonly Mock<ILogger<SalesReportEmailService>> logger = new();
+
+        // Monday 2026-07-13 00:00 UTC — the first Monday after the salesperson's
+        // start date, and the anchor date used across the weekly-path tests.
+        private readonly DateTimeOffset monday = new(2026, 7, 13, 0, 0, 0, TimeSpan.Zero);
+
+        // First-of-month anchor for the monthly-path tests.
+        private readonly DateTimeOffset firstOfMonth = new(2026, 8, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // A non-send day: Tuesday, mid-month.
+        private readonly DateTimeOffset tuesday = new(2026, 7, 14, 0, 0, 0, TimeSpan.Zero);
+
+        public SalesReportEmailServiceTests()
+        {
+            var options = new DbContextOptionsBuilder<MobDbContext>()
+                .UseInMemoryDatabase(databaseName: $"SalesReportEmail_{Guid.NewGuid()}")
+                .Options;
+            db = new MobDbContext(options);
+        }
+
+        private SalesReportEmailService BuildSut(DateTimeOffset now)
+        {
+            var clock = new FakeTimeProvider(now);
+            return new SalesReportEmailService(
+                db,
+                weekly.Object,
+                monthly.Object,
+                subscribers.Object,
+                emailManager.Object,
+                logger.Object,
+                clock);
+        }
+
+        private static WeeklySalesReportDto NonEmptyWeekly() => new()
+        {
+            OutreachTouches = 3,
+        };
+
+        private static WeeklySalesReportDto EmptyWeekly() => new();
+
+        private static MonthlySalesReportDto NonEmptyMonthly() => new()
+        {
+            Metrics =
+            [
+                new MonthlySalesMetricDto { Metric = 3, Label = "Outreach touches", Target = 15, Actual = 8, Status = "OnTrack" },
+            ],
+        };
+
+        private static MonthlySalesReportDto EmptyMonthly() => new()
+        {
+            Metrics =
+            [
+                new MonthlySalesMetricDto { Metric = 3, Label = "Outreach touches", Target = 15, Actual = 0, Status = "Behind" },
+            ],
+        };
+
+        private static List<SalesReportSubscriber> OneSubscriber() =>
+        [
+            new SalesReportSubscriber
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                IncludeWeekly = true,
+                IncludeMonthly = true,
+                User = new User { Id = Guid.NewGuid(), UserName = "cynthia", Email = "cynthia@test.com" },
+            },
+        ];
+
+        private void SetupTemplateFetch()
+        {
+            emailManager
+                .Setup(m => m.GetHtmlEmailCopy(It.IsAny<string>()))
+                .Returns("<p>{PeriodLabel}</p>");
+        }
+
+        // ---------- Weekly ----------
+
+        [Fact]
+        public async Task Weekly_NotMonday_ReturnsZero_NoSideEffects()
+        {
+            var sut = BuildSut(tuesday);
+
+            var sent = await sut.SendWeeklyReportIfDueAsync();
+
+            Assert.Equal(0, sent);
+            weekly.Verify(w => w.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()), Times.Never);
+            emailManager.Verify(m => m.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(), It.IsAny<CancellationToken>()), Times.Never);
+            Assert.Empty(db.SalesReports);
+        }
+
+        [Fact]
+        public async Task Weekly_MondayEmptyReport_ReturnsZero_NoDedupeRow()
+        {
+            weekly.Setup(w => w.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyWeekly());
+
+            var sut = BuildSut(monday);
+            var sent = await sut.SendWeeklyReportIfDueAsync();
+
+            Assert.Equal(0, sent);
+            emailManager.Verify(m => m.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(), It.IsAny<CancellationToken>()), Times.Never);
+            Assert.Empty(db.SalesReports);
+        }
+
+        [Fact]
+        public async Task Weekly_MondayNoSubscribers_ReturnsZero_NoDedupeRow()
+        {
+            weekly.Setup(w => w.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(NonEmptyWeekly());
+            subscribers.Setup(s => s.GetForCadenceAsync(
+                    SalesReportPeriodTypeEnum.Weekly, It.IsAny<CancellationToken>()))
+                .ReturnsAsync([]);
+
+            var sut = BuildSut(monday);
+            var sent = await sut.SendWeeklyReportIfDueAsync();
+
+            Assert.Equal(0, sent);
+            Assert.Empty(db.SalesReports);
+        }
+
+        [Fact]
+        public async Task Weekly_HappyPath_SendsToEachSubscriberAndMarksSent()
+        {
+            weekly.Setup(w => w.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(NonEmptyWeekly());
+            subscribers.Setup(s => s.GetForCadenceAsync(
+                    SalesReportPeriodTypeEnum.Weekly, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OneSubscriber());
+            SetupTemplateFetch();
+
+            var sut = BuildSut(monday);
+            var sent = await sut.SendWeeklyReportIfDueAsync();
+
+            Assert.Equal(1, sent);
+            emailManager.Verify(m => m.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.Is<List<EmailAddress>>(r => r.Count == 1 && r[0].Email == "cynthia@test.com"),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+            Assert.Single(db.SalesReports);
+            Assert.NotNull(db.SalesReports.First().EmailSentDate);
+        }
+
+        [Fact]
+        public async Task Weekly_SecondFiringSameDay_IsIdempotent()
+        {
+            // Seed a "sent" dedupe row for the just-ended week.
+            var weekEnding = DateOnly.FromDateTime(monday.UtcDateTime).AddDays(-1);
+            var weekStart = weekEnding.AddDays(-6);
+            db.SalesReports.Add(new SalesReport
+            {
+                Id = Guid.NewGuid(),
+                PeriodType = (int)SalesReportPeriodTypeEnum.Weekly,
+                PeriodStart = weekStart.ToDateTime(TimeOnly.MinValue),
+                PeriodEnd = weekEnding.ToDateTime(TimeOnly.MinValue),
+                EmailSentDate = monday,
+                CreatedDate = monday,
+                LastUpdatedDate = monday,
+            });
+            db.SaveChanges();
+
+            var sut = BuildSut(monday);
+            var sent = await sut.SendWeeklyReportIfDueAsync();
+
+            Assert.Equal(0, sent);
+            weekly.Verify(w => w.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()), Times.Never);
+            emailManager.Verify(m => m.SendTemplatedEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        // ---------- Monthly ----------
+
+        [Fact]
+        public async Task Monthly_NotFirstOfMonth_ReturnsZero_NoSideEffects()
+        {
+            var sut = BuildSut(monday); // 13th, not the 1st
+
+            var sent = await sut.SendMonthlyReportIfDueAsync();
+
+            Assert.Equal(0, sent);
+            monthly.Verify(m => m.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Monthly_FirstOfMonthEmpty_ReturnsZero()
+        {
+            monthly.Setup(m => m.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyMonthly());
+
+            var sut = BuildSut(firstOfMonth);
+            var sent = await sut.SendMonthlyReportIfDueAsync();
+
+            Assert.Equal(0, sent);
+            Assert.Empty(db.SalesReports);
+        }
+
+        [Fact]
+        public async Task Monthly_HappyPath_SendsAndMarksSent()
+        {
+            monthly.Setup(m => m.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(NonEmptyMonthly());
+            subscribers.Setup(s => s.GetForCadenceAsync(
+                    SalesReportPeriodTypeEnum.Monthly, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(OneSubscriber());
+            SetupTemplateFetch();
+
+            var sut = BuildSut(firstOfMonth);
+            var sent = await sut.SendMonthlyReportIfDueAsync();
+
+            Assert.Equal(1, sent);
+            var row = Assert.Single(db.SalesReports);
+            Assert.Equal((int)SalesReportPeriodTypeEnum.Monthly, row.PeriodType);
+            // Previous month → July 2026
+            Assert.Equal(new DateTime(2026, 7, 1), row.PeriodStart);
+            Assert.NotNull(row.EmailSentDate);
+        }
+
+        [Fact]
+        public async Task Monthly_SecondFiringSameDay_IsIdempotent()
+        {
+            var previousMonthStart = new DateOnly(2026, 7, 1);
+            db.SalesReports.Add(new SalesReport
+            {
+                Id = Guid.NewGuid(),
+                PeriodType = (int)SalesReportPeriodTypeEnum.Monthly,
+                PeriodStart = previousMonthStart.ToDateTime(TimeOnly.MinValue),
+                PeriodEnd = previousMonthStart.AddMonths(1).AddDays(-1).ToDateTime(TimeOnly.MinValue),
+                EmailSentDate = firstOfMonth,
+                CreatedDate = firstOfMonth,
+                LastUpdatedDate = firstOfMonth,
+            });
+            db.SaveChanges();
+
+            var sut = BuildSut(firstOfMonth);
+            var sent = await sut.SendMonthlyReportIfDueAsync();
+
+            Assert.Equal(0, sent);
+            monthly.Verify(m => m.GenerateAsync(It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        public void Dispose()
+        {
+            db.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Trivial <see cref="TimeProvider"/> stub — the service's clock is the
+        /// only piece of ambient state under test, so a two-line override is
+        /// simpler than pulling in Microsoft.Extensions.Time.Testing.
+        /// </summary>
+        private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+        {
+            public override DateTimeOffset GetUtcNow() => now;
+        }
+    }
+}

--- a/TrashMob.Shared/Engine/EmailCopy/SalesReportMonthly.html
+++ b/TrashMob.Shared/Engine/EmailCopy/SalesReportMonthly.html
@@ -1,0 +1,38 @@
+<p style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 16px;">
+    Here's the municipal sales pipeline report for <strong>{PeriodLabel}</strong>.
+</p>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Goals vs. Actuals</h3>
+<table role="presentation" style="border-collapse: collapse; width: 100%; margin-bottom: 16px; font-size: 15px; color: #333333;">
+    <thead>
+        <tr style="border-bottom: 1px solid #dddddd;">
+            <th style="text-align: left; padding: 6px 12px 6px 0;">Metric</th>
+            <th style="text-align: right; padding: 6px 8px;">Target</th>
+            <th style="text-align: right; padding: 6px 8px;">Actual</th>
+            <th style="text-align: left; padding: 6px 0 6px 8px;">Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        {MetricRowsHtml}
+    </tbody>
+</table>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Best Responding Departments</h3>
+<div style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 15px;">
+    {DepartmentsHtml}
+</div>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Common Objections</h3>
+<div style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 15px;">
+    {ObjectionsHtml}
+</div>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Pricing Feedback</h3>
+<div style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 15px;">
+    {PricingHtml}
+</div>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Recommended Next-Month Priority</h3>
+<div style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 15px;">
+    {NextMonthPriorityHtml}
+</div>

--- a/TrashMob.Shared/Engine/EmailCopy/SalesReportWeekly.html
+++ b/TrashMob.Shared/Engine/EmailCopy/SalesReportWeekly.html
@@ -1,0 +1,30 @@
+<p style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 16px;">
+    Here's the municipal sales pipeline report for the week of <strong>{PeriodLabel}</strong>.
+</p>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Activity</h3>
+<table role="presentation" style="border-collapse: collapse; width: 100%; margin-bottom: 16px; font-size: 15px; color: #333333;">
+    <tr><td style="padding: 6px 12px 6px 0;">Prospects researched</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{ProspectsResearched}</td></tr>
+    <tr><td style="padding: 6px 12px 6px 0;">New contacts added</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{NewContactsAdded}</td></tr>
+    <tr><td style="padding: 6px 12px 6px 0;">Outreach touches</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{OutreachTouches}</td></tr>
+    <tr><td style="padding: 6px 12px 6px 0;">Follow-up touches</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{FollowUpTouches}</td></tr>
+    <tr><td style="padding: 6px 12px 6px 0;">Responses</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{Responses}</td></tr>
+    <tr><td style="padding: 6px 12px 6px 0;">Meetings requested</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{MeetingsRequested}</td></tr>
+    <tr><td style="padding: 6px 12px 6px 0;">Meetings scheduled</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{MeetingsScheduled}</td></tr>
+    <tr><td style="padding: 6px 12px 6px 0;">Meetings held</td><td style="padding: 6px 0; font-weight: bold; text-align: right;">{MeetingsHeld}</td></tr>
+</table>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Key Municipal Feedback</h3>
+<div style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 15px;">
+    {KeyMunicipalFeedbackHtml}
+</div>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Pricing / Business Model Feedback</h3>
+<div style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 15px;">
+    {PricingFeedbackHtml}
+</div>
+
+<h3 style="margin: 24px 0 8px 0; font-size: 18px; color: #333333;">Next Steps</h3>
+<div style="margin: 0 0 16px 0; line-height: 1.6; color: #333333; font-size: 15px;">
+    {NextStepsHtml}
+</div>

--- a/TrashMob.Shared/Engine/NotificationTypeEnum.cs
+++ b/TrashMob.Shared/Engine/NotificationTypeEnum.cs
@@ -269,5 +269,15 @@
         /// Notification sent to a user when a role is revoked from their account (Project 64).
         /// </summary>
         RoleRevoked = 53,
+
+        /// <summary>
+        /// Weekly municipal sales pipeline report emailed to subscribers (Project 63).
+        /// </summary>
+        SalesReportWeekly = 54,
+
+        /// <summary>
+        /// Monthly municipal sales pipeline report emailed to subscribers (Project 63).
+        /// </summary>
+        SalesReportMonthly = 55,
     }
 }

--- a/TrashMob.Shared/Managers/Interfaces/ISalesReportEmailService.cs
+++ b/TrashMob.Shared/Managers/Interfaces/ISalesReportEmailService.cs
@@ -1,0 +1,44 @@
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Sends the weekly and monthly municipal sales pipeline emails to the
+    /// distribution list (Project 63 Phase 4b). Called by processors in
+    /// <c>TrashMobDailyJobs</c>; each method decides internally whether
+    /// today is a "send day" (Monday for weekly, day-1 for monthly) and
+    /// whether the previous period's report already went out.
+    /// </summary>
+    /// <remarks>
+    /// Cadence:
+    /// <list type="bullet">
+    /// <item>Weekly — fires on any Monday. Reports on the just-ended
+    /// Mon–Sun window ending on the previous Sunday.</item>
+    /// <item>Monthly — fires on the 1st of any month. Reports on the
+    /// just-ended calendar month.</item>
+    /// </list>
+    /// The daily job container fires twice a day (00:00 and 12:00 UTC), so
+    /// each method dedupes via <c>SalesReport.EmailSentDate</c> — the second
+    /// firing on the same send-day is a no-op.
+    ///
+    /// Empty periods are skipped: if there was no activity in the window,
+    /// no email is sent and no dedupe row is written.
+    /// </remarks>
+    public interface ISalesReportEmailService
+    {
+        /// <summary>
+        /// Sends last week's report to weekly subscribers if today is Monday
+        /// (UTC), the report has activity, and it has not already been sent.
+        /// Returns the number of recipient emails dispatched (0 on any skip).
+        /// </summary>
+        Task<int> SendWeeklyReportIfDueAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends last month's report to monthly subscribers if today is the
+        /// 1st (UTC), the report has activity, and it has not already been
+        /// sent. Returns the number of recipient emails dispatched.
+        /// </summary>
+        Task<int> SendMonthlyReportIfDueAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/Interfaces/ISalesReportSubscriberService.cs
+++ b/TrashMob.Shared/Managers/Interfaces/ISalesReportSubscriberService.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+namespace TrashMob.Shared.Managers.Interfaces
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TrashMob.Models;
+
+    /// <summary>
+    /// Distribution-list management for the weekly and monthly sales pipeline
+    /// emails (Project 63 Phase 4b). SiteAdmin-only from the API side; the
+    /// scheduled job reads via <see cref="GetForCadenceAsync"/>.
+    /// </summary>
+    public interface ISalesReportSubscriberService
+    {
+        /// <summary>
+        /// Returns all subscribers with their <see cref="SalesReportSubscriber.User"/>
+        /// navigation populated, ordered by user name.
+        /// </summary>
+        Task<IReadOnlyCollection<SalesReportSubscriber>> ListAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns subscribers currently opted in to the given cadence.
+        /// Used by the hourly job to build the recipient list.
+        /// </summary>
+        Task<IReadOnlyCollection<SalesReportSubscriber>> GetForCadenceAsync(
+            SalesReportPeriodTypeEnum periodType,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds a new subscription. If the user is already subscribed, updates
+        /// the cadence flags in place instead of throwing.
+        /// </summary>
+        Task<SalesReportSubscriber> AddOrUpdateAsync(
+            Guid userId,
+            bool includeWeekly,
+            bool includeMonthly,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates cadence flags on an existing subscription by id.
+        /// Returns null when the subscription does not exist.
+        /// </summary>
+        Task<SalesReportSubscriber?> UpdateAsync(
+            Guid subscriptionId,
+            bool includeWeekly,
+            bool includeMonthly,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a subscription. Returns false when no matching row exists.
+        /// </summary>
+        Task<bool> DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default);
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/SalesReportEmailService.cs
+++ b/TrashMob.Shared/Managers/Prospects/SalesReportEmailService.cs
@@ -1,0 +1,355 @@
+#nullable enable
+
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Models;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Shared.Engine;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence;
+    using TrashMob.Shared.Poco;
+
+    /// <summary>
+    /// Dispatches the weekly and monthly sales pipeline emails on send-days
+    /// (Project 63 Phase 4b). See <see cref="ISalesReportEmailService"/> for
+    /// the cadence contract.
+    /// </summary>
+    public class SalesReportEmailService(
+        MobDbContext db,
+        IWeeklySalesReportService weeklyReportService,
+        IMonthlySalesReportService monthlyReportService,
+        ISalesReportSubscriberService subscriberService,
+        IEmailManager emailManager,
+        ILogger<SalesReportEmailService> logger,
+        TimeProvider? timeProvider = null) : ISalesReportEmailService
+    {
+        private readonly TimeProvider clock = timeProvider ?? TimeProvider.System;
+
+        // System user for automated writes — matches the id used by the
+        // Project 64 backfill migration.
+        private static readonly Guid SystemUserId = new("00000000-0000-0000-0000-000000000001");
+
+        /// <inheritdoc />
+        public async Task<int> SendWeeklyReportIfDueAsync(CancellationToken cancellationToken = default)
+        {
+            var todayUtc = DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime);
+            if (todayUtc.DayOfWeek != DayOfWeek.Monday)
+            {
+                return 0;
+            }
+
+            // Just-ended week: Sunday one day ago; the isoWeek that ends there.
+            var weekEnding = todayUtc.AddDays(-1);
+            var weekStart = weekEnding.AddDays(-6);
+
+            var alreadySent = await IsAlreadySentAsync(
+                SalesReportPeriodTypeEnum.Weekly, weekStart, cancellationToken);
+            if (alreadySent)
+            {
+                logger.LogInformation(
+                    "Weekly sales report for week ending {WeekEnding} already emailed; skipping.",
+                    weekEnding);
+                return 0;
+            }
+
+            var report = await weeklyReportService.GenerateAsync(weekEnding, cancellationToken);
+            if (IsEmpty(report))
+            {
+                logger.LogInformation(
+                    "Weekly sales report for week ending {WeekEnding} has no activity; skipping.",
+                    weekEnding);
+                return 0;
+            }
+
+            var subscribers = await subscriberService.GetForCadenceAsync(
+                SalesReportPeriodTypeEnum.Weekly, cancellationToken);
+            if (subscribers.Count == 0)
+            {
+                logger.LogInformation(
+                    "Weekly sales report for week ending {WeekEnding} has 0 subscribers; skipping.",
+                    weekEnding);
+                return 0;
+            }
+
+            var subject = $"TrashMob municipal sales pipeline — week of {weekStart:MMM d}–{weekEnding:MMM d, yyyy}";
+            var html = BuildWeeklyHtml(report, weekStart, weekEnding);
+            var count = await DispatchAsync(subject, html, subscribers, cancellationToken);
+
+            await MarkSentAsync(
+                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnding, cancellationToken);
+
+            logger.LogInformation(
+                "Weekly sales report for week ending {WeekEnding} sent to {Count} subscribers.",
+                weekEnding, count);
+            return count;
+        }
+
+        /// <inheritdoc />
+        public async Task<int> SendMonthlyReportIfDueAsync(CancellationToken cancellationToken = default)
+        {
+            var todayUtc = DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime);
+            if (todayUtc.Day != 1)
+            {
+                return 0;
+            }
+
+            // Just-ended calendar month.
+            var monthAnchor = todayUtc.AddMonths(-1);
+            var monthStart = new DateOnly(monthAnchor.Year, monthAnchor.Month, 1);
+            var monthEnd = monthStart.AddMonths(1).AddDays(-1);
+
+            var alreadySent = await IsAlreadySentAsync(
+                SalesReportPeriodTypeEnum.Monthly, monthStart, cancellationToken);
+            if (alreadySent)
+            {
+                logger.LogInformation(
+                    "Monthly sales report for {Month:yyyy-MM} already emailed; skipping.",
+                    monthStart);
+                return 0;
+            }
+
+            var report = await monthlyReportService.GenerateAsync(monthAnchor, cancellationToken);
+            if (IsEmpty(report))
+            {
+                logger.LogInformation(
+                    "Monthly sales report for {Month:yyyy-MM} has no activity; skipping.",
+                    monthStart);
+                return 0;
+            }
+
+            var subscribers = await subscriberService.GetForCadenceAsync(
+                SalesReportPeriodTypeEnum.Monthly, cancellationToken);
+            if (subscribers.Count == 0)
+            {
+                logger.LogInformation(
+                    "Monthly sales report for {Month:yyyy-MM} has 0 subscribers; skipping.",
+                    monthStart);
+                return 0;
+            }
+
+            var subject = $"TrashMob municipal sales pipeline — {monthStart:MMMM yyyy}";
+            var html = BuildMonthlyHtml(report, monthStart);
+            var count = await DispatchAsync(subject, html, subscribers, cancellationToken);
+
+            await MarkSentAsync(
+                SalesReportPeriodTypeEnum.Monthly, monthStart, monthEnd, cancellationToken);
+
+            logger.LogInformation(
+                "Monthly sales report for {Month:yyyy-MM} sent to {Count} subscribers.",
+                monthStart, count);
+            return count;
+        }
+
+        private async Task<bool> IsAlreadySentAsync(
+            SalesReportPeriodTypeEnum periodType,
+            DateOnly periodStart,
+            CancellationToken cancellationToken)
+        {
+            var start = periodStart.ToDateTime(TimeOnly.MinValue);
+            return await db.SalesReports.AnyAsync(
+                r => r.PeriodType == (int)periodType
+                     && r.PeriodStart == start
+                     && r.EmailSentDate != null,
+                cancellationToken);
+        }
+
+        private async Task MarkSentAsync(
+            SalesReportPeriodTypeEnum periodType,
+            DateOnly periodStart,
+            DateOnly periodEnd,
+            CancellationToken cancellationToken)
+        {
+            var start = periodStart.ToDateTime(TimeOnly.MinValue);
+            var end = periodEnd.ToDateTime(TimeOnly.MinValue);
+            var now = clock.GetUtcNow();
+
+            var existing = await db.SalesReports.FirstOrDefaultAsync(
+                r => r.PeriodType == (int)periodType && r.PeriodStart == start,
+                cancellationToken);
+
+            if (existing == null)
+            {
+                db.SalesReports.Add(new SalesReport
+                {
+                    Id = Guid.NewGuid(),
+                    PeriodType = (int)periodType,
+                    PeriodStart = start,
+                    PeriodEnd = end,
+                    EmailSentDate = now,
+                    CreatedByUserId = SystemUserId,
+                    CreatedDate = now,
+                    LastUpdatedByUserId = SystemUserId,
+                    LastUpdatedDate = now,
+                });
+            }
+            else
+            {
+                existing.EmailSentDate = now;
+                existing.LastUpdatedByUserId = SystemUserId;
+                existing.LastUpdatedDate = now;
+            }
+
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        private async Task<int> DispatchAsync(
+            string subject,
+            string emailCopy,
+            IReadOnlyCollection<SalesReportSubscriber> subscribers,
+            CancellationToken cancellationToken)
+        {
+            var recipients = subscribers
+                .Where(s => !string.IsNullOrWhiteSpace(s.User?.Email))
+                .Select(s => new EmailAddress { Name = s.User.DisplayFirstName ?? s.User.UserName, Email = s.User.Email })
+                .ToList();
+
+            if (recipients.Count == 0)
+            {
+                return 0;
+            }
+
+            var dynamicTemplateData = new
+            {
+                username = "TrashMob subscriber",
+                emailCopy,
+                subject,
+            };
+
+            await emailManager.SendTemplatedEmailAsync(
+                subject,
+                SendGridEmailTemplateId.GenericEmail,
+                SendGridEmailGroupId.General,
+                dynamicTemplateData,
+                recipients,
+                cancellationToken);
+
+            return recipients.Count;
+        }
+
+        private static bool IsEmpty(WeeklySalesReportDto r) =>
+            r.ProspectsResearched == 0
+            && r.NewContactsAdded == 0
+            && r.OutreachTouches == 0
+            && r.FollowUpTouches == 0
+            && r.Responses == 0
+            && r.MeetingsRequested == 0
+            && r.MeetingsScheduled == 0
+            && r.MeetingsHeld == 0
+            && r.KeyMunicipalFeedback.Count == 0
+            && r.PricingFeedback.Count == 0;
+
+        private static bool IsEmpty(MonthlySalesReportDto r) =>
+            r.Metrics.All(m => m.Actual == 0)
+            && r.BestRespondingDepartments.Count == 0
+            && r.CommonObjections.Count == 0
+            && r.PricingFeedback.Count == 0;
+
+        private string BuildWeeklyHtml(WeeklySalesReportDto report, DateOnly periodStart, DateOnly periodEnd)
+        {
+            var template = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.SalesReportWeekly.ToString());
+            var periodLabel = $"{periodStart:MMM d}–{periodEnd:MMM d, yyyy}";
+
+            return template
+                .Replace("{PeriodLabel}", periodLabel)
+                .Replace("{ProspectsResearched}", report.ProspectsResearched.ToString())
+                .Replace("{NewContactsAdded}", report.NewContactsAdded.ToString())
+                .Replace("{OutreachTouches}", report.OutreachTouches.ToString())
+                .Replace("{FollowUpTouches}", report.FollowUpTouches.ToString())
+                .Replace("{Responses}", report.Responses.ToString())
+                .Replace("{MeetingsRequested}", report.MeetingsRequested.ToString())
+                .Replace("{MeetingsScheduled}", report.MeetingsScheduled.ToString())
+                .Replace("{MeetingsHeld}", report.MeetingsHeld.ToString())
+                .Replace("{KeyMunicipalFeedbackHtml}", RenderBulletList(report.KeyMunicipalFeedback))
+                .Replace("{PricingFeedbackHtml}", RenderBulletList(report.PricingFeedback))
+                .Replace("{NextStepsHtml}", RenderNarrative(report.NextSteps));
+        }
+
+        private string BuildMonthlyHtml(MonthlySalesReportDto report, DateOnly monthStart)
+        {
+            var template = emailManager.GetHtmlEmailCopy(NotificationTypeEnum.SalesReportMonthly.ToString());
+            var periodLabel = monthStart.ToString("MMMM yyyy");
+
+            return template
+                .Replace("{PeriodLabel}", periodLabel)
+                .Replace("{MetricRowsHtml}", RenderMetricRows(report.Metrics))
+                .Replace("{DepartmentsHtml}", RenderCountList(report.BestRespondingDepartments))
+                .Replace("{ObjectionsHtml}", RenderCountList(report.CommonObjections))
+                .Replace("{PricingHtml}", RenderCountList(report.PricingFeedback))
+                .Replace("{NextMonthPriorityHtml}", RenderNarrative(report.NextMonthPriority));
+        }
+
+        private static string RenderBulletList(IReadOnlyCollection<string> items)
+        {
+            if (items.Count == 0)
+            {
+                return "<p style=\"color: #666666; margin: 0;\">None captured for this window.</p>";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("<ul style=\"margin: 0; padding-left: 20px;\">");
+            foreach (var item in items)
+            {
+                sb.Append("<li style=\"margin-bottom: 4px;\">").Append(HtmlEncode(item)).Append("</li>");
+            }
+            sb.Append("</ul>");
+            return sb.ToString();
+        }
+
+        private static string RenderCountList(IReadOnlyCollection<MarketIntelligenceCountDto> items)
+        {
+            if (items.Count == 0)
+            {
+                return "<p style=\"color: #666666; margin: 0;\">None captured for this window.</p>";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("<ul style=\"margin: 0; padding-left: 20px;\">");
+            foreach (var item in items)
+            {
+                sb.Append("<li style=\"margin-bottom: 4px;\">")
+                    .Append(HtmlEncode(item.Label))
+                    .Append(" <span style=\"color: #666666;\">(")
+                    .Append(item.Count)
+                    .Append(")</span></li>");
+            }
+            sb.Append("</ul>");
+            return sb.ToString();
+        }
+
+        private static string RenderMetricRows(IReadOnlyCollection<MonthlySalesMetricDto> metrics)
+        {
+            var sb = new StringBuilder();
+            foreach (var m in metrics)
+            {
+                sb.Append("<tr style=\"border-bottom: 1px solid #eeeeee;\">")
+                    .Append("<td style=\"padding: 6px 12px 6px 0;\">").Append(HtmlEncode(m.Label)).Append("</td>")
+                    .Append("<td style=\"padding: 6px 8px; text-align: right;\">").Append(m.Target).Append("</td>")
+                    .Append("<td style=\"padding: 6px 8px; text-align: right; font-weight: bold;\">").Append(m.Actual).Append("</td>")
+                    .Append("<td style=\"padding: 6px 0 6px 8px;\">").Append(HtmlEncode(m.Status)).Append("</td>")
+                    .Append("</tr>");
+            }
+            return sb.ToString();
+        }
+
+        private static string RenderNarrative(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return "<p style=\"color: #666666; margin: 0;\">The salesperson did not add a narrative for this period.</p>";
+            }
+
+            return "<p style=\"margin: 0; white-space: pre-wrap;\">" + HtmlEncode(text) + "</p>";
+        }
+
+        private static string HtmlEncode(string s) =>
+            System.Net.WebUtility.HtmlEncode(s);
+    }
+}

--- a/TrashMob.Shared/Managers/Prospects/SalesReportSubscriberService.cs
+++ b/TrashMob.Shared/Managers/Prospects/SalesReportSubscriberService.cs
@@ -1,0 +1,127 @@
+#nullable enable
+
+namespace TrashMob.Shared.Managers.Prospects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using TrashMob.Models;
+    using TrashMob.Shared.Managers.Interfaces;
+    using TrashMob.Shared.Persistence;
+
+    /// <summary>
+    /// EF-backed subscriber list for the weekly and monthly sales pipeline
+    /// emails (Project 63 Phase 4b).
+    /// </summary>
+    public class SalesReportSubscriberService(MobDbContext db) : ISalesReportSubscriberService
+    {
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<SalesReportSubscriber>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return await db.SalesReportSubscribers
+                .Include(s => s.User)
+                .OrderBy(s => s.User.UserName)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<SalesReportSubscriber>> GetForCadenceAsync(
+            SalesReportPeriodTypeEnum periodType,
+            CancellationToken cancellationToken = default)
+        {
+            var query = db.SalesReportSubscribers.Include(s => s.User).AsQueryable();
+            query = periodType == SalesReportPeriodTypeEnum.Weekly
+                ? query.Where(s => s.IncludeWeekly)
+                : query.Where(s => s.IncludeMonthly);
+
+            // Never fan out to accounts without an email address on file.
+            return await query
+                .Where(s => s.User.Email != null && s.User.Email != string.Empty)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<SalesReportSubscriber> AddOrUpdateAsync(
+            Guid userId,
+            bool includeWeekly,
+            bool includeMonthly,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var existing = await db.SalesReportSubscribers
+                .FirstOrDefaultAsync(s => s.UserId == userId, cancellationToken);
+
+            if (existing != null)
+            {
+                if (existing.IncludeWeekly != includeWeekly || existing.IncludeMonthly != includeMonthly)
+                {
+                    existing.IncludeWeekly = includeWeekly;
+                    existing.IncludeMonthly = includeMonthly;
+                    existing.LastUpdatedByUserId = actingUserId;
+                    existing.LastUpdatedDate = now;
+                    await db.SaveChangesAsync(cancellationToken);
+                }
+
+                return existing;
+            }
+
+            var subscriber = new SalesReportSubscriber
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                IncludeWeekly = includeWeekly,
+                IncludeMonthly = includeMonthly,
+                CreatedByUserId = actingUserId,
+                CreatedDate = now,
+                LastUpdatedByUserId = actingUserId,
+                LastUpdatedDate = now,
+            };
+            db.SalesReportSubscribers.Add(subscriber);
+            await db.SaveChangesAsync(cancellationToken);
+            return subscriber;
+        }
+
+        /// <inheritdoc />
+        public async Task<SalesReportSubscriber?> UpdateAsync(
+            Guid subscriptionId,
+            bool includeWeekly,
+            bool includeMonthly,
+            Guid actingUserId,
+            CancellationToken cancellationToken = default)
+        {
+            var existing = await db.SalesReportSubscribers
+                .FirstOrDefaultAsync(s => s.Id == subscriptionId, cancellationToken);
+            if (existing == null)
+            {
+                return null;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            existing.IncludeWeekly = includeWeekly;
+            existing.IncludeMonthly = includeMonthly;
+            existing.LastUpdatedByUserId = actingUserId;
+            existing.LastUpdatedDate = now;
+            await db.SaveChangesAsync(cancellationToken);
+            return existing;
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
+        {
+            var existing = await db.SalesReportSubscribers
+                .FirstOrDefaultAsync(s => s.Id == subscriptionId, cancellationToken);
+            if (existing == null)
+            {
+                return false;
+            }
+
+            db.SalesReportSubscribers.Remove(existing);
+            await db.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+    }
+}

--- a/TrashMob.Shared/Migrations/20260705005602_AddSalesReportSubscribers.Designer.cs
+++ b/TrashMob.Shared/Migrations/20260705005602_AddSalesReportSubscribers.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using TrashMob.Shared.Persistence;
 
 #nullable disable
 
-namespace TrashMob.Migrations
+namespace TrashMob.Shared.Migrations
 {
     [DbContext(typeof(MobDbContext))]
-    partial class MobDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260705005602_AddSalesReportSubscribers")]
+    partial class AddSalesReportSubscribers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TrashMob.Shared/Migrations/20260705005602_AddSalesReportSubscribers.cs
+++ b/TrashMob.Shared/Migrations/20260705005602_AddSalesReportSubscribers.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrashMob.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSalesReportSubscribers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SalesReportSubscribers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    IncludeWeekly = table.Column<bool>(type: "bit", nullable: false),
+                    IncludeMonthly = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastUpdatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LastUpdatedDate = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SalesReportSubscribers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SalesReportSubscribers_User",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SalesReportSubscribers_User_CreatedBy",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_SalesReportSubscribers_User_LastUpdatedBy",
+                        column: x => x.LastUpdatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SalesReportSubscribers_CreatedByUserId",
+                table: "SalesReportSubscribers",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SalesReportSubscribers_LastUpdatedByUserId",
+                table: "SalesReportSubscribers",
+                column: "LastUpdatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_SalesReportSubscribers_User",
+                table: "SalesReportSubscribers",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SalesReportSubscribers");
+        }
+    }
+}

--- a/TrashMob.Shared/Persistence/MobDbContext.cs
+++ b/TrashMob.Shared/Persistence/MobDbContext.cs
@@ -175,6 +175,8 @@
 
         public virtual DbSet<SalesReport> SalesReports { get; set; }
 
+        public virtual DbSet<SalesReportSubscriber> SalesReportSubscribers { get; set; }
+
         public virtual DbSet<Contact> Contacts { get; set; }
 
         public virtual DbSet<Donation> Donations { get; set; }
@@ -3704,6 +3706,36 @@
                     .HasForeignKey(d => d.LastUpdatedByUserId)
                     .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_SalesReports_User_LastUpdatedBy");
+            });
+
+            modelBuilder.Entity<SalesReportSubscriber>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                // One subscription row per user — the "toggle weekly / monthly"
+                // UI upserts through this unique constraint so callers don't
+                // race on duplicate inserts.
+                entity.HasIndex(e => e.UserId)
+                    .IsUnique()
+                    .HasDatabaseName("UX_SalesReportSubscribers_User");
+
+                entity.HasOne(d => d.User)
+                    .WithMany()
+                    .HasForeignKey(d => d.UserId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .HasConstraintName("FK_SalesReportSubscribers_User");
+
+                entity.HasOne(d => d.CreatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.CreatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_SalesReportSubscribers_User_CreatedBy");
+
+                entity.HasOne(d => d.LastUpdatedByUser)
+                    .WithMany()
+                    .HasForeignKey(d => d.LastUpdatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
+                    .HasConstraintName("FK_SalesReportSubscribers_User_LastUpdatedBy");
             });
 
             // ===== Contact Management System (Project 51) =====

--- a/TrashMob.Shared/ServiceBuilder.cs
+++ b/TrashMob.Shared/ServiceBuilder.cs
@@ -175,6 +175,8 @@
             services.AddScoped<IWeeklySalesReportService, WeeklySalesReportService>();
             services.AddScoped<IMonthlySalesReportService, MonthlySalesReportService>();
             services.AddScoped<ISalesReportNarrativeService, SalesReportNarrativeService>();
+            services.AddScoped<ISalesReportSubscriberService, SalesReportSubscriberService>();
+            services.AddScoped<ISalesReportEmailService, SalesReportEmailService>();
 
             // Contact Management
             services.AddScoped<IContactManager, ContactManager>();

--- a/TrashMob.Shared/TrashMob.Shared.csproj
+++ b/TrashMob.Shared/TrashMob.Shared.csproj
@@ -54,6 +54,8 @@
     <None Remove="Engine\EmailCopy\UpcomingTeamEventsSoon.html" />
     <None Remove="Engine\EmailCopy\RoleGranted.html" />
     <None Remove="Engine\EmailCopy\RoleRevoked.html" />
+    <None Remove="Engine\EmailCopy\SalesReportWeekly.html" />
+    <None Remove="Engine\EmailCopy\SalesReportMonthly.html" />
   </ItemGroup>
 
   <ItemGroup>
@@ -110,6 +112,8 @@
     <EmbeddedResource Include="Engine\EmailCopy\DependentRegisteredForEvent.html" />
     <EmbeddedResource Include="Engine\EmailCopy\RoleGranted.html" />
     <EmbeddedResource Include="Engine\EmailCopy\RoleRevoked.html" />
+    <EmbeddedResource Include="Engine\EmailCopy\SalesReportWeekly.html" />
+    <EmbeddedResource Include="Engine\EmailCopy\SalesReportMonthly.html" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TrashMob/Controllers/V2/SalesReportSubscribersV2Controller.cs
+++ b/TrashMob/Controllers/V2/SalesReportSubscribersV2Controller.cs
@@ -1,0 +1,144 @@
+namespace TrashMob.Controllers.V2
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Asp.Versioning;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Cors;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Identity.Web.Resource;
+    using TrashMob.Models.Extensions.V2;
+    using TrashMob.Models.Poco.V2;
+    using TrashMob.Security;
+    using TrashMob.Shared;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// V2 controller for the sales-report distribution list (Project 63 Phase 4b).
+    /// SiteAdmin-only — the salesperson can't add themselves to Cynthia's
+    /// weekly email.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2.0")]
+    [EnableCors("_myAllowSpecificOrigins")]
+    [Route("api/v{version:apiVersion}/reports/sales/subscribers")]
+    [Authorize(Policy = AuthorizationPolicyConstants.UserIsAdmin)]
+    [RequiredScope(Constants.TrashMobWriteScope)]
+    public class SalesReportSubscribersV2Controller(
+        ISalesReportSubscriberService subscriberService,
+        ILogger<SalesReportSubscribersV2Controller> logger) : ControllerBase
+    {
+        private Guid UserId => Guid.TryParse(HttpContext.Items["UserId"]?.ToString(), out var parsedUserId)
+            ? parsedUserId
+            : Guid.Empty;
+
+        /// <summary>
+        /// Lists every subscription, ordered by user name.
+        /// </summary>
+        /// <response code="200">Returns the subscriber list.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<SalesReportSubscriberDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> List(CancellationToken cancellationToken)
+        {
+            var subscribers = await subscriberService.ListAsync(cancellationToken);
+            return Ok(subscribers.Select(s => s.ToV2Dto()).ToList());
+        }
+
+        /// <summary>
+        /// Adds a new subscription, or updates the cadence flags on an existing
+        /// one when the user is already subscribed.
+        /// </summary>
+        /// <param name="request">Subscription details.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the created/updated subscription.</response>
+        /// <response code="400">Missing or invalid <c>UserId</c>.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(SalesReportSubscriberDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Add(
+            [FromBody] AddSalesReportSubscriberRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (request?.UserId == Guid.Empty)
+            {
+                return Problem("UserId is required.", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            logger.LogInformation(
+                "V2 AddSalesReportSubscriber UserId={UserId} Weekly={Weekly} Monthly={Monthly} By={ActorId}",
+                request!.UserId, request.IncludeWeekly, request.IncludeMonthly, UserId);
+
+            var subscriber = await subscriberService.AddOrUpdateAsync(
+                request.UserId,
+                request.IncludeWeekly,
+                request.IncludeMonthly,
+                UserId,
+                cancellationToken);
+
+            // Reload with User navigation for the response payload.
+            var withUser = (await subscriberService.ListAsync(cancellationToken))
+                .FirstOrDefault(s => s.Id == subscriber.Id);
+            return Ok((withUser ?? subscriber).ToV2Dto());
+        }
+
+        /// <summary>
+        /// Updates cadence flags on an existing subscription.
+        /// </summary>
+        /// <param name="subscriptionId">The subscription id.</param>
+        /// <param name="request">Cadence flags to apply.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the updated subscription.</response>
+        /// <response code="404">Subscription not found.</response>
+        [HttpPut("{subscriptionId}")]
+        [ProducesResponseType(typeof(SalesReportSubscriberDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(
+            Guid subscriptionId,
+            [FromBody] UpdateSalesReportSubscriberRequest request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation(
+                "V2 UpdateSalesReportSubscriber SubscriptionId={SubscriptionId} Weekly={Weekly} Monthly={Monthly}",
+                subscriptionId, request.IncludeWeekly, request.IncludeMonthly);
+
+            var updated = await subscriberService.UpdateAsync(
+                subscriptionId,
+                request.IncludeWeekly,
+                request.IncludeMonthly,
+                UserId,
+                cancellationToken);
+
+            if (updated == null)
+            {
+                return NotFound();
+            }
+
+            var withUser = (await subscriberService.ListAsync(cancellationToken))
+                .FirstOrDefault(s => s.Id == subscriptionId);
+            return Ok((withUser ?? updated).ToV2Dto());
+        }
+
+        /// <summary>
+        /// Removes a subscription.
+        /// </summary>
+        /// <param name="subscriptionId">The subscription id.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Subscription removed.</response>
+        /// <response code="404">Subscription not found.</response>
+        [HttpDelete("{subscriptionId}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(Guid subscriptionId, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 DeleteSalesReportSubscriber SubscriptionId={SubscriptionId}", subscriptionId);
+
+            var removed = await subscriberService.DeleteAsync(subscriptionId, cancellationToken);
+            return removed ? NoContent() : NotFound();
+        }
+    }
+}

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -429,6 +429,11 @@ const SiteAdminProspectMonthlyReport = lazy(() =>
         default: m.SiteAdminProspectMonthlyReport,
     })),
 );
+const SiteAdminProspectSubscribers = lazy(() =>
+    import('./pages/siteadmin/prospects/reports/subscribers').then((m) => ({
+        default: m.SiteAdminProspectSubscribers,
+    })),
+);
 const SiteAdminDocuments = lazy(() =>
     import('./pages/siteadmin/documents/page').then((m) => ({ default: m.SiteAdminDocuments })),
 );
@@ -757,6 +762,10 @@ const AppContent: FC = () => {
                                 <Route path='prospects/analytics' element={<SiteAdminProspectAnalytics />} />
                                 <Route path='prospects/reports/weekly' element={<SiteAdminProspectWeeklyReport />} />
                                 <Route path='prospects/reports/monthly' element={<SiteAdminProspectMonthlyReport />} />
+                                <Route
+                                    path='prospects/reports/subscribers'
+                                    element={<SiteAdminProspectSubscribers />}
+                                />
                                 <Route path='prospects/:prospectId' element={<SiteAdminProspectDetail />} />
                                 <Route path='prospects/:prospectId/edit' element={<SiteAdminProspectEdit />} />
                                 <Route path='contacts' element={<SiteAdminContacts />} />

--- a/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
@@ -60,6 +60,7 @@ const navGroups: NavGroup[] = [
             { name: 'Pipeline Analytics', href: `${pathPrefix}/prospects/analytics`, icon: BarChart3 },
             { name: 'Weekly Report', href: `${pathPrefix}/prospects/reports/weekly`, icon: CalendarClock },
             { name: 'Monthly Report', href: `${pathPrefix}/prospects/reports/monthly`, icon: CalendarDays },
+            { name: 'Report Subscribers', href: `${pathPrefix}/prospects/reports/subscribers`, icon: Mail },
         ],
     },
     {

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/reports/subscribers.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/reports/subscribers.tsx
@@ -1,0 +1,254 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Send, Trash2, UserPlus } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { getErrorMessage } from '@/lib/api-errors';
+import {
+    AddSalesReportSubscriber,
+    DeleteSalesReportSubscriber,
+    GetSalesReportSubscribers,
+    UpdateSalesReportSubscriber,
+    type SalesReportSubscriberDto,
+} from '@/services/sales-report-subscribers';
+import { GetAllUsers } from '@/services/users';
+
+/**
+ * Sales Report Subscribers — distribution list management (Project 63 Phase 4b).
+ * SiteAdmin only. The daily job reads from this table when deciding who
+ * receives the weekly Monday-morning report and the monthly 1st-of-month
+ * report.
+ *
+ * Route: /siteadmin/prospects/reports/subscribers
+ */
+export const SiteAdminProspectSubscribers = () => {
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+
+    const [selectedUserId, setSelectedUserId] = useState<string>('');
+    const [addWeekly, setAddWeekly] = useState(true);
+    const [addMonthly, setAddMonthly] = useState(true);
+    const [userSearch, setUserSearch] = useState<string>('');
+
+    const { data: subscribers, isLoading } = useQuery({
+        queryKey: GetSalesReportSubscribers().key,
+        queryFn: GetSalesReportSubscribers().service,
+        select: (res) => res.data,
+    });
+
+    const { data: users } = useQuery({
+        queryKey: GetAllUsers().key,
+        queryFn: GetAllUsers().service,
+        select: (res) => res.data.items,
+    });
+
+    const subscribedUserIds = useMemo(() => new Set((subscribers ?? []).map((s) => s.userId)), [subscribers]);
+
+    const availableUsers = useMemo(() => {
+        const list = (users ?? []).filter((u) => !subscribedUserIds.has(u.id));
+        const search = userSearch.trim().toLowerCase();
+        if (!search) return list.slice(0, 25);
+        return list
+            .filter(
+                (u) =>
+                    (u.userName ?? '').toLowerCase().includes(search) ||
+                    ((u as unknown as { email?: string }).email ?? '').toLowerCase().includes(search),
+            )
+            .slice(0, 25);
+    }, [users, subscribedUserIds, userSearch]);
+
+    const invalidate = () => queryClient.invalidateQueries({ queryKey: GetSalesReportSubscribers().key });
+
+    const addMutation = useMutation({
+        mutationKey: AddSalesReportSubscriber().key,
+        mutationFn: AddSalesReportSubscriber().service,
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Subscriber added' });
+            invalidate();
+            setSelectedUserId('');
+            setUserSearch('');
+        },
+        onError: (error: Error) => {
+            toast({ variant: 'destructive', title: 'Add failed', description: getErrorMessage(error) });
+        },
+    });
+
+    const deleteMutation = useMutation({
+        mutationKey: DeleteSalesReportSubscriber().key,
+        mutationFn: DeleteSalesReportSubscriber().service,
+        onSuccess: () => {
+            toast({ variant: 'primary', title: 'Subscriber removed' });
+            invalidate();
+        },
+        onError: (error: Error) => {
+            toast({ variant: 'destructive', title: 'Remove failed', description: getErrorMessage(error) });
+        },
+    });
+
+    const handleToggleWeekly = (sub: SalesReportSubscriberDto, checked: boolean) => {
+        UpdateSalesReportSubscriber({ subscriptionId: sub.id })
+            .service({ includeWeekly: checked, includeMonthly: sub.includeMonthly })
+            .then(() => invalidate())
+            .catch((error: Error) =>
+                toast({
+                    variant: 'destructive',
+                    title: 'Update failed',
+                    description: getErrorMessage(error),
+                }),
+            );
+    };
+
+    const handleToggleMonthly = (sub: SalesReportSubscriberDto, checked: boolean) => {
+        UpdateSalesReportSubscriber({ subscriptionId: sub.id })
+            .service({ includeWeekly: sub.includeWeekly, includeMonthly: checked })
+            .then(() => invalidate())
+            .catch((error: Error) =>
+                toast({
+                    variant: 'destructive',
+                    title: 'Update failed',
+                    description: getErrorMessage(error),
+                }),
+            );
+    };
+
+    const submitAdd = () => {
+        if (!selectedUserId) return;
+        addMutation.mutate({ userId: selectedUserId, includeWeekly: addWeekly, includeMonthly: addMonthly });
+    };
+
+    return (
+        <div className='space-y-6'>
+            <Card>
+                <CardHeader>
+                    <CardTitle>Sales Report Subscribers</CardTitle>
+                    <CardDescription>
+                        The distribution list for the weekly Monday-morning and monthly 1st-of-month emails. The daily
+                        job reads from here — changes apply on the next send day.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <h3 className='mb-3 text-sm font-medium text-muted-foreground'>Current subscribers</h3>
+                    {isLoading ? (
+                        <p className='text-sm text-muted-foreground'>Loading…</p>
+                    ) : (subscribers ?? []).length === 0 ? (
+                        <p className='text-sm text-muted-foreground'>
+                            No subscribers yet. Add one below and the next Monday's report will send to them.
+                        </p>
+                    ) : (
+                        <ul className='divide-y'>
+                            {(subscribers ?? []).map((sub) => (
+                                <li key={sub.id} className='flex items-center justify-between py-3'>
+                                    <div>
+                                        <p className='font-medium'>{sub.userName || '—'}</p>
+                                        <p className='text-xs text-muted-foreground'>{sub.email || 'No email'}</p>
+                                    </div>
+                                    <div className='flex items-center gap-4'>
+                                        <label className='flex items-center gap-2 text-sm'>
+                                            <Checkbox
+                                                checked={sub.includeWeekly}
+                                                onCheckedChange={(checked) => handleToggleWeekly(sub, checked === true)}
+                                            />
+                                            Weekly
+                                        </label>
+                                        <label className='flex items-center gap-2 text-sm'>
+                                            <Checkbox
+                                                checked={sub.includeMonthly}
+                                                onCheckedChange={(checked) =>
+                                                    handleToggleMonthly(sub, checked === true)
+                                                }
+                                            />
+                                            Monthly
+                                        </label>
+                                        <Button
+                                            variant='ghost'
+                                            size='sm'
+                                            onClick={() => deleteMutation.mutate({ subscriptionId: sub.id })}
+                                            disabled={deleteMutation.isPending}
+                                        >
+                                            <Trash2 className='h-4 w-4' />
+                                        </Button>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Add a subscriber</CardTitle>
+                    <CardDescription>
+                        Only existing TrashMob users can be added — the daily job needs a valid email address on file.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
+                        <div className='md:col-span-2'>
+                            <Label htmlFor='user-search'>Search users</Label>
+                            <Input
+                                id='user-search'
+                                value={userSearch}
+                                onChange={(e) => setUserSearch(e.target.value)}
+                                placeholder='Type a name or email fragment…'
+                            />
+                            <div className='mt-2'>
+                                <Select value={selectedUserId} onValueChange={setSelectedUserId}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder='Select a user…' />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {availableUsers.length === 0 ? (
+                                            <SelectItem value='__none__' disabled>
+                                                No matching users.
+                                            </SelectItem>
+                                        ) : (
+                                            availableUsers.map((u) => (
+                                                <SelectItem key={u.id} value={u.id}>
+                                                    {u.userName}
+                                                </SelectItem>
+                                            ))
+                                        )}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
+                        <div className='space-y-3'>
+                            <label className='flex items-center gap-2 text-sm'>
+                                <Checkbox
+                                    checked={addWeekly}
+                                    onCheckedChange={(checked) => setAddWeekly(checked === true)}
+                                />
+                                Weekly Monday email
+                            </label>
+                            <label className='flex items-center gap-2 text-sm'>
+                                <Checkbox
+                                    checked={addMonthly}
+                                    onCheckedChange={(checked) => setAddMonthly(checked === true)}
+                                />
+                                Monthly 1st-of-month email
+                            </label>
+                            <Button
+                                onClick={submitAdd}
+                                disabled={!selectedUserId || addMutation.isPending}
+                                className='w-full'
+                            >
+                                {addMutation.isPending ? (
+                                    <Send className='mr-1 h-4 w-4 animate-pulse' />
+                                ) : (
+                                    <UserPlus className='mr-1 h-4 w-4' />
+                                )}
+                                Add subscriber
+                            </Button>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+};

--- a/TrashMob/client-app/src/services/sales-report-subscribers.ts
+++ b/TrashMob/client-app/src/services/sales-report-subscribers.ts
@@ -1,0 +1,66 @@
+import { ApiService } from '.';
+
+/**
+ * V2 API service factories for the sales-report distribution list
+ * (Project 63 Phase 4b). SiteAdmin only.
+ */
+
+export interface SalesReportSubscriberDto {
+    id: string;
+    userId: string;
+    userName: string | null;
+    email: string | null;
+    includeWeekly: boolean;
+    includeMonthly: boolean;
+}
+
+export const GetSalesReportSubscribers = () => ({
+    key: ['/reports/sales/subscribers'],
+    service: async () =>
+        ApiService('protected').fetchData<SalesReportSubscriberDto[]>({
+            url: '/v2/reports/sales/subscribers',
+            method: 'get',
+        }),
+});
+
+export interface AddSalesReportSubscriberBody {
+    userId: string;
+    includeWeekly: boolean;
+    includeMonthly: boolean;
+}
+
+export const AddSalesReportSubscriber = () => ({
+    key: ['/reports/sales/subscribers', 'add'],
+    service: async (body: AddSalesReportSubscriberBody) =>
+        ApiService('protected').fetchData<SalesReportSubscriberDto, AddSalesReportSubscriberBody>({
+            url: '/v2/reports/sales/subscribers',
+            method: 'post',
+            data: body,
+        }),
+});
+
+export interface UpdateSalesReportSubscriberBody {
+    includeWeekly: boolean;
+    includeMonthly: boolean;
+}
+
+export type UpdateSalesReportSubscriber_Params = { subscriptionId: string };
+
+export const UpdateSalesReportSubscriber = (params: UpdateSalesReportSubscriber_Params) => ({
+    key: ['/reports/sales/subscribers', params.subscriptionId, 'update'],
+    service: async (body: UpdateSalesReportSubscriberBody) =>
+        ApiService('protected').fetchData<SalesReportSubscriberDto, UpdateSalesReportSubscriberBody>({
+            url: `/v2/reports/sales/subscribers/${params.subscriptionId}`,
+            method: 'put',
+            data: body,
+        }),
+});
+
+export const DeleteSalesReportSubscriber = () => ({
+    key: ['/reports/sales/subscribers', 'delete'],
+    service: async (params: { subscriptionId: string }) =>
+        ApiService('protected').fetchData<unknown>({
+            url: `/v2/reports/sales/subscribers/${params.subscriptionId}`,
+            method: 'delete',
+        }),
+});

--- a/TrashMobDailyJobs/MonthlySalesReportEmailer.cs
+++ b/TrashMobDailyJobs/MonthlySalesReportEmailer.cs
@@ -1,0 +1,26 @@
+namespace TrashMobDailyJobs
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// Daily-job processor for the monthly municipal sales pipeline email
+    /// (Project 63 Phase 4b). The service itself decides whether today is
+    /// the 1st (UTC) and skips otherwise.
+    /// </summary>
+    public class MonthlySalesReportEmailer(
+        ISalesReportEmailService salesReportEmailService,
+        ILogger<MonthlySalesReportEmailer> logger)
+    {
+        public async Task RunAsync()
+        {
+            logger.LogInformation("MonthlySalesReportEmailer started at: {Time}", DateTime.UtcNow);
+            var sent = await salesReportEmailService.SendMonthlyReportIfDueAsync();
+            logger.LogInformation(
+                "MonthlySalesReportEmailer completed at: {Time}. Emails dispatched: {Count}",
+                DateTime.UtcNow, sent);
+        }
+    }
+}

--- a/TrashMobDailyJobs/Program.cs
+++ b/TrashMobDailyJobs/Program.cs
@@ -32,6 +32,8 @@ namespace TrashMobDailyJobs
             await RunProcessorAsync<StatGenerator>(scope, logger);
             await RunProcessorAsync<LeaderboardGenerator>(scope, logger);
             await RunProcessorAsync<AchievementProcessor>(scope, logger);
+            await RunProcessorAsync<WeeklySalesReportEmailer>(scope, logger);
+            await RunProcessorAsync<MonthlySalesReportEmailer>(scope, logger);
         }
 
         private static async Task RunProcessorAsync<T>(IServiceScope scope, ILogger logger) where T : class
@@ -100,6 +102,8 @@ namespace TrashMobDailyJobs
             services.AddScoped<StatGenerator>();
             services.AddScoped<LeaderboardGenerator>();
             services.AddScoped<AchievementProcessor>();
+            services.AddScoped<WeeklySalesReportEmailer>();
+            services.AddScoped<MonthlySalesReportEmailer>();
             ServiceBuilder.AddManagers(services);
             ServiceBuilder.AddRepositories(services);
             services.AddDbContext<MobDbContext>();

--- a/TrashMobDailyJobs/WeeklySalesReportEmailer.cs
+++ b/TrashMobDailyJobs/WeeklySalesReportEmailer.cs
@@ -1,0 +1,27 @@
+namespace TrashMobDailyJobs
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using TrashMob.Shared.Managers.Interfaces;
+
+    /// <summary>
+    /// Daily-job processor for the weekly municipal sales pipeline email
+    /// (Project 63 Phase 4b). The service itself decides whether today is a
+    /// send day (Monday UTC) and skips otherwise, so this class is a thin
+    /// shell that fits the daily-job dispatch pattern.
+    /// </summary>
+    public class WeeklySalesReportEmailer(
+        ISalesReportEmailService salesReportEmailService,
+        ILogger<WeeklySalesReportEmailer> logger)
+    {
+        public async Task RunAsync()
+        {
+            logger.LogInformation("WeeklySalesReportEmailer started at: {Time}", DateTime.UtcNow);
+            var sent = await salesReportEmailService.SendWeeklyReportIfDueAsync();
+            logger.LogInformation(
+                "WeeklySalesReportEmailer completed at: {Time}. Emails dispatched: {Count}",
+                DateTime.UtcNow, sent);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes out [Project 63](Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md). The weekly and monthly municipal sales pipeline reports now email themselves to a managed distribution list — no login required for Cynthia and the Board to see the numbers.

### Delivery model
- Two thin processors piggyback on the existing `TrashMobDailyJobs` container job (fires 00:00 and 12:00 UTC). Each processor checks `DayOfWeek` / day-of-month internally and short-circuits otherwise, so ~11 firings of every 12 are no-ops.
- **Weekly:** any Monday UTC, reports on the just-ended Mon–Sun window.
- **Monthly:** any 1st UTC, reports on the just-ended calendar month.
- **Dedupe** via `SalesReport.EmailSentDate` — the two daily fires on the same send-day are idempotent; the second one sees the marker and skips.
- **Empty windows** (no activity) are skipped without writing a dedupe row, so the salesperson's data appearing late doesn't lose a period.

### Backend
- `SalesReportSubscriber` entity + `AddSalesReportSubscribers` migration, unique index on `UserId`.
- **`ISalesReportSubscriberService`** — `List` / `GetForCadence` / `AddOrUpdate` / `Update` / `Delete`. Filters recipients with no `Email` set at the DB layer so no subscriber ever silently fails to receive.
- **`ISalesReportEmailService.SendWeeklyReportIfDueAsync` / `SendMonthlyReportIfDueAsync`** — the whole cadence gate lives here. Injects `TimeProvider` so tests can pin "today".
- **`SalesReportSubscribersV2Controller`** (SiteAdmin only) — the salesperson can't add themselves to Cynthia's distribution list.
- Two new HTML email templates + `NotificationTypeEnum` entries (`SalesReportWeekly = 54`, `SalesReportMonthly = 55`). Rendered as `emailCopy` substitutions into the existing SendGrid `GenericEmail` template so branding matches every other TrashMob transactional email.
- **11 new service tests** cover day-gate, empty skip, no-subscribers skip, happy path, and the idempotent second-firing case for both cadences. Suite: **1,186 passing**.

### Frontend
- **`/siteadmin/prospects/reports/subscribers`** page — list, per-row weekly and monthly toggles, delete, "Add subscriber" panel with a user picker that excludes already-subscribed users.
- `services/sales-report-subscribers.ts` factory.
- **"Report Subscribers"** nav item under the reports section.

### Project 63 wrap-up

| Phase | Purpose | State |
|-------|---------|-------|
| 1 | Prospect field additions + 10-stage enum + admin form | Merged |
| 2 | Weekly report screen | Merged |
| 3 | Monthly report + editable targets + Market Intelligence Notes | Merged |
| 4a | Narrative persistence with autosave | Merged |
| **4b (this PR)** | Subscribers + scheduled email delivery | Open |

## Test plan
- [x] `dotnet build TrashMob.sln` — 0 warnings, 0 errors
- [x] `dotnet test` — 1,186 passing / 0 failing
- [x] `npm run check` — 0 errors (14 pre-existing warnings unchanged)
- [x] `npm run build` — production build succeeds
- [ ] Deploy to dev, run migration, add yourself as a subscriber
- [ ] Manually trigger `TrashMobDailyJobs` on a **Monday** and confirm you receive the weekly email; run again same day and confirm no duplicate arrives
- [ ] Manually trigger on the **1st of a month** and confirm the monthly email arrives
- [ ] Trigger on a non-send day — confirm no email + no dedupe row created
- [ ] Confirm empty-week window (delete all activities) yields no email + no dedupe row (so a data-appearing-late replay would still fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)