### PR TITLE
Hotfix: add required queryStringCachingBehavior to Front Door route

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -209,6 +209,15 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
     httpsRedirect: 'Disabled'
     enabledState: 'Enabled'
     cacheConfiguration: {
+      // Required by the AFD Standard/Premium schema whenever
+      // cacheConfiguration is set. Matches the effective behavior of
+      // the historic config that was accepted under an older API
+      // version — Front Door treats a URL's cache key without regard
+      // to query string, which is correct for our SPA (all client
+      // routing lives in the app; the same index.html is served for
+      // any path). Origin Cache-Control headers still control whether
+      // any given response is actually cached.
+      queryStringCachingBehavior: 'IgnoreQueryString'
       compressionSettings: {
         isCompressionEnabled: true
         contentTypesToCompress: [


### PR DESCRIPTION
## Hotfix: Fix A deploy blocked on schema validation

Applying Fix A via \`az deployment group create\` on 2026-07-05 failed preflight with:

\`\`\`
CustomValidationError: Unsupported QueryStringCachingBehavior type: ''.
RequiredPropertyMissing: Property 'RouteV2.CacheConfiguration.QueryStringCachingBehavior' is required but it was not set.
\`\`\`

### Root cause
Not related to Fix A itself — the pre-existing block. The property became required under \`Microsoft.Cdn 2024-02-01\` (the historic config was accepted by an older API version). Any re-apply of \`Deploy/frontDoor.bicep\` since that schema change would have failed the same way.

### Fix
One line inside \`cacheConfiguration\`:

\`\`\`bicep
queryStringCachingBehavior: 'IgnoreQueryString'
\`\`\`

That matches the effective behavior in production today: Front Door uses the URL path (not query string) as the cache key. Correct for our SPA — client-side routing lives in the app, all paths get \`index.html\`, and origin \`Cache-Control\` headers still determine whether any given response is cached at all.

\`az bicep build\` compiles clean.

Once this lands, re-run:
\`\`\`bash
az deployment group create   --resource-group rg-trashmob-pr-westus2   --template-file Deploy/frontDoor.bicep   --parameters     environment=pr     containerAppFqdn=ca-tm-pr-westus2.greenground-fd8fc385.westus2.azurecontainerapps.io     primaryDomain=www.trashmob.eco     apexDomain=trashmob.eco
\`\`\`

Should now pass preflight and apply cleanly. I'll separately sync this commit back to main once we've confirmed the apply works.

## Test plan

- [x] \`az bicep build\` clean
- [ ] \`az deployment group create\` passes preflight and reports Succeeded
- [ ] Smoke tests confirm Fix A behavior (single-hop 308 from http apex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)