### PR TITLE
Backport dropdown-visibility fix from release (#3512)

### DIFF
--- a/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
+++ b/TrashMob/client-app/src/components/Map/AzureSearchLocationInput/AzureSearchLocationInput.tsx
@@ -149,8 +149,12 @@ export function AzureSearchLocationInput(props: AzureSearchLocationInputProps) {
             )}
             <CommandList
                 className={cn(
-                    'hidden [&.cmdk-list-sizer]:w-full',
-                    { flex: showSuggestion && query.length > 1 },
+                    '[&.cmdk-list-sizer]:w-full',
+                    // Toggle between hidden and flex (don't stack both) — in
+                    // Tailwind 4's generated CSS `hidden` comes after `flex`
+                    // in the display-utility group, so stacking makes the
+                    // dropdown invisible even when `flex` is present.
+                    showSuggestion && query.length > 1 ? 'flex' : 'hidden',
                     listClassName,
                 )}
             >


### PR DESCRIPTION
## Summary

Backports #3512 (already merged and deployed to prod on `release`) so a future release cut doesn't undo it.

`<CommandList>` in `AzureSearchLocationInput` was stacking `hidden` and `flex` — Tailwind 4's CSS emits `.hidden` after `.flex` in the display-utility group, so `hidden` won and the dropdown was never visible. Details in #3512.

## Test plan

- [ ] Type any city in the home page "Events near" input → dropdown of suggestions appears (identical behavior to what's now on prod).
- [ ] No new behavior on top of #3512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)