### PR TITLE
Project 65 Phase 1: Instant Events mobile UI

### DIFF
--- a/TrashMobMobile/AppShell.xaml.cs
+++ b/TrashMobMobile/AppShell.xaml.cs
@@ -24,6 +24,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(ManageEventPartnersPage), typeof(ManageEventPartnersPage));
         Routing.RegisterRoute(nameof(MainTabsPage), typeof(MainTabsPage));
         Routing.RegisterRoute(nameof(MyDashboardPage), typeof(MyDashboardPage));
+        Routing.RegisterRoute(nameof(InstantEventPage), typeof(InstantEventPage));
         Routing.RegisterRoute(nameof(ProfilePage), typeof(ProfilePage));
         Routing.RegisterRoute(nameof(QuickActionPlaceholderPage), typeof(QuickActionPlaceholderPage));
         Routing.RegisterRoute(nameof(SearchEventsPage), typeof(SearchEventsPage));

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -80,6 +80,8 @@ public static class MauiProgram
         builder.Services.AddTransient<MainPage>();
         builder.Services.AddTransient<ManageEventPartnersPage>();
         builder.Services.AddTransient<MyDashboardPage>();
+        builder.Services.AddTransient<InstantEventPage>();
+        builder.Services.AddTransient<InstantEventViewModel>();
         builder.Services.AddTransient<ProfilePage>();
         builder.Services.AddTransient<QuickActionPlaceholderPage>();
         builder.Services.AddTransient<SearchEventsPage>();

--- a/TrashMobMobile/Pages/InstantEventPage.xaml
+++ b/TrashMobMobile/Pages/InstantEventPage.xaml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:InstantEventViewModel"
+             x:Class="TrashMobMobile.Pages.InstantEventPage"
+             Title="Instant Event"
+             Shell.NavBarIsVisible="False">
+
+    <Grid RowDefinitions="*, Auto, Auto, Auto, *" Padding="20">
+
+        <!-- Elapsed time (only visible while running) -->
+        <Label Grid.Row="1"
+               Text="{Binding ElapsedTime}"
+               FontFamily="LexendSemibold"
+               FontSize="72"
+               HorizontalOptions="Center"
+               VerticalOptions="Center"
+               IsVisible="{Binding IsRunning}" />
+
+        <!-- Status message (visible during startup + failure) -->
+        <VerticalStackLayout Grid.Row="2" Spacing="12" HorizontalOptions="Center">
+
+            <ActivityIndicator IsRunning="{Binding IsBusy}"
+                               IsVisible="{Binding IsBusy}"
+                               HorizontalOptions="Center" />
+
+            <Label Text="{Binding StatusMessage}"
+                   FontSize="18"
+                   HorizontalOptions="Center"
+                   HorizontalTextAlignment="Center" />
+        </VerticalStackLayout>
+
+        <!-- Action buttons -->
+        <VerticalStackLayout Grid.Row="3" Spacing="12" Margin="0,20,0,0">
+
+            <Button Text="STOP"
+                    Command="{Binding StopCommand}"
+                    Style="{StaticResource PrimaryLargeButton}"
+                    IsVisible="{Binding IsRunning}"
+                    HeightRequest="64"
+                    FontSize="20"
+                    FontAttributes="Bold" />
+
+            <Button Text="Go Back"
+                    Command="{Binding GoBackCommand}"
+                    Style="{StaticResource SecondaryLargeButton}"
+                    IsVisible="{Binding IsFailed}"
+                    HeightRequest="52" />
+        </VerticalStackLayout>
+
+    </Grid>
+</ContentPage>

--- a/TrashMobMobile/Pages/InstantEventPage.xaml.cs
+++ b/TrashMobMobile/Pages/InstantEventPage.xaml.cs
@@ -1,0 +1,22 @@
+namespace TrashMobMobile.Pages;
+
+using TrashMobMobile.ViewModels;
+
+public partial class InstantEventPage : ContentPage
+{
+    private readonly InstantEventViewModel viewModel;
+
+    public InstantEventPage(InstantEventViewModel viewModel)
+    {
+        InitializeComponent();
+        this.viewModel = viewModel;
+        this.viewModel.Navigation = Navigation;
+        BindingContext = this.viewModel;
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        base.OnNavigatedTo(args);
+        await viewModel.Init();
+    }
+}

