### PR TITLE
Instant Events Phase 2: route tracking toggle + coordinator

### DIFF
--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@
             services.AddSingleton<RoutePointWriter>();
             services.AddSingleton<SyncQueue>();
             services.AddSingleton<SyncService>();
+            services.AddSingleton<IRouteRecordingCoordinator, RouteRecordingCoordinator>();
 
             return services;
         }

--- a/TrashMobMobile/Pages/InstantEventPage.xaml.cs
+++ b/TrashMobMobile/Pages/InstantEventPage.xaml.cs
@@ -2,6 +2,7 @@ namespace TrashMobMobile.Pages;
 
 using TrashMobMobile.ViewModels;
 
+[QueryProperty(nameof(TrackRoute), nameof(TrackRoute))]
 public partial class InstantEventPage : ContentPage
 {
     private readonly InstantEventViewModel viewModel;
@@ -14,9 +15,17 @@ public partial class InstantEventPage : ContentPage
         BindingContext = this.viewModel;
     }
 
+    /// <summary>
+    /// Query parameter from the Dashboard: "true" (or "True") when the user opted in
+    /// to route tracking via the toggle. Any other value (missing, "false") means no
+    /// route recording. Query params always arrive as strings; parse manually.
+    /// </summary>
+    public string TrackRoute { get; set; } = string.Empty;
+
     protected override async void OnNavigatedTo(NavigatedToEventArgs args)
     {
         base.OnNavigatedTo(args);
+        viewModel.RequestedTrackRoute = bool.TryParse(TrackRoute, out var t) && t;
         await viewModel.Init();
     }
 }

--- a/TrashMobMobile/Pages/MyDashboardPage.xaml
+++ b/TrashMobMobile/Pages/MyDashboardPage.xaml
@@ -153,16 +153,31 @@
                 <!-- Instant Event primary action — Project 65. Strava-style: tap once and
                      you're recording. Sits above the secondary Create Event / Report Litter
                      row so it reads as the primary Dashboard action. Hidden when a running
-                     Instant Event is already persisted (the resume banner replaces it). -->
-                <Button Command="{Binding StartInstantEventCommand}"
-                        HorizontalOptions="Fill"
-                        Margin="5,5,5,10"
-                        Style="{StaticResource PrimaryLargeButton}"
-                        Text="Start a New Pick"
-                        ContentLayout="Left, 8"
-                        HeightRequest="56"
-                        IsVisible="{Binding CanStartFreshInstantEvent}"
-                        ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconPlusCircle}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
+                     Instant Event is already persisted (the resume banner replaces it).
+
+                     Route-tracking toggle sits inline above the button per the Phase 2
+                     Decisions table: remembered per-user, defaults off on first-ever use.
+                     Placed inline (not in a bottom sheet) to preserve the "one tap and go"
+                     ethos — with the toggle remembered, most users touch it once ever. -->
+                <VerticalStackLayout Spacing="8" Margin="5,5,5,10"
+                                     IsVisible="{Binding CanStartFreshInstantEvent}">
+                    <HorizontalStackLayout Spacing="10"
+                                           HorizontalOptions="Center">
+                        <Switch IsToggled="{Binding TrackRouteForNextPick}"
+                                VerticalOptions="Center" />
+                        <Label Text="Track my route"
+                               VerticalOptions="Center"
+                               FontSize="14" />
+                    </HorizontalStackLayout>
+
+                    <Button Command="{Binding StartInstantEventCommand}"
+                            HorizontalOptions="Fill"
+                            Style="{StaticResource PrimaryLargeButton}"
+                            Text="Start a New Pick"
+                            ContentLayout="Left, 8"
+                            HeightRequest="56"
+                            ImageSource="{FontImageSource FontFamily=GoogleMaterialIcons, Glyph={DynamicResource IconPlusCircle}, Color={AppThemeBinding Light={StaticResource PrimaryReverseText}, Dark={StaticResource PrimaryDarkReverseText}}}" />
+                </VerticalStackLayout>
 
                 <Grid ColumnDefinitions="*, *, *, *"
                       RowDefinitions="Auto"

