### PR TITLE
Instant Events Phase 3: community auto-detection banner

### DIFF
--- a/TrashMob.Models/Poco/V2/CommunityLocationMatchDto.cs
+++ b/TrashMob.Models/Poco/V2/CommunityLocationMatchDto.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+namespace TrashMob.Models.Poco.V2;
+
+/// <summary>
+/// A lightweight response for GET /api/v2/communities/at-location — enough to
+/// display the "contributing to [Community Name]" banner and link to the
+/// community page, without pulling the full Partner DTO. See Project 65 Phase 3.
+/// </summary>
+public class CommunityLocationMatchDto
+{
+    /// <summary>The community's partner id.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Display name (e.g. "Seattle, WA").</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>URL slug for the community page (e.g. "seattle-wa").</summary>
+    public string Slug { get; set; } = string.Empty;
+}

--- a/TrashMob.Shared.Tests/Controllers/V2/CommunitiesV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/CommunitiesV2ControllerTests.cs
@@ -76,6 +76,40 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         }
 
         [Fact]
+        public async Task GetCommunityAtLocation_ReturnsOkWithMatchWhenCommunityContainsPoint()
+        {
+            var seattle = new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = "Seattle, WA",
+                Slug = "seattle-wa",
+            };
+            communityManager
+                .Setup(m => m.GetCommunityAtLocationAsync(47.6, -122.3, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(seattle);
+
+            var result = await controller.GetCommunityAtLocation(47.6, -122.3, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<CommunityLocationMatchDto>(ok.Value);
+            Assert.Equal(seattle.Id, dto.Id);
+            Assert.Equal("Seattle, WA", dto.Name);
+            Assert.Equal("seattle-wa", dto.Slug);
+        }
+
+        [Fact]
+        public async Task GetCommunityAtLocation_Returns404WhenNoCommunityMatches()
+        {
+            communityManager
+                .Setup(m => m.GetCommunityAtLocationAsync(It.IsAny<double>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Partner)null!);
+
+            var result = await controller.GetCommunityAtLocation(0.0, 0.0, CancellationToken.None);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
         public async Task GetCommunities_WithGeoFilter_PassesParamsToManager()
         {
             communityManager

--- a/TrashMob.Shared.Tests/Managers/Communities/CommunityManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Communities/CommunityManagerTests.cs
@@ -305,6 +305,126 @@ namespace TrashMob.Shared.Tests.Managers.Communities
 
         #endregion
 
+        #region GetCommunityAtLocationAsync
+
+        private static Partner MakeCommunity(
+            string name,
+            string slug,
+            double southLat,
+            double northLat,
+            double westLng,
+            double eastLng,
+            RegionTypeEnum regionType = RegionTypeEnum.City,
+            bool enabled = true,
+            bool active = true)
+        {
+            return new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = name,
+                Slug = slug,
+                HomePageEnabled = enabled,
+                PartnerStatusId = active ? (int)PartnerStatusEnum.Active : (int)PartnerStatusEnum.Inactive,
+                BoundsSouth = southLat,
+                BoundsNorth = northLat,
+                BoundsWest = westLng,
+                BoundsEast = eastLng,
+                RegionType = (int)regionType,
+            };
+        }
+
+        [Fact]
+        public async Task GetCommunityAtLocationAsync_ReturnsCommunityWhenBoundsContainPoint()
+        {
+            var seattle = MakeCommunity("Seattle, WA", "seattle-wa",
+                southLat: 47.4, northLat: 47.8, westLng: -122.5, eastLng: -122.2);
+            _partnerRepository.SetupGet(new List<Partner> { seattle });
+
+            // 47.6, -122.3 is inside Seattle's bounds.
+            var result = await _sut.GetCommunityAtLocationAsync(47.6, -122.3);
+
+            Assert.NotNull(result);
+            Assert.Equal(seattle.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task GetCommunityAtLocationAsync_ReturnsNullWhenNoCommunityContainsPoint()
+        {
+            var seattle = MakeCommunity("Seattle, WA", "seattle-wa",
+                southLat: 47.4, northLat: 47.8, westLng: -122.5, eastLng: -122.2);
+            _partnerRepository.SetupGet(new List<Partner> { seattle });
+
+            // 40.7, -74.0 is New York — outside Seattle bounds.
+            var result = await _sut.GetCommunityAtLocationAsync(40.7, -74.0);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetCommunityAtLocationAsync_PrefersMoreSpecificRegionType()
+        {
+            // City sits inside the county sits inside the state — all three contain
+            // 47.6, -122.3. Expect the City (RegionType=0) to win.
+            var seattleCity = MakeCommunity("Seattle, WA", "seattle-wa",
+                47.4, 47.8, -122.5, -122.2, RegionTypeEnum.City);
+            var kingCounty = MakeCommunity("King County, WA", "king-county-wa",
+                47.0, 48.0, -122.6, -121.0, RegionTypeEnum.County);
+            var washingtonState = MakeCommunity("Washington", "washington",
+                45.5, 49.0, -125.0, -116.0, RegionTypeEnum.State);
+            _partnerRepository.SetupGet(new List<Partner> { washingtonState, kingCounty, seattleCity });
+
+            var result = await _sut.GetCommunityAtLocationAsync(47.6, -122.3);
+
+            Assert.NotNull(result);
+            Assert.Equal(seattleCity.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task GetCommunityAtLocationAsync_ExcludesDisabledCommunities()
+        {
+            var seattle = MakeCommunity("Seattle, WA", "seattle-wa",
+                47.4, 47.8, -122.5, -122.2, enabled: false);
+            _partnerRepository.SetupGet(new List<Partner> { seattle });
+
+            var result = await _sut.GetCommunityAtLocationAsync(47.6, -122.3);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetCommunityAtLocationAsync_ExcludesInactiveCommunities()
+        {
+            var seattle = MakeCommunity("Seattle, WA", "seattle-wa",
+                47.4, 47.8, -122.5, -122.2, active: false);
+            _partnerRepository.SetupGet(new List<Partner> { seattle });
+
+            var result = await _sut.GetCommunityAtLocationAsync(47.6, -122.3);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetCommunityAtLocationAsync_IgnoresCommunitiesWithoutBounds()
+        {
+            var noBounds = new Partner
+            {
+                Id = Guid.NewGuid(),
+                Name = "Legacy Community",
+                Slug = "legacy",
+                HomePageEnabled = true,
+                PartnerStatusId = (int)PartnerStatusEnum.Active,
+                RegionType = (int)RegionTypeEnum.City,
+                // BoundsNorth/South/East/West all null
+            };
+            _partnerRepository.SetupGet(new List<Partner> { noBounds });
+
+            var result = await _sut.GetCommunityAtLocationAsync(47.6, -122.3);
+
+            Assert.Null(result);
+        }
+
+        #endregion
+
         #region GetCommunityEventsAsync
 
         [Fact]

--- a/TrashMob.Shared/Managers/Communities/CommunityManager.cs
+++ b/TrashMob.Shared/Managers/Communities/CommunityManager.cs
@@ -127,6 +127,40 @@ namespace TrashMob.Shared.Managers.Communities
         }
 
         /// <inheritdoc />
+        public async Task<Partner> GetCommunityAtLocationAsync(double latitude, double longitude,
+            CancellationToken cancellationToken = default)
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            // Bounding-box filter runs in SQL — only Enabled + Active communities with all
+            // four bounds set are candidates. Nullable comparisons in EF need HasValue guards.
+            var candidates = await partnerRepository.Get()
+                .Where(p => p.HomePageEnabled
+                    && (p.HomePageStartDate == null || p.HomePageStartDate <= now)
+                    && (p.HomePageEndDate == null || p.HomePageEndDate >= now)
+                    && p.PartnerStatusId == (int)PartnerStatusEnum.Active
+                    && p.BoundsNorth != null && p.BoundsSouth != null
+                    && p.BoundsEast != null && p.BoundsWest != null
+                    && p.BoundsSouth <= latitude && p.BoundsNorth >= latitude
+                    && p.BoundsWest <= longitude && p.BoundsEast >= longitude)
+                .ToListAsync(cancellationToken);
+
+            if (candidates.Count == 0)
+            {
+                return null;
+            }
+
+            // Multiple communities can contain the same GPS point (a City sits inside a
+            // County, which sits inside a State). RegionType is ordered from most to least
+            // specific (City=0, County=1, State=2, Province=3, Region=4, Country=5), so
+            // OrderBy gives the most-specific match first. Communities with a null
+            // RegionType default to City per the DB default and existing convention.
+            return candidates
+                .OrderBy(c => c.RegionType ?? (int)RegionTypeEnum.City)
+                .First();
+        }
+
+        /// <inheritdoc />
         public async Task<IEnumerable<Event>> GetCommunityEventsAsync(string slug, bool upcomingOnly = true, CancellationToken cancellationToken = default)
         {
             var community = await GetBySlugAsync(slug, cancellationToken);

--- a/TrashMob.Shared/Managers/Interfaces/ICommunityManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/ICommunityManager.cs
@@ -28,6 +28,17 @@ namespace TrashMob.Shared.Managers.Interfaces
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Returns the community whose bounding box contains the specified GPS point,
+        /// or null when no enabled community matches. When multiple communities contain
+        /// the point (e.g. a city inside a county), the more specific one wins (City
+        /// beats County beats State). Only enabled communities are considered.
+        /// Used by Instant Events (Project 65 Phase 3) to surface which community a
+        /// solo pick contributes to.
+        /// </summary>
+        Task<Partner> GetCommunityAtLocationAsync(double latitude, double longitude,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Gets a community by its URL slug.
         /// </summary>
         /// <param name="slug">The URL-friendly slug (e.g., "seattle-wa").</param>

--- a/TrashMob/Controllers/V2/CommunitiesV2Controller.cs
+++ b/TrashMob/Controllers/V2/CommunitiesV2Controller.cs
@@ -73,6 +73,46 @@ namespace TrashMob.Controllers.V2
         }
 
         /// <summary>
+        /// Returns the community whose geographic bounds contain the specified GPS point,
+        /// or 404 when no enabled community matches. When several communities contain the
+        /// point (e.g. a city inside a county), the most specific one wins. Used by the
+        /// Instant Events post-Stop screen to show "your pick is contributing to X" —
+        /// see Planning/Projects/Project_65_Instant_Events.md Phase 3.
+        /// </summary>
+        /// <param name="latitude">GPS latitude.</param>
+        /// <param name="longitude">GPS longitude.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Returns the matching community.</response>
+        /// <response code="404">No enabled community contains this point.</response>
+        [HttpGet("at-location")]
+        [ProducesResponseType(typeof(CommunityLocationMatchDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetCommunityAtLocation(
+            [FromQuery] double latitude,
+            [FromQuery] double longitude,
+            CancellationToken cancellationToken = default)
+        {
+            logger.LogInformation(
+                "V2 GetCommunityAtLocation requested Lat={Latitude}, Lon={Longitude}",
+                latitude, longitude);
+
+            var community = await communityManager.GetCommunityAtLocationAsync(
+                latitude, longitude, cancellationToken);
+
+            if (community == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(new CommunityLocationMatchDto
+            {
+                Id = community.Id,
+                Name = community.Name,
+                Slug = community.Slug,
+            });
+        }
+
+        /// <summary>
         /// Gets a community by its URL slug.
         /// </summary>
         /// <param name="slug">The URL-friendly slug (e.g., "seattle-wa").</param>

--- a/TrashMobMobile/Pages/EditEventSummaryPage.xaml
+++ b/TrashMobMobile/Pages/EditEventSummaryPage.xaml
@@ -20,6 +20,32 @@
                     TextColor="{AppThemeBinding Light={StaticResource MutedForegroundLight}, Dark={StaticResource MutedForegroundDark}}"
                     Margin="5,8,5,0" />
 
+                <!-- Community-contribution banner (Project 65 Phase 3). Shown when the
+                     event's GPS lies inside a community's boundary. Purely informational —
+                     the community's stats aggregate this event automatically via the same
+                     bounding-box, so no explicit opt-in mechanism is needed. -->
+                <Border Padding="12" Margin="5,8,5,0"
+                        BackgroundColor="{AppThemeBinding Light=#f0fdf4, Dark=#052e16}"
+                        StrokeShape="RoundRectangle 10"
+                        Stroke="{AppThemeBinding Light=#86efac, Dark=#16a34a}"
+                        StrokeThickness="1"
+                        IsVisible="{Binding HasMatchedCommunity}">
+                    <VerticalStackLayout Spacing="4">
+                        <Label FontFamily="LexendSemibold" FontSize="14"
+                               TextColor="{AppThemeBinding Light=#166534, Dark=#bbf7d0}">
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="Contributing to " />
+                                    <Span Text="{Binding MatchedCommunityName}" FontAttributes="Bold" />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+                        <Label Text="Your impact rolls up into this community's totals."
+                               FontSize="12"
+                               TextColor="{AppThemeBinding Light=#166534, Dark=#dcfce7}" />
+                    </VerticalStackLayout>
+                </Border>
+
                 <Label
                     Text="Pre-filled from route tracking data"
                     FontSize="Micro"

--- a/TrashMobMobile/Services/CommunityRestService.cs
+++ b/TrashMobMobile/Services/CommunityRestService.cs
@@ -82,4 +82,21 @@ public class CommunityRestService(IHttpClientFactory httpClientFactory) : RestSe
         var dto = JsonConvert.DeserializeObject<StatsDto>(content)!;
         return dto.ToEntity();
     }
+
+    public async Task<CommunityLocationMatchDto?> GetCommunityAtLocationAsync(double latitude, double longitude,
+        CancellationToken cancellationToken = default)
+    {
+        var requestUri = $"{Controller}/at-location?latitude={latitude.ToString(CultureInfo.InvariantCulture)}&longitude={longitude.ToString(CultureInfo.InvariantCulture)}";
+        using var response = await AnonymousHttpClient.GetAsync(requestUri, cancellationToken);
+
+        // 404 = no matching community — normal result, not an error condition.
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonConvert.DeserializeObject<CommunityLocationMatchDto>(content);
+    }
 }

--- a/TrashMobMobile/Services/ICommunityRestService.cs
+++ b/TrashMobMobile/Services/ICommunityRestService.cs
@@ -2,6 +2,7 @@ namespace TrashMobMobile.Services;
 
 using TrashMob.Models;
 using TrashMob.Models.Poco;
+using TrashMob.Models.Poco.V2;
 
 public interface ICommunityRestService
 {
@@ -14,4 +15,12 @@ public interface ICommunityRestService
     Task<IEnumerable<Team>> GetCommunityTeamsAsync(string slug, double radiusMiles = 50, CancellationToken cancellationToken = default);
 
     Task<Stats> GetCommunityStatsAsync(string slug, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the community whose bounds contain the given GPS point, or null when
+    /// no enabled community matches. Backing endpoint returns 404 when no match — the
+    /// implementation translates that to a null result. See Project 65 Phase 3.
+    /// </summary>
+    Task<CommunityLocationMatchDto?> GetCommunityAtLocationAsync(double latitude, double longitude,
+        CancellationToken cancellationToken = default);
 }

--- a/TrashMobMobile/ViewModels/EditEventSummaryViewModel.cs
+++ b/TrashMobMobile/ViewModels/EditEventSummaryViewModel.cs
@@ -3,6 +3,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Sentry;
 using TrashMob.Models;
 using TrashMobMobile.Services;
 
@@ -10,11 +11,13 @@ public partial class EditEventSummaryViewModel(
     IMobEventManager mobEventManager,
     INotificationService notificationService,
     IUserManager userManager,
-    IEventAttendeeRouteRestService eventAttendeeRouteRestService) : BaseViewModel(notificationService)
+    IEventAttendeeRouteRestService eventAttendeeRouteRestService,
+    ICommunityRestService communityRestService) : BaseViewModel(notificationService)
 {
     private readonly IMobEventManager mobEventManager = mobEventManager;
     private readonly IUserManager userManager = userManager;
     private readonly IEventAttendeeRouteRestService eventAttendeeRouteRestService = eventAttendeeRouteRestService;
+    private readonly ICommunityRestService communityRestService = communityRestService;
 
     [ObservableProperty]
     private bool enableSaveEventSummary;
@@ -27,6 +30,20 @@ public partial class EditEventSummaryViewModel(
 
     [ObservableProperty]
     private bool isFromRouteData;
+
+    // Community-contribution banner (Project 65 Phase 3). Populated after Init if the
+    // event's GPS falls inside an enabled community's bounds. Purely informational —
+    // the community's stats aggregate this event automatically via the same bounding
+    // box, so there's no explicit opt-in step needed. See
+    // Planning/Projects/Project_65_Instant_Events.md Phase 3.
+    [ObservableProperty]
+    private string matchedCommunityName = string.Empty;
+
+    [ObservableProperty]
+    private string matchedCommunitySlug = string.Empty;
+
+    [ObservableProperty]
+    private bool hasMatchedCommunity;
 
     public ObservableCollection<WeightUnit> WeightUnits { get; } =
     [
@@ -80,7 +97,35 @@ public partial class EditEventSummaryViewModel(
             }
 
             EnableSaveEventSummary = true;
+
+            await TryLoadMatchedCommunityAsync(new Guid(eventId));
         }, "An error has occurred while loading the event summary. Please wait and try again in a moment.");
+    }
+
+    private async Task TryLoadMatchedCommunityAsync(Guid eventId)
+    {
+        try
+        {
+            var mobEvent = await mobEventManager.GetEventAsync(eventId);
+            if (mobEvent?.Latitude is not { } lat || mobEvent.Longitude is not { } lng)
+            {
+                return;
+            }
+
+            var match = await communityRestService.GetCommunityAtLocationAsync(lat, lng);
+            if (match != null)
+            {
+                MatchedCommunityName = match.Name;
+                MatchedCommunitySlug = match.Slug;
+                HasMatchedCommunity = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Non-critical — the community banner is purely informational, don't break
+            // the summary screen if the lookup fails.
+            SentrySdk.CaptureException(ex);
+        }
     }
 
     private async Task TryPrefillFromRouteData(Guid eventId)


### PR DESCRIPTION
## Summary
Fills Phase 3. When a user finishes an event whose GPS falls inside a community's bounds, the post-Stop stats screen shows a green "Contributing to [Community Name]" banner. Purely informational — no opt-in mechanism needed because community stats already aggregate events automatically via the same bounding-box filter that this endpoint uses.

Applies to wizard events too. Same value proposition ("your pick contributes to X"), no reason to gate it.

## Design divergence from the planning doc
The doc's Phase 3 talked about a "one-tap 'Log this to [Community Name]' opt-in" — that assumed a schema change (a `CommunityId` FK on Event, or similar linkage table). During implementation I found `CommunityManager.GetCommunityStatsAsync` already aggregates events via bounding-box match ([CommunityManager.cs:247-267](../blob/dev/joe/instant-events-community-lookup/TrashMob.Shared/Managers/Communities/CommunityManager.cs#L247-L267)) with **no per-event flag involved**. So the linkage happens automatically. This PR just surfaces which community the GPS falls in; nothing needs to be persisted or opted into.

Planning doc's Q4 decision (*"count equally"*) is honored — Instant Event contributions and wizard-event contributions both roll up identically.

## Backend
- **`ICommunityManager.GetCommunityAtLocationAsync(lat, lng)`** — returns the community whose bounds contain the point, or null.
  - Filters: enabled home page + active partner status + date range current + all four bounds set.
  - When multiple communities contain the point (a city inside a county inside a state), the more specific one wins. Uses `RegionType` (`City=0, County=1, State=2, Province=3, Region=4, Country=5`) — `OrderBy` gives most-specific first.
- **`GET /api/v2/communities/at-location?latitude=&longitude=`** — returns `CommunityLocationMatchDto` (id, name, slug) or 404.
- 8 new tests (6 manager + 2 controller): happy path, no match, most-specific-wins, disabled/inactive exclusion, no-bounds ignored, 404 response.

## Mobile
- **`ICommunityRestService.GetCommunityAtLocationAsync`** — new method. Translates 404 to `null` so callers get a clean nullable result.
- **`EditEventSummaryViewModel`** — after `Init` loads the summary, calls `TryLoadMatchedCommunityAsync` which reads the event's GPS and queries the endpoint. Populates `MatchedCommunityName` + `HasMatchedCommunity`. Failure is Sentry-captured and swallowed — the banner is informational, must not break the summary screen.
- **`EditEventSummaryPage.xaml`** — green banner between the title and the form. `"Contributing to [Community Name]"` + tagline `"Your impact rolls up into this community's totals."` Visibility bound to `HasMatchedCommunity`.

## Test plan
- [x] Backend build clean (0 warnings)
- [x] `dotnet test --filter CommunityAtLocation` — 8 new tests pass, no regressions in `CommunityManagerTests` or `CommunitiesV2ControllerTests` suites
- [x] Mobile Android build clean (0 errors)
- [ ] Manual smoke test on `pixel_8_api_35` (Joe to run):
  - [ ] Complete an Instant Event where the emulator's simulated GPS is inside a real community's bounds (e.g. use Seattle coordinates + a Seattle community if one exists in the dev DB) — verify banner shows on EditEventSummaryPage
  - [ ] Complete an Instant Event with GPS outside any community — verify NO banner shows
  - [ ] Complete a wizard-created event — same banner behavior (Phase 3 is not Instant-only)

Refs [Planning/Projects/Project_65_Instant_Events.md](../blob/dev/joe/instant-events-community-lookup/Planning/Projects/Project_65_Instant_Events.md) Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)