### PR TITLE
URGENT: Restore Front Door route → custom-domain associations (apex outage)

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -183,11 +183,24 @@ resource redirectWwwHttpToHttpsRule 'Microsoft.Cdn/profiles/ruleSets/rules@2024-
   ]
 }
 
-// Route for primary domain (www)
+// Route for both custom domains (www + apex).
+//
+// customDomains MUST be listed here — Bicep re-deploys are Incremental
+// but ARM still resets Route.customDomains to whatever the template
+// declares. The initial cutover set the associations manually via the
+// Azure portal, which left the Bicep silent on this property; the
+// 2026-07-05 Fix A re-deploy consequently stripped the associations
+// and produced a production outage on trashmob.eco (Front Door
+// returning 404 because no route was bound to that host). Never leave
+// this array implicit again.
 resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
   parent: endpoint
   name: routeName
   properties: {
+    customDomains: concat(
+      primaryDomain != '' ? [{ id: customDomainWww.id }] : [],
+      apexDomain != '' ? [{ id: customDomainApex.id }] : []
+    )
     originGroup: {
       id: originGroup.id
     }


### PR DESCRIPTION
## 🚨 Prod incident 2026-07-05 evening

The Fix A re-deploy stripped the route → custom-domain associations. Current production symptom (verified via three consecutive probes ~30 min post-deploy):

\`\`\`
http://trashmob.eco/    →  404 Not Found
https://trashmob.eco/   →  connection closed
http://www.trashmob.eco/  →  (redirect behavior; parse quirk in my probe, likely 308)
https://www.trashmob.eco/ →  200 (still fine)
\`\`\`

\`www.trashmob.eco\` continues to work — probably via \`linkToDefaultDomain: 'Enabled'\`. Apex is completely broken.

## Root cause

\`Deploy/frontDoor.bicep\` declares both custom domain resources (\`customDomainWww\`, \`customDomainApex\`) but the route resource has **no \`customDomains\` array binding them**. The historic associations were set manually via the Azure portal at initial cutover and were never captured in Bicep.

ARM deployments are Incremental by default, but on a resource that IS in the template, ARM still resets un-declared properties to the template's stated value (in this case, absent = empty). So the Fix A re-deploy zeroed the custom-domain bindings on the route.

## Fix

One property added to the route:

\`\`\`bicep
customDomains: concat(
  primaryDomain != '' ? [{ id: customDomainWww.id }] : [],
  apexDomain != '' ? [{ id: customDomainApex.id }] : []
)
\`\`\`

Bicep infers the deploy ordering from the \`.id\` references, so no explicit \`dependsOn\` needed (IDE analyzer confirmed).

Added a WARNING comment above the route so future editors don't strip this array by accident.

\`az bicep build\` compiles clean.

## Recovery plan

Once this PR merges to release, re-run the same \`az deployment group create\` command that failed in the earlier session:

\`\`\`bash
az deployment group create   --resource-group rg-trashmob-pr-westus2   --template-file Deploy/frontDoor.bicep   --parameters     environment=pr     containerAppFqdn=ca-tm-pr-westus2.greenground-fd8fc385.westus2.azurecontainerapps.io     primaryDomain=www.trashmob.eco     apexDomain=trashmob.eco
\`\`\`

Wait ~5–15 min for edge propagation, then verify:

\`\`\`
curl -sSI http://trashmob.eco   # HTTP/1.1 308, location: https://www.trashmob.eco/  ← was 404
curl -sSI https://trashmob.eco  # HTTP/2 308, location: https://www.trashmob.eco/  ← was connection reset
curl -sSI https://www.trashmob.eco  # HTTP/2 200
\`\`\`

If those come back right, apex is restored AND Fix A is live simultaneously (single-hop apex redirect chain, which is what we've been trying to ship all evening).

I'll sync the same commit back to \`main\` once release is confirmed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)