### PR TITLE
E6 phase 1: additive frontDoor.bicep scaffold for custom auth domain

### DIFF
--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -13,9 +13,19 @@ param primaryDomain string
 @description('Apex domain for redirect (e.g., trashmob.eco)')
 param apexDomain string = ''
 
+@description('Custom auth domain for Entra External ID (e.g., auth.trashmob.eco). Empty disables E6 auth-domain plumbing. Requires ciamTenantHost to also be set. See Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6.')
+param ciamAuthDomain string = ''
+
+@description('Entra External ID tenant hostname (e.g., trashmobecopr.ciamlogin.com). Empty disables E6 auth-domain plumbing. Requires ciamAuthDomain to also be set.')
+param ciamTenantHost string = ''
+
 @description('Front Door SKU')
 @allowed(['Standard_AzureFrontDoor', 'Premium_AzureFrontDoor'])
 param skuName string = 'Standard_AzureFrontDoor'
+
+// E6 gate: both auth params must be set together. Prevents half-configured deployments
+// (e.g. CIAM origin without a custom domain to route to, or vice versa).
+var enableAuthDomain = ciamAuthDomain != '' && ciamTenantHost != ''
 
 // Naming convention
 var frontDoorProfileName = 'fd-tm-${environment}'
@@ -278,6 +288,115 @@ resource customDomainApex 'Microsoft.Cdn/profiles/customDomains@2024-02-01' = if
   }
 }
 
+// ---------------------------------------------------------------------------
+// E6 — Custom auth domain plumbing for Entra External ID.
+// See Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6.
+//
+// When enabled, adds a second origin group targeting the Entra External ID
+// tenant (e.g. trashmobecopr.ciamlogin.com) and a second route on the same
+// AFD endpoint bound to a branded custom domain (e.g. auth.trashmob.eco).
+// User-facing sign-in URLs then use the branded domain instead of the raw
+// ciamlogin.com hostname.
+//
+// This entire section is gated on `enableAuthDomain` — when the two auth
+// params are empty (the default), no resources are created and this file
+// behaves exactly as before.
+//
+// Known caveat (as of 2026-07): during the OAuth round-trip to Google or
+// Facebook, users may briefly see ciamlogin.com. Microsoft has documented
+// this as expected behavior. See the E6 checklist section for details.
+// ---------------------------------------------------------------------------
+
+// CIAM origin group. Health probe hits the origin host at `/` with HEAD —
+// ciamlogin.com returns a 2xx/3xx/4xx from the bare host, which AFD treats
+// as healthy. A more specific probe (e.g. /{tenantId}/v2.0/.well-known/
+// openid-configuration) would need the tenant ID here, which we don't want
+// to hardcode; the bare-host probe is sufficient for liveness.
+resource ciamOriginGroup 'Microsoft.Cdn/profiles/originGroups@2024-02-01' = if (enableAuthDomain) {
+  parent: frontDoorProfile
+  name: 'og-ciam'
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+    healthProbeSettings: {
+      probePath: '/'
+      probeRequestType: 'HEAD'
+      probeProtocol: 'Https'
+      probeIntervalInSeconds: 100
+    }
+    sessionAffinityState: 'Disabled'
+  }
+}
+
+// CIAM origin. `originHostHeader` MUST match `hostName` — CIAM tenant TLS
+// certs are issued for the ciamlogin.com hostname, so SNI has to send it.
+// `enforceCertificateNameCheck: true` keeps AFD → CIAM traffic verified.
+resource ciamOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2024-02-01' = if (enableAuthDomain) {
+  parent: ciamOriginGroup
+  name: 'origin-ciam'
+  properties: {
+    hostName: ciamTenantHost
+    httpPort: 80
+    httpsPort: 443
+    originHostHeader: ciamTenantHost
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+    enforceCertificateNameCheck: true
+  }
+}
+
+// Custom domain for the branded auth hostname.
+resource customDomainAuth 'Microsoft.Cdn/profiles/customDomains@2024-02-01' = if (enableAuthDomain) {
+  parent: frontDoorProfile
+  name: replace(ciamAuthDomain, '.', '-')
+  properties: {
+    hostName: ciamAuthDomain
+    tlsSettings: {
+      certificateType: 'ManagedCertificate'
+      minimumTlsVersion: 'TLS12'
+    }
+  }
+}
+
+// Route that binds the branded auth domain to the CIAM origin group.
+//
+// `customDomains` MUST be listed explicitly (same lesson as the www/apex
+// route above — see the 2026-07-05 apex-outage note). `linkToDefaultDomain`
+// is Disabled so the auth flow is NOT reachable via the AFD default hostname
+// (fde-tm-*.azurefd.net) — only via the branded domain.
+//
+// No cacheConfiguration: CIAM responses contain tokens/cookies and MUST NOT
+// be cached at the CDN edge. Omitting the property disables caching.
+//
+// No ruleSet: unlike the www/apex route, we don't need to rewrite apex → www
+// or add HTTP→HTTPS logic beyond the route-level `httpsRedirect: Enabled`.
+resource ciamRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2024-02-01' = if (enableAuthDomain) {
+  parent: endpoint
+  name: 'route-ciam'
+  properties: {
+    customDomains: [
+      { id: customDomainAuth.id }
+    ]
+    originGroup: {
+      id: ciamOriginGroup.id
+    }
+    originPath: '/'
+    supportedProtocols: ['Http', 'Https']
+    patternsToMatch: ['/*']
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: 'Disabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+  }
+  dependsOn: [
+    ciamOrigin
+  ]
+}
+
 // Outputs
 output frontDoorId string = frontDoorProfile.id
 output frontDoorEndpointHostName string = endpoint.properties.hostName
