### PR TITLE
Instant Events: route resume after app force-close

### DIFF
--- a/TrashMobMobile/Services/Offline/IRouteRecordingCoordinator.cs
+++ b/TrashMobMobile/Services/Offline/IRouteRecordingCoordinator.cs
@@ -45,12 +45,29 @@ public interface IRouteRecordingCoordinator
     /// <see cref="RouteRecordingStopOutcome.NotStarted"/>.
     /// </summary>
     Task<RouteRecordingStopResult> StopAsync(DateTimeOffset endTime);
+
+    /// <summary>
+    /// Attempt to resume an in-progress route recording after an app-close/reopen. If
+    /// <see cref="IRouteTrackingSessionManager"/> holds a persisted session for the
+    /// specified event AND the SQLite session record is still in <c>Recording</c>
+    /// state, this method hydrates the coordinator's in-memory state, loads existing
+    /// GPS points into <paramref name="displayCollection"/>, reopens the writer
+    /// preserving point order, and restarts the GPS listener. Returns
+    /// <see cref="RouteRecordingStartOutcome.NothingToResume"/> when no matching
+    /// interrupted session exists.
+    /// </summary>
+    Task<RouteRecordingStartResult> TryResumeAsync(
+        Guid eventId,
+        string eventName,
+        Guid userId,
+        ObservableCollection<Microsoft.Maui.Devices.Sensors.Location> displayCollection);
 }
 
 public enum RouteRecordingStartOutcome
 {
     Success,
     ConflictOtherEvent,
+    NothingToResume,
 }
 
 public enum RouteRecordingStopOutcome

