### PR TITLE
Hotfix: location search dropdown never visible (hidden+flex stack)

### DIFF
--- a/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
+++ b/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
@@ -149,8 +149,12 @@ export function AzureSearchLocationInput(props: AzureSearchLocationInputProps) {
             )}
             <CommandList
                 className={cn(
-                    'hidden [&.cmdk-list-sizer]:w-full',
-                    { flex: showSuggestion && query.length > 1 },
+                    '[&.cmdk-list-sizer]:w-full',
+                    // Toggle between hidden and flex (don't stack both) — in
+                    // Tailwind 4's generated CSS `hidden` comes after `flex`
+                    // in the display-utility group, so stacking makes the
+                    // dropdown invisible even when `flex` is present.
+                    showSuggestion && query.length > 1 ? 'flex' : 'hidden',
                     listClassName,
                 )}
             >


### PR DESCRIPTION
## Summary

Screenshot from prod today confirmed: typing "Issaquah" into the home page "Events near" search shows no dropdown at all, and the page's "N events found in {city}" text stays on the user's saved city because no selection is ever made.

**Root cause:** [AzureSearchLocationInput.tsx CommandList](TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx#L150) stacked both `hidden` and conditionally-added `flex` on the same element:

```tsx
<CommandList
  className={cn(
    'hidden [&.cmdk-list-sizer]:w-full',
    { flex: showSuggestion && query.length > 1 },
    listClassName,
  )}
>
```

In Tailwind 4's generated CSS, `hidden` (`display: none`) is emitted after `flex` (`display: flex`) in the display-utility group, so `hidden` wins whenever both classes are on the element — the dropdown was **never** visible in this component.

**Why we thought it worked earlier:** cmdk auto-selects the first item when suggestions load, and hitting Enter fires the invisible aria-selected item's `onSelect`. So Joe's earlier "typed Issaquah, got Wellesley" was cmdk keyboard-selecting from an invisible list of partial "Iss…" matches (Wellesley Islands, QLD scored top for that prefix). The dropdown component has been broken for a while — we mistook the Enter-select behavior for it working.

Fix: toggle between `hidden` and `flex` instead of stacking both, so only one display class is present at a time.

## Test plan

- [ ] After deploy, on the home page type any city in "Events near". A dropdown of suggestions should appear.
- [ ] Click a suggestion → input clears, dropdown closes, "N events found in {city}" updates, map recenters, event list refetches.
- [ ] Type another city after selecting one → dropdown appears again (my earlier `setShowSuggestion(true)` fix on onChange still applies).
- [ ] Backport to main after this lands on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)