--- a/TrashMobMobile/Pages/MyDashboardPage.xaml
+++ b/TrashMobMobile/Pages/MyDashboardPage.xaml
@@ -121,6 +121,18 @@
                                HorizontalTextAlignment="Center" />
                     </Grid>
                 </Border>
+                <!-- Instant Event primary action — Project 65. Strava-style: tap once and
+                     you're recording. Sits above the secondary Create Event / Report Litter
+                     row so it reads as the primary Dashboard action. -->
+                <Button Command="{Binding StartInstantEventCommand}"
+                        HorizontalOptions="Fill"
+                        Margin="5,5,5,10"
+                        Style="{StaticResource PrimaryLargeButton}"
+                        Text="Start a New Pick"
+                        ContentLayout="Left, 8"
+                        HeightRequest="56"
+                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconPlusCircle}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
+
                 <Grid ColumnDefinitions="*, *, *, *"
                       RowDefinitions="Auto"
                       VerticalOptions="End"

--- a/TrashMobMobile/Pages/MyDashboardPage.xaml
+++ b/TrashMobMobile/Pages/MyDashboardPage.xaml
@@ -121,9 +121,39 @@
                                HorizontalTextAlignment="Center" />
                     </Grid>
                 </Border>
+                <!-- Instant Event in-progress banner — appears when a running Instant Event
+                     is persisted locally from a prior session that got closed before Stop.
+                     Tapping Resume goes to InstantEventPage which rebuilds the timer from
+                     the persisted start time. Hides the fresh-Start button below so the
+                     Dashboard has one clear next action. -->
+                <Border Padding="12" Margin="5,5"
+                        BackgroundColor="{AppThemeBinding Light=#eff6ff, Dark=#1e3a8a}"
+                        StrokeShape="RoundRectangle 10"
+                        Stroke="{AppThemeBinding Light=#93c5fd, Dark=#3b82f6}"
+                        StrokeThickness="1"
+                        IsVisible="{Binding HasInProgressInstantEvent}">
+                    <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto" ColumnSpacing="12">
+                        <Label Grid.Row="0" Grid.Column="0"
+                               Text="Pick in progress"
+                               FontFamily="LexendSemibold" FontSize="14"
+                               TextColor="{AppThemeBinding Light=#1e40af, Dark=#bfdbfe}" />
+                        <Label Grid.Row="1" Grid.Column="0"
+                               Text="You started a pick that wasn't finished. Tap Resume to keep going."
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#1e40af, Dark=#dbeafe}" />
+                        <Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                Text="Resume"
+                                Style="{StaticResource PrimaryLargeButton}"
+                                HeightRequest="40" Padding="16,0" FontSize="Small"
+                                VerticalOptions="Center"
+                                Command="{Binding StartInstantEventCommand}" />
+                    </Grid>
+                </Border>
+
                 <!-- Instant Event primary action — Project 65. Strava-style: tap once and
                      you're recording. Sits above the secondary Create Event / Report Litter
-                     row so it reads as the primary Dashboard action. -->
+                     row so it reads as the primary Dashboard action. Hidden when a running
+                     Instant Event is already persisted (the resume banner replaces it). -->
                 <Button Command="{Binding StartInstantEventCommand}"
                         HorizontalOptions="Fill"
                         Margin="5,5,5,10"
@@ -131,6 +161,7 @@
                         Text="Start a New Pick"
                         ContentLayout="Left, 8"
                         HeightRequest="56"
+                        IsVisible="{Binding CanStartFreshInstantEvent}"
                         ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconPlusCircle}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
 
                 <Grid ColumnDefinitions="*, *, *, *"

--- a/TrashMobMobile/Services/IMobEventManager.cs
+++ b/TrashMobMobile/Services/IMobEventManager.cs
@@ -41,5 +41,10 @@
 
         Task<IEnumerable<TrashMob.Models.Poco.Location>> GetLocationsByTimeRangeAsync(DateTimeOffset startDate,
             DateTimeOffset endDate, CancellationToken cancellationToken = default);
