### PR TITLE
Project 65 Phase 1: Instant Events backend endpoints

### DIFF
--- a/TrashMob.Models/Poco/V2/InstantEventRequestDto.cs
+++ b/TrashMob.Models/Poco/V2/InstantEventRequestDto.cs
@@ -1,0 +1,17 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// Request body for creating a new Instant Event — a zero-friction solo private cleanup
+/// where the server auto-fills title, description, date, event type, visibility, and status.
+/// See Planning/Projects/Project_65_Instant_Events.md for context.
+/// </summary>
+public class InstantEventRequestDto
+{
+    /// <summary>Gets or sets the latitude of the user's current location at Start. Required.</summary>
+    public double Latitude { get; set; }
+
+    /// <summary>Gets or sets the longitude of the user's current location at Start. Required.</summary>
+    public double Longitude { get; set; }
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
@@ -214,6 +214,115 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         }
 
         [Fact]
+        public async Task AddInstantEvent_ReturnsCreated_WithPersistedEvent()
+        {
+            var userId = Guid.NewGuid();
+            var newEventId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var request = new InstantEventRequestDto { Latitude = 47.6, Longitude = -122.3 };
+            eventManager.Setup(m => m.AddInstantEventAsync(request.Latitude, request.Longitude, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event
+                {
+                    Id = newEventId,
+                    Name = "Instant Event – 2026-07-12 14:30",
+                    EventVisibilityId = (int)EventVisibilityEnum.Private,
+                    Latitude = request.Latitude,
+                    Longitude = request.Longitude,
+                });
+
+            var result = await controller.AddInstantEvent(request, CancellationToken.None);
+
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            Assert.Equal(nameof(EventsV2Controller.GetEvent), createdResult.ActionName);
+            var dto = Assert.IsType<EventDto>(createdResult.Value);
+            Assert.Equal(newEventId, dto.Id);
+        }
+
+        [Fact]
+        public async Task AddInstantEvent_ReturnsForbid_WhenCreatorIsMinor()
+        {
+            // Minors cannot create events — mirrors the AddEvent minor check for defence-in-depth
+            // against a UI regression that exposed the Start-a-Pick button to a minor account.
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            userManager.Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new User { Id = userId, IsMinor = true, DependentId = Guid.NewGuid() });
+
+            var result = await controller.AddInstantEvent(
+                new InstantEventRequestDto { Latitude = 0, Longitude = 0 },
+                CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+            eventManager.Verify(
+                m => m.AddInstantEventAsync(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task CompleteEvent_ReturnsNotFound_WhenEventMissing()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var missingId = Guid.NewGuid();
+            eventManager.Setup(m => m.GetAsync(missingId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Event)null!);
+
+            var result = await controller.CompleteEvent(missingId, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task CompleteEvent_ReturnsForbid_WhenCallerNotEventLead()
+        {
+            controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();
+            var eventId = Guid.NewGuid();
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event { Id = eventId });
+            authorizationService.Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(),
+                    It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Failed());
+
+            var result = await controller.CompleteEvent(eventId, CancellationToken.None);
+
+            Assert.IsType<ForbidResult>(result);
+            eventManager.Verify(m => m.CompleteEventAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CompleteEvent_ReturnsOkWithCompletedEvent()
+        {
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+            controller.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    new[] { new System.Security.Claims.Claim("sub", userId.ToString()) }, "test"));
+
+            eventManager.Setup(m => m.GetAsync(eventId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event { Id = eventId });
+            authorizationService.Setup(a => a.AuthorizeAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(),
+                    It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
+            eventManager.Setup(m => m.CompleteEventAsync(eventId, userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Event
+                {
+                    Id = eventId,
+                    EventStatusId = (int)EventStatusEnum.Complete,
+                    DurationHours = 1,
+                    DurationMinutes = 15,
+                });
+
+            var result = await controller.CompleteEvent(eventId, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<EventDto>(ok.Value);
+            Assert.Equal(eventId, dto.Id);
+        }
+
+        [Fact]
         public async Task UpdateEvent_ReturnsForbid_WhenNotAuthorized()
         {
             controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();

--- a/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
@@ -352,6 +352,156 @@ namespace TrashMob.Shared.Tests.Managers.Events
 
         #endregion
 
+        #region AddInstantEventAsync Tests
+
+        [Fact]
+        public async Task AddInstantEventAsync_SetsExpectedDefaults()
+        {
+            var userId = Guid.NewGuid();
+            _eventRepository.SetupAddAsync();
+            _eventAttendeeManager.Setup(m => m.AddAsync(It.IsAny<EventAttendee>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EventAttendee ea, Guid _, CancellationToken _) => ea);
+
+            var result = await _sut.AddInstantEventAsync(47.6, -122.3, userId);
+
+            Assert.NotNull(result);
+            Assert.StartsWith("Instant Event", result.Name);
+            Assert.Equal("Instant private event", result.Description);
+            Assert.Equal((int)EventVisibilityEnum.Private, result.EventVisibilityId);
+            Assert.Equal((int)EventStatusEnum.Active, result.EventStatusId);
+            Assert.Equal(47.6, result.Latitude);
+            Assert.Equal(-122.3, result.Longitude);
+            Assert.Equal(1, result.MaxNumberOfParticipants);
+            Assert.Null(result.TeamId);
+        }
+
+        [Fact]
+        public async Task AddInstantEventAsync_RegistersCreatorAsEventLead()
+        {
+            var userId = Guid.NewGuid();
+            _eventRepository.SetupAddAsync();
+            _eventAttendeeManager.Setup(m => m.AddAsync(It.IsAny<EventAttendee>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EventAttendee ea, Guid _, CancellationToken _) => ea);
+
+            var result = await _sut.AddInstantEventAsync(0, 0, userId);
+
+            _eventAttendeeManager.Verify(m => m.AddAsync(
+                It.Is<EventAttendee>(ea => ea.UserId == userId
+                                           && ea.EventId == result.Id
+                                           && ea.IsEventLead),
+                userId,
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddInstantEventAsync_DoesNotSendNewEventNotificationEmail()
+        {
+            // The regular AddAsync fires a "New Event Alert" email to info@trashmob.eco.
+            // For solo private cleanups that would spam the inbox — the AddInstantEventAsync
+            // path deliberately skips it. Guarding the behavior with a test so a future refactor
+            // doesn't accidentally re-enable it.
+            var userId = Guid.NewGuid();
+            _eventRepository.SetupAddAsync();
+            _eventAttendeeManager.Setup(m => m.AddAsync(It.IsAny<EventAttendee>(), userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EventAttendee ea, Guid _, CancellationToken _) => ea);
+
+            await _sut.AddInstantEventAsync(0, 0, userId);
+
+            _emailManager.Verify(e => e.SendTemplatedEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<object>(),
+                It.IsAny<List<EmailAddress>>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        #endregion
+
+        #region CompleteEventAsync Tests
+
+        [Fact]
+        public async Task CompleteEventAsync_SetsStatusToCompleteAndComputesDuration()
+        {
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var startedTwoHoursAgo = DateTimeOffset.UtcNow.AddHours(-2).AddMinutes(-15);
+            var existing = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Instant Event to Complete")
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+            existing.EventDate = startedTwoHoursAgo;
+
+            _eventRepository.SetupGetAsync(existing);
+            _eventRepository.SetupUpdateAsync();
+
+            var result = await _sut.CompleteEventAsync(eventId, userId);
+
+            Assert.Equal((int)EventStatusEnum.Complete, result.EventStatusId);
+            Assert.Equal(2, result.DurationHours);
+            // Minutes field is the sub-hour remainder; allow ±1 for clock skew during test run.
+            Assert.InRange(result.DurationMinutes, 14, 16);
+        }
+
+        [Fact]
+        public async Task CompleteEventAsync_ClampsDurationTo24Hours_WhenEventAbandoned()
+        {
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var existing = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Abandoned Instant Event")
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+            existing.EventDate = DateTimeOffset.UtcNow.AddDays(-3);
+
+            _eventRepository.SetupGetAsync(existing);
+            _eventRepository.SetupUpdateAsync();
+
+            var result = await _sut.CompleteEventAsync(eventId, userId);
+
+            Assert.Equal(24, result.DurationHours);
+            Assert.Equal(0, result.DurationMinutes);
+        }
+
+        [Fact]
+        public async Task CompleteEventAsync_ClampsNegativeDurationToZero_ForBackdatedFutureEvents()
+        {
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var existing = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Future-dated Event")
+                .CreatedBy(userId)
+                .AsActive()
+                .Build();
+            existing.EventDate = DateTimeOffset.UtcNow.AddHours(2);
+
+            _eventRepository.SetupGetAsync(existing);
+            _eventRepository.SetupUpdateAsync();
+
+            var result = await _sut.CompleteEventAsync(eventId, userId);
+
+            Assert.Equal(0, result.DurationHours);
+            Assert.Equal(0, result.DurationMinutes);
+        }
+
+        [Fact]
+        public async Task CompleteEventAsync_Throws_WhenEventNotFound()
+        {
+            var missingId = Guid.NewGuid();
+            _eventRepository.Setup(r => r.GetAsync(missingId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Event)null!);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.CompleteEventAsync(missingId, Guid.NewGuid()));
+        }
+
+        #endregion
+
         #region DeleteAsync Tests
 
         [Fact]

--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -37,6 +37,11 @@ namespace TrashMob.Shared.Managers.Events
         : KeyedManager<Event>(repository), IEventManager
     {
         private const int StandardEventWindowInMinutes = 120;
+
+        // Seed EventType row for a general "Cleanup" event. Used as the default type for
+        // Instant Events per Project 65 Decisions (reuse rather than adding a "Solo Pick" type).
+        // Corresponds to the seeded EventType with Name = "Cleanup".
+        private const int DefaultEventTypeIdCleanup = 1;
         private readonly IEventLitterReportManager eventLitterReportManager = eventLitterReportManager;
 
         /// <inheritdoc />
@@ -336,6 +341,75 @@ namespace TrashMob.Shared.Managers.Events
             }
 
             return updatedEvent;
+        }
+
+        /// <inheritdoc />
+        public async Task<Event> AddInstantEventAsync(double latitude, double longitude, Guid userId,
+            CancellationToken cancellationToken = default)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var localTimestamp = now.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+
+            var instantEvent = new Event
+            {
+                Name = $"Instant Event – {localTimestamp}",
+                Description = "Instant private event",
+                EventDate = now,
+                DurationHours = 0,
+                DurationMinutes = 0,
+                EventTypeId = DefaultEventTypeIdCleanup,
+                EventStatusId = (int)EventStatusEnum.Active,
+                EventVisibilityId = (int)EventVisibilityEnum.Private,
+                Latitude = latitude,
+                Longitude = longitude,
+                MaxNumberOfParticipants = 1,
+            };
+
+            // Bypass this.AddAsync — that override sends a "new event alert" email to
+            // info@trashmob.eco which is spam for solo private cleanups. Call base directly
+            // to persist the event, then wire up the creator-as-lead attendee ourselves.
+            var newEvent = await base.AddAsync(instantEvent, userId, cancellationToken);
+
+            var newEventAttendee = new EventAttendee
+            {
+                UserId = userId,
+                EventId = newEvent.Id,
+                SignUpDate = DateTime.UtcNow,
+                IsEventLead = true,
+            };
+
+            await eventAttendeeManager.AddAsync(newEventAttendee, userId, cancellationToken);
+
+            return newEvent;
+        }
+
+        /// <inheritdoc />
+        public async Task<Event> CompleteEventAsync(Guid eventId, Guid userId,
+            CancellationToken cancellationToken = default)
+        {
+            var mobEvent = await Repo.GetAsync(eventId, cancellationToken)
+                ?? throw new InvalidOperationException($"Event {eventId} not found.");
+
+            var elapsed = DateTimeOffset.UtcNow - mobEvent.EventDate;
+
+            // Clamp to [0, 24h]. Negative can happen if EventDate was backdated to the future
+            // (weird but possible via manual DB edits). 24h cap prevents an abandoned Instant
+            // Event that never got Stopped from returning a comically long duration when the
+            // background-abandonment job (Phase 4) eventually completes it.
+            if (elapsed < TimeSpan.Zero)
+            {
+                elapsed = TimeSpan.Zero;
+            }
+            else if (elapsed > TimeSpan.FromHours(24))
+            {
+                elapsed = TimeSpan.FromHours(24);
+            }
+
+            mobEvent.DurationHours = (int)elapsed.TotalHours;
+            mobEvent.DurationMinutes = elapsed.Minutes;
+            mobEvent.EventStatusId = (int)EventStatusEnum.Complete;
+
+            return await base.UpdateAsync(mobEvent, userId, cancellationToken);
         }
 
         private async Task<List<Guid>> GetUserTeamIdsAsync(Guid? userId,

--- a/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
@@ -109,5 +109,34 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <returns>The number of entities deleted.</returns>
         Task<int> DeleteAsync(Guid id, string cancellationReason, Guid userId,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new solo private Instant Event for the specified user at the given GPS
+        /// coordinates. Auto-fills name (with timestamp), description, EventType (Cleanup),
+        /// visibility (Private), status (Active), and EventDate (now). Registers the creator
+        /// as sole attendee + event lead. Deliberately skips the info@ new-event notification
+        /// email — private solo cleanups would flood that inbox.
+        /// See Planning/Projects/Project_65_Instant_Events.md.
+        /// </summary>
+        /// <param name="latitude">Latitude of the user's location at Start.</param>
+        /// <param name="longitude">Longitude of the user's location at Start.</param>
+        /// <param name="userId">The user creating the event.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The newly created event.</returns>
+        Task<Event> AddInstantEventAsync(double latitude, double longitude, Guid userId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Marks an event as Complete and computes its actual duration from the elapsed time
+        /// since the event was created. Used by the Instant Events "Stop" flow but works for
+        /// any event. Duration is clamped to [0, 24h] as a safeguard against abandoned or
+        /// backdated events producing absurd values.
+        /// </summary>
+        /// <param name="eventId">The event to complete.</param>
+        /// <param name="userId">The user completing the event (used for audit fields).</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The updated event.</returns>
+        Task<Event> CompleteEventAsync(Guid eventId, Guid userId,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMob/Controllers/V2/EventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventsV2Controller.cs
@@ -337,6 +337,78 @@ namespace TrashMob.Controllers.V2
         }
 
         /// <summary>
+        /// Creates a new solo private "Instant Event" at the given GPS location.
+        /// Zero user input required beyond the coordinates — server auto-fills Name (with
+        /// local timestamp), Description, EventDate (now), EventType (Cleanup), Visibility
+        /// (Private), and Status (Active). Registers the caller as sole attendee + event lead.
+        /// Skips the info@trashmob.eco new-event notification email.
+        /// See Planning/Projects/Project_65_Instant_Events.md.
+        /// </summary>
+        /// <param name="request">The GPS coordinates at Start.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="201">Instant event created.</response>
+        /// <response code="403">Minor accounts cannot create events (event leads must be adults).</response>
+        [HttpPost("instant")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventDto), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> AddInstantEvent(InstantEventRequestDto request,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 AddInstantEvent User={UserId} Lat={Latitude} Lng={Longitude}",
+                UserId, request.Latitude, request.Longitude);
+
+            // Mirrors AddEvent — minors cannot create events because event creators are
+            // auto-assigned as event lead and event leads must be adults.
+            var creator = await userManager.GetAsync(UserId, cancellationToken);
+            if (creator is { IsMinor: true })
+            {
+                return Forbid();
+            }
+
+            var newEvent = await eventManager
+                .AddInstantEventAsync(request.Latitude, request.Longitude, UserId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetEvent), new { id = newEvent.Id }, newEvent.ToV2Dto());
+        }
+
+        /// <summary>
+        /// Marks an event as Complete and computes its actual duration from the elapsed time
+        /// since EventDate. Used by the Instant Events "Stop" flow. Only event leads or admins
+        /// can complete an event.
+        /// </summary>
+        /// <param name="id">The event to complete.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the completed event with computed duration.</response>
+        /// <response code="403">User is not an event lead or admin for this event.</response>
+        /// <response code="404">Event not found.</response>
+        [HttpPut("{id}/complete")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobWriteScope)]
+        [ProducesResponseType(typeof(EventDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> CompleteEvent(Guid id, CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 CompleteEvent Event={EventId}", id);
+
+            var mobEvent = await eventManager.GetAsync(id, cancellationToken);
+            if (mobEvent == null)
+            {
+                return NotFound();
+            }
+
+            if (!await IsAuthorizedAsync(mobEvent, AuthorizationPolicyConstants.UserIsEventLeadOrIsAdmin))
+            {
+                return Forbid();
+            }
+
+            var completed = await eventManager.CompleteEventAsync(id, UserId, cancellationToken);
+            return Ok(completed.ToV2Dto());
+        }
+
+        /// <summary>
         /// Updates an existing event. Only event leads can update.
         /// </summary>
         /// <param name="eventDto">The event to update.</param>


### PR DESCRIPTION
## Summary
- **`POST /api/v2/events/instant`** — creates a Private Event with server-filled defaults (name = `"Instant Event – <local timestamp>"`, EventType = Cleanup, visibility = Private, status = Active, EventDate = now, GPS from body). Registers the caller as sole attendee + event lead.
- **`PUT /api/v2/events/{id}/complete`** — marks as Complete, computes duration from elapsed time, clamped to [0, 24h].
- `AddInstantEventAsync` + `CompleteEventAsync` added to `IEventManager` / `EventManager`.
- New DTO: `InstantEventRequestDto` (Latitude, Longitude).
- 12 new tests (7 manager, 5 controller). No regressions.

## Design notes
- **Skips the info@trashmob.eco "New Event Alert" email.** The regular `AddAsync` fires one for every event created; for solo private cleanups it would spam the inbox. `AddInstantEventAsync` bypasses that override and wires up the creator-as-lead attendee manually. Guarded with a dedicated test so a future refactor can't accidentally re-enable it.
- **Minor guard mirrored from `AddEvent`** — event leads must be adults; the endpoint returns `403` for minor callers.
- **Duration clamping to [0, 24h]** on complete — safeguard against abandoned events (Phase 4 will add background-abandonment logic that eventually completes long-Running Instant Events) or backdated future events producing weird values.
- **No waiver enforcement in the endpoint** — matches existing `POST /events` behavior. Waiver gating happens at attendee sign-up (`EventAttendeesV2Controller.Add`) and will happen at the mobile UI (block Start if unsigned) per the planning doc. Adding a check only here would be inconsistent.
- **EventType = 1 hardcoded** for "Cleanup" seed row, with a comment. A proper `EventTypeEnum` doesn't exist and adding one touches lookups across the codebase — out of scope for Phase 1.

## Not included in this PR
- Mobile UI (`Start a New Pick` button, in-progress view, Stop → EditEventSummaryPage) — separate PR incoming
- Route tracking toggle wiring (Phase 2)
- Reverse geocoding at Start (Phase 2)
- Community auto-assignment (Phase 3)
- Background-abandonment guard (Phase 4)

## Test plan
- [x] `dotnet build TrashMob.sln` — clean, 0 warnings, 0 errors
- [x] 12 new tests pass
- [x] All 47 tests in `EventManagerTests` + `EventsV2ControllerTests` pass — no regressions
- [ ] Manual test with Swagger against local: `POST /api/v2/events/instant { latitude: 47.6, longitude: -122.3 }` then `PUT /api/v2/events/{id}/complete` (Joe to run before merging)

Refs [Planning/Projects/Project_65_Instant_Events.md](../blob/dev/joe/instant-events-backend/Planning/Projects/Project_65_Instant_Events.md) Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)