### PR TITLE
SPA Cache-Control headers + auto-deploy Front Door on release

### DIFF
--- a/.github/workflows/release_frontdoor-tm-pr.yml
+++ b/.github/workflows/release_frontdoor-tm-pr.yml
@@ -1,0 +1,91 @@
+# Workflow for deploying the production Azure Front Door profile from Deploy/frontDoor.bicep.
+#
+# Before this workflow existed, frontDoor.bicep was a manual `az deployment group create` per
+# OPERATIONS_RUNBOOK.md — easy to forget. On 2026-07-18 a queryStringCachingBehavior fix was
+# merged to `release` and appeared to deploy (the Container App workflow succeeded), but Front
+# Door was unchanged for ~40 minutes because nobody ran the manual bicep re-apply.
+
+name: TrashMobProd - Front Door
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - '.github/workflows/release_frontdoor-tm-pr.yml'
+      - 'Deploy/frontDoor.bicep'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod-frontdoor
+  cancel-in-progress: true
+
+env:
+  RESOURCE_GROUP: rg-trashmob-pr-westus2
+  CONTAINER_APP_NAME: ca-tm-pr-westus2
+  FRONT_DOOR_PROFILE: fd-tm-pr
+  FRONT_DOOR_ENDPOINT: fde-tm-pr
+  PRIMARY_DOMAIN: www.trashmob.eco
+  APEX_DOMAIN: trashmob.eco
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Login to Azure
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # Fetch the container-app FQDN at deploy time so we don't hardcode the environment's
+      # `greenground-fd8fc385` subdomain — that value would change if the Container Apps
+      # environment were ever recreated.
+      - name: Get Container App FQDN
+        id: get-fqdn
+        run: |
+          FQDN=$(az containerapp show \
+            --name ${{ env.CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --query properties.configuration.ingress.fqdn \
+            -o tsv)
+          echo "Container App FQDN: $FQDN"
+          echo "fqdn=$FQDN" >> $GITHUB_OUTPUT
+
+      - name: Deploy Front Door
+        run: |
+          az deployment group create \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --template-file Deploy/frontDoor.bicep \
+            --parameters \
+              environment=pr \
+              containerAppFqdn=${{ steps.get-fqdn.outputs.fqdn }} \
+              primaryDomain=${{ env.PRIMARY_DOMAIN }} \
+              apexDomain=${{ env.APEX_DOMAIN }}
+
+      # Purge cached HTML/asset responses so the new bicep behavior (and any updated
+      # cache-control from a same-deploy container image) takes effect immediately, not
+      # after Front Door's default TTL expires. Backend Cache-Control: no-store on
+      # index.html (Program.cs, added alongside this workflow) makes future purges
+      # optional for the SPA shell, but purging is still the right call because bicep
+      # changes to cacheConfiguration don't invalidate cached entries.
+      - name: Purge Front Door cache
+        run: |
+          az afd endpoint purge \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --profile-name ${{ env.FRONT_DOOR_PROFILE }} \
+            --endpoint-name ${{ env.FRONT_DOOR_ENDPOINT }} \
+            --content-paths "/" "/index.html" "/assets/*"
+
+      - name: Logout from Azure
+        if: always()
+        run: az logout

--- a/Deploy/OPERATIONS_RUNBOOK.md
+++ b/Deploy/OPERATIONS_RUNBOOK.md
@@ -123,19 +123,33 @@ curl -sSI https://trashmob.eco   # expect: HTTP/2 308, location: https://www.tra
 curl -sSI https://www.trashmob.eco   # expect: HTTP/2 200
 ```
 
-### Re-deploy Front Door (rare — only if config drift)
+### Re-deploy Front Door
 
-The deployed state is described by [`Deploy/frontDoor.bicep`](frontDoor.bicep). Re-applying the template is idempotent:
+The deployed state is described by [`Deploy/frontDoor.bicep`](frontDoor.bicep). Any commit to `release` that touches that file (or the workflow itself) triggers [`release_frontdoor-tm-pr.yml`](../.github/workflows/release_frontdoor-tm-pr.yml), which redeploys the bicep and purges the Front Door cache. Prefer that path — merge to `release`.
+
+If you need to reapply outside CI (config drift, testing a parameter tweak, GitHub Actions outage), the workflow can be triggered manually from the Actions tab (`workflow_dispatch`), or you can run the underlying command locally — the template is idempotent:
 
 ```bash
+CONTAINER_APP_FQDN=$(az containerapp show \
+  --name ca-tm-pr-westus2 \
+  --resource-group rg-trashmob-pr-westus2 \
+  --query properties.configuration.ingress.fqdn -o tsv)
+
 az deployment group create \
   --resource-group rg-trashmob-pr-westus2 \
   --template-file Deploy/frontDoor.bicep \
   --parameters \
     environment=pr \
-    containerAppFqdn=ca-tm-pr-westus2.greenground-fd8fc385.westus2.azurecontainerapps.io \
+    containerAppFqdn=$CONTAINER_APP_FQDN \
     primaryDomain=www.trashmob.eco \
     apexDomain=trashmob.eco
+
+# Purge cache so any cacheConfiguration change takes effect immediately.
+az afd endpoint purge \
+  --resource-group rg-trashmob-pr-westus2 \
+  --profile-name fd-tm-pr \
+  --endpoint-name fde-tm-pr \
+  --content-paths "/" "/index.html" "/assets/*"
 ```
 
 ## Azure DNS Zone

--- a/TrashMob/Program.cs
+++ b/TrashMob/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.EntityFrameworkCore;
@@ -427,8 +428,35 @@ public class Program
 
         app.UseHttpsRedirection();
         app.UseResponseCompression();
-        app.UseStaticFiles();
-        app.UseSpaStaticFiles();
+
+        // Cache policy for SPA assets:
+        //   /assets/*  → Vite emits hashed filenames (e.g. index-mf4CIRi9.js), so the URL itself
+        //                changes every deploy. Safe to cache aggressively (1 year, immutable).
+        //   everything else (index.html, /) → the URL is stable but the content — specifically the
+        //                <script src="/assets/index-<hash>.js"> — changes every deploy. If any
+        //                intermediate cache (Front Door, browser, corporate proxy) serves a stale
+        //                index.html, users load fresh code from a bundle URL the shell doesn't
+        //                reference, or worse the reverse. We hit this on 2026-07-18 when Front Door
+        //                cached index.html and users were pinned to the old bundle for ~40 minutes
+        //                after a fix deployed. no-store prevents both edge and browser caching.
+        static void SetSpaCacheHeaders(StaticFileResponseContext ctx)
+        {
+            var path = ctx.Context.Request.Path.Value ?? string.Empty;
+            // Set the raw header string directly — the typed CacheControlHeaderValue doesn't
+            // expose the "immutable" directive and mixing typed + raw would produce two headers.
+            ctx.Context.Response.Headers["Cache-Control"] = path.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase)
+                ? "public, max-age=31536000, immutable"
+                : "no-store, no-cache, must-revalidate";
+        }
+
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            OnPrepareResponse = SetSpaCacheHeaders,
+        });
+        app.UseSpaStaticFiles(new StaticFileOptions
+        {
+            OnPrepareResponse = SetSpaCacheHeaders,
+        });
 
         app.UseRouting();
 


### PR DESCRIPTION
## Summary

Two follow-ups from the 2026-07-18 dropdown-fix chain — root fixes for the two gaps I flagged, so the same class of incident doesn't recur.

### 1. `Cache-Control` on SPA static files ([TrashMob/Program.cs](TrashMob/Program.cs))

On 2026-07-18 a fix landed on `release`, the Container App deploy succeeded, the new bundle was live at the origin — but Front Door kept serving the old `index.html` for ~40 minutes because the origin never sent `Cache-Control`. Front Door fell back to its own default TTL.

Now `UseStaticFiles` + `UseSpaStaticFiles` share an `OnPrepareResponse` that sets:

- `/assets/*` → `public, max-age=31536000, immutable`
- everything else (`index.html`, `/`) → `no-store, no-cache, must-revalidate`

Vite already hashes files under `/assets/`, so those URLs change every build — safe to cache aggressively. The SPA shell URL is stable but its `<script src>` reference changes every deploy, so serving a stale shell pins users to a bundle that may no longer exist. `no-store` on the shell prevents both edge and browser caching of it.

### 2. Auto-deploy workflow for Front Door ([release_frontdoor-tm-pr.yml](.github/workflows/release_frontdoor-tm-pr.yml))

`frontDoor.bicep` was a manual `az deployment group create` per the runbook — easy to forget. Same 2026-07-18 incident: the querystring cache fix merged to release, but nobody ran the manual apply, and prod behavior didn't change until I ran it by hand hours later.

New workflow triggers on push to `release` when either the workflow itself or `Deploy/frontDoor.bicep` changes (also `workflow_dispatch`). It:

1. Fetches the Container App FQDN at deploy time — no hardcoded `.greenground-fd8fc385` subdomain that would break if the environment were ever recreated.
2. Deploys `Deploy/frontDoor.bicep` with the `pr` parameters.
3. Purges the endpoint cache so any `cacheConfiguration` change takes effect immediately (bicep changes don't auto-invalidate cached entries).

Runbook updated to point at the workflow first; the manual command stays as a fallback but no longer hardcodes the FQDN.

## Test plan

- [ ] After deploy, `curl -I https://www.trashmob.eco/` → `Cache-Control: no-store, no-cache, must-revalidate`.
- [ ] `curl -I https://www.trashmob.eco/assets/index-<hash>.js` → `Cache-Control: public, max-age=31536000, immutable`.
- [ ] Merge a trivial change to `Deploy/frontDoor.bicep` on `release` → `TrashMobProd - Front Door` workflow runs, redeploys, purges cache. (Don't test on `main`; the workflow doesn't trigger there.)
- [ ] `.github/workflows/release_frontdoor-tm-pr.yml` shows up in the Actions tab as `workflow_dispatch`-runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)