+
+        Task<Event> AddInstantEventAsync(double latitude, double longitude,
+            CancellationToken cancellationToken = default);
+
+        Task<Event> CompleteEventAsync(Guid eventId, CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobMobile/Services/IMobEventRestService.cs
+++ b/TrashMobMobile/Services/IMobEventRestService.cs
@@ -26,5 +26,18 @@
 
         Task<IEnumerable<TrashMob.Models.Poco.Location>> GetLocationsByTimeRangeAsync(DateTimeOffset startDate,
             DateTimeOffset endDate, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new Instant Event (solo private cleanup) at the given GPS coordinates.
+        /// Server auto-fills name, description, event type, visibility, and status. See
+        /// Planning/Projects/Project_65_Instant_Events.md.
+        /// </summary>
+        Task<Event> AddInstantEventAsync(double latitude, double longitude,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Marks an event as Complete and computes its duration from elapsed time.
+        /// </summary>
+        Task<Event> CompleteEventAsync(Guid eventId, CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobMobile/Services/MobEventManager.cs
+++ b/TrashMobMobile/Services/MobEventManager.cs
@@ -100,5 +100,16 @@
         {
             return mobEventRestService.GetLocationsByTimeRangeAsync(startDate, endDate, cancellationToken);
         }
+
+        public Task<Event> AddInstantEventAsync(double latitude, double longitude,
+            CancellationToken cancellationToken = default)
+        {
+            return mobEventRestService.AddInstantEventAsync(latitude, longitude, cancellationToken);
+        }
+
+        public Task<Event> CompleteEventAsync(Guid eventId, CancellationToken cancellationToken = default)
+        {
+            return mobEventRestService.CompleteEventAsync(eventId, cancellationToken);
+        }
     }
 }

--- a/TrashMobMobile/Services/MobEventRestService.cs
+++ b/TrashMobMobile/Services/MobEventRestService.cs
@@ -133,4 +133,24 @@ public class MobEventRestService(IHttpClientFactory httpClientFactory) : RestSer
             return JsonConvert.DeserializeObject<IEnumerable<Location>>(content) ?? [];
         }
     }
