### PR TITLE
Collapse apex → www redirect chain to a single hop (Fix A)

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -86,13 +86,23 @@ resource origin 'Microsoft.Cdn/profiles/originGroups/origins@2024-02-01' = {
   }
 }
 
-// Rule Set for apex domain redirect
+// Rule Set for apex + www HTTPS canonicalisation. See
+// Deploy/APEX_FIRST_VISIT_INVESTIGATION.md for background — the route
+// used to have httpsRedirect: Enabled, which auto-307'd HTTP-apex
+// traffic to HTTPS-apex before the rule set could see it, causing a
+// two-hop redirect chain (http://apex → 307 → https://apex → 308 →
+// https://www) with two consecutive TLS handshakes on cold browser
+// sessions. Now the route delegates HTTPS enforcement to this rule
+// set so http://apex resolves to https://www in a single 308.
 resource ruleSet 'Microsoft.Cdn/profiles/ruleSets@2024-02-01' = if (apexDomain != '') {
   parent: frontDoorProfile
   name: ruleSetName
 }
 
-// Rule to redirect apex to www
+// Rule to redirect apex traffic (either HTTP or HTTPS) straight to
+// https://www.trashmob.eco/ in a single hop. Matches both schemes on
+// purpose so cold browsers never pay the http-apex → https-apex
+// interstitial handshake.
 resource redirectRule 'Microsoft.Cdn/profiles/ruleSets/rules@2024-02-01' = if (apexDomain != '') {
   parent: ruleSet
   name: 'RedirectApexToWww'
@@ -125,6 +135,54 @@ resource redirectRule 'Microsoft.Cdn/profiles/ruleSets/rules@2024-02-01' = if (a
   }
 }
 
+// Rule to redirect http://www.trashmob.eco/ traffic to
+// https://www.trashmob.eco/ (same host, upgrade scheme). Previously
+// route.httpsRedirect handled this, but we disabled it above so the
+// apex rule could catch HTTP-apex directly. This rule preserves the
+// prior HTTP→HTTPS behavior for www without adding a second hop.
+resource redirectWwwHttpToHttpsRule 'Microsoft.Cdn/profiles/ruleSets/rules@2024-02-01' = if (apexDomain != '') {
+  parent: ruleSet
+  name: 'RedirectWwwHttpToHttps'
+  properties: {
+    order: 2
+    conditions: [
+      {
+        name: 'HostName'
+        parameters: {
+          typeName: 'DeliveryRuleHostNameConditionParameters'
+          operator: 'Equal'
+          matchValues: [primaryDomain]
+          transforms: ['Lowercase']
+          negateCondition: false
+        }
+      }
+      {
+        name: 'RequestScheme'
+        parameters: {
+          typeName: 'DeliveryRuleRequestSchemeConditionParameters'
+          operator: 'Equal'
+          matchValues: ['HTTP']
+          negateCondition: false
+        }
+      }
+    ]
+    actions: [
+      {
+        name: 'UrlRedirect'
+        parameters: {
+          typeName: 'DeliveryRuleUrlRedirectActionParameters'
+          redirectType: 'PermanentRedirect'
+          destinationProtocol: 'Https'
+        }
+      }
+    ]
+    matchProcessingBehavior: 'Stop'
+  }
+  dependsOn: [
+    redirectRule
+  ]
+}
+
 // Route for primary domain (www)
 resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
   parent: endpoint
@@ -143,7 +201,12 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
     patternsToMatch: ['/*']
     forwardingProtocol: 'HttpsOnly'
     linkToDefaultDomain: 'Enabled'
