### PR TITLE
Homepage follow-ups: reverse-geocode overwrite fix + Front Door cache backport

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -222,15 +222,16 @@ resource route 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = {
     httpsRedirect: 'Disabled'
     enabledState: 'Enabled'
     cacheConfiguration: {
-      // Required by the AFD Standard/Premium schema whenever
-      // cacheConfiguration is set. Matches the effective behavior of
-      // the historic config that was accepted under an older API
-      // version — Front Door treats a URL's cache key without regard
-      // to query string, which is correct for our SPA (all client
-      // routing lives in the app; the same index.html is served for
-      // any path). Origin Cache-Control headers still control whether
-      // any given response is actually cached.
-      queryStringCachingBehavior: 'IgnoreQueryString'
+      // Cache key MUST include the query string — otherwise API responses
+      // like /api/v2/maps/search?query=X and ?query=Y share a cache entry
+      // and the first response wins for every subsequent caller (2026-07-18:
+      // "Toronto" returned an Azure Maps response for query="iss" —
+      // Wellesley Islands, Australia). The SPA doesn't rely on query
+      // strings for HTML delivery, so this only adds harmless per-URL
+      // cache fragmentation for /*.html while making /api/* correct.
+      // Origin Cache-Control headers still control whether any given
+      // response is actually cached.
+      queryStringCachingBehavior: 'UseQueryString'
       compressionSettings: {
         isCompressionEnabled: true
         contentTypesToCompress: [

--- a/TrashMob/client-app/src/pages/_home/event-section.tsx
+++ b/TrashMob/client-app/src/pages/_home/event-section.tsx
@@ -138,12 +138,18 @@ export const EventSection = (props: EventSectionProps) => {
     /**
      * Side Effect
      */
-    // Side Effect 1: Reverse Search City from lat,lng
+    // Side Effect 1: Reverse Search City from lat,lng.
+    // Key on scalar lat/lng — not the defaultMapCenter object — so an
+    // async browser-geolocation resolve (which produces a new useMemo
+    // object with unchanged user coords) does not re-fire this effect
+    // and clobber a location the user just picked from the search box.
+    const centerLat = defaultMapCenter.lat;
+    const centerLng = defaultMapCenter.lng;
     useEffect(() => {
         ReverseGeocode()
             .service({
-                lat: defaultMapCenter.lat,
-                long: defaultMapCenter.lng,
+                lat: centerLat,
+                long: centerLng,
             })
             .then((response) => {
                 const result = response.data.addresses[0];
@@ -156,7 +162,7 @@ export const EventSection = (props: EventSectionProps) => {
                 };
                 setSelectedLocation(location);
             });
-    }, [defaultMapCenter]);
+    }, [centerLat, centerLng]);
 
     // Side Effect 2: When eventStatusFilter change, set timeRangeOption accordingly
     useEffect(() => {


### PR DESCRIPTION
## Summary

Two things:

### 1. Reverse-geocode useEffect overwrote user's manual city pick

Regression from #3508. The reverse-geocode effect on the home page was keyed on the whole `defaultMapCenter` object. When the browser geolocation resolved after mount — including cases where the user allowed the geolocation prompt late — `useGetDefaultMapCenter` returned a new object, causing `useMemo` to recompute a new `defaultMapCenter` object (same user coords, different identity). The effect then re-ran and `setSelectedLocation` back to the user's saved city, silently clobbering whatever the user had just picked in the Events-Near search.

Symptom Joe reported today: type a different city in "Events near", nothing happens.

Fix: extract scalar `centerLat`/`centerLng` and depend on those, so the effect only re-runs when coords actually change.

### 2. Backport of Front Door cache fix (already on `release`, #3510)

`release` got the `queryStringCachingBehavior: 'IgnoreQueryString' → 'UseQueryString'` fix as a hotfix directly to `release` on 2026-07-18 (also deployed to prod via `az deployment` — verified `?query=toronto` returns Toronto). Bringing that commit back to `main` so a future release cut doesn't undo it.

## Test plan

- [ ] After deploy: on the home page while signed in, type a city other than your saved location → search stays selected, map recenters, event list refetches for that city.
- [ ] Repeat with geolocation prompt still open, click Allow after picking a city → picked city stays (this is the specific race the fix addresses).
- [ ] `curl "https://www.trashmob.eco/api/v2/maps/search?query=toronto"` still returns Toronto (Front Door cache fix already deployed; this is just source alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)