### PR TITLE
Hotfix: drop fake SystemUserId — prod deploy 2026-07-05 failed on FK

### DIFF
--- a/TrashMob.Shared/Managers/Prospects/SalesReportEmailService.cs
+++ b/TrashMob.Shared/Managers/Prospects/SalesReportEmailService.cs
@@ -33,10 +33,6 @@ namespace TrashMob.Shared.Managers.Prospects
     {
         private readonly TimeProvider clock = timeProvider ?? TimeProvider.System;
 
-        // System user for automated writes — matches the id used by the
-        // Project 64 backfill migration.
-        private static readonly Guid SystemUserId = new("00000000-0000-0000-0000-000000000001");
-
         /// <inheritdoc />
         public async Task<int> SendWeeklyReportIfDueAsync(CancellationToken cancellationToken = default)
         {
@@ -84,7 +80,7 @@ namespace TrashMob.Shared.Managers.Prospects
             var count = await DispatchAsync(subject, html, subscribers, cancellationToken);
 
             await MarkSentAsync(
-                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnding, cancellationToken);
+                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnding, subscribers, cancellationToken);
 
             logger.LogInformation(
                 "Weekly sales report for week ending {WeekEnding} sent to {Count} subscribers.",
@@ -140,7 +136,7 @@ namespace TrashMob.Shared.Managers.Prospects
             var count = await DispatchAsync(subject, html, subscribers, cancellationToken);
 
             await MarkSentAsync(
-                SalesReportPeriodTypeEnum.Monthly, monthStart, monthEnd, cancellationToken);
+                SalesReportPeriodTypeEnum.Monthly, monthStart, monthEnd, subscribers, cancellationToken);
 
             logger.LogInformation(
                 "Monthly sales report for {Month:yyyy-MM} sent to {Count} subscribers.",
@@ -165,11 +161,20 @@ namespace TrashMob.Shared.Managers.Prospects
             SalesReportPeriodTypeEnum periodType,
             DateOnly periodStart,
             DateOnly periodEnd,
+            IReadOnlyCollection<SalesReportSubscriber> subscribers,
             CancellationToken cancellationToken)
         {
             var start = periodStart.ToDateTime(TimeOnly.MinValue);
             var end = periodEnd.ToDateTime(TimeOnly.MinValue);
             var now = clock.GetUtcNow();
+
+            // Attribute the audit trail to the first recipient. The daily job has
+            // no natural user context, and the SalesReport CreatedBy/LastUpdatedBy
+            // FKs must resolve to real Users rows (see the Project 64 P1 backfill
+            // failure on 2026-07-05 for what happens when you use a fake
+            // 00000000-0000-0000-0000-000000000001 sentinel). "First subscriber
+            // received this report" is a fine placeholder.
+            var attributionUserId = subscribers.First().UserId;
 
             var existing = await db.SalesReports.FirstOrDefaultAsync(
                 r => r.PeriodType == (int)periodType && r.PeriodStart == start,
@@ -184,16 +189,16 @@ namespace TrashMob.Shared.Managers.Prospects
                     PeriodStart = start,
                     PeriodEnd = end,
                     EmailSentDate = now,
-                    CreatedByUserId = SystemUserId,
+                    CreatedByUserId = attributionUserId,
                     CreatedDate = now,
-                    LastUpdatedByUserId = SystemUserId,
+                    LastUpdatedByUserId = attributionUserId,
                     LastUpdatedDate = now,
                 });
             }
             else
             {
                 existing.EmailSentDate = now;
-                existing.LastUpdatedByUserId = SystemUserId;
+                existing.LastUpdatedByUserId = attributionUserId;
                 existing.LastUpdatedDate = now;
             }
 

--- a/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.cs
+++ b/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.cs
@@ -128,21 +128,24 @@ namespace TrashMob.Shared.Migrations
                 unique: true,
                 filter: "[RevokedDate] IS NULL");
 