+
+    public async Task<Event> AddInstantEventAsync(double latitude, double longitude,
+        CancellationToken cancellationToken = default)
+    {
+        var body = new InstantEventRequestDto { Latitude = latitude, Longitude = longitude };
+        var content = JsonContent.Create(body, typeof(InstantEventRequestDto), null, SerializerOptions);
+        var response = await AuthorizedHttpClient.PostAsync($"{Controller}/instant", content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<EventDto>(returnContent)!.ToEntity();
+    }
+
+    public async Task<Event> CompleteEventAsync(Guid eventId, CancellationToken cancellationToken = default)
+    {
+        var response = await AuthorizedHttpClient.PutAsync($"{Controller}/{eventId}/complete",
+            content: null, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<EventDto>(returnContent)!.ToEntity();
+    }
 }

--- a/TrashMobMobile/ViewModels/InstantEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/InstantEventViewModel.cs
@@ -4,20 +4,31 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Maui.Devices.Sensors;
 using Sentry;
+using TrashMob.Models;
 using TrashMobMobile.Pages;
 using TrashMobMobile.Services;
 
 /// <summary>
-/// In-progress view for a running Instant Event. Init captures GPS + creates the event on the
-/// server, then a 1-second dispatcher timer drives the elapsed-time display. Stop calls the
-/// backend Complete endpoint and hands off to the existing EditEventSummaryPage for stats entry.
-/// See Planning/Projects/Project_65_Instant_Events.md Phase 1.
+/// In-progress view for a running Instant Event. Init decides between two paths based on
+/// persisted Preferences:
+///  - Resume path: a prior Init already created an event and saved its id/start time.
+///    Validate with the server, then rebuild the timer from the persisted start.
+///  - Fresh path: capture GPS, create the event on the server, persist state for
+///    later resume, start the timer.
+/// The persistence handles the "user closed the app mid-pick" case — the running event
+/// still exists on the server as Active, and this VM is where we teach the app to pick
+/// it back up. See Planning/Projects/Project_65_Instant_Events.md Phase 1.
 /// </summary>
 public partial class InstantEventViewModel(
     IMobEventManager mobEventManager,
     INotificationService notificationService)
     : BaseViewModel(notificationService)
 {
+    // Preferences keys for a running Instant Event that survives app-close/reopen.
+    // Cleared on Stop and on server-side confirmation that the event is no longer Active.
+    public const string PrefKeyEventId = "instant_event_id";
+    public const string PrefKeyStartedAt = "instant_event_started_at";
+
     private readonly IMobEventManager mobEventManager = mobEventManager;
     private DateTimeOffset startedAt;
     private IDispatcherTimer? timer;
@@ -41,26 +52,92 @@ public partial class InstantEventViewModel(
     {
         await ExecuteAsync(async () =>
         {
-            StatusMessage = "Getting location…";
-            var location = await GetCurrentLocationAsync();
-
-            if (location == null)
+            // Resume path — a previously-started Instant Event may still be running
+            // on the server if the user closed the app mid-pick.
+            if (await TryResumeAsync())
             {
-                IsFailed = true;
-                StatusMessage = "Location required. Check your device settings and try again.";
                 return;
             }
 
-            StatusMessage = "Starting your pick…";
-            var mobEvent = await mobEventManager
-                .AddInstantEventAsync(location.Latitude, location.Longitude);
-
-            EventId = mobEvent.Id;
-            startedAt = mobEvent.EventDate;
-            IsRunning = true;
-            StatusMessage = "Recording your pick";
-            StartTimer();
+            // Fresh path — no pending event; start a brand new one.
+            await StartFreshAsync();
         }, "Failed to start Instant Event. Please try again.");
+    }
+
+    private async Task<bool> TryResumeAsync()
+    {
+        var persistedIdString = Preferences.Default.Get(PrefKeyEventId, string.Empty);
+        if (string.IsNullOrEmpty(persistedIdString) || !Guid.TryParse(persistedIdString, out var persistedId))
+        {
+            return false;
+        }
+
+        var persistedStartedAtString = Preferences.Default.Get(PrefKeyStartedAt, string.Empty);
+        if (string.IsNullOrEmpty(persistedStartedAtString)
+            || !DateTimeOffset.TryParse(persistedStartedAtString, out var persistedStartedAt))
+        {
+            // Half-persisted state — clear and fall through to a fresh start.
+            ClearPersistedState();
+            return false;
+        }
+
+        StatusMessage = "Resuming your pick…";
+
+        Event? serverEvent;
+        try
+        {
+            serverEvent = await mobEventManager.GetEventAsync(persistedId);
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+            // Server unreachable or 404 — treat as no resume target and let user start fresh.
+            ClearPersistedState();
+            return false;
+        }
+
+        // If someone completed the event out-of-band (another device, admin action, or the
+        // Phase 4 background-abandonment guard once we ship it), the server status will be
+        // Complete or Canceled. Don't resume — clear state and let the user start fresh.
+        if (serverEvent == null
+            || serverEvent.EventStatusId == (int)EventStatusEnum.Complete
+            || serverEvent.EventStatusId == (int)EventStatusEnum.Canceled)
+        {
+            ClearPersistedState();
+            return false;
+        }
+
+        EventId = serverEvent.Id;
+        startedAt = persistedStartedAt;
+        IsRunning = true;
+        StatusMessage = "Recording your pick";
+        StartTimer();
+        return true;
+    }
+
+    private async Task StartFreshAsync()
+    {
+        StatusMessage = "Getting location…";
+        var location = await GetCurrentLocationAsync();
+
+        if (location == null)
+        {
+            IsFailed = true;
+            StatusMessage = "Location required. Check your device settings and try again.";
+            return;
+        }
+
+        StatusMessage = "Starting your pick…";
+        var mobEvent = await mobEventManager
+            .AddInstantEventAsync(location.Latitude, location.Longitude);
+
+        EventId = mobEvent.Id;
+        startedAt = mobEvent.EventDate;
+        PersistState(mobEvent.Id, mobEvent.EventDate);
+
+        IsRunning = true;
+        StatusMessage = "Recording your pick";
+        StartTimer();
     }
 
     [RelayCommand]
@@ -81,6 +158,12 @@ public partial class InstantEventViewModel(
         await ExecuteAsync(async () =>
         {
             await mobEventManager.CompleteEventAsync(completedEventId);
+
+            // Clear persisted state only after the server confirms Complete — if the
+            // Complete call fails, we still want the user to be able to resume and try
+            // again from the Dashboard.
+            ClearPersistedState();
+
             await Shell.Current
                 .GoToAsync($"//{nameof(EditEventSummaryPage)}?EventId={completedEventId}");
         }, "Failed to complete the Instant Event. You can complete it manually from your event history.");
@@ -114,6 +197,18 @@ public partial class InstantEventViewModel(
     {
         timer?.Stop();
         timer = null;
+    }
+
+    private static void PersistState(Guid eventId, DateTimeOffset startedAt)
+    {
+        Preferences.Default.Set(PrefKeyEventId, eventId.ToString());
+        Preferences.Default.Set(PrefKeyStartedAt, startedAt.ToString("o"));
+    }
+
+    private static void ClearPersistedState()
+    {
+        Preferences.Default.Remove(PrefKeyEventId);
+        Preferences.Default.Remove(PrefKeyStartedAt);
     }
 
     private static async Task<Location?> GetCurrentLocationAsync()

--- a/TrashMobMobile/ViewModels/InstantEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/InstantEventViewModel.cs
@@ -1,0 +1,132 @@
+namespace TrashMobMobile.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Devices.Sensors;
+using Sentry;
+using TrashMobMobile.Pages;
+using TrashMobMobile.Services;
+
+/// <summary>
+/// In-progress view for a running Instant Event. Init captures GPS + creates the event on the
+/// server, then a 1-second dispatcher timer drives the elapsed-time display. Stop calls the
+/// backend Complete endpoint and hands off to the existing EditEventSummaryPage for stats entry.
+/// See Planning/Projects/Project_65_Instant_Events.md Phase 1.
+/// </summary>
+public partial class InstantEventViewModel(
+    IMobEventManager mobEventManager,
+    INotificationService notificationService)
+    : BaseViewModel(notificationService)
+{
+    private readonly IMobEventManager mobEventManager = mobEventManager;
+    private DateTimeOffset startedAt;
+    private IDispatcherTimer? timer;
+
+    [ObservableProperty]
+    private Guid eventId;
+
+    [ObservableProperty]
+    private string elapsedTime = "00:00:00";
+
+    [ObservableProperty]
+    private bool isRunning;
+
+    [ObservableProperty]
+    private bool isFailed;
+
+    [ObservableProperty]
+    private string statusMessage = "Getting location…";
+
+    public async Task Init()
+    {
+        await ExecuteAsync(async () =>
+        {
+            StatusMessage = "Getting location…";
+            var location = await GetCurrentLocationAsync();
+
+            if (location == null)
+            {
+                IsFailed = true;
+                StatusMessage = "Location required. Check your device settings and try again.";
+                return;
+            }
+
+            StatusMessage = "Starting your pick…";
+            var mobEvent = await mobEventManager
+                .AddInstantEventAsync(location.Latitude, location.Longitude);
+
+            EventId = mobEvent.Id;
+            startedAt = mobEvent.EventDate;
+            IsRunning = true;
+            StatusMessage = "Recording your pick";
+            StartTimer();
+        }, "Failed to start Instant Event. Please try again.");
+    }
+
+    [RelayCommand]
+    private async Task Stop()
+    {
+        if (!IsRunning)
+        {
+            return;
+        }
+
+        StopTimer();
+        IsRunning = false;
+
+        // Capture EventId before ExecuteAsync so the navigation URL is stable if the
+        // ViewModel state gets tossed while the API call is in flight.
+        var completedEventId = EventId;
+
+        await ExecuteAsync(async () =>
+        {
+            await mobEventManager.CompleteEventAsync(completedEventId);
+            await Shell.Current
+                .GoToAsync($"//{nameof(EditEventSummaryPage)}?EventId={completedEventId}");
+        }, "Failed to complete the Instant Event. You can complete it manually from your event history.");
+    }
+
+    [RelayCommand]
+    private async Task GoBack()
+    {
+        StopTimer();
+        await Shell.Current.GoToAsync("..");
+    }
+
+    private void StartTimer()
+    {
+        timer = Application.Current!.Dispatcher.CreateTimer();
+        timer.Interval = TimeSpan.FromSeconds(1);
+        timer.Tick += (_, _) =>
+        {
+            var elapsed = DateTimeOffset.UtcNow - startedAt;
+            if (elapsed < TimeSpan.Zero)
+            {
+                elapsed = TimeSpan.Zero;
+            }
+
+            ElapsedTime = elapsed.ToString(@"hh\:mm\:ss");
+        };
+        timer.Start();
+    }
+
+    private void StopTimer()
+    {
+        timer?.Stop();
+        timer = null;
+    }
+
+    private static async Task<Location?> GetCurrentLocationAsync()
+    {
+        try
+        {
+            var request = new GeolocationRequest(GeolocationAccuracy.Best, TimeSpan.FromSeconds(10));
+            return await Geolocation.Default.GetLocationAsync(request);
+        }
+        catch (Exception ex)
+        {
+            SentrySdk.CaptureException(ex);
+            return null;
+        }
+    }
+}

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -422,6 +422,22 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
         await Shell.Current.GoToAsync($"{nameof(CreateEventPage)}?LitterReportId={Guid.Empty}");
     }
 
+    [RelayCommand]
+    private async Task StartInstantEvent()
+    {
+        // Waiver gate mirrors CreateEvent — Instant Events still register the user as
+        // an event attendee under the hood, so the same waiver requirement applies.
+        // Project 65 Phase 1 design decision: block Start if unsigned, redirect to
+        // WaiverListPage; no in-flow signing.
+        if (!await waiverManager.HasUserSignedAllRequiredWaiversAsync())
+        {
+            await Shell.Current.GoToAsync(nameof(WaiverListPage));
+            return;
+        }
+
+        await Shell.Current.GoToAsync(nameof(InstantEventPage));
+    }
+
     private async void HandleUpcomingDateRangeSelected()
     {
         try

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -44,6 +44,16 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
     [ObservableProperty]
     private bool hasPendingWaiverAlerts;
 
+    // True when local Preferences hold a started-but-not-completed Instant Event. Drives
+    // the resume banner + hides the fresh Start button. Refreshed on every Dashboard load
+    // via RefreshInstantEventResumeState so the state stays in sync after Stop / cancel /
+    // out-of-band server completion. See Project 65 Phase 1 gap discussion.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanStartFreshInstantEvent))]
+    private bool hasInProgressInstantEvent;
+
+    public bool CanStartFreshInstantEvent => !HasInProgressInstantEvent;
+
     public ObservableCollection<string> UpcomingDateRanges { get; set; } = [];
 
     public ObservableCollection<string> CompletedDateRanges { get; set; } = [];
@@ -221,7 +231,17 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
             SelectedCreatedDateRange = DateRanges.LastMonth;
 
             await Task.WhenAll(RefreshEvents(), RefreshStatistics(), RefreshLitterReports(), RefreshPendingWaiverAlerts());
+            RefreshInstantEventResumeState();
         }, "An error has occurred while loading the dashboard. Please wait and try again in a moment.");
+    }
+
+    private void RefreshInstantEventResumeState()
+    {
+        // Cheap synchronous check — server validation happens inside InstantEventViewModel
+        // when the user taps Resume. Dashboard only cares whether *something* is worth
+        // offering to resume.
+        var pending = Preferences.Default.Get(InstantEventViewModel.PrefKeyEventId, string.Empty);
+        HasInProgressInstantEvent = !string.IsNullOrEmpty(pending);
     }
 
     private async void PerformEventNavigation(EventViewModel eventViewModel)
@@ -425,6 +445,16 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
     [RelayCommand]
     private async Task StartInstantEvent()
     {
+        // Resume path: if a running Instant Event is persisted locally, skip the waiver
+        // gate — the user already signed to create it — and go straight to the recording
+        // page. InstantEventViewModel.Init validates with the server and falls through to
+        // a fresh start if the persisted event was completed/canceled out-of-band.
+        if (HasInProgressInstantEvent)
+        {
+            await Shell.Current.GoToAsync(nameof(InstantEventPage));
+            return;
+        }
+
         // Waiver gate mirrors CreateEvent — Instant Events still register the user as
         // an event attendee under the hood, so the same waiver requirement applies.
         // Project 65 Phase 1 design decision: block Start if unsigned, redirect to


### PR DESCRIPTION
## Summary
Wires the mobile Start-a-Pick flow onto the backend endpoints from [#3497](https://github.com/TrashMob-eco/TrashMob/pull/3497).

- **Dashboard**: prominent "Start a New Pick" primary button above the existing Create Event / Report Litter row. Strava-style visual weight — this is the main Dashboard action.
- **[InstantEventPage](../blob/dev/joe/instant-events-mobile/TrashMobMobile/Pages/InstantEventPage.xaml)** (new): full-screen recording view with elapsed-time display, status message, prominent STOP button. NavBar hidden so the timer view feels distinct.
- **[InstantEventViewModel](../blob/dev/joe/instant-events-mobile/TrashMobMobile/ViewModels/InstantEventViewModel.cs)** (new): captures GPS via `Geolocation.Default`, calls `AddInstantEventAsync`, drives a 1-second `IDispatcherTimer`. Stop calls `CompleteEventAsync`, then routes to `EditEventSummaryPage` for stats entry (via `//` shell navigation so the page stack doesn't accumulate).
- **Service layer**: `AddInstantEventAsync` + `CompleteEventAsync` added to `IMobEventRestService` (REST) and `IMobEventManager` (pass-through).
- **Waiver gate**: `StartInstantEvent` command mirrors `CreateEvent` — unsigned users get redirected to `WaiverListPage` before the Start flow can begin. Matches the Project 65 decision "block Start if unsigned; no in-flow signing."
- **Failure paths**: GPS unavailable → friendly "Location required" message + Go Back button, no event created. API failures surface via existing `ExecuteAsync`/`NotificationService` error handling.

## User flow
1. Dashboard → tap **Start a New Pick**
2. (First-time users) waiver gate → sign then come back
3. Navigate to `InstantEventPage`, shows "Getting location…"
4. GPS acquired → server creates Instant Event → timer starts, status shows "Recording your pick"
5. Tap **STOP** → server marks Complete → navigate to `EditEventSummaryPage` for optional stats entry

## Design choices worth flagging
- **Icon**: `IconPlusCircle` (already enabled). `IconPlay` is commented out in the icon XAML; enabling it would require font-glyph work outside Phase 1 scope.
- **No bottom sheet**: the planning doc mentions a "single-toggle bottom sheet" but that toggle is for route tracking, which is Phase 2. With no toggle to show, a full-page navigation is cleaner than a modal wrapping a single Start button. Bottom sheet returns in Phase 2 when tracking is wired.
- **Endpoint naming**: mobile calls `PUT /events/{id}/complete` (not `/stop`), matching the backend's chosen endpoint.

## What's NOT in this PR (per Phase 1 scope)
- Route tracking toggle wiring — Phase 2
- Reverse geocoding at Start — Phase 2
- Community auto-assignment — Phase 3
- Background-abandonment guard — Phase 4

## Testability gap (candidate follow-up)
No `InstantEventViewModel` unit tests. The VM has three static dependencies with no existing abstraction to mock around:
- `Application.Current.Dispatcher` (timer)
- `Shell.Current` (navigation)
- `Geolocation.Default` (GPS)

Other GPS-using ViewModels (`CreateLitterReportViewModel`) don't test those paths either, so this is a codebase-wide pattern. A future testability refactor introducing an `IGeolocationService` abstraction could unlock unit tests for a whole class of ViewModels — good candidate for [Project 4 (Mobile Robustness)](../blob/dev/joe/instant-events-mobile/Planning/Projects/Project_04_Mobile_Robustness.md) or [Project 25 (Automated Testing)](../blob/dev/joe/instant-events-mobile/Planning/Projects/Project_25_Automated_Testing.md).

## Test plan
- [x] Android build passes: `dotnet build TrashMobMobile -f net10.0-android` — 0 errors, only pre-existing warnings
- [ ] Manual smoke test on `pixel_8_api_35` emulator (Joe to run):
  - [ ] Dashboard shows Start-a-Pick button
  - [ ] Tap → GPS acquired → InstantEventPage renders with running timer
  - [ ] Stop → navigates to EditEventSummaryPage with the new event's ID
  - [ ] Event appears in Dashboard history under Completed
  - [ ] Stats entered on EditEventSummaryPage roll up into personal totals
  - [ ] With location permission denied, "Location required" message shows and no event is created

Refs [Planning/Projects/Project_65_Instant_Events.md](../blob/dev/joe/instant-events-mobile/Planning/Projects/Project_65_Instant_Events.md) Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)