@@ -293,4 +412,6 @@ DNS Configuration Required:
 2. For ${apexDomain}: Create ALIAS/ANAME record -> ${endpoint.properties.hostName}
    (Microsoft 365 DNS may not support ALIAS records - consider Azure DNS or Cloudflare)
 3. For domain validation, create TXT record: _dnsauth.${primaryDomain} with the validation token from Azure Portal
+4. (E6) If ciamAuthDomain is set: create CNAME ${ciamAuthDomain} -> ${endpoint.properties.hostName}
+        and TXT record _dnsauth.${ciamAuthDomain} with the validation token from Azure Portal
 '''


### PR DESCRIPTION
## Summary

First implementation step for E6 (custom auth domain — `auth.trashmob.eco` in front of `trashmobecopr.ciamlogin.com`), per [`Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md` §E6](Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md#L1701-L1738) and the status flip in **#3526**.

**This PR is scaffolding only** — no production behavior change on merge. New parameters default to empty; when empty, no new resources are created and today's Front Door deployment behavior is identical.

## What changed

Only [`Deploy/frontDoor.bicep`](Deploy/frontDoor.bicep). Two new optional params, one gate variable, four new conditional resources, one extended output.

**New params (both default `''`):**
```bicep
param ciamAuthDomain string = ''  // e.g. 'auth.trashmob.eco'
param ciamTenantHost string = ''  // e.g. 'trashmobecopr.ciamlogin.com'

var enableAuthDomain = ciamAuthDomain != '' && ciamTenantHost != ''
```

**New resources, all gated on `enableAuthDomain`:**
| Resource | Purpose |
|---|---|
| `og-ciam` (originGroup) | CIAM tenant target, `HEAD /` health probe |
| `origin-ciam` (origin) | `hostName` + `originHostHeader` = `ciamTenantHost`, `enforceCertificateNameCheck: true` |
| `<auth-domain>` (customDomain) | Managed Certificate, TLS 1.2 min |
| `route-ciam` (route) | Bound to `og-ciam` + auth custom domain; `patternsToMatch /*`, `HttpsOnly`, `httpsRedirect Enabled`, **no cache** (auth responses carry tokens), `linkToDefaultDomain Disabled` (auth flow not reachable via `*.azurefd.net`), `customDomains` listed explicitly (2026-07-05 apex-outage lesson) |

**Extended output:** `dnsInstructions` now includes CNAME + validation TXT guidance for the auth domain when set.

## Why it's safe to merge now

- Workflow `.github/workflows/release_frontdoor-tm-pr.yml` is **unchanged** and doesn't pass either new param → `enableAuthDomain` evaluates false → the `if (enableAuthDomain)` guards on every new resource → nothing new is created in production
- The gate requires **both** params to be non-empty, so a partial future config (e.g. someone sets one but forgets the other) will not create half-configured infrastructure
- Validated with `az bicep build` — clean compile, no errors

## What's NOT in this PR (subsequent phases)

- **Workflow:** update `release_frontdoor-tm-pr.yml` env with `CIAM_AUTH_DOMAIN` / `CIAM_TENANT_HOST` and pass them through — do this only when DNS + Entra portal are ready
- **App-level config:** `Deploy/containerApp.bicep` `entraInstance`, `TrashMob/appsettings.Development.json`, `TrashMobMobile/Authentication/AuthConstants.cs`, `TrashMob/client-app/src/store/AuthStore.tsx`, `TrashMob/client-app/e2e/fixtures/auth.fixture.ts`
- **Dev Front Door workflow:** dev has no Front Door workflow today; if we want a dev-first cutover per checklist item 206, we'll need one
- **DNS record:** CNAME `auth.trashmob.eco` → `fde-tm-pr.<random>.azurefd.net` (+ `_dnsauth` TXT)
- **Portal work:** Entra External ID custom URL domain association, app registration redirect URIs, Google/Apple/Microsoft social IDP redirect URIs
- **Support ticket** to block default `ciamlogin.com` endpoint (30 days post-stability, per checklist item 209)

## Test plan

- [ ] `az bicep build --file Deploy/frontDoor.bicep` compiles cleanly
- [ ] `az deployment group what-if` against a non-prod resource group shows **zero changes** when neither auth param is set (proves additive-only)
- [ ] Same `what-if` with both params set previews exactly the four new resources
- [ ] Existing prod deployment via `release_frontdoor-tm-pr.yml` (or `workflow_dispatch`) still runs green (no schema break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)