### PR TITLE
Mark Project 65 (Instant Events) complete

### DIFF
--- a/Planning/Projects/Project_65_Instant_Events.md
+++ b/Planning/Projects/Project_65_Instant_Events.md
@@ -2,11 +2,35 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Status** | Not Started |
+| **Status** | Complete — all phases shipped 2026-07-12 through 2026-07-14 |
 | **Priority** | Medium |
 | **Risk** | Low |
-| **Size** | Small |
+| **Size** | Small (grew to ~10 PRs; each individually small) |
 | **Dependencies** | [Project 15 (Route Tracing)](./Project_15_Route_Tracing.md) — the optional route-tracking toggle depends on the mobile route-recording pipeline already shipped in Phases 1–5 |
+
+## Shipped
+
+| Phase / Slice | PR | Shipped |
+|---------------|-----|---------|
+| Planning doc + decisions | [#3496](https://github.com/TrashMob-eco/TrashMob/pull/3496) | 2026-07-12 |
+| Phase 1 backend endpoints (`POST /events/instant`, `PUT /events/{id}/complete`) | [#3497](https://github.com/TrashMob-eco/TrashMob/pull/3497) | 2026-07-12 |
+| Phase 1 mobile UI + local resume (Preferences-backed) | [#3498](https://github.com/TrashMob-eco/TrashMob/pull/3498) | 2026-07-12 |
+| Phase 1 cross-device resume (server-side lookup fallback) | [#3499](https://github.com/TrashMob-eco/TrashMob/pull/3499) | 2026-07-12 |
+| Phase 2 reverse geocoding (server-side at creation) | [#3500](https://github.com/TrashMob-eco/TrashMob/pull/3500) | 2026-07-13 |
+| Phase 2 route tracking toggle + shared `IRouteRecordingCoordinator` | [#3501](https://github.com/TrashMob-eco/TrashMob/pull/3501) | 2026-07-13 |
+| Wizard refactor to use the coordinator (net −70 lines) | [#3502](https://github.com/TrashMob-eco/TrashMob/pull/3502) | 2026-07-13 |
+| Phase 2 route resume after app force-close | [#3503](https://github.com/TrashMob-eco/TrashMob/pull/3503) | 2026-07-13 |
+| Phase 3 community auto-detection banner | [#3504](https://github.com/TrashMob-eco/TrashMob/pull/3504) | 2026-07-14 |
+| Phase 4 abandonment guard (hourly job) | [#3505](https://github.com/TrashMob-eco/TrashMob/pull/3505) | 2026-07-14 |
+
+## Lessons learned
+
+- **The doc's "opt-in" mechanism for Phase 3 turned out to be unnecessary.** The doc assumed community linkage would need a `CommunityId` FK on `Event`. Discovered during implementation that `CommunityManager.GetCommunityStatsAsync` already aggregates events via bounding-box match with no per-event flag involved — so linkage happens automatically. Shipped as an informational banner instead of an opt-in.
+- **Server-side reverse geocoding beat client-side.** Doc suggested mobile-side; server-side was cleaner (one API call, no follow-up round trip, no stale-address gap) and `IMapManager.GetAddressAsync` already existed in the manager's constructor scope.
+- **Route resume after force-close needed hydration in three places**, not just the one the initial doc implied. `RouteTrackingSessionManager.TryRestoreSession` had to actually be called (nobody was), the coordinator needed a `TryResumeAsync` method distinct from `StartAsync`, and the writer's `pointOrder` had to be re-seeded from `SyncQueue.GetMaxPointOrderAsync` to avoid PointOrder collisions with existing SQLite points.
+- **Sharing the coordinator with wizard events was worth the refactor.** Phase 2 slice 2 shipped the coordinator + Instant Events integration; a follow-up PR ripped ~120 lines of near-duplicate code out of `ViewEventViewModel` in exchange for a single Start/Stop call sandwiched by `Task.Delay(Timeout.Infinite, cancellationToken)`. Net −70 lines in the wizard VM, behavior fully preserved.
+- **Abandonment guard didn't need the mobile "prompt on next open" the doc suggested.** Once auto-Completed, the event drops out of `GetInProgressInstantEventsAsync` (which requires Active status), so the resume banner just doesn't appear. Local Preferences → server validation → clean fresh start. No prompt needed — the existing resume flow degrades gracefully.
+- **Reverse-engineering community aggregation before writing Phase 3 saved a schema migration.** Would have been easy to charge in with a `CommunityId` FK + backfill migration + join queries. Reading `GetCommunityStatsAsync` first showed that the bounding-box match was already doing the work.
 
 ## Business Rationale
 

--- a/Planning/README.md
+++ b/Planning/README.md
@@ -49,7 +49,7 @@
 | [Project 55 - Event Check-In](./Projects/Project_55_Event_Check_In.md) | Pre-event waiver validation, configurable check-in notifications, attendance roster for event leads | Not Started |
 | [Project 56 - Board Metrics Dashboard](./Projects/Project_56_Board_Metrics_Dashboard.md) | Unified admin dashboard consolidating App Insights, GA4, Sentry, Clarity, Azure costs, and QuickBooks for board meetings | Planning |
 | [Project 57 - Participation Report](./Projects/Project_57_Participation_Report.md) | Official volunteer participation report email with PDF for school/court/employer verification | In Progress (Phases 1-3 Complete) |
-| [Project 65 - Instant Events](./Projects/Project_65_Instant_Events.md) | Strava-style one-tap "Start a Pick" mobile flow for solo private cleanups with optional route tracking and deferred stats entry | Not Started |
+| [Project 65 - Instant Events](./Projects/Project_65_Instant_Events.md) | Strava-style one-tap "Start a Pick" mobile flow for solo private cleanups with optional route tracking and deferred stats entry | Complete (all phases shipped 2026-07-12 through 2026-07-14) |
 
 #### High Priority (Marketing & Growth)
 
@@ -148,7 +148,7 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 ### Event Experience
 - [Project 55 - Event Check-In](./Projects/Project_55_Event_Check_In.md)
 - [Project 59 - Event Weather Forecast](./Projects/Archive/Project_59_Event_Weather_Forecast.md) ✅
-- [Project 65 - Instant Events](./Projects/Project_65_Instant_Events.md)
+- [Project 65 - Instant Events](./Projects/Project_65_Instant_Events.md) ✅
 
 ### Impact Tracking
 - [Project 7 - Event Weights](./Projects/Archive/Project_07_Event_Weights.md) ✅
@@ -197,12 +197,12 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 | Status | Count | Projects |
 |--------|-------|----------|
 | ✅ **Complete** (archived) | 34 | Projects 3, 7, 9, 10, 11, 13, 14, 16, 17, 18, 19, 20, 21, 22, 24, 26, 27, 28, 29, 32, 34, 35, 37, 38, 39, 40, 42, 44, 47, 48, 50, 51, 53, 59 |
-| ✅ **Complete** (production live, in-place) | 2 | Project 23 (PRIVO live 2026-05-20, testing complete 2026-07-01), Project 63 (Municipal Sales Pipeline live 2026-07-05) |
+| ✅ **Complete** (production live, in-place) | 3 | Project 23 (PRIVO live 2026-05-20, testing complete 2026-07-01), Project 63 (Municipal Sales Pipeline live 2026-07-05), Project 65 (Instant Events, all phases shipped 2026-07-12 through 2026-07-14) |
 | ✅ **Complete** (pending external) | 1 | Project 8 (minor waiver text pending legal review) |
 | **In Progress** | 14 | Projects 1, 4, 5, 6, 15, 25, 30, 36, 41, 45, 46, 49, 57, **64** (Phases 1–4a live; Phase 4b column-drop queued for ~2026-08-05) |
 | **Planning** | 3 | Projects 56, 58, 62 |
 | **Ready for Review** | 1 | Project 2 |
-| **Not Started** | 6 | Projects 12, 31, 43, 52, 54, 55, 65 |
+| **Not Started** | 6 | Projects 12, 31, 43, 52, 54, 55 |
 | **Deprioritized** | 1 | Project 33 |
 
 **Total:** 63 project specifications documented
@@ -256,7 +256,6 @@ Complete projects have been moved to [Projects/Archive/](./Projects/Archive/). T
 | [Project 52 - Volunteer Rewards](./Projects/Project_52_Volunteer_Rewards.md) | Partner reward sourcing, criteria, distribution, fraud prevention (future) |
 | [Project 54 - Community Adoption Outreach](./Projects/Project_54_Community_Adoption_Outreach.md) | AI-powered sponsor/adopter discovery and outreach for community managers |
 | [Project 55 - Event Check-In](./Projects/Project_55_Event_Check_In.md) | Pre-event waiver validation, configurable check-in notifications, attendance roster |
-| [Project 65 - Instant Events](./Projects/Project_65_Instant_Events.md) | One-tap mobile "Start a Pick" flow for solo private cleanups (Strava-style) with optional route tracking and deferred stats entry |
 
 ---
 


### PR DESCRIPTION
## Summary
Docs housekeeping to reflect that Project 65 shipped in full. 2 files, no code changes.

- **`Project_65_Instant_Events.md`** — status header changed from *Not Started* → *Complete*, added a **Shipped** table listing all 10 PRs (mirrors the Project 64 pattern), added a **Lessons learned** section capturing the design surprises worth remembering.
- **`Planning/README.md`** — moved from *Not Started* bucket to *Complete (production live, in-place)* (matches Projects 23 + 63), added ✅ to the Event Experience theme link, updated Status Overview counts.

## Lessons captured (from the new section on the project doc)
- The doc's "opt-in" mechanism for Phase 3 turned out unnecessary — community aggregation is already bounding-box-based, so linkage is automatic.
- Server-side reverse geocoding beat the doc's client-side plan.
- Route resume after force-close needed hydration in three places, not one.
- Sharing the coordinator with wizard events was worth the refactor (net −70 lines in `ViewEventViewModel`).
- The abandonment guard's "prompt on next open" wasn't needed — the existing resume flow degrades gracefully to no banner + clean fresh start.

## Not in this PR
- **Archive move.** Complete projects have historically been moved to `Planning/Projects/Archive/`. That's a bigger structural change than status housekeeping and involves updating link paths throughout. Left for a separate PR if/when it makes sense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)