-            // Project 64 Phase 1 backfill: grant every existing IsSiteAdmin=true user
-            // the SiteAdmin role (id=1). GrantedByUserId points at the system user id
-            // used elsewhere for automated writes. Preserves current behavior; the
-            // compatibility bridge in IUserRoleService.HasRoleAsync also honours the
-            // legacy boolean, so no read path breaks between deploy and this backfill.
+            // Project 64 Phase 1 backfill: grant every existing IsSiteAdmin=true
+            // user the SiteAdmin role (id=1). All attribution fields point at u.Id
+            // — the "well-known system user" the plan called out doesn't actually
+            // exist in the Users table (dev happened to pass because it has no
+            // IsSiteAdmin=1 rows so this INSERT ran on zero rows; prod deploy
+            // 2026-07-05 failed with FK_UserRoles_User_CreatedBy). Attributing the
+            // grant to the recipient user is semantically "you granted yourself
+            // this role during migration" — a placeholder audit trail, but every
+            // FK resolves to a real row.
             migrationBuilder.Sql(@"
-                DECLARE @SystemUserId UNIQUEIDENTIFIER = '00000000-0000-0000-0000-000000000001';
                 DECLARE @Now DATETIMEOFFSET = SYSDATETIMEOFFSET();
 
                 INSERT INTO UserRoles (Id, UserId, RoleId, GrantedByUserId, GrantedDate,
                                        CreatedByUserId, CreatedDate,
                                        LastUpdatedByUserId, LastUpdatedDate)
-                SELECT NEWID(), u.Id, 1, @SystemUserId, @Now,
-                       @SystemUserId, @Now,
-                       @SystemUserId, @Now
+                SELECT NEWID(), u.Id, 1, u.Id, @Now,
+                       u.Id, @Now,
+                       u.Id, @Now
                 FROM Users u
                 WHERE u.IsSiteAdmin = 1
                   AND NOT EXISTS (


### PR DESCRIPTION
## Prod incident

Release deploy [#28726676599](https://github.com/TrashMob-eco/TrashMob/actions/runs/28726676599) failed applying the Project 64 Phase 1 migration \`20260703202044_AddRolesAndUserRoles\`:

> Microsoft.Data.SqlClient.SqlException (0x80131904): The INSERT statement conflicted with the FOREIGN KEY constraint "FK_UserRoles_User_CreatedBy". The conflict occurred in database "db-tm-pr-westus2", table "dbo.Users", column 'Id'.

Supersedes #3482 (had add/add conflicts from prior release-branch history rewrites — this one is based directly off \`release\`).

### Root cause
The Phase 1 backfill migration and the Phase 4b email dispatcher both attributed audit fields to \`00000000-0000-0000-0000-000000000001\` — the "well-known system user id" the plan called out — but that user doesn't actually exist in the \`Users\` table.

Dev migration succeeded because dev has no \`IsSiteAdmin = 1\` rows, so the backfill \`INSERT SELECT\` ran on zero rows and never hit the FK. Prod has real admins and blew up on \`FK_UserRoles_User_CreatedBy\`.

### Fix
**Migration** — attribute all three audit fields on the backfill row (\`GrantedByUserId\`, \`CreatedByUserId\`, \`LastUpdatedByUserId\`) to \`u.Id\`. Reads as "each SiteAdmin granted themselves the role during migration" — a placeholder, but every FK resolves to a real row.

**\`SalesReportEmailService\`** — \`MarkSentAsync\` now takes the subscribers collection and attributes the \`SalesReport\` dedupe row to the first subscriber's \`UserId\`. \`MarkSentAsync\` is only called after the empty-subscribers check, so we're always guaranteed a real UserId. Removes the unused \`SystemUserId\` constant.

### Deploy state
EF Core wraps migrations in a transaction and SQL Server supports transactional DDL, so the failed migration should have rolled back cleanly — \`__EFMigrationsHistory\` will not contain the row, and the \`Roles\` / \`UserRoles\` tables should not exist on prod. On re-deploy, EF retries the whole migration with the corrected SQL.

No changes to dev data expected — the original migration already ran on dev with zero rows inserted. This edits an "applied" migration but there's no data divergence.

### Follow-up
Once this merges to release and prod re-deploys cleanly, I'll open a follow-up PR to sync this commit back to \`main\` so future dev migrations don't regress.

## Test plan
- [x] \`dotnet build\` — clean, 0 warnings, 0 errors
- [x] \`dotnet test\` — 1,186 passing / 0 failing
- [ ] Merge → prod deploy runs \`dotnet ef database update\` again → confirm no FK error
- [ ] Confirm \`SELECT COUNT(*) FROM UserRoles WHERE RoleId = 1\` on prod matches \`SELECT COUNT(*) FROM Users WHERE IsSiteAdmin = 1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)