### PR TITLE
Project 65 Phase 4: abandonment guard for Instant Events

### DIFF
--- a/Planning/Projects/Project_65_Instant_Events.md
+++ b/Planning/Projects/Project_65_Instant_Events.md
@@ -171,10 +171,13 @@ Not blocked by any project. Can start immediately.
 
 **Exit criteria:** a user standing in a community's boundary is offered the community linkage; the community's stats page reflects the Instant Event's metrics.
 
-### Phase 4 — Abandonment guard
+### Phase 4 — Abandonment guard (shipped 2026-07-14)
 
-- Background-transition logic: if an Instant Event has been In Progress > 4 hours and the app has been backgrounded, auto-transition to Completed with elapsed = 4h and prompt on next open.
-- Analytics: report on stopped-vs-abandoned ratio.
+- **Server-side hourly sweep** in `TrashMobHourlyJobs`. `EventManager.CompleteAbandonedInstantEventsAsync(TimeSpan threshold)` queries for Instant Events in Active status with zero duration and `EventDate < now - threshold`, sets each to Complete with duration = threshold, and returns the count for logging.
+- Threshold set to 4h per the original plan. Configurable via the call site if we ever want to change it.
+- **Design note — no mobile prompt on next open.** The doc originally suggested "prompt on next open." In practice the interaction is cleaner: once auto-Completed the event drops out of `GetInProgressInstantEventsAsync` (which requires Active status), so the resume banner just doesn't appear. If local Preferences still point at the completed event, the VM resume path validates with the server, sees the Complete status, and clears Preferences without needing an explicit prompt.
+- **Design note — audit fields use the event creator's user id**, not a system-user sentinel. Direct application of the [Project 64 lesson](./Project_64_Roles_and_RBAC_Refactor.md) about never inventing sentinel user ids. Semantic reading: "the user's own event was auto-completed on their behalf."
+- **Deferred — analytics on stopped-vs-abandoned ratio.** Would need a boolean flag on `Event` (or similar) to distinguish. Not worth a schema migration for a metric that isn't driving decisions today. Duration = exactly 4h 0min is a reasonable proxy signal in ad-hoc queries.
 
 ### Phase 5 — Web parity (deferred; see Open Questions)
 

--- a/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
+++ b/TrashMob.Shared.Tests/Managers/Events/EventManagerTests.cs
@@ -551,6 +551,115 @@ namespace TrashMob.Shared.Tests.Managers.Events
 
         #endregion
 
+        #region CompleteAbandonedInstantEventsAsync Tests
+
+        [Fact]
+        public async Task CompleteAbandonedInstantEventsAsync_TransitionsMatchingEventsToComplete()
+        {
+            var userId = Guid.NewGuid();
+            var eventId = Guid.NewGuid();
+            var abandoned = new EventBuilder()
+                .WithId(eventId)
+                .WithName("Instant Event abandoned")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(0, 0)
+                .WithEventDate(DateTimeOffset.UtcNow.AddHours(-6))
+                .Build();
+
+            _eventRepository.SetupGetWithFilter(new[] { abandoned });
+            _eventRepository.SetupUpdateAsync();
+
+            var count = await _sut.CompleteAbandonedInstantEventsAsync(TimeSpan.FromHours(4));
+
+            Assert.Equal(1, count);
+            Assert.Equal((int)EventStatusEnum.Complete, abandoned.EventStatusId);
+            Assert.Equal(4, abandoned.DurationHours);
+            Assert.Equal(0, abandoned.DurationMinutes);
+        }
+
+        [Fact]
+        public async Task CompleteAbandonedInstantEventsAsync_ExcludesCompletedEventsAndWizardEvents()
+        {
+            var userId = Guid.NewGuid();
+
+            // Completed Instant — Duration set, should NOT match.
+            var completedInstant = new EventBuilder()
+                .WithName("Completed Instant")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(2, 15)
+                .WithEventDate(DateTimeOffset.UtcNow.AddHours(-6))
+                .Build();
+
+            // Wizard event — Public visibility, should NOT match even with zero duration.
+            var wizardEvent = new EventBuilder()
+                .WithName("Wizard Event")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPublic()
+                .WithDuration(0, 0)
+                .WithEventDate(DateTimeOffset.UtcNow.AddHours(-6))
+                .Build();
+
+            // Recent Instant — under the 4h cutoff, should NOT match.
+            var recentInstant = new EventBuilder()
+                .WithName("Recent Instant")
+                .CreatedBy(userId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(0, 0)
+                .WithEventDate(DateTimeOffset.UtcNow.AddMinutes(-30))
+                .Build();
+
+            _eventRepository.SetupGetWithFilter(new[] { completedInstant, wizardEvent, recentInstant });
+            _eventRepository.SetupUpdateAsync();
+
+            var count = await _sut.CompleteAbandonedInstantEventsAsync(TimeSpan.FromHours(4));
+
+            Assert.Equal(0, count);
+            Assert.Equal((int)EventStatusEnum.Active, wizardEvent.EventStatusId);
+            Assert.Equal((int)EventStatusEnum.Active, recentInstant.EventStatusId);
+        }
+
+        [Fact]
+        public async Task CompleteAbandonedInstantEventsAsync_UsesCreatorForAuditFields()
+        {
+            // Never invent a sentinel system-user id (Project 64 lessons learned).
+            // The event creator gets attributed as the auto-completer of their own event.
+            var creatorId = Guid.NewGuid();
+            var abandoned = new EventBuilder()
+                .WithName("Instant")
+                .CreatedBy(creatorId)
+                .AsActive()
+                .AsPrivate()
+                .WithDuration(0, 0)
+                .WithEventDate(DateTimeOffset.UtcNow.AddHours(-6))
+                .Build();
+
+            _eventRepository.SetupGetWithFilter(new[] { abandoned });
+            _eventRepository.SetupUpdateAsync();
+
+            await _sut.CompleteAbandonedInstantEventsAsync(TimeSpan.FromHours(4));
+
+            _eventRepository.Verify(r => r.UpdateAsync(
+                It.Is<Event>(e => e.LastUpdatedByUserId == creatorId)), Times.Once);
+        }
+
+        [Fact]
+        public async Task CompleteAbandonedInstantEventsAsync_ReturnsZero_WhenNoAbandonedEvents()
+        {
+            _eventRepository.SetupGetWithFilter(Array.Empty<Event>());
+
+            var count = await _sut.CompleteAbandonedInstantEventsAsync(TimeSpan.FromHours(4));
+
+            Assert.Equal(0, count);
+        }
+
+        #endregion
+
         #region GetInProgressInstantEventsAsync Tests
 
         [Fact]

--- a/TrashMob.Shared/Managers/Events/EventManager.cs
+++ b/TrashMob.Shared/Managers/Events/EventManager.cs
@@ -423,6 +423,48 @@ namespace TrashMob.Shared.Managers.Events
         }
 
         /// <inheritdoc />