--- a/TrashMobMobile/Services/Offline/RouteRecordingCoordinator.cs
+++ b/TrashMobMobile/Services/Offline/RouteRecordingCoordinator.cs
@@ -57,12 +57,96 @@ public class RouteRecordingCoordinator(
         activeStartTime = startTime;
         activeSkipDefaultTrim = skipDefaultTrim;
 
+        StartGpsListener();
+
+        return new RouteRecordingStartResult(
+            RouteRecordingStartOutcome.Success,
+            SessionId: session.SessionId,
+            ConflictingEventName: null);
+    }
+
+    public async Task<RouteRecordingStartResult> TryResumeAsync(
+        Guid eventId,
+        string eventName,
+        Guid userId,
+        ObservableCollection<Microsoft.Maui.Devices.Sensors.Location> displayCollection)
+    {
+        // Hydrate session manager's in-memory state from Preferences. If the previous
+        // process died before Stop, this brings back IsTracking + ActiveEventId +
+        // ActiveSessionId. No-op if the manager already has state in memory.
+        if (!sessionManager.IsTracking)
+        {
+            sessionManager.TryRestoreSession();
+        }
+
+        if (!sessionManager.IsTracking
+            || sessionManager.ActiveEventId != eventId
+            || sessionManager.ActiveSessionId is not { } sessionId)
+        {
+            return new RouteRecordingStartResult(
+                RouteRecordingStartOutcome.NothingToResume, null, null);
+        }
+
+        // Cross-check against SQLite. GetInterruptedSessionsAsync returns everything in
+        // Recording status — the source of truth for "was actually mid-flight when the
+        // process died." If sessionManager thinks we're tracking but SQLite disagrees,
+        // clear the stale sessionManager state and bail.
+        var interrupted = await syncQueue.GetInterruptedSessionsAsync();
+        var session = interrupted.FirstOrDefault(s => s.SessionId == sessionId);
+        if (session == null)
+        {
+            sessionManager.EndSession();
+            return new RouteRecordingStartResult(
+                RouteRecordingStartOutcome.NothingToResume, null, null);
+        }
+
+        // Load existing points into the display collection so the map shows the
+        // pre-close portion of the route.
+        var existingPoints = await syncQueue.GetRoutePointsAsync(sessionId);
+        foreach (var p in existingPoints.OrderBy(p => p.PointOrder))
+        {
+            displayCollection.Add(new Microsoft.Maui.Devices.Sensors.Location(p.Latitude, p.Longitude)
+            {
+                Altitude = p.Altitude,
+                Timestamp = DateTimeOffset.TryParse(p.Timestamp, out var ts) ? ts : DateTimeOffset.UtcNow,
+            });
+        }
+
+        // Rehydrate coordinator state.
+        this.displayCollection = displayCollection;
+        activeEventId = eventId;
+        activeUserId = userId;
+        activeSessionId = sessionId;
+        activeStartTime = DateTimeOffset.TryParse(session.StartTime, out var startTime)
+            ? startTime
+            : DateTimeOffset.UtcNow;
+        activeSkipDefaultTrim = session.SkipDefaultTrim;
+
+        // Reopen the writer. StartSession resets pointOrder to 0 (fine for fresh
+        // sessions), so use SetPointOrder to continue past the existing max so new
+        // points don't collide with old ones on the same SessionId.
+        routePointWriter.StartSession(sessionId);
+        var maxOrder = await syncQueue.GetMaxPointOrderAsync(sessionId);
+        routePointWriter.SetPointOrder(maxOrder);
+
+        StartGpsListener();
+
+        return new RouteRecordingStartResult(
+            RouteRecordingStartOutcome.Success,
+            SessionId: sessionId,
+            ConflictingEventName: null);
+    }
+
+    private void StartGpsListener()
+    {
+        listenerCts?.Dispose();
         listenerCts = new CancellationTokenSource();
+
         var progress = new Progress<Microsoft.Maui.Devices.Sensors.Location>(OnPointReceived);
 
-        // Fire-and-forget the listener — it awaits until cancellation. We don't await
-        // it here (that would block StartAsync forever). Any exception the listener
-        // throws surfaces to Sentry via the continuation.
+        // Fire-and-forget the listener — it awaits until cancellation. Not awaited here
+        // (that would block the caller forever). Any exception surfaces to Sentry via
+        // the continuation.
         _ = Geolocator.Default.StartListening(progress, listenerCts.Token)
             .ContinueWith(t =>
             {
@@ -71,11 +155,6 @@ public class RouteRecordingCoordinator(
                     SentrySdk.CaptureException(t.Exception);
                 }
             }, TaskScheduler.Default);
-
-        return new RouteRecordingStartResult(
-            RouteRecordingStartOutcome.Success,
-            SessionId: session.SessionId,
-            ConflictingEventName: null);
     }
 
     public async Task<RouteRecordingStopResult> StopAsync(DateTimeOffset endTime)

