### PR TITLE
Hotfix: Front Door caches API responses per query string (Wellesley bug)

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -222,15 +222,16 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
     httpsRedirect: 'Disabled'
     enabledState: 'Enabled'
     cacheConfiguration: {
-      // Required by the AFD Standard/Premium schema whenever
-      // cacheConfiguration is set. Matches the effective behavior of
-      // the historic config that was accepted under an older API
-      // version — Front Door treats a URL's cache key without regard
-      // to query string, which is correct for our SPA (all client
-      // routing lives in the app; the same index.html is served for
-      // any path). Origin Cache-Control headers still control whether
-      // any given response is actually cached.
-      queryStringCachingBehavior: 'IgnoreQueryString'
+      // Cache key MUST include the query string — otherwise API responses
+      // like /api/v2/maps/search?query=X and ?query=Y share a cache entry
+      // and the first response wins for every subsequent caller (2026-07-18:
+      // "Toronto" returned an Azure Maps response for query="iss" —
+      // Wellesley Islands, Australia). The SPA doesn't rely on query
+      // strings for HTML delivery, so this only adds harmless per-URL
+      // cache fragmentation for /*.html while making /api/* correct.
+      // Origin Cache-Control headers still control whether any given
+      // response is actually cached.
+      queryStringCachingBehavior: 'UseQueryString'
       compressionSettings: {
         isCompressionEnabled: true
         contentTypesToCompress: [


### PR DESCRIPTION
## Summary

Production Front Door route was set to `queryStringCachingBehavior: 'IgnoreQueryString'`, which cache-keys every request under just its path — so `/api/v2/maps/search?query=iss` and `?query=toronto` share a single cache entry. First response wins, everybody after gets it.

Confirmed active on prod today:

```
Request:  GET /api/v2/maps/search?query=toronto&entityType=Municipality
Response: { "summary": { "query": "iss" }, "results": [ { ... "Wellesley Islands, QLD" ... } ] }
```

This is why "type Issaquah" and even "type Toronto" both surface Wellesley Islands, Australia — Azure Maps never sees the actual query; Front Door replies from cache.

The original comment on the `IgnoreQueryString` line argued the SPA's `index.html` is the same for any path so query strings didn't matter — but the same `/*` route also handles `/api/*`, and the API doesn't send `Cache-Control: no-store`, so dynamic responses were being cross-cached.

## Fix

Switch to `queryStringCachingBehavior: 'UseQueryString'`. The SPA still serves the same `index.html` for any client-side route; this only adds harmless per-URL cache fragmentation for `/*.html` while making `/api/*` correct.

## Follow-up worth considering (not in this PR)

- Send `Cache-Control: no-store` on `/api/v2/*` responses (or an AFD rule that bypasses cache for `/api/*`), so dynamic API responses aren't cached at the edge at all. `UseQueryString` fixes correctness; disabling cache entirely for the API would also fix staleness on things like the leaderboard.

## Test plan

- [ ] After Front Door deploy, hit `/api/v2/maps/search?query=toronto` — response body's `summary.query` should be `"toronto"`, top result `Toronto ON`.
- [ ] Repeat with `?query=issaquah` — should return `Issaquah, WA`.
- [ ] Home page "Events near" search returns the city typed.
- [ ] Merge back to `main` after this lands on `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)