### PR TITLE
Fix homepage map recenter, location search, news category filter, and leaderboard default

### DIFF
--- a/TrashMob/Controllers/V2/CmsV2Controller.cs
+++ b/TrashMob/Controllers/V2/CmsV2Controller.cs
@@ -206,7 +206,7 @@ namespace TrashMob.Controllers.V2
 
                 if (!string.IsNullOrEmpty(category))
                 {
-                    url += $"&filters[news_category][slug][$eq]={category}";
+                    url += $"&filters[category][slug][$eq]={category}";
                 }
 
                 var client = httpClientFactory.CreateClient();

--- a/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
+++ b/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
@@ -119,6 +119,7 @@ export function AzureSearchLocationInput(props: AzureSearchLocationInputProps) {
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setQuery(e.target.value);
+        setShowSuggestion(true);
     };
 
     const customInputProps: RenderInputProps = {

--- a/TrashMob/client-app/src/pages/_home/event-section.tsx
+++ b/TrashMob/client-app/src/pages/_home/event-section.tsx
@@ -50,7 +50,14 @@ const useGetFilteredEvents = (params: GetFilteredEvents_Params) => {
 
 export const EventSection = (props: EventSectionProps) => {
     const { isUserLoaded, currentUser } = useLogin();
-    const defaultMapCenter = useGetDefaultMapCenter();
+    const geoDefaultCenter = useGetDefaultMapCenter();
+    const defaultMapCenter = useMemo(
+        () =>
+            isUserLoaded && currentUser.latitude != null && currentUser.longitude != null
+                ? { lat: currentUser.latitude, lng: currentUser.longitude }
+                : geoDefaultCenter,
+        [isUserLoaded, currentUser.latitude, currentUser.longitude, geoDefaultCenter],
+    );
 
     /** Statuses */
     const statuses = [

--- a/TrashMob/client-app/src/pages/leaderboards/page.tsx
+++ b/TrashMob/client-app/src/pages/leaderboards/page.tsx
@@ -17,7 +17,7 @@ export const LeaderboardsPage = () => {
     const canViewRanking = isFeatureEnabled(PrivoFeature.Leaderboard);
     const [entityType, setEntityType] = useState<'users' | 'teams'>('users');
     const [leaderboardType, setLeaderboardType] = useState('Events');
-    const [timeRange, setTimeRange] = useState('Month');
+    const [timeRange, setTimeRange] = useState('AllTime');
 
     // Fetch available options
     const { data: optionsResponse } = useQuery({


### PR DESCRIPTION
## Summary

Four independent bug fixes surfaced during a sales demo:

- **Home page map didn't recenter to preferred area when logged in.**
  [useGetDefaultMapCenter](TrashMob/client-app/src/hooks/useGetDefaultMapCenter.ts) uses browser geolocation only. Now [event-section.tsx](TrashMob/client-app/src/pages/_home/event-section.tsx) prefers the signed-in user's saved `latitude`/`longitude` when available, falling back to geolocation → global default.
- **"Issaquah, WA" search resolved to "Wellesley Islands, Australia" and then locked up.** Root cause was two things — Azure Maps returning odd partial matches (e.g., `"Iss"` → Wellesley Islands, QLD as top result), combined with our own bug where the suggestions dropdown never reopened after a selection because `handleInputChange` didn't reset `showSuggestion`. Users can now correct a bad pick just by typing again.
- **News category pills returned 503.** [CmsV2Controller.cs](TrashMob/Controllers/V2/CmsV2Controller.cs) sent `filters[news_category][slug][$eq]` to Strapi, but the schema field is `category` ([news-post/schema.json](Strapi/src/api/news-post/content-types/news-post/schema.json)). Fixed the field name; the frontend swallowed the error into an empty state so this was silently broken.
- **Leaderboards page looked empty on first load.** Default `timeRange` was `'Month'`, which currently has zero qualifying users on prod (the 3+ events / 30 days bar isn't hit). Default is now `'AllTime'` (9 entries) so first view has data. Users can still switch back via the dropdown.

## Test plan

- [ ] Sign in on the home page while logged-in user has a saved location → map centers on that area, not browser geolocation.
- [ ] While signed out, home page falls back to browser geolocation → global default.
- [ ] Search "Issaquah, WA" in the Events Near box → picks Issaquah correctly.
- [ ] Pick a wrong result, then start typing again → dropdown reappears and a new pick works.
- [ ] On `/news`, click each category pill → returns filtered posts (not empty).
- [ ] Load `/leaderboards` → AllTime data appears immediately; switching to Month still works (shows empty state if no qualifiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)