### PR TITLE
Sync hotfix #3492 (customDomains on route) back to main

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -183,11 +183,24 @@ resource redirectWwwHttpToHttpsRule 'Microsoft.Cdn/profiles/ruleSets/rules@2024-
   ]
 }
 
-// Route for primary domain (www)
+// Route for both custom domains (www + apex).
+//
+// customDomains MUST be listed here — Bicep re-deploys are Incremental
+// but ARM still resets Route.customDomains to whatever the template
+// declares. The initial cutover set the associations manually via the
+// Azure portal, which left the Bicep silent on this property; the
+// 2026-07-05 Fix A re-deploy consequently stripped the associations
+// and produced a production outage on trashmob.eco (Front Door
+// returning 404 because no route was bound to that host). Never leave
+// this array implicit again.
 resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
   parent: endpoint
   name: routeName
   properties: {
+    customDomains: concat(
+      primaryDomain != '' ? [{ id: customDomainWww.id }] : [],
+      apexDomain != '' ? [{ id: customDomainApex.id }] : []
+    )
     originGroup: {
       id: originGroup.id
     }


### PR DESCRIPTION
Follow-up to #3492 — brings the route → custom-domain binding onto \`main\` so the next release doesn't regress.

Cherry-picked from \`ac756ac8\` on release.

### Recap
The Fix A re-deploy stripped the route's \`customDomains\` array (originally set manually via the Azure portal at initial cutover, never captured in Bicep). Symptom: 404 on http://trashmob.eco/, connection reset on https, apex effectively down. Fix in #3492 added \`customDomains: concat([{ id: customDomainWww.id }], [{ id: customDomainApex.id }])\` on the route and a WARNING comment above so future editors know not to strip it again. Verified in prod via \`az afd route show\` — both domains bound, \`isActive: true\`. Edge propagation is still catching up as of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)