### PR TITLE
Sync hotfix #3483 (SystemUserId → u.Id) back to main

### DIFF
--- a/TrashMob.Shared/Managers/Prospects/SalesReportEmailService.cs
+++ b/TrashMob.Shared/Managers/Prospects/SalesReportEmailService.cs
@@ -33,10 +33,6 @@ namespace TrashMob.Shared.Managers.Prospects
     {
         private readonly TimeProvider clock = timeProvider ?? TimeProvider.System;
 
-        // System user for automated writes — matches the id used by the
-        // Project 64 backfill migration.
-        private static readonly Guid SystemUserId = new("00000000-0000-0000-0000-000000000001");
-
         /// <inheritdoc />
         public async Task<int> SendWeeklyReportIfDueAsync(CancellationToken cancellationToken = default)
         {
@@ -84,7 +80,7 @@ namespace TrashMob.Shared.Managers.Prospects
             var count = await DispatchAsync(subject, html, subscribers, cancellationToken);
 
             await MarkSentAsync(
-                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnding, cancellationToken);
+                SalesReportPeriodTypeEnum.Weekly, weekStart, weekEnding, subscribers, cancellationToken);
 
             logger.LogInformation(
                 "Weekly sales report for week ending {WeekEnding} sent to {Count} subscribers.",
@@ -140,7 +136,7 @@ namespace TrashMob.Shared.Managers.Prospects
             var count = await DispatchAsync(subject, html, subscribers, cancellationToken);
 
             await MarkSentAsync(
-                SalesReportPeriodTypeEnum.Monthly, monthStart, monthEnd, cancellationToken);
+                SalesReportPeriodTypeEnum.Monthly, monthStart, monthEnd, subscribers, cancellationToken);
 
             logger.LogInformation(
                 "Monthly sales report for {Month:yyyy-MM} sent to {Count} subscribers.",
@@ -165,11 +161,20 @@ namespace TrashMob.Shared.Managers.Prospects
             SalesReportPeriodTypeEnum periodType,
             DateOnly periodStart,
             DateOnly periodEnd,
+            IReadOnlyCollection<SalesReportSubscriber> subscribers,
             CancellationToken cancellationToken)
         {
             var start = periodStart.ToDateTime(TimeOnly.MinValue);
             var end = periodEnd.ToDateTime(TimeOnly.MinValue);
             var now = clock.GetUtcNow();
+
+            // Attribute the audit trail to the first recipient. The daily job has
+            // no natural user context, and the SalesReport CreatedBy/LastUpdatedBy
+            // FKs must resolve to real Users rows (see the Project 64 P1 backfill
+            // failure on 2026-07-05 for what happens when you use a fake
+            // 00000000-0000-0000-0000-000000000001 sentinel). "First subscriber
+            // received this report" is a fine placeholder.
+            var attributionUserId = subscribers.First().UserId;
 
             var existing = await db.SalesReports.FirstOrDefaultAsync(
                 r => r.PeriodType == (int)periodType && r.PeriodStart == start,
@@ -184,16 +189,16 @@ namespace TrashMob.Shared.Managers.Prospects
                     PeriodStart = start,
                     PeriodEnd = end,
                     EmailSentDate = now,
-                    CreatedByUserId = SystemUserId,
+                    CreatedByUserId = attributionUserId,
                     CreatedDate = now,
-                    LastUpdatedByUserId = SystemUserId,
+                    LastUpdatedByUserId = attributionUserId,
                     LastUpdatedDate = now,
                 });
             }
             else
             {
                 existing.EmailSentDate = now;
-                existing.LastUpdatedByUserId = SystemUserId;
+                existing.LastUpdatedByUserId = attributionUserId;
                 existing.LastUpdatedDate = now;
             }
 

--- a/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.cs
+++ b/TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.cs
@@ -128,21 +128,24 @@ namespace TrashMob.Shared.Migrations
                 unique: true,
                 filter: "[RevokedDate] IS NULL");
 
-            // Project 64 Phase 1 backfill: grant every existing IsSiteAdmin=true user
-            // the SiteAdmin role (id=1). GrantedByUserId points at the system user id
-            // used elsewhere for automated writes. Preserves current behavior; the
-            // compatibility bridge in IUserRoleService.HasRoleAsync also honours the
-            // legacy boolean, so no read path breaks between deploy and this backfill.
+            // Project 64 Phase 1 backfill: grant every existing IsSiteAdmin=true
+            // user the SiteAdmin role (id=1). All attribution fields point at u.Id
+            // — the "well-known system user" the plan called out doesn't actually
+            // exist in the Users table (dev happened to pass because it has no
+            // IsSiteAdmin=1 rows so this INSERT ran on zero rows; prod deploy
+            // 2026-07-05 failed with FK_UserRoles_User_CreatedBy). Attributing the
+            // grant to the recipient user is semantically "you granted yourself
+            // this role during migration" — a placeholder audit trail, but every
+            // FK resolves to a real row.
             migrationBuilder.Sql(@"
-                DECLARE @SystemUserId UNIQUEIDENTIFIER = '00000000-0000-0000-0000-000000000001';
                 DECLARE @Now DATETIMEOFFSET = SYSDATETIMEOFFSET();
 
                 INSERT INTO UserRoles (Id, UserId, RoleId, GrantedByUserId, GrantedDate,
                                        CreatedByUserId, CreatedDate,
                                        LastUpdatedByUserId, LastUpdatedDate)
-                SELECT NEWID(), u.Id, 1, @SystemUserId, @Now,
-                       @SystemUserId, @Now,
-                       @SystemUserId, @Now
+                SELECT NEWID(), u.Id, 1, u.Id, @Now,
+                       u.Id, @Now,
+                       u.Id, @Now
                 FROM Users u
                 WHERE u.IsSiteAdmin = 1
                   AND NOT EXISTS (


### PR DESCRIPTION
## Summary

Follow-up to #3483 — brings the same migration + \`SalesReportEmailService\` fix onto \`main\` so the next dev deploy (and any future release cut) doesn't hit the same FK failure.

### What this fixes on main
Same as #3483 — the Project 64 Phase 1 backfill migration and \`SalesReportEmailService.MarkSentAsync\` both wrote to \`CreatedByUserId\` / \`LastUpdatedByUserId\` / \`GrantedByUserId\` using a fake system user id (\`00000000-...-000001\`) that doesn't exist in \`Users\`. Dev happened to survive because it has no \`IsSiteAdmin = 1\` rows; prod deploy 2026-07-05 failed with \`FK_UserRoles_User_CreatedBy\`. The fix attributes those audit fields to \`u.Id\` (migration) and the first subscriber's \`UserId\` (email service).

### Why this exists
The release branch had prior history-rewriting merges, so my original hotfix branch off main couldn't clean-merge to release (add/add conflicts). I based #3483 directly off \`release\` to sidestep that topology. Now the fix needs to land on \`main\` too, hence this PR.

Cherry-picked from #3483 (commit \`a5d10fbd\` on release).

### Dev deploy state
Dev already ran the original migration with zero rows inserted. Editing the migration file after the fact would normally be a red flag, but there's no data divergence to worry about — dev's \`UserRoles\` table simply has zero rows to compare against. The change is safe.

## Test plan
- [x] \`dotnet build\` — clean
- [x] \`dotnet test\` — 1,186 passing
- [ ] Merge triggers \`TrashMobDev - Container App\` — confirm dev deploy still succeeds (no schema change from dev's POV since migration is already applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)