### PR TITLE
Sync hotfix #3490 (queryStringCachingBehavior) back to main

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -209,6 +209,15 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
     httpsRedirect: 'Disabled'
     enabledState: 'Enabled'
     cacheConfiguration: {
+      // Required by the AFD Standard/Premium schema whenever
+      // cacheConfiguration is set. Matches the effective behavior of
+      // the historic config that was accepted under an older API
+      // version — Front Door treats a URL's cache key without regard
+      // to query string, which is correct for our SPA (all client
+      // routing lives in the app; the same index.html is served for
+      // any path). Origin Cache-Control headers still control whether
+      // any given response is actually cached.
+      queryStringCachingBehavior: 'IgnoreQueryString'
       compressionSettings: {
         isCompressionEnabled: true
         contentTypesToCompress: [


### PR DESCRIPTION
## Summary

Follow-up to #3490 — brings the same one-line \`Deploy/frontDoor.bicep\` schema fix onto \`main\` so the next release doesn't regress.

Cherry-picked from \`e3f45be4\` on release.

### Recap
Preflight validation on the Fix A apply (2026-07-05) failed because \`Microsoft.Cdn 2024-02-01\` now requires \`queryStringCachingBehavior\` whenever \`cacheConfiguration\` is set. Set to \`IgnoreQueryString\` — matches the effective behavior in prod (path-based cache keys, correct for the SPA). The Front Door \`az deployment group create\` retry after #3490 landed reported \`provisioningState: Succeeded\` at 2026-07-05 16:56Z with all 10 resources deployed, including \`RedirectApexToWww\` and the new \`RedirectWwwHttpToHttps\` rule.

### Test plan
- [x] \`az bicep build\` clean
- [x] Real deploy already validated the change on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)