### PR TITLE
Hotfix: home page location dropdown clipped to 2px (invisible)

### DIFF
--- a/TrashMob/client-app/src/pages/_home/event-section.tsx
+++ b/TrashMob/client-app/src/pages/_home/event-section.tsx
@@ -190,8 +190,14 @@ export const EventSection = (props: EventSectionProps) => {
                             <AzureSearchLocationInput
                                 entityType={['Municipality']}
                                 placeholder={selectedLocation ? selectedLocation.address.municipality : 'Location ...'}
-                                className='rounded-none! border-none! shadow-none! bg-transparent!'
-                                listClassName='rounded-lg! border md:min-w-[200px] relative shadow-md bg-card mt-2!'
+                                // overflow-visible! overrides shadcn Command's default
+                                // overflow-hidden so the dropdown isn't clipped by the
+                                // 60px fixed-height wrapper above.
+                                className='rounded-none! border-none! shadow-none! bg-transparent! overflow-visible!'
+                                // absolute-position the dropdown so it overlays content
+                                // below the input instead of trying to expand inside the
+                                // 60px flex-column parent (which had 0 room for it).
+                                listClassName='absolute top-full left-0 z-20 rounded-lg! border md:min-w-[200px] shadow-md bg-card mt-2!'
                                 renderInput={(inputProps) => (
                                     <div className='w-fit flex flex-row items-center'>
                                         <input


### PR DESCRIPTION
## Summary

Followup to #3512 (which fixed the Tailwind `hidden`+`flex` stacking issue). A headless-browser probe against prod confirmed the dropdown IS now rendering with `display: flex` and content "No results found." — but its computed rect is only **2px tall**, so it's invisible on screen.

**Cause:** [event-section.tsx](TrashMob/client-app/src/pages/_home/event-section.tsx#L189) wraps `AzureSearchLocationInput` in a fixed-height 60px container:

```tsx
<div className='relative z-10 h-[60px]'>
  <AzureSearchLocationInput ... />
</div>
```

shadcn's `<Command>` primitive has `h-full flex flex-col overflow-hidden` on its root. Inside a 60px parent with `h-full`, the input takes all the room; the `CommandList` (its sibling in the flex column) has ~0 px left; and `overflow-hidden` clips anything that would have spilled below.

**Fix, scoped to this call site only:**

- Add `overflow-visible!` to the `AzureSearchLocationInput` `className` so shadcn's `overflow-hidden` on the `Command` root doesn't clip the dropdown.
- Add `absolute top-full left-0 z-20` to the `listClassName` so the dropdown overlays content below the input instead of fighting the fixed-height flex-column layout for space.

Other `AzureSearchLocationInput` call sites (locationpreference, partnerdashboard) use the shared component's defaults and are unaffected.

## Diagnostic evidence

Playwright probe against `https://www.trashmob.eco/` after typing "issaq":
```json
{
  "className": "... [&.cmdk-list-sizer]:w-full flex ... shadow-md bg-card mt-2!",
  "display": "flex",
  "visibility": "visible",
  "rect": { "width": 320, "height": 2 },
  "innerText": "No results found."
}
```

## Test plan

- [ ] Type any city in the home page "Events near" input → dropdown of suggestions appears BELOW the input, overlaying content underneath.
- [ ] Click a suggestion → input clears, dropdown closes, map recenters, event list refetches.
- [ ] After merge, backport to main (mirroring #3512 → #3513).

🤖 Generated with [Claude Code](https://claude.com/claude-code)