### PR TITLE
E6 phase 2: optional entraAuthDomain param on containerApp.bicep

### DIFF
--- a/Deploy/containerApp.bicep
+++ b/Deploy/containerApp.bicep
@@ -27,6 +27,9 @@ param managedCertificateName string = ''
 param apexDomainName string = ''
 param apexManagedCertificateName string = ''
 
+@description('E6: Optional custom auth domain (e.g. auth.trashmob.eco). When set, overrides the default per-environment *.ciamlogin.com authority for AzureAdEntra__Instance. This flows to both the backend (JWT authority) and the SPA (via ConfigV2Controller). Must be paired with matching ciamAuthDomain/ciamTenantHost in frontDoor.bicep and DNS/portal work — see Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6.')
+param entraAuthDomain string = ''
+
 // Build the managed certificate resource IDs if provided
 var managedCertificateId = managedCertificateName != '' ? '${containerAppsEnvironmentId}/managedCertificates/${managedCertificateName}' : ''
 var apexManagedCertificateId = apexManagedCertificateName != '' ? '${containerAppsEnvironmentId}/managedCertificates/${apexManagedCertificateName}' : ''
@@ -36,7 +39,11 @@ var appInsightsName = 'ai-tm-${environment}-${region}'
 
 // Azure AD Entra External ID configuration - these are public values, not secrets
 // Note: Microsoft accounts work natively in Entra External ID (no external IDP setup needed)
-var entraInstance = environment == 'dev' ? 'https://trashmobecodev.ciamlogin.com/' : 'https://trashmobecopr.ciamlogin.com/'
+// When entraAuthDomain is set (E6 cutover), it replaces the ciamlogin.com host for user-facing
+// sign-in URLs. The tenant ID + client IDs + scopes stay the same — only the host changes.
+var entraInstance = entraAuthDomain != ''
+  ? 'https://${entraAuthDomain}/'
+  : (environment == 'dev' ? 'https://trashmobecodev.ciamlogin.com/' : 'https://trashmobecopr.ciamlogin.com/')
 var entraDomain = environment == 'dev' ? 'TrashMobEcoDev.onmicrosoft.com' : 'trashmobecopr.onmicrosoft.com'
 var entraBackendClientId = environment == 'dev' ? '84df543d-6535-45f5-afab-4d38528b721a' : 'dc09e17b-bce4-4af9-82ab-f7b12af586b4'
 var entraTenantId = environment == 'dev' ? '8577fa31-4b86-4e4b-8b02-93fba708cb19' : 'b5fc8717-29eb-496e-8e09-cf90d344ce9f'


### PR DESCRIPTION
## Summary

Second implementation step for E6 (custom auth domain — `auth.trashmob.eco` in front of `trashmobecopr.ciamlogin.com`), per [`Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md` §E6](Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md#L1701-L1738) and building on [phase 1 PR #3527 (frontDoor.bicep scaffold)](https://github.com/TrashMob-eco/TrashMob/pull/3527).

**This PR is scaffolding only** — no production behavior change on merge. The workflow doesn't pass the new param, so it defaults to empty and the existing ternary produces the same `entraInstance` value it does today.

## What changed

Only [`Deploy/containerApp.bicep`](Deploy/containerApp.bicep). One new optional param, one modified var expression (+8 / -1).

```bicep
@description('E6: Optional custom auth domain (e.g. auth.trashmob.eco). When set,
overrides the default per-environment *.ciamlogin.com authority for
AzureAdEntra__Instance...')
param entraAuthDomain string = ''

var entraInstance = entraAuthDomain != ''
  ? 'https://${entraAuthDomain}/'
  : (environment == 'dev' ? 'https://trashmobecodev.ciamlogin.com/' : 'https://trashmobecopr.ciamlogin.com/')
```

## Why this single param covers both backend and SPA

The chain today:

```
entraAuthDomain (this PR)
  → AzureAdEntra__Instance (env var on Container App)
    → backend reads AzureAdEntra:Instance for JWT authority validation
    → ConfigV2Controller.GetConfig() derives `authority` + `authorityDomain` from it
      → GET /api/v2/config returns those to the SPA
        → AuthStore.tsx initializes MSAL with the values from the API
```

At the cutover moment, flipping this single bicep param (via workflow env) changes both:
- **Backend token validation** (JWT authority)
- **SPA sign-in URLs** (MSAL authority + knownAuthorities)

...in one deploy, atomically, no code change required in either surface.

## Why mobile isn't touched here

`TrashMobMobile/Authentication/AuthConstants.cs` hardcodes the authority at compile time via `#if USETEST`. There's no runtime config for MSAL to read from, so a "prep refactor" wouldn't buy any flexibility — the eventual change is a one-line edit at cutover time. Deferring to a later phase.

## What's still needed before cutover (subsequent phases)

1. **Dev Front Door bootstrap** (needed to test on dev first per checklist item #206) — dev has no AFD workflow today
2. **DNS + Entra portal + Google/Apple/Microsoft console work** — manual, your part
3. **Workflow enable** — update `release_frontdoor-tm-pr.yml` to pass `ciamAuthDomain` + `ciamTenantHost`; update `release_ca-tm-pr-westus2.yml` to pass `entraAuthDomain`. Both flip at the same deploy for a clean cutover
4. **Mobile authority swap** — one-line edit in `AuthConstants.cs`, ship via app store update
5. **Post-stability support ticket** — after 30 days, block the default `ciamlogin.com` endpoint (per checklist #209)

## Test plan

- [ ] `az bicep build --file Deploy/containerApp.bicep` compiles cleanly
- [ ] `az deployment group what-if` on prod shows **zero changes** (proves additive-only)
- [ ] Same `what-if` with `entraAuthDomain=auth.trashmob.eco` supplied previews exactly one change: the `AzureAdEntra__Instance` env var on the Container App
- [ ] Existing prod container-app deploy via `release_ca-tm-pr-westus2.yml` still runs green (no schema break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)