### PR TITLE
Instant Events: cross-device / fresh-install resume (Option B)

### DIFF
--- a/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/EventsV2ControllerTests.cs
@@ -261,6 +261,33 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         }
 
         [Fact]
+        public async Task GetInProgressInstantEvents_ReturnsCallerScopedList()
+        {
+            var userId = Guid.NewGuid();
+            controller.HttpContext.Items["UserId"] = userId.ToString();
+
+            var candidate = new Event
+            {
+                Id = Guid.NewGuid(),
+                Name = "Instant Event – 2026-07-13 09:30",
+                EventStatusId = (int)EventStatusEnum.Active,
+                EventVisibilityId = (int)EventVisibilityEnum.Private,
+                CreatedByUserId = userId,
+            };
+
+            eventManager
+                .Setup(m => m.GetInProgressInstantEventsAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync([candidate]);
+
+            var result = await controller.GetInProgressInstantEvents(CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsAssignableFrom<IEnumerable<EventDto>>(ok.Value);
+            Assert.Single(dtos);
+            Assert.Equal(candidate.Id, dtos.First().Id);
+        }
+
+        [Fact]
         public async Task CompleteEvent_ReturnsNotFound_WhenEventMissing()
         {
             controller.HttpContext.Items["UserId"] = Guid.NewGuid().ToString();

--- a/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
@@ -502,6 +502,86 @@ namespace TrashMob.Shared.Tests.Managers.Events
 
         #endregion
 
+        #region GetInProgressInstantEventsAsync Tests
+
+        [Fact]
+        public async Task GetInProgressInstantEventsAsync_ReturnsOnlyResumableInstantEventsForUser()
+        {
+            var userId = Guid.NewGuid();
+            var otherUserId = Guid.NewGuid();
+            var thirtyMinAgo = DateTimeOffset.UtcNow.AddMinutes(-30);
+
+            // Ideal candidate — owned by user, Active, Private, zero duration, started recently.
+            var resumable = new EventBuilder()
+                .WithName("Instant Event – 2026-07-13 09:30")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(0, 0)
+                .WithEventDate(thirtyMinAgo)
+                .Build();
+
+            // Completed Instant Event — has a duration set. Should NOT resume.
+            var completed = new EventBuilder()
+                .WithName("Instant Event – 2026-07-13 08:00")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(1, 15)
+                .WithEventDate(thirtyMinAgo)
+                .Build();
+
+            // Public event — wrong visibility. Should NOT resume.
+            var publicEvent = new EventBuilder()
+                .WithName("Public event")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPublic()
+                .WithDuration(0, 0)
+                .WithEventDate(thirtyMinAgo)
+                .Build();
+
+            // Owned by another user. Should NOT resume for this caller.
+            var otherUsers = new EventBuilder()
+                .WithName("Someone else's instant event")
+                .CreatedBy(otherUserId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(0, 0)
+                .WithEventDate(thirtyMinAgo)
+                .Build();
+
+            // Too old — outside the 24h resume window. Belongs to Phase 4 abandonment guard.
+            var tooOld = new EventBuilder()
+                .WithName("Instant Event – three days ago")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(0, 0)
+                .WithEventDate(DateTimeOffset.UtcNow.AddDays(-3))
+                .Build();
+
+            _eventRepository.SetupGetWithFilter(new[] { resumable, completed, publicEvent, otherUsers, tooOld });
+
+            var result = await _sut.GetInProgressInstantEventsAsync(userId);
+
+            var list = result.ToList();
+            Assert.Single(list);
+            Assert.Equal(resumable.Id, list[0].Id);
+        }
+
+        [Fact]
+        public async Task GetInProgressInstantEventsAsync_ReturnsEmpty_WhenNoCandidates()
+        {
+            _eventRepository.SetupGetWithFilter(Array.Empty<Event>());
+
+            var result = await _sut.GetInProgressInstantEventsAsync(Guid.NewGuid());
+
+            Assert.Empty(result);
+        }
+
+        #endregion
+
         #region DeleteAsync Tests
 
         [Fact]

--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -412,6 +412,33 @@ namespace TrashMob.Shared.Managers.Events
             return await base.UpdateAsync(mobEvent, userId, cancellationToken);
         }
 
+        /// <inheritdoc />
+        public async Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(Guid userId,
+            CancellationToken cancellationToken = default)
+        {
+            // Signal for "an Instant Event that never got Stopped":
+            //   - Owned by the caller
+            //   - Status Active (never transitioned to Complete)
+            //   - Visibility Private (Instant Events are always Private)
+            //   - Duration = 0h 0m (Complete would have set it from elapsed time)
+            //   - Started in the last 24 hours (older ones are abandonment cases
+            //     Phase 4 will auto-complete server-side rather than resume)
+            //
+            // Deliberately no filter on Name — the "Instant Event – <timestamp>" prefix
+            // is a display convention, and coupling this query to a string format that
+            // could change is more brittle than the semantic filter above.
+            var cutoff = DateTimeOffset.UtcNow.AddHours(-24);
+            return await Repo.Get(e =>
+                    e.CreatedByUserId == userId
+                    && e.EventStatusId == (int)EventStatusEnum.Active
+                    && e.EventVisibilityId == (int)EventVisibilityEnum.Private
+                    && e.DurationHours == 0
+                    && e.DurationMinutes == 0
+                    && e.EventDate >= cutoff)
+                .OrderByDescending(e => e.EventDate)
+                .ToListAsync(cancellationToken);
+        }
+
         private async Task<List<Guid>> GetUserTeamIdsAsync(Guid? userId,
             CancellationToken cancellationToken = default)
         {

--- a/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
@@ -138,5 +138,16 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// <returns>The updated event.</returns>
         Task<Event> CompleteEventAsync(Guid eventId, Guid userId,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns Instant Events owned by the specified user that appear to still be in
+        /// progress — status Active, visibility Private, zero duration (never Completed),
+        /// and started within the last 24 hours. Used by the mobile Dashboard to offer a
+        /// resume path after a fresh install, cross-device switch, or cleared app data
+        /// where the local Preferences record was lost. See
+        /// Planning/Projects/Project_65_Instant_Events.md Phase 1 (Option B).
+        /// </summary>
+        Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(Guid userId,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMob/Controllers/V2/EventsV2Controller.cs
+++ b/TrashMob/Controllers/V2/EventsV2Controller.cs
@@ -374,6 +374,27 @@ namespace TrashMob.Controllers.V2
         }
 
         /// <summary>
+        /// Returns the caller's Instant Events that appear to still be in progress — status
+        /// Active, visibility Private, zero duration, started within the last 24 hours. Used
+        /// by the mobile Dashboard to offer a resume path after a fresh install, cross-device
+        /// switch, or cleared app data. Returns empty list when no such events exist.
+        /// See Planning/Projects/Project_65_Instant_Events.md Phase 1 (Option B).
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns candidate in-progress Instant Events, newest first.</response>
+        [HttpGet("instant/in-progress")]
+        [Authorize(Policy = AuthorizationPolicyConstants.ValidUser)]
+        [RequiredScope(Constants.TrashMobReadScope)]
+        [ProducesResponseType(typeof(IEnumerable<EventDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetInProgressInstantEvents(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("V2 GetInProgressInstantEvents User={UserId}", UserId);
+
+            var events = await eventManager.GetInProgressInstantEventsAsync(UserId, cancellationToken);
+            return Ok(events.Select(e => e.ToV2Dto()));
+        }
+
+        /// <summary>
         /// Marks an event as Complete and computes its actual duration from the elapsed time
         /// since EventDate. Used by the Instant Events "Stop" flow. Only event leads or admins
         /// can complete an event.

--- a/TrashMobMobile/Services/IMobEventManager.cs
+++ b/TrashMobMobile/Services/IMobEventManager.cs
@@ -46,5 +46,8 @@
             CancellationToken cancellationToken = default);
 
         Task<Event> CompleteEventAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+        Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobMobile/Services/IMobEventRestService.cs
+++ b/TrashMobMobile/Services/IMobEventRestService.cs
@@ -39,5 +39,13 @@
         /// Marks an event as Complete and computes its duration from elapsed time.
         /// </summary>
         Task<Event> CompleteEventAsync(Guid eventId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns the caller's Instant Events that still look in-progress on the server
+        /// (Active + Private + zero duration + started within the last 24 hours). Used to
+        /// offer a cross-device / fresh-install resume path when local Preferences is empty.
+        /// </summary>
+        Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobMobile/Services/MobEventManager.cs
+++ b/TrashMobMobile/Services/MobEventManager.cs
@@ -111,5 +111,11 @@
         {
             return mobEventRestService.CompleteEventAsync(eventId, cancellationToken);
         }
+
+        public Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return mobEventRestService.GetInProgressInstantEventsAsync(cancellationToken);
+        }
     }
 }

--- a/TrashMobMobile/Services/MobEventRestService.cs
+++ b/TrashMobMobile/Services/MobEventRestService.cs
@@ -153,4 +153,15 @@ public class MobEventRestService(IHttpClientFactory httpClientFactory) : RestSer
         var returnContent = await response.Content.ReadAsStringAsync(cancellationToken);
         return JsonConvert.DeserializeObject<EventDto>(returnContent)!.ToEntity();
     }
+
+    public async Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var response = await AuthorizedHttpClient
+            .GetAsync($"{Controller}/instant/in-progress", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var dtos = JsonConvert.DeserializeObject<List<EventDto>>(content) ?? [];
+        return dtos.Select(d => d.ToEntity());
+    }
 }

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -230,18 +230,46 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
 
             SelectedCreatedDateRange = DateRanges.LastMonth;
 
-            await Task.WhenAll(RefreshEvents(), RefreshStatistics(), RefreshLitterReports(), RefreshPendingWaiverAlerts());
-            RefreshInstantEventResumeState();
+            await Task.WhenAll(RefreshEvents(), RefreshStatistics(), RefreshLitterReports(), RefreshPendingWaiverAlerts(), RefreshInstantEventResumeStateAsync());
         }, "An error has occurred while loading the dashboard. Please wait and try again in a moment.");
     }
 