--- a/TrashMobMobile/ViewModels/InstantEventViewModel.cs
+++ b/TrashMobMobile/ViewModels/InstantEventViewModel.cs
@@ -142,16 +142,24 @@ public partial class InstantEventViewModel(
         StatusMessage = "Recording your pick";
         StartTimer();
 
-        // Route-tracking resume is best-effort. The coordinator's in-memory state
-        // (listener CTS, active session id, in-progress point collection) doesn't
-        // survive an app-close, so on a fresh boot IsRecording will be false and we
-        // can't rejoin the GPS listener seamlessly. Any GPS points captured before
-        // the close are safe in SQLite (RoutePointWriter flushes on process shutdown
-        // best-effort, and SyncQueue.GetInterruptedSessionsAsync surfaces stragglers
-        // on next app boot). Full route-recording resume would need broader work in
-        // RouteTrackingSessionManager.TryRestoreSession + coordinator boot hydration;
-        // out of scope for this Phase 2 slice.
-        IsTrackingRoute = routeCoordinator.IsRecording && routeCoordinator.ActiveEventId == serverEvent.Id;
+        // If the pre-close session had route tracking on, try to resume the recording
+        // pipeline. The coordinator rehydrates its in-memory state from persisted
+        // Preferences + SQLite, loads existing GPS points into Locations for the map
+        // view, and restarts the GPS listener. Any points captured between the
+        // process death and this call are lost (no GPS listener was running), but the
+        // pre-close portion is preserved and new points continue to accumulate.
+        var wasTrackingRoute = Preferences.Default.Get(PrefKeyTrackRoute, false);
+        if (wasTrackingRoute)
+        {
+            var resumeResult = await routeCoordinator.TryResumeAsync(
+                serverEvent.Id,
+                serverEvent.Name,
+                userManager.CurrentUser.Id,
+                Locations);
+
+            IsTrackingRoute = resumeResult.Outcome == RouteRecordingStartOutcome.Success;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Summary
Fills the last documented Phase 2 gap. When a user starts a route-tracked Instant Event, force-quits the app mid-pick, then reopens the app, **the route recording now rejoins**: GPS listener restarts, existing SQLite session continues, pre-close GPS points show on the map.

Before this PR: event resumed but route didn't; user had to Stop-then-restart or lose the route. Documented as a known limitation in PR #3501; now resolved.

## Coordinator changes
- **New method** `IRouteRecordingCoordinator.TryResumeAsync(eventId, eventName, userId, displayCollection)`.
- **New outcome** `RouteRecordingStartOutcome.NothingToResume` — for when there's no matching interrupted session.
- **Refactor** `StartAsync`'s GPS-listener startup into a private `StartGpsListener()` helper. Both `StartAsync` and `TryResumeAsync` use it. No duplication.

## `TryResumeAsync` flow
1. **Hydrate `RouteTrackingSessionManager`** in-memory state from Preferences via `TryRestoreSession()` — was never called on boot before this PR, effectively unused.
2. **Verify** the persisted session id matches this event.
3. **Cross-check against SQLite** via `GetInterruptedSessionsAsync` — the source of truth for "in Recording status." If session manager thinks we're tracking but SQLite disagrees, clear the stale state and return `NothingToResume`.
4. **Load existing GPS points** from SQLite → `displayCollection`.
5. **Rehydrate coordinator state** — `activeStartTime` + `activeSkipDefaultTrim` come from the SQLite session record (only place they survive the process death; `sessionManager` only persists id + name).
6. **Reopen `RoutePointWriter`** with the same sessionId, then `SetPointOrder(existing max + 1)` so new points don't collide with old ones on the same SessionId.
7. **Restart the GPS listener**.

## VM changes (`InstantEventViewModel.TryResumeAsync`)
- Reads `PrefKeyTrackRoute` (persisted per event since Phase 2 slice 2). If true, calls `routeCoordinator.TryResumeAsync` after the event is validated with the server.
- Sets `IsTrackingRoute` based on the outcome — Success means map view + red-dot indicator light up as if fresh Start.

## Known small-loss
Points captured between app-close and app-reopen are lost — no GPS listener was running during that window. Pre-close portion is preserved, and new points continue accumulating post-reopen. Acceptable — no cheap way to record GPS while the process is dead.

## Test plan
- [x] Android build passes: `dotnet build -f net10.0-android` — 0 errors, only pre-existing warnings
- [ ] Manual smoke test on `pixel_8_api_35` (Joe to run):
  - [ ] Start a pick with **Track my route** on. Move around emulator briefly (fake GPS or just Emulator > Extended > Location).
  - [ ] Force-quit the app (swipe from recents).
  - [ ] Reopen the app. Dashboard should show "Pick in progress" banner. Tap Resume.
  - [ ] InstantEventPage should show the timer resumed AND (this is the new behavior) the map should render the pre-close route.
  - [ ] Move around more. Verify new points get added to the route.
  - [ ] Tap Stop. On EditEventSummaryPage, verify the route is complete (pre-close + post-reopen points).

Refs [Planning/Projects/Project_65_Instant_Events.md](../blob/dev/joe/route-resume-after-close/Planning/Projects/Project_65_Instant_Events.md) Phase 2. Closes the gap flagged in [#3501](https://github.com/TrashMob-eco/TrashMob/pull/3501).

🤖 Generated with [Claude Code](https://claude.com/claude-code)