-    httpsRedirect: 'Enabled'
+    // Disabled on purpose — HTTPS enforcement now lives in the rule
+    // set (RedirectApexToWww + RedirectWwwHttpToHttps). Route-level
+    // httpsRedirect would fire *before* the rule set, forcing
+    // http://apex to bounce through https://apex on the way to
+    // https://www and doubling the cold-visit TLS handshakes.
+    httpsRedirect: 'Disabled'
     enabledState: 'Enabled'
     cacheConfiguration: {
       compressionSettings: {
@@ -162,6 +225,7 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
   dependsOn: [
     origin
     redirectRule
+    redirectWwwHttpToHttpsRule
   ]
 }
 


### PR DESCRIPTION
## Summary

Applies **Fix A** from [\`Deploy/APEX_FIRST_VISIT_INVESTIGATION.md\`](Deploy/APEX_FIRST_VISIT_INVESTIGATION.md) (added in #3486, still open as of this PR): collapse the two-hop redirect chain that cold browser sessions currently walk when a user types \`trashmob.eco\`.

### Root cause recap

The route in \`Deploy/frontDoor.bicep\` had \`httpsRedirect: 'Enabled'\`. Route-level \`httpsRedirect\` fires **before** the \`ApexRedirect\` rule set, so HTTP-apex traffic got a 307 to HTTPS-apex first, then the rule set fired and did a 308 to HTTPS-www. That's **two consecutive TLS handshakes on the same navigation** (SNI differs between apex and www, so no session reuse), which on cold browser sessions can time out or trip intermediaries. On refresh the browser has HSTS + TLS session tickets for www, skips the double-handshake, and looks like "just refresh, it works" to the user.

### What the change does

- Route: \`httpsRedirect: 'Enabled'\` → \`'Disabled'\`
- Existing \`RedirectApexToWww\` rule now catches HTTP-apex too. Its \`UrlRedirect\` action already outputs a full \`https://www.trashmob.eco/\` URL, so both \`http://\` and \`https://\` apex requests get one 308 to HTTPS-www in a single hop.
- New \`RedirectWwwHttpToHttps\` rule preserves HTTP → HTTPS for \`www\` visitors (previously handled by \`route.httpsRedirect\`).

### Expected behavior after edge propagation

| Request | Before | After |
|---|---|---|
| \`http://trashmob.eco/\` | 307 → https://apex → 308 → https://www | **308 → https://www** |
| \`http://www.trashmob.eco/\` | 307 → https://www | 308 → https://www |
| \`https://trashmob.eco/\` | 308 → https://www | 308 → https://www (unchanged) |
| \`https://www.trashmob.eco/\` | 200 | 200 (unchanged) |

Net effect: cold browsers now do exactly **one TLS handshake** for apex traffic instead of two.

### Reversibility

Reversible: flip \`httpsRedirect\` back to \`'Enabled'\` and delete the \`RedirectWwwHttpToHttps\` rule to restore prior state. The apex rule is unchanged in behavior — it was already emitting a full https-www Location header, so on the "revert" path it still 308s https-apex to https-www correctly.

### Deploy notes

- \`az bicep build\` compiles clean locally
- Front Door config changes take ~5–15 minutes to propagate to edge POPs after the release deploy applies the template. During propagation some POPs may serve the old two-hop chain and others the new single-hop; both are correct, just different overhead.
- Smoke-test commands are in \`Deploy/OPERATIONS_RUNBOOK.md\` under \`### Verify Front Door state\`. Expected output after propagation:
  \`\`\`
  curl -sSI https://trashmob.eco   # HTTP/2 308, location: https://www.trashmob.eco/
  curl -sSI https://www.trashmob.eco   # HTTP/2 200
  curl -sSI http://trashmob.eco   # HTTP/1.1 308, location: https://www.trashmob.eco/  ← this is the fix
  \`\`\`

## Test plan

- [x] \`az bicep build\` compiles frontDoor.bicep clean
- [ ] Deploy triggers on merge → confirm Front Door custom-domain deployment succeeds
- [ ] After propagation, \`curl -sSI http://trashmob.eco\` returns a single 308 with \`Location: https://www.trashmob.eco/\` (was two hops)
- [ ] Confirm \`https://trashmob.eco\` and \`https://www.trashmob.eco\` still resolve correctly
- [ ] Test from a fresh incognito / different browser and see whether the "first-visit site-not-found" symptom recurs. If it does, our theory was wrong or incomplete — reopen the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)