### PR TITLE
Bump System.Security.Cryptography.Xml 10.0.9 -> 10.0.10 (CVE-2026-50527)

### DIFF
--- a/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
+++ b/TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
@@ -20,8 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <!-- Override transitive vulnerability from Microsoft.Identity.Web (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf) -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <!-- Override transitive vulnerability from Microsoft.Identity.Web (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf, CVE-2026-50527) -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <!-- Override transitive vulnerability in Microsoft.AspNetCore.DataProtection 10.0.0 (GHSA-9mv3-2cwr-p262) -->
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
     <!-- Override transitive vulnerability in Microsoft.OpenApi 2.4.1 (GHSA-v5pm-xwqc-g5wc) -->


### PR DESCRIPTION
## Summary

Unblocks the failing PR #3528 CI check. Patches CVE-2026-50527 (CVSS 7.5, DoS in \`EncryptedXml\` validation) by bumping the pinned override of \`System.Security.Cryptography.Xml\` from 10.0.9 to 10.0.10.

The build failure on #3528 was:

\`\`\`
error NU1903: Warning As Error: Package 'System.Security.Cryptography.Xml' 10.0.9 has a known high severity vulnerability
\`\`\`

## What changed

Single-line change in [\`TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj\`](TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj):

\`\`\`diff
-    <!-- Override transitive vulnerability from Microsoft.Identity.Web (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf) -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <!-- Override transitive vulnerability from Microsoft.Identity.Web (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf, CVE-2026-50527) -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
\`\`\`

Same override pattern the file already uses — just bumping the pin. Comment updated to include the new CVE.

## Advisory

- **CVE-2026-50527** — .NET Denial of Service Vulnerability
- **CVSS:** 7.5 High
- **Affected:** \`System.Security.Cryptography.Xml\` 10.0.0 through 10.0.9
- **Fixed:** 10.0.10 (released 2026-07-14)
- **Root cause:** crafted encrypted XML that is improperly validated causes DoS
- Ref: [dotnet/announcements#416](https://github.com/dotnet/announcements/issues/416)

## Verification

\`\`\`
$ dotnet restore TrashMob.Shared.Tests/TrashMob.Shared.Tests.csproj
  Restored ... (no NU1903 warnings)
\`\`\`

## Test plan

- [ ] CI green on this PR
- [ ] Rebase / re-run CI on #3528 (E6 phase 2) picks up the fix and passes
- [ ] No transitive version conflicts elsewhere in the solution (\`dotnet build\` at solution root)

## Follow-up (not this PR)

The csproj also pins \`Microsoft.EntityFrameworkCore.InMemory\` and \`Microsoft.AspNetCore.DataProtection\` at 10.0.9. Worth a spot-check that neither has a similar patch-required advisory — but that's a separate audit, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)