-    private void RefreshInstantEventResumeState()
+    private async Task RefreshInstantEventResumeStateAsync()
     {
-        // Cheap synchronous check — server validation happens inside InstantEventViewModel
-        // when the user taps Resume. Dashboard only cares whether *something* is worth
-        // offering to resume.
+        // Local state is the fast path — if Preferences hold a running Instant Event,
+        // that's the resume target and we're done.
         var pending = Preferences.Default.Get(InstantEventViewModel.PrefKeyEventId, string.Empty);
-        HasInProgressInstantEvent = !string.IsNullOrEmpty(pending);
+        if (!string.IsNullOrEmpty(pending))
+        {
+            HasInProgressInstantEvent = true;
+            return;
+        }
+
+        // Cross-device / fresh-install fallback — Preferences got wiped or the user
+        // started their pick on another device. Ask the server for any in-progress
+        // Instant Events owned by the caller in the last 24h; if one exists, hydrate
+        // Preferences from it so the resume flow behaves identically to the local case.
+        try
+        {
+            var candidates = await mobEventManager.GetInProgressInstantEventsAsync();
+            var candidate = candidates?.FirstOrDefault();
+            if (candidate != null)
+            {
+                Preferences.Default.Set(InstantEventViewModel.PrefKeyEventId, candidate.Id.ToString());
+                Preferences.Default.Set(InstantEventViewModel.PrefKeyStartedAt, candidate.EventDate.ToString("o"));
+                HasInProgressInstantEvent = true;
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Non-critical — the local Preferences check already returned false, so
+            // the worst outcome is the user doesn't see a resume banner they could have.
+            // Don't break the dashboard for this.
+            SentrySdk.CaptureException(ex);
+        }
+
+        HasInProgressInstantEvent = false;
     }
 
     private async void PerformEventNavigation(EventViewModel eventViewModel)


### PR DESCRIPTION
## Summary
Follow-up to **Option A** (local Preferences resume) that landed in [#3498](https://github.com/TrashMob-eco/TrashMob/pull/3498). Handles the cases local persistence can't:
- User starts a pick on phone A, opens the app on phone B
- Fresh app install
- Cleared app data

For those, Preferences is empty but the event is still `Active` on the server, and the user had no local signal that anything was pending. Now the Dashboard falls through to a server check.

## Backend
- New **`GET /api/v2/events/instant/in-progress`** — returns the caller's Instant Events that look resumable: `EventStatus = Active`, `EventVisibility = Private`, `DurationHours + DurationMinutes = 0`, `EventDate` within the last 24 hours.
- New `GetInProgressInstantEventsAsync` on `IEventManager` / `EventManager`.
- **Deliberately no name-prefix filter** — the `"Instant Event – <timestamp>"` string is a display convention, and the semantic filter (zero duration + Active + Private) is more robust to future name changes.
- **24h cutoff** — anything older is either (a) unlikely to match this filter anyway, or (b) an abandoned Instant Event that Phase 4's background-abandonment guard will auto-Complete server-side rather than resume.

## Mobile
- Passthrough on the REST service + manager surface.
- **`MyDashboardViewModel.RefreshInstantEventResumeStateAsync`**: fast path unchanged (local Preferences), new fallback calls the server when Preferences is empty. If a server candidate comes back, hydrate Preferences from it so the Resume flow (built in PR #3498) works identically to the local case.
- Server-check failure is captured to Sentry and swallowed — the local Preferences check already returned false, so the worst outcome is the user doesn't see a resume banner they could have. Doesn't break the Dashboard.

## Test coverage
- Manager tests (2): happy path with a mixed dataset covering the exclusion cases (Completed, wrong visibility, other user, too old); empty-list case.
- Controller test (1): caller-scoped list + DTO mapping.
- All 3 pass, plus 15 existing `EventManager` + `EventsV2Controller` tests still pass — no regressions.

## Test plan for the mobile flow
- [x] Backend build clean (0 errors, 0 warnings)
- [x] Backend tests: 3 new pass, 47 existing regressions checked
- [x] Mobile Android build clean (0 errors)
- [ ] Manual smoke test on `pixel_8_api_35` after #3498 lands (Joe to run):
  - [ ] Start a pick, force-quit the app, **uninstall + reinstall** it, re-log in → Dashboard shows the resume banner (Preferences was cleared by uninstall; server check found the event)
  - [ ] Repeat but let the event age past 24h before reinstall → no banner (24h cutoff working)
  - [ ] Start a pick, force-quit, admin-complete the event via Swagger → reopen the app → banner shows briefly, tap Resume → falls back to fresh-start flow (server check on Resume rejects the stale-completed event; Preferences gets cleared)

## Stacking
This PR is stacked on [#3498](https://github.com/TrashMob-eco/TrashMob/pull/3498) (Option A). When #3498 gets squash-merged, this branch will need a rebase — per my earlier note about stacked branches, reset to `origin/main` and cherry-pick the single commit here.

Refs [Planning/Projects/Project_65_Instant_Events.md](../blob/dev/joe/instant-events-crossdevice-resume/Planning/Projects/Project_65_Instant_Events.md) Phase 1 (Option B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)