+        public async Task<int> CompleteAbandonedInstantEventsAsync(TimeSpan abandonmentThreshold,
+            CancellationToken cancellationToken = default)
+        {
+            var cutoff = DateTimeOffset.UtcNow - abandonmentThreshold;
+
+            var abandoned = await Repo.Get(e =>
+                    e.EventStatusId == (int)EventStatusEnum.Active
+                    && e.EventVisibilityId == (int)EventVisibilityEnum.Private
+                    && e.DurationHours == 0
+                    && e.DurationMinutes == 0
+                    && e.EventDate < cutoff)
+                .ToListAsync(cancellationToken);
+
+            if (abandoned.Count == 0)
+            {
+                return 0;
+            }
+
+            // Duration is set to the threshold rather than the true elapsed time. The
+            // user was probably done long before the "abandoned" line — we don't know
+            // when, so pick a plausible cap. Also keeps abandoned events from returning
+            // absurd durations (e.g. an event started three days ago shouldn't show as
+            // 72h of cleanup).
+            var thresholdHours = (int)abandonmentThreshold.TotalHours;
+            var thresholdMinutes = abandonmentThreshold.Minutes;
+
+            foreach (var mobEvent in abandoned)
+            {
+                mobEvent.EventStatusId = (int)EventStatusEnum.Complete;
+                mobEvent.DurationHours = thresholdHours;
+                mobEvent.DurationMinutes = thresholdMinutes;
+
+                // Use the event creator for audit fields — never invent a sentinel
+                // system-user id (Project 64 lessons learned). Semantic reading:
+                // "the user's own event was auto-completed on their behalf."
+                await base.UpdateAsync(mobEvent, mobEvent.CreatedByUserId, cancellationToken);
+            }
+
+            return abandoned.Count;
+        }
+
+        /// <inheritdoc />
         public async Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(Guid userId,
             CancellationToken cancellationToken = default)
         {

--- a/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
+++ b/TrashMob.Shared/Managers/Interfaces/IEventManager.cs
@@ -151,5 +151,26 @@ namespace TrashMob.Shared.Managers.Interfaces
         /// </summary>
         Task<IEnumerable<Event>> GetInProgressInstantEventsAsync(Guid userId,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sweeps Instant Events that have been left in Active status past the given
+        /// threshold and auto-transitions them to Complete. Used by the hourly job
+        /// (Project 65 Phase 4) to prevent orphaned Instant Events from piling up when
+        /// users forget to hit Stop.
+        ///
+        /// Match criteria (all must hold):
+        /// - EventStatusId = Active
+        /// - EventVisibilityId = Private
+        /// - DurationHours == 0 AND DurationMinutes == 0 (never completed)
+        /// - EventDate &lt; UtcNow - <paramref name="abandonmentThreshold"/>
+        ///
+        /// Duration on the completed event is set to the threshold value (not the true
+        /// elapsed time) — the user was probably done long before the app started
+        /// counting them as abandoned. Audit fields use the event creator's user id
+        /// (per Project 64 lesson: never invent a sentinel system-user id).
+        /// </summary>
+        /// <returns>The number of Instant Events that were auto-completed.</returns>
+        Task<int> CompleteAbandonedInstantEventsAsync(TimeSpan abandonmentThreshold,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/TrashMobHourlyJobs/Program.cs
+++ b/TrashMobHourlyJobs/Program.cs
@@ -54,6 +54,24 @@ namespace TrashMobHourlyJobs
             var followUpCount = await outreachManager.ProcessDueFollowUpsAsync();
             logger.LogInformation("Processed {Count} outreach follow-up emails", followUpCount);
 
+            // Auto-complete abandoned Instant Events. Users who forget to hit Stop leave
+            // the event in Active status with zero duration; without this sweep those
+            // pile up in the DB and skew personal-stats displays. 4h threshold per the
+            // Project 65 Phase 4 plan — well past the typical solo pick duration.
+            //
+            // Interaction with mobile resume: the resume banner filters for Active
+            // status, so once an event crosses the 4h line and is auto-Completed it
+            // stops showing as resumable. Users returning between 4h and 24h see no
+            // banner, and if their local Preferences still point at that event the VM
+            // resume path validates with the server, sees the Complete status, and
+            // falls through to a fresh start.
+            //
+            // See Project 65 Phase 4.
+            logger.LogInformation("Sweeping abandoned Instant Events...");
+            var eventManager = scope.ServiceProvider.GetRequiredService<IEventManager>();
+            var abandonedCount = await eventManager.CompleteAbandonedInstantEventsAsync(TimeSpan.FromHours(4));
+            logger.LogInformation("Auto-completed {Count} abandoned Instant Events", abandonedCount);
+
             logger.LogInformation("Hourly jobs completed at: {Time}", DateTime.UtcNow);
         }
 


### PR DESCRIPTION
## Summary
Closes out Project 65. Hourly server-side sweep that auto-completes Instant Events left in Active status past a 4h threshold. Prevents orphaned events from piling up when users forget to hit Stop.

**Backend-only.** No mobile changes needed — see the "interaction with mobile resume" note below.

## What changed
- **`EventManager.CompleteAbandonedInstantEventsAsync(TimeSpan threshold, CancellationToken)`** — returns the count of events auto-completed. Match criteria: `Active` + `Private` + zero duration + `EventDate < now - threshold`. Same semantic filter as the Phase 1 Option B `GetInProgressInstantEventsAsync`, just a longer time window.
- **`TrashMobHourlyJobs/Program.cs`** — new step between outreach follow-ups and end-of-run log. 4h threshold hardcoded per plan; trivially configurable if we want to tune it.
- **Planning doc** updated to mark Phase 4 shipped + document design decisions inline.
- **4 new tests**, 30 total EventManager tests still pass.

## Design decisions
- **Duration = threshold, not true elapsed.** A 6h-old event gets `DurationHours=4`, not 6. The user was probably done long before the abandonment line — picking the threshold as a plausible cap keeps personal-stats displays sane. Alternative would be capping at 24h like the existing `CompleteEventAsync`, but that would report 24h of "cleanup" for events started three days ago.
- **Audit fields use the event creator's own user id**, not a sentinel system-user id. Direct application of the Project 64 lesson (never invent sentinel user ids). Semantic reading: "the user's own event was auto-completed on their behalf." Weird but every FK resolves to a real row.
- **No analytics flag for stopped-vs-abandoned differentiation.** Would need a schema migration for a metric not driving decisions today. Duration = exactly 4h 0min is a fine proxy signal for ad-hoc queries.

## Interaction with mobile resume (worth flagging)
Once auto-Completed, the event drops out of `GetInProgressInstantEventsAsync` (which requires Active status). So:
- The Dashboard resume banner just doesn't appear for auto-completed events. No mobile change needed.
- If local Preferences still point at the completed event, the VM resume path validates with the server, sees Complete, and clears Preferences. Falls through to fresh start.

That's why the original planning-doc requirement "prompt on next open" isn't implemented separately — the existing resume flow degrades gracefully to "no banner, no prompt, clean fresh start."

## Test plan
- [x] `dotnet build TrashMob.sln` — clean
- [x] `dotnet test --filter EventManagerTests` — 30 pass, no regressions
- [ ] Manual verification (Joe to run once in dev):
  - Insert a test Instant Event via Swagger with EventDate = 5h ago, Status = Active, Duration = 0
  - Run `dotnet run --project TrashMobHourlyJobs`
  - Verify the event's status flipped to Complete with DurationHours = 4, DurationMinutes = 0
  - Verify a wizard-created event (Public visibility) with the same age is NOT touched

Refs [Planning/Projects/Project_65_Instant_Events.md](../blob/dev/joe/instant-events-abandonment-guard/Planning/Projects/Project_65_Instant_Events.md) Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)