### PR TITLE
Container image tag = {semVer}-{shortSha} so ACA rolls a fresh revision every commit

### DIFF
--- a/.github/actions/container-build-push/action.yml
+++ b/.github/actions/container-build-push/action.yml
@@ -30,12 +30,19 @@ inputs:
     default: ''
 
 outputs:
+  # The unique per-commit tag consumers should deploy. GitVersion emits the same semVer
+  # (`2.11.1169`) for many consecutive commits on release under the current Mainline
+  # config (probably tag-derived + slow-to-increment). Deploying the same tag causes
+  # Azure Container Apps to see "no image change" and skip creating a new revision even
+  # when the pushed bytes at that tag differ — which stranded three Program.cs deploys
+  # on 2026-07-18 until the revision was manually rolled. Suffixing with the short SHA
+  # guarantees each commit produces a unique tag, so ACA rolls reliably.
   semver:
-    description: 'Semantic version from GitVersion'
-    value: ${{ steps.version_step.outputs.semVer }}
+    description: 'Unique per-commit tag (`{semVer}-{shortSha}`) — deploy this.'
+    value: ${{ steps.version_step.outputs.semVer }}-${{ steps.version_step.outputs.shortSha }}
   image-tag:
-    description: 'Full image tag (registry/image:version)'
-    value: ${{ inputs.registry-name }}.azurecr.io/${{ inputs.image-name }}:${{ steps.version_step.outputs.semVer }}
+    description: 'Full unique image tag (registry/image:{semVer}-{shortSha})'
+    value: ${{ inputs.registry-name }}.azurecr.io/${{ inputs.image-name }}:${{ steps.version_step.outputs.semVer }}-${{ steps.version_step.outputs.shortSha }}
 
 runs:
   using: 'composite'
@@ -68,9 +75,17 @@ runs:
     - name: Build and push Docker image
       shell: bash
       run: |
-        IMAGE_TAG="${{ inputs.registry-name }}.azurecr.io/${{ inputs.image-name }}:${{ steps.version_step.outputs.semVer }}"
+        # Unique per-commit tag — this is what the caller deploys.
+        IMAGE_TAG_UNIQUE="${{ inputs.registry-name }}.azurecr.io/${{ inputs.image-name }}:${{ steps.version_step.outputs.semVer }}-${{ steps.version_step.outputs.shortSha }}"
+        # Rolling semver tag — kept for humans doing manual pulls / rollbacks by version.
+        IMAGE_TAG_SEMVER="${{ inputs.registry-name }}.azurecr.io/${{ inputs.image-name }}:${{ steps.version_step.outputs.semVer }}"
         IMAGE_TAG_LATEST="${{ inputs.registry-name }}.azurecr.io/${{ inputs.image-name }}:latest"
 
-        docker build -f ${{ inputs.dockerfile }} ${{ inputs.build-args }} -t $IMAGE_TAG -t $IMAGE_TAG_LATEST ${{ inputs.context }}
-        docker push $IMAGE_TAG
+        docker build -f ${{ inputs.dockerfile }} ${{ inputs.build-args }} \
+          -t $IMAGE_TAG_UNIQUE \
+          -t $IMAGE_TAG_SEMVER \
+          -t $IMAGE_TAG_LATEST \
+          ${{ inputs.context }}
+        docker push $IMAGE_TAG_UNIQUE
+        docker push $IMAGE_TAG_SEMVER
         docker push $IMAGE_TAG_LATEST


### PR DESCRIPTION
## Summary

**Root cause of the 2026-07-18 stranded-deploys pattern.** GitVersion is emitting the same `semVer` (`2.11.1169`) for many consecutive commits on `release` under the current `Mainline` config. Every Docker build was pushed to the same `:2.11.1169` tag. When the workflow's `az deployment group create` step then set `containerImage=…:2.11.1169` in the bicep parameter, ACA saw the image reference match the running revision's image reference and **skipped creating a new revision** — three separate Program.cs changes sat in ACR at the same tag but the running revision kept serving the *original* pull.

**The fix:** append the short SHA to the tag inside [`container-build-push`](.github/actions/container-build-push/action.yml). Every commit now produces a unique image reference; ACA reliably creates a new revision on every deploy.

Push three tags per build:
- `:{semVer}-{shortSha}` — unique per commit, used by deploys.
- `:{semVer}` — rolling, for humans doing manual rollback pulls by version.
- `:latest` — unchanged.

## Scope of the change

Change is inside the composite action. All 10 container/container-app workflows consume `steps.build.outputs.semver` and inherit the new tag automatically:

```
.github/workflows/container_ca-authext-tm-dev-westus2.yml
.github/workflows/container_ca-tm-dev-westus2.yml
.github/workflows/container_caj-tm-dev-westus2-daily.yml
.github/workflows/container_caj-tm-dev-westus2-hourly.yml
.github/workflows/container_mcp-tm-dev-westus2.yml
.github/workflows/container_strapi-tm-dev-westus2.yml
.github/workflows/release_ca-authext-tm-pr-westus2.yml
.github/workflows/release_ca-tm-pr-westus2.yml
.github/workflows/release_caj-tm-pr-westus2-daily.yml
.github/workflows/release_caj-tm-pr-westus2-hourly.yml
```

## Mobile app workflows are unaffected

`main_trashmobmobileapp.yml` and `PullRequest-Mobile.yml` run their **own** `gittools/actions/gitversion/execute` step (with id `version_step`) and read `steps.version_step.outputs.semVer` directly — never calling `container-build-push`. Their App Store / Play Store `buildNumber` continues to be the plain `2.11.1169` shape those stores require.

Verified with:
```
grep -rn "container-build-push\|steps.version_step.outputs.semVer\b" .github/
```

## Test plan

- [ ] Merge to main → `TrashMobDev - Container App` workflow runs → new image tag looks like `2.11.1169-abc1234`.
- [ ] Check `az containerapp revision list --name ca-tm-dev-westus2 -g rg-trashmob-dev-westus2` after deploy → a **new revision** exists, not just a restart of the existing one.
- [ ] After main→release sync, same behavior on prod → new revision every deploy → running container actually picks up code changes.
- [ ] Mobile CI (`PullRequest-Mobile.yml`) still shows `buildNumber=2.11.1169` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)