### PR TITLE
Update Projects 63 + 64 plans + Planning/README with shipped state

### DIFF
--- a/Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md
+++ b/Planning/Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md
@@ -2,11 +2,24 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | Planning |
+| **Status** | ✅ Complete (all phases shipped to production 2026-07-05) |
 | **Priority** | High |
 | **Risk** | Medium |
 | **Size** | Large |
 | **Dependencies** | [Project 60 — Prospect Multi-Contact Tracking](./Project_60_Prospect_Contact_Tracking.md), [Project 64 — Roles & RBAC Refactor](./Project_64_Roles_and_RBAC_Refactor.md) |
+
+## Shipped
+
+| Phase | PR | Shipped |
+|-------|-----|---------|
+| Phase 1 — Model + admin form extensions | [#3476](https://github.com/TrashMob-eco/TrashMob/pull/3476) | 2026-07-04 |
+| Phase 2 — Weekly Report screen | [#3477](https://github.com/TrashMob-eco/TrashMob/pull/3477) | 2026-07-04 |
+| Phase 3 — Monthly Goals + Market Intelligence Notes | [#3478](https://github.com/TrashMob-eco/TrashMob/pull/3478) | 2026-07-04 |
+| Phase 4a — Narrative persistence with autosave | [#3479](https://github.com/TrashMob-eco/TrashMob/pull/3479) | 2026-07-04 |
+| Phase 4b — Subscribers + scheduled email delivery | [#3480](https://github.com/TrashMob-eco/TrashMob/pull/3480) | 2026-07-04 |
+| Prod release + hotfix | [#3481](https://github.com/TrashMob-eco/TrashMob/pull/3481) + [#3483](https://github.com/TrashMob-eco/TrashMob/pull/3483) | 2026-07-05 |
+
+**Note:** the "well-known system user id" the plan called out for the backfill migration didn't actually exist in the `Users` table. Dev migration passed by luck (no `IsSiteAdmin=1` rows to attempt the FK-violating INSERT); prod caught it. Hotfix #3483 re-attributes the audit fields to `u.Id` for the migration and to the first subscriber's `UserId` for the email dispatcher. Documented here so anyone repeating this pattern for a future migration knows to avoid inventing a "system user."
 
 ---
 
@@ -387,7 +400,7 @@ Deferred; each item is a candidate follow-up project, not a commitment.
 
 ---
 
-**Last Updated:** 2026-07-03
+**Last Updated:** 2026-07-05
 **Owner:** Joe (engineering) + Cynthia (sales lead + Board) + 1099 salesperson
-**Status:** Planning
-**Next Review:** 2026-07-10 — align on Phase 1 scope before starting model changes
+**Status:** ✅ Complete — all phases in production 2026-07-05
+**Next Review:** 30 days after salesperson start (2026-08-13) — measure whether the salesperson prefers the CRM over a private spreadsheet, whether Cynthia trusts the weekly numbers as-is for Board meetings, and whether the Market Intelligence Notes have surfaced actionable insight

--- a/Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md
+++ b/Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md
@@ -2,11 +2,30 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | Planning |
+| **Status** | In Progress — Phases 1–4a shipped to production 2026-07-05; Phase 4b (column drop) time-gated on 30-day observation window |
 | **Priority** | High |
 | **Risk** | Medium |
 | **Size** | Large |
 | **Dependencies** | _None_ — this project unblocks [Project 63 (Municipal Sales Pipeline Reporting)](./Project_63_Municipal_Sales_Pipeline_Reporting.md) and any future non-admin role |
+
+## Shipped
+
+| Phase | PR | Shipped |
+|-------|-----|---------|
+| Phase 1 — Role / UserRole model + `IUserRoleService` + compat bridge | [#3468](https://github.com/TrashMob-eco/TrashMob/pull/3468) | 2026-07-03 |
+| Phase 2 — Auth handler migration + `SalesRep` policy + `UsersV2Controller` `[Authorize]` | [#3473](https://github.com/TrashMob-eco/TrashMob/pull/3473) | 2026-07-04 |
+| Phase 3 — Role admin UI + `RolesV2Controller` + grant/revoke emails | [#3474](https://github.com/TrashMob-eco/TrashMob/pull/3474) | 2026-07-04 |
+| Phase 4a — Sweep production `IsSiteAdmin` readers | [#3475](https://github.com/TrashMob-eco/TrashMob/pull/3475) | 2026-07-04 |
+| Prod release + backfill migration hotfix | [#3481](https://github.com/TrashMob-eco/TrashMob/pull/3481) + [#3483](https://github.com/TrashMob-eco/TrashMob/pull/3483) | 2026-07-05 |
+| **Phase 4b — Drop `IsSiteAdmin` column** | (queued) | Earliest ~2026-08-05 (30 days after Phase 4a in prod) |
+
+## Lessons learned
+
+- **The "well-known system user" pattern was a fiction.** The plan referenced "a well-known 'System' user id used elsewhere for automated writes" and told the backfill migration to use `00000000-0000-0000-0000-000000000001` for the `GrantedBy` / `CreatedBy` / `LastUpdatedBy` audit fields. That row doesn't actually exist in the `Users` table. Dev happened to pass because dev has no `IsSiteAdmin = 1` rows to trigger the failing `INSERT SELECT`; prod caught it with `FK_UserRoles_User_CreatedBy`.
+  - Fix: [#3483](https://github.com/TrashMob-eco/TrashMob/pull/3483) — re-attributed audit fields to `u.Id` (the user whose grant is being backfilled). Semantically weird ("each SiteAdmin granted themselves this role during migration") but every FK resolves to a real row.
+  - Guardrail for future migrations: **never invent a sentinel user id.** Either use a real existing user (self-reference, or query for any admin), or add a nullable FK.
+
+- **Dev-passing migrations can still fail in prod.** The dev DB has a much smaller / different user base than prod, and any migration that touches `Users`-referencing tables should be tested against a schema populated with production-representative rows before rolling to release.
 
 ---
 
@@ -347,7 +366,7 @@ Sweep the codebase, drop the column, close the loop.
 
 ---
 
-**Last Updated:** 2026-07-03
+**Last Updated:** 2026-07-05
 **Owner:** Joe (engineering)
-**Status:** Planning
-**Next Review:** 2026-07-10 — coordinate Phase 1 kickoff with Project 63 timeline
+**Status:** In Progress — Phases 1–4a shipped; Phase 4b (column drop) queued for ~2026-08-05
+**Next Review:** 2026-08-05 — decide whether the 30-day observation window is enough to drop `IsSiteAdmin`; if any missed reader has caused a production incident since 4a, extend the window and grep the codebase again first

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -195,10 +195,10 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 | Status | Count | Projects |
 |--------|-------|----------|
 | ✅ **Complete** (archived) | 34 | Projects 3, 7, 9, 10, 11, 13, 14, 16, 17, 18, 19, 20, 21, 22, 24, 26, 27, 28, 29, 32, 34, 35, 37, 38, 39, 40, 42, 44, 47, 48, 50, 51, 53, 59 |
-| ✅ **Complete** (production live, in-place) | 1 | Project 23 (PRIVO live 2026-05-20, testing complete 2026-07-01) |
+| ✅ **Complete** (production live, in-place) | 2 | Project 23 (PRIVO live 2026-05-20, testing complete 2026-07-01), Project 63 (Municipal Sales Pipeline live 2026-07-05) |
 | ✅ **Complete** (pending external) | 1 | Project 8 (minor waiver text pending legal review) |
-| **In Progress** | 13 | Projects 1, 4, 5, 6, 15, 25, 30, 36, 41, 45, 46, 49, 57 |
-| **Planning** | 5 | Projects 56, 58, 62, 63, 64 |
+| **In Progress** | 14 | Projects 1, 4, 5, 6, 15, 25, 30, 36, 41, 45, 46, 49, 57, **64** (Phases 1–4a live; Phase 4b column-drop queued for ~2026-08-05) |
+| **Planning** | 3 | Projects 56, 58, 62 |
 | **Ready for Review** | 1 | Project 2 |
 | **Not Started** | 5 | Projects 12, 31, 43, 52, 54, 55 |
 | **Deprioritized** | 1 | Project 33 |
@@ -228,6 +228,7 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 | [Project 49 - Privacy & Compliance](./Projects/Project_49_Privacy_Compliance_Review.md) | Phase 5: Cookie consent & tracking audit — update Privacy Policy, document third-party services (Clarity, App Insights) |
 | [Project 36 - Marketing Materials](./Projects/Project_36_Marketing_Materials.md) | Community tier pricing, feature comparison, branding guidelines, digital assets |
 | [Project 57 - Participation Report](./Projects/Project_57_Participation_Report.md) | Phases 1-3 complete (backend + web + mobile). Phase 4 deferred: verification URLs with QR codes |
+| [Project 64 - Roles & RBAC Refactor](./Projects/Project_64_Roles_and_RBAC_Refactor.md) | Phases 1–4a shipped 2026-07-05 (Role + UserRole model, auth handler migration, `SalesRep` role, admin UI, sweep of `IsSiteAdmin` readers). Phase 4b (drop the `IsSiteAdmin` column + remove compat bridge) queued for ~2026-08-05 after a 30-day observation window. |
 
 ### Ready for Design Review
 
@@ -242,8 +243,6 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 | [Project 56 - Board Metrics Dashboard](./Projects/Project_56_Board_Metrics_Dashboard.md) | Unified admin dashboard pulling from App Insights, GA4, Sentry, Clarity, Azure Cost Management, and QuickBooks for monthly board meetings |
 | [Project 58 - Community Event Seeding](./Projects/Project_58_Community_Event_Seeding.md) | Admin-seeded public cleanup events with organizer claim workflow to solve cold-start growth |
 | [Project 62 - TrashMob Site & Codebase Re-evaluation](./Projects/Project_62_TrashMob_Site_and_Codebase_Reevaluation.md) | **Engineering health check.** Codebase is in solid shape (A- architecture, no surprise debt); real constraint is WIP overload. Recommends capping in-progress at 6, finishing Mobile Robustness Phases 3–5 and unblocking E2E CI as P0 for Q3 2026. Living doc, updated every 6 months. |
-| [Project 63 - Municipal Sales Pipeline Reporting](./Projects/Project_63_Municipal_Sales_Pipeline_Reporting.md) | Extends the existing prospect CRM (from Project 60) with municipal-specific fields, a weekly report screen matching Cynthia's spreadsheet, monthly goals with target-vs-actual rollups, and market-intelligence aggregation. Supports the 1099 sales contractor selling TrashMob SaaS to cities. |
-| [Project 64 - Roles & RBAC Refactor](./Projects/Project_64_Roles_and_RBAC_Refactor.md) | Replaces the single `IsSiteAdmin` boolean with a proper Role + UserRole model. Ships `SiteAdmin` and `SalesRep` on day 1; establishes the pattern for future roles (`PartnerAdmin`, `ContentEditor`, etc.). Prerequisite for Project 63 to give the sales contractor a scoped login. |
 
 ### Not Started
 


### PR DESCRIPTION
## Summary

Docs-only. Projects 63 (Municipal Sales Pipeline) and 64 (Roles & RBAC Refactor) shipped to production 2026-07-05; the plan docs were still marked "Planning" and needed to catch up.

### Project 63 — Complete
- Status header updated with a Shipped table listing each phase PR (#3476–#3480), the release PR (#3481), and the migration hotfix (#3483)
- Called out the "well-known system user id" lesson inline — the sentinel `00000000-...-000001` was a plan fiction that survived on dev by luck (no `IsSiteAdmin = 1` rows) and blew up on prod's FK. Any future migration that reaches for a system-user sentinel should self-attribute to a real Users row instead
- Retargeted the "Next Review" to 30 days after the salesperson's 2026-07-13 start (so 2026-08-13)

### Project 64 — In Progress
- Status header updated with a Shipped table listing Phases 1–4a (#3468, #3473–#3475), the release + hotfix, and Phase 4b queued for ~2026-08-05 (30-day observation window before we drop the `IsSiteAdmin` column)
- Added a **Lessons learned** section: (1) never invent a sentinel user id in a migration; (2) dev-passing migrations can still fail in prod when the Users population is different — worth testing schema-change migrations against production-representative data before rolling to release

### Planning/README.md
- Moved Project 63 into the Complete (production live, in-place) row
- Moved Project 64 into the In Progress row with a per-phase status note
- Removed 63 and 64 from the Planning table so it accurately shows only 56, 58, 62
- Updated the Complete / In Progress / Planning counts

## Test plan
- [x] Rendered locally, links resolve, tables align

🤖 Generated with [Claude Code](https://claude.com/claude-code)