--- a/TrashMobMobile/Services/Offline/IRouteRecordingCoordinator.cs
+++ b/TrashMobMobile/Services/Offline/IRouteRecordingCoordinator.cs
@@ -1,0 +1,71 @@
+namespace TrashMobMobile.Services.Offline;
+
+using System.Collections.ObjectModel;
+
+/// <summary>
+/// Encapsulates the full route-recording pipeline: SQLite session creation, the
+/// session-tracking Preferences marker, the SQLite point writer, the GPS listener, and
+/// the on-stop upload with offline fallback. Callers handle consent prompts + UI state
+/// separately; this service just runs the pipeline.
+///
+/// Used by <see cref="TrashMobMobile.ViewModels.InstantEventViewModel"/> to attach
+/// route recording to an Instant Event's Start/Stop lifecycle. The wizard-created event
+/// flow in <c>ViewEventViewModel</c> still has its own inline implementation as of
+/// Project 65 Phase 2 slice 2 — refactoring that call site to use this coordinator is a
+/// follow-up PR to reduce risk to already-shipped wizard behavior.
+/// </summary>
+public interface IRouteRecordingCoordinator
+{
+    bool IsRecording { get; }
+
+    Guid? ActiveEventId { get; }
+
+    string? ActiveEventName { get; }
+
+    /// <summary>
+    /// Creates a SQLite session, starts the point writer, and begins listening for GPS
+    /// updates on the platform Geolocator. Every received point is appended to
+    /// <paramref name="displayCollection"/> (for map display) and persisted for crash
+    /// safety. Returns <see cref="RouteRecordingStartOutcome.ConflictOtherEvent"/> if
+    /// another event is currently being tracked (only one route can be recorded at a
+    /// time).
+    /// </summary>
+    Task<RouteRecordingStartResult> StartAsync(
+        Guid eventId,
+        string eventName,
+        Guid userId,
+        DateTimeOffset startTime,
+        bool skipDefaultTrim,
+        ObservableCollection<Microsoft.Maui.Devices.Sensors.Location> displayCollection);
+
+    /// <summary>
+    /// Stops the current recording (if any), flushes the writer, and posts the route to
+    /// the server. On upload failure the session is left marked pending so the
+    /// background sync service will retry. Safe to call when not recording — returns
+    /// <see cref="RouteRecordingStopOutcome.NotStarted"/>.
+    /// </summary>
+    Task<RouteRecordingStopResult> StopAsync(DateTimeOffset endTime);
+}
+
+public enum RouteRecordingStartOutcome
+{
+    Success,
+    ConflictOtherEvent,
+}
+
+public enum RouteRecordingStopOutcome
+{
+    Uploaded,
+    QueuedForRetry,
+    EmptyDiscarded,
+    NotStarted,
+}
+
+public record RouteRecordingStartResult(
+    RouteRecordingStartOutcome Outcome,
+    string? SessionId,
+    string? ConflictingEventName);
+
+public record RouteRecordingStopResult(
+    RouteRecordingStopOutcome Outcome,
+    int PointCount);

--- a/TrashMobMobile/Services/Offline/RouteRecordingCoordinator.cs
+++ b/TrashMobMobile/Services/Offline/RouteRecordingCoordinator.cs
@@ -1,0 +1,176 @@
+namespace TrashMobMobile.Services.Offline;
+
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Devices.Sensors;
+using Sentry;
+using TrashMob.Models.Poco;
+using TrashMobMobile.Services;
+
+/// <inheritdoc cref="IRouteRecordingCoordinator" />
+public class RouteRecordingCoordinator(
+    IRouteTrackingSessionManager sessionManager,
+    RoutePointWriter routePointWriter,
+    SyncQueue syncQueue,
+    IEventAttendeeRouteRestService routeRestService)
+    : IRouteRecordingCoordinator
+{
+    private ObservableCollection<Microsoft.Maui.Devices.Sensors.Location>? displayCollection;
+    private CancellationTokenSource? listenerCts;
+    private Guid activeEventId;
+    private Guid activeUserId;
+    private string? activeSessionId;
+    private DateTimeOffset activeStartTime;
+    private bool activeSkipDefaultTrim;
+
+    public bool IsRecording => activeSessionId != null;
+
+    public Guid? ActiveEventId => IsRecording ? activeEventId : null;
+
+    public string? ActiveEventName => sessionManager.ActiveEventName;
+
+    public async Task<RouteRecordingStartResult> StartAsync(
+        Guid eventId,
+        string eventName,
+        Guid userId,
+        DateTimeOffset startTime,
+        bool skipDefaultTrim,
+        ObservableCollection<Microsoft.Maui.Devices.Sensors.Location> displayCollection)
+    {
+        if (sessionManager.IsTracking && sessionManager.ActiveEventId != eventId)
+        {
+            return new RouteRecordingStartResult(
+                RouteRecordingStartOutcome.ConflictOtherEvent,
+                SessionId: null,
+                ConflictingEventName: sessionManager.ActiveEventName);
+        }
+
+        var session = await syncQueue.CreateRouteSessionAsync(
+            eventId, userId, startTime, skipDefaultTrim);
+
+        sessionManager.TryStartSession(eventId, eventName, session.SessionId);
+        routePointWriter.StartSession(session.SessionId);
+
+        this.displayCollection = displayCollection;
+        activeEventId = eventId;
+        activeUserId = userId;
+        activeSessionId = session.SessionId;
+        activeStartTime = startTime;
+        activeSkipDefaultTrim = skipDefaultTrim;
+
+        listenerCts = new CancellationTokenSource();
+        var progress = new Progress<Microsoft.Maui.Devices.Sensors.Location>(OnPointReceived);
+
+        // Fire-and-forget the listener — it awaits until cancellation. We don't await
+        // it here (that would block StartAsync forever). Any exception the listener
+        // throws surfaces to Sentry via the continuation.
+        _ = Geolocator.Default.StartListening(progress, listenerCts.Token)
+            .ContinueWith(t =>
+            {
+                if (t.Exception != null)
+                {
+                    SentrySdk.CaptureException(t.Exception);
+                }
+            }, TaskScheduler.Default);
+
+        return new RouteRecordingStartResult(
+            RouteRecordingStartOutcome.Success,
+            SessionId: session.SessionId,
+            ConflictingEventName: null);
+    }
+
+    public async Task<RouteRecordingStopResult> StopAsync(DateTimeOffset endTime)
+    {
+        if (!IsRecording || activeSessionId is not { } sessionId)
+        {
+            return new RouteRecordingStopResult(RouteRecordingStopOutcome.NotStarted, 0);
+        }
+
+        listenerCts?.Cancel();
+        listenerCts?.Dispose();
+        listenerCts = null;
+
+        await routePointWriter.StopAndFlushAsync();
+
+        sessionManager.EndSession();
+        await syncQueue.MarkSessionPendingUploadAsync(sessionId, endTime);
+
+        var points = SnapshotPoints();
+        var outcome = await UploadAsync(sessionId, endTime, points);
+
+        activeSessionId = null;
+        displayCollection = null;
+
+        return new RouteRecordingStopResult(outcome, points.Count);
+    }
+
+    private void OnPointReceived(Microsoft.Maui.Devices.Sensors.Location location)
+    {
+        location.Timestamp = DateTimeOffset.Now;
+        displayCollection?.Add(location);
+        routePointWriter.AddPoint(location.Latitude, location.Longitude, location.Altitude, location.Timestamp);
+    }
+
+    private List<Microsoft.Maui.Devices.Sensors.Location> SnapshotPoints()
+    {
+        return displayCollection?.ToList() ?? [];
+    }
+
+    private async Task<RouteRecordingStopOutcome> UploadAsync(
+        string sessionId,
+        DateTimeOffset endTime,
+        List<Microsoft.Maui.Devices.Sensors.Location> points)
+    {
+        if (points.Count == 0)
+        {
+            await syncQueue.DiscardSessionAsync(sessionId);
+            return RouteRecordingStopOutcome.EmptyDiscarded;
+        }
+
+        // A single-point route is degenerate — Locations.Count == 1 in the wizard flow
+        // gets padded to 2 so the polyline has something to render. Preserve that.
+        var normalized = points.Count == 1 ? [points[0], points[0]] : points;
+
+        try
+        {
+            await routeRestService.AddEventAttendeeRouteAsync(new DisplayEventAttendeeRoute
+            {
+                EventId = activeEventId,
+                UserId = activeUserId,
+                Locations = ToSortable(normalized),
+                StartTime = activeStartTime,
+                EndTime = endTime,
+                SkipDefaultTrim = activeSkipDefaultTrim,
+                SessionId = Guid.Parse(sessionId),
+            });
+
+            await syncQueue.MarkSessionUploadedAsync(sessionId);
+            return RouteRecordingStopOutcome.Uploaded;
+        }
+        catch (Exception ex)
+        {
+            await syncQueue.MarkSessionFailedAsync(sessionId, ex.Message);
+            SentrySdk.AddBreadcrumb(
+                $"Route queued offline: event={activeEventId}, session={sessionId}",
+                "sync",
+                level: BreadcrumbLevel.Info);
+            return RouteRecordingStopOutcome.QueuedForRetry;
+        }
+    }
+
+    private static List<SortableLocation> ToSortable(IReadOnlyList<Microsoft.Maui.Devices.Sensors.Location> locations)
+    {
+        var sortable = new List<SortableLocation>(locations.Count);
+        var order = 0;
+        foreach (var location in locations.OrderBy(l => l.Timestamp))
+        {
+            sortable.Add(new SortableLocation
+            {
+                Latitude = location.Latitude,
+                Longitude = location.Longitude,
+                SortOrder = order++,
+            });
+        }
+
+        return sortable;
+    }
+}

--- a/TrashMobMobile/ViewModels/InstantEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/InstantEventViewModel.cs
@@ -1,5 +1,6 @@
 namespace TrashMobMobile.ViewModels;
 
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Maui.Devices.Sensors;
@@ -7,6 +8,7 @@ using Sentry;
 using TrashMob.Models;
 using TrashMobMobile.Pages;
 using TrashMobMobile.Services;
+using TrashMobMobile.Services.Offline;
 
 /// <summary>
 /// In-progress view for a running Instant Event. Init decides between two paths based on
@@ -21,6 +23,8 @@ using TrashMobMobile.Services;
 /// </summary>
 public partial class InstantEventViewModel(
     IMobEventManager mobEventManager,
+    IRouteRecordingCoordinator routeCoordinator,
+    IUserManager userManager,
     INotificationService notificationService)
     : BaseViewModel(notificationService)
 {
@@ -29,7 +33,16 @@ public partial class InstantEventViewModel(
     public const string PrefKeyEventId = "instant_event_id";
     public const string PrefKeyStartedAt = "instant_event_started_at";
 
+    // Persisted per-event opt-in for route tracking. Set from the query parameter on
+    // fresh Start. On resume (persisted event id) we re-read this to know whether the
+    // in-flight event had tracking enabled — the coordinator state already lives in
+    // RouteTrackingSessionManager, but we still need the flag for UI (e.g. showing
+    // the map view).
+    public const string PrefKeyTrackRoute = "instant_event_track_route";
+
     private readonly IMobEventManager mobEventManager = mobEventManager;
+    private readonly IRouteRecordingCoordinator routeCoordinator = routeCoordinator;
+    private readonly IUserManager userManager = userManager;
     private DateTimeOffset startedAt;
     private IDispatcherTimer? timer;
 
@@ -46,7 +59,23 @@ public partial class InstantEventViewModel(
     private bool isFailed;
 
     [ObservableProperty]
+    private bool isTrackingRoute;
+
+    [ObservableProperty]
     private string statusMessage = "Getting location…";
+
+    /// <summary>
+    /// Populated with GPS points as they arrive when route tracking is enabled. Bound to
+    /// the map view on <see cref="Pages.InstantEventPage"/> for live route rendering.
+    /// </summary>
+    public ObservableCollection<Location> Locations { get; } = [];
+
+    /// <summary>
+    /// Set by <see cref="Pages.InstantEventPage"/> from the TrackRoute query parameter
+    /// before Init runs. Determines whether a fresh Start also opens a route session.
+    /// Resume path reads Preferences instead (the query param isn't passed on resume).
+    /// </summary>
+    public bool RequestedTrackRoute { get; set; }
 
     public async Task Init()
     {
@@ -112,6 +141,17 @@ public partial class InstantEventViewModel(
         IsRunning = true;
         StatusMessage = "Recording your pick";
         StartTimer();
+
+        // Route-tracking resume is best-effort. The coordinator's in-memory state
+        // (listener CTS, active session id, in-progress point collection) doesn't
+        // survive an app-close, so on a fresh boot IsRecording will be false and we
+        // can't rejoin the GPS listener seamlessly. Any GPS points captured before
+        // the close are safe in SQLite (RoutePointWriter flushes on process shutdown
+        // best-effort, and SyncQueue.GetInterruptedSessionsAsync surfaces stragglers
+        // on next app boot). Full route-recording resume would need broader work in
+        // RouteTrackingSessionManager.TryRestoreSession + coordinator boot hydration;
+        // out of scope for this Phase 2 slice.
+        IsTrackingRoute = routeCoordinator.IsRecording && routeCoordinator.ActiveEventId == serverEvent.Id;
         return true;
     }
 
@@ -133,11 +173,40 @@ public partial class InstantEventViewModel(
 
         EventId = mobEvent.Id;
         startedAt = mobEvent.EventDate;
-        PersistState(mobEvent.Id, mobEvent.EventDate);
+        PersistState(mobEvent.Id, mobEvent.EventDate, RequestedTrackRoute);
 
         IsRunning = true;
         StatusMessage = "Recording your pick";
         StartTimer();
+
+        if (RequestedTrackRoute)
+        {
+            await StartRouteTrackingAsync(mobEvent);
+        }
+    }
+
+    private async Task StartRouteTrackingAsync(Event mobEvent)
+    {
+        var result = await routeCoordinator.StartAsync(
+            mobEvent.Id,
+            mobEvent.Name,
+            userManager.CurrentUser.Id,
+            startedAt,
+            skipDefaultTrim: false,
+            Locations);
+
+        if (result.Outcome == RouteRecordingStartOutcome.Success)
+        {
+            IsTrackingRoute = true;
+        }
+        else if (result.Outcome == RouteRecordingStartOutcome.ConflictOtherEvent)
+        {
+            // Another event is currently being tracked — surface a soft warning but
+            // let the Instant Event continue running without a route. Turning off the
+            // route toggle for this session is preferable to failing the whole flow.
+            await NotificationService.Notify(
+                $"Route tracking is already active for '{result.ConflictingEventName}'. Your Instant Event is running without a route.");
+        }
     }
 
     [RelayCommand]
@@ -157,6 +226,14 @@ public partial class InstantEventViewModel(
 
         await ExecuteAsync(async () =>
         {
+            // Stop the route recording first so its cleanup (flush writer, mark session
+            // pending upload, POST route) runs even if the CompleteEvent call fails.
+            // The route is separately valuable from the completed-event state.
+            if (routeCoordinator.IsRecording && routeCoordinator.ActiveEventId == completedEventId)
+            {
+                await routeCoordinator.StopAsync(DateTimeOffset.UtcNow);
+            }
+
             await mobEventManager.CompleteEventAsync(completedEventId);
 
             // Clear persisted state only after the server confirms Complete — if the
@@ -199,16 +276,18 @@ public partial class InstantEventViewModel(
         timer = null;
     }
 
-    private static void PersistState(Guid eventId, DateTimeOffset startedAt)
+    private static void PersistState(Guid eventId, DateTimeOffset startedAt, bool trackRoute)
     {
         Preferences.Default.Set(PrefKeyEventId, eventId.ToString());
         Preferences.Default.Set(PrefKeyStartedAt, startedAt.ToString("o"));
+        Preferences.Default.Set(PrefKeyTrackRoute, trackRoute);
     }
 
     private static void ClearPersistedState()
     {
         Preferences.Default.Remove(PrefKeyEventId);
         Preferences.Default.Remove(PrefKeyStartedAt);
+        Preferences.Default.Remove(PrefKeyTrackRoute);
     }
 
     private static async Task<Location?> GetCurrentLocationAsync()

--- a/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
+++ b/TrashMobMobile/ViewModels/MyDashboardViewModel.cs
@@ -54,6 +54,21 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
 
     public bool CanStartFreshInstantEvent => !HasInProgressInstantEvent;
 
+    // Route-tracking toggle for the next Start-a-Pick tap. Remembered across sessions
+    // per Project 65 decision (Q2: default off on first-ever use, then remember). Stored
+    // in Preferences under PrefKeyLastTrackRouteChoice; loaded on Init, saved on change.
+    // The toggle is only meaningful when starting fresh — Resume uses the value the
+    // event was originally started with, stored on the event's persisted state.
+    public const string PrefKeyLastTrackRouteChoice = "instant_event_last_track_route_choice";
+
+    [ObservableProperty]
+    private bool trackRouteForNextPick;
+
+    partial void OnTrackRouteForNextPickChanged(bool value)
+    {
+        Preferences.Default.Set(PrefKeyLastTrackRouteChoice, value);
+    }
+
     public ObservableCollection<string> UpcomingDateRanges { get; set; } = [];
 
     public ObservableCollection<string> CompletedDateRanges { get; set; } = [];
@@ -229,6 +244,12 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
             }
 
             SelectedCreatedDateRange = DateRanges.LastMonth;
+
+            // Load the remembered route-tracking toggle choice. Direct field write to
+            // avoid the change notification writing back to Preferences with the same
+            // value (harmless, just noise).
+            trackRouteForNextPick = Preferences.Default.Get(PrefKeyLastTrackRouteChoice, false);
+            OnPropertyChanged(nameof(TrackRouteForNextPick));
 
             await Task.WhenAll(RefreshEvents(), RefreshStatistics(), RefreshLitterReports(), RefreshPendingWaiverAlerts(), RefreshInstantEventResumeStateAsync());
         }, "An error has occurred while loading the dashboard. Please wait and try again in a moment.");
@@ -475,8 +496,10 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
     {
         // Resume path: if a running Instant Event is persisted locally, skip the waiver
         // gate — the user already signed to create it — and go straight to the recording
-        // page. InstantEventViewModel.Init validates with the server and falls through to
-        // a fresh start if the persisted event was completed/canceled out-of-band.
+        // page. Don't pass TrackRoute here; the resume flow reads the value the event
+        // was originally started with from Preferences. InstantEventViewModel.Init
+        // validates with the server and falls through to a fresh start if the persisted
+        // event was completed/canceled out-of-band.
         if (HasInProgressInstantEvent)
         {
             await Shell.Current.GoToAsync(nameof(InstantEventPage));
@@ -493,7 +516,8 @@ public partial class MyDashboardViewModel(IMobEventManager mobEventManager,
             return;
         }
 
-        await Shell.Current.GoToAsync(nameof(InstantEventPage));
+        await Shell.Current.GoToAsync(
+            $"{nameof(InstantEventPage)}?TrackRoute={TrackRouteForNextPick}");
     }
 
     private async void HandleUpcomingDateRangeSelected()


### PR DESCRIPTION
## Summary
Opt-in route tracking for Instant Events, wired to the existing Project 15 offline pipeline (SQLite session + writer + sync queue + background upload). Toggle sits on the Dashboard, remembered per user, defaults off on first-ever use per the Project 65 Decisions table.

**Introduces a shared coordinator service** rather than copying the recording pipeline. `ViewEventViewModel`'s inline route flow is deliberately **not** touched by this PR — that refactor is a follow-up to avoid disturbing battle-tested wizard-event code.

## What changed

### New service — `IRouteRecordingCoordinator`
Two files under `TrashMobMobile/Services/Offline/`:
- **Interface + result types** (`RouteRecordingStartOutcome`, `RouteRecordingStopOutcome`) — cleanly separates "session started" from "another event was already active" and "uploaded" from "queued for retry".
- **Implementation** wraps the existing session manager / point writer / sync queue / GPS listener into a single Start/Stop API. Handles the fire-and-forget `Geolocator.StartListening` pattern via a private `CancellationTokenSource`. Handles the 1-point degenerate route case (pad to 2 for renderable polyline) that the wizard flow also does. Upload failure → `MarkSessionFailedAsync` + Sentry breadcrumb, matching the wizard behavior — background `SyncService` retries.

### Dashboard
- New **"Track my route"** toggle inline above the Start-a-Pick button. Preferences-remembered on change, loaded on Init.
- `StartInstantEventCommand` passes toggle state as `?TrackRoute=` query param. Resume path deliberately omits it (resume uses the value the event was originally started with).

### `InstantEventViewModel`
- `RequestedTrackRoute` property set from the query param before `Init` runs.
- `StartFreshAsync`: after event creation, if opt-in, calls `routeCoordinator.StartAsync`. The "conflict — another route already active" case surfaces a soft notification and continues the Instant Event without a route (better UX than failing Start).
- `Stop`: cancels route recording **first**, so its cleanup runs even if the `CompleteEvent` call fails. Route data is separately valuable.
- `Locations` `ObservableCollection` exposed for future live-map rendering.
- New `PrefKeyTrackRoute` persisted per event so resume knows the original opt-in.

### `InstantEventPage`
- `[QueryProperty(TrackRoute)]` receives toggle state.
- `OnNavigatedTo` parses and passes to VM before `Init`.

## Known limitation — route resume after force-close
If a user starts a route-tracked Instant Event, then force-quits the app before Stop, the event itself resumes cleanly (via [#3498](https://github.com/TrashMob-eco/TrashMob/pull/3498)'s Preferences + [#3499](https://github.com/TrashMob-eco/TrashMob/pull/3499)'s server-side fallback), **but the route recording does not rejoin**. The coordinator's in-memory state (listener CTS, active session id) is lost with the process. GPS points captured before the close are safe in SQLite and surface via `SyncQueue.GetInterruptedSessionsAsync` on next boot.

Full route-resume would need broader work: nobody calls `RouteTrackingSessionManager.TryRestoreSession` on app boot today, and the coordinator would need hydration. That's out of Phase 2 scope. Documented inline in `InstantEventViewModel.TryResumeAsync`.

## Deferred to a follow-up PR
- **Refactor `ViewEventViewModel` to use the coordinator.** Currently the wizard flow still has ~120 lines of inline session/writer/listener code that's a near-duplicate of what the coordinator now provides. The two implementations should be one, but that touches shipped and tested code so I want it separate from this PR.

## Test plan
- [x] Android build passes: `dotnet build -f net10.0-android` — 0 errors, only pre-existing warnings
- [ ] Manual smoke test on `pixel_8_api_35` (Joe to run):
  - [ ] Dashboard shows toggle above Start button. Toggle default OFF for first-ever user.
  - [ ] Turn toggle on, tap Start. Verify status message, event created, timer running.
  - [ ] Move around emulator (or use fake GPS) — points should show up on map after route review.
  - [ ] Tap Stop → navigates to EditEventSummaryPage → route visible with distance.
  - [ ] Return to Dashboard, toggle now defaults ON (remembered).
  - [ ] Turn toggle off, tap Start — verify no route session created, no map visible on in-progress page.
  - [ ] Waiver flow still works: sign out of waivers, tap Start-a-Pick — routes to WaiverListPage regardless of toggle.

Refs [Planning/Projects/Project_65_Instant_Events.md](../blob/dev/joe/instant-events-route-tracking/Planning/Projects/Project_65_Instant_Events.md) Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)