### PR TITLE
E6 phase 3: dev Front Door workflow for auth-only routing

### DIFF
--- a/.github/workflows/container_frontdoor-tm-dev-westus2.yml
+++ b/.github/workflows/container_frontdoor-tm-dev-westus2.yml
@@ -1,0 +1,114 @@
+# Workflow for deploying the dev Azure Front Door profile from Deploy/frontDoor.bicep.
+#
+# Purpose: E6 (custom auth domain) dev-first testing per
+# Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6 item 206. Deploys an AFD profile
+# with only the CIAM auth flow wired up — no www/apex customer-facing routing on
+# dev. Existing dev.trashmob.eco traffic keeps going direct to the Container App
+# (bound at the ACA env level, not via AFD).
+#
+# The Container App origin group + route still deploy (bicep requires them), but
+# with no custom domains attached they're only reachable at the default AFD
+# hostname fde-tm-dev.<random>.azurefd.net — harmless, nobody hits that URL.
+
+name: TrashMobDev - Front Door
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/container_frontdoor-tm-dev-westus2.yml'
+      - 'Deploy/frontDoor.bicep'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-dev-frontdoor
+  cancel-in-progress: true
+
+env:
+  RESOURCE_GROUP: rg-trashmob-dev-westus2
+  CONTAINER_APP_NAME: ca-tm-dev-westus2
+  FRONT_DOOR_PROFILE: fd-tm-dev
+  FRONT_DOOR_ENDPOINT: fde-tm-dev
+  # E6 — auth-only routing. When Joe adds the DNS CNAME + Entra portal
+  # association, sign-ins on the dev tenant will resolve through this domain.
+  CIAM_AUTH_DOMAIN: auth-dev.trashmob.eco
+  CIAM_TENANT_HOST: trashmobecodev.ciamlogin.com
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: test
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Login to Azure
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # Container App FQDN is required by the bicep even when we're not using
+      # AFD for customer traffic on dev. The route it creates is harmless
+      # (reachable only at the default AFD hostname, nobody hits that URL).
+      - name: Get Container App FQDN
+        id: get-fqdn
+        run: |
+          FQDN=$(az containerapp show \
+            --name ${{ env.CONTAINER_APP_NAME }} \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --query properties.configuration.ingress.fqdn \
+            -o tsv)
+          echo "Container App FQDN: $FQDN"
+          echo "fqdn=$FQDN" >> $GITHUB_OUTPUT
+
+      - name: Deploy Front Door
+        run: |
+          az deployment group create \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --template-file Deploy/frontDoor.bicep \
+            --parameters \
+              environment=dev \
+              containerAppFqdn=${{ steps.get-fqdn.outputs.fqdn }} \
+              primaryDomain='' \
+              apexDomain='' \
+              ciamAuthDomain=${{ env.CIAM_AUTH_DOMAIN }} \
+              ciamTenantHost=${{ env.CIAM_TENANT_HOST }}
+
+      # After the deploy, the auth custom domain will be in "Pending validation"
+      # state until the DNS validation TXT record is added. Print the values
+      # Joe needs to publish so he doesn't have to hunt them down in the portal.
+      - name: Print DNS setup instructions
+        run: |
+          echo "==== E6 DNS setup for ${{ env.CIAM_AUTH_DOMAIN }} ===="
+          echo ""
+          echo "1) CNAME record:"
+          echo "   ${{ env.CIAM_AUTH_DOMAIN }}  ->  ${{ env.FRONT_DOOR_ENDPOINT }}.<random>.azurefd.net"
+          echo ""
+          echo "   Look up the exact <random> segment with:"
+          echo "   az afd endpoint show --resource-group ${{ env.RESOURCE_GROUP }} \\"
+          echo "     --profile-name ${{ env.FRONT_DOOR_PROFILE }} \\"
+          echo "     --endpoint-name ${{ env.FRONT_DOOR_ENDPOINT }} --query hostName -o tsv"
+          echo ""
+          echo "2) TXT record for domain validation:"
+          echo "   _dnsauth.${{ env.CIAM_AUTH_DOMAIN }}  ->  <validation token>"
+          echo ""
+          echo "   Get the validation token with:"
+          echo "   az afd custom-domain show --resource-group ${{ env.RESOURCE_GROUP }} \\"
+          echo "     --profile-name ${{ env.FRONT_DOOR_PROFILE }} \\"
+          echo "     --custom-domain-name $(echo '${{ env.CIAM_AUTH_DOMAIN }}' | tr '.' '-') \\"
+          echo "     --query validationProperties.validationToken -o tsv"
+          echo ""
+          echo "3) After DNS validation propagates (a few minutes), associate the"
+          echo "   custom URL domain in Entra portal on the TrashMobEcoDev tenant:"
+          echo "   Entra admin center > External Identities > Custom URL domains"
+
+      - name: Logout from Azure
+        if: always()
+        run: az logout

--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -7,10 +7,10 @@ param environment string
 @description('The FQDN of the Container App backend')
 param containerAppFqdn string
 
-@description('Primary custom domain (e.g., www.trashmob.eco)')
-param primaryDomain string
+@description('Primary custom domain (e.g., www.trashmob.eco). Empty is allowed for auth-only deployments (e.g. dev, where the ACA hostname is bound directly).')
+param primaryDomain string = ''
 
-@description('Apex domain for redirect (e.g., trashmob.eco)')
+@description('Apex domain for redirect (e.g., trashmob.eco). Empty skips the apex→primary redirect rule set.')
 param apexDomain string = ''
 
 @description('Custom auth domain for Entra External ID (e.g., auth.trashmob.eco). Empty disables E6 auth-domain plumbing. Requires ciamTenantHost to also be set. See Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6.')


### PR DESCRIPTION
## Summary

Bootstraps a minimal Azure Front Door on **dev** so we can test the E6 auth-domain flow end-to-end before touching production (per [\`PRODUCTION_DEPLOYMENT_CHECKLIST.md\` §E6 item 206](Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md#L1701-L1738)).

**Auth-only deployment shape** — dev.trashmob.eco keeps going direct to the Container App (unchanged). The new \`fd-tm-dev\` AFD only serves \`auth-dev.trashmob.eco\` → dev CIAM tenant.

## What changed

### [\`Deploy/frontDoor.bicep\`](Deploy/frontDoor.bicep) (+2 / -2)
\`primaryDomain\` param default \`''\` (was mandatory). Enables the auth-only deployment shape. The prod workflow already passes it explicitly → no behavior change on prod.

### [\`.github/workflows/container_frontdoor-tm-dev-westus2.yml\`](.github/workflows/container_frontdoor-tm-dev-westus2.yml) (new, +115)
Push-triggered on \`main\` for changes to this workflow or \`frontDoor.bicep\` (mirrors the prod workflow's trigger shape).

\`\`\`yaml
env:
  RESOURCE_GROUP: rg-trashmob-dev-westus2
  CONTAINER_APP_NAME: ca-tm-dev-westus2
  FRONT_DOOR_PROFILE: fd-tm-dev
  FRONT_DOOR_ENDPOINT: fde-tm-dev
  CIAM_AUTH_DOMAIN: auth-dev.trashmob.eco
  CIAM_TENANT_HOST: trashmobecodev.ciamlogin.com
\`\`\`

Deploys with \`primaryDomain=''\`, \`apexDomain=''\`, \`ciamAuthDomain=auth-dev.trashmob.eco\`, \`ciamTenantHost=trashmobecodev.ciamlogin.com\`.

After deploy, emits an inline **"DNS setup instructions"** block with the exact \`az\` commands to fetch the AFD endpoint hostname and the validation token — so the DNS + Entra portal follow-up is scripted out, not a portal treasure hunt.

## Deploy shape (post-merge)

Two routes exist on the AFD endpoint:

| Route | Origin group | Custom domains | Reachable via |
|---|---|---|---|
| \`route-default\` | \`og-containerapp\` → \`ca-tm-dev-westus2\` | none (bicep quirk — always deploys) | \`fde-tm-dev.<random>.azurefd.net\` (nobody hits it) |
| \`route-ciam\` | \`og-ciam\` → \`trashmobecodev.ciamlogin.com\` | \`auth-dev.trashmob.eco\` (once validated) | \`https://auth-dev.trashmob.eco/...\` |

## What still needs to happen after this merges (Joe's manual part)

1. Wait for the workflow to run and read the DNS instructions from its log
2. Add CNAME \`auth-dev.trashmob.eco\` → \`fde-tm-dev.<random>.azurefd.net\`
3. Add TXT \`_dnsauth.auth-dev.trashmob.eco\` with the validation token
4. Associate \`auth-dev.trashmob.eco\` as a Custom URL Domain on the **TrashMobEcoDev** tenant in Entra admin center
5. Add \`https://auth-dev.trashmob.eco/...\` redirect URIs to:
   - Dev app registrations (Web SPA, API, Mobile)
   - Google + Apple + Microsoft social IDP consoles (dev-specific credentials)
6. Set \`AzureAdEntra__Instance=https://auth-dev.trashmob.eco/\` on \`ca-tm-dev-westus2\` — one-line addition to the dev container-app workflow: pass \`entraAuthDomain=auth-dev.trashmob.eco\` to \`Deploy/containerApp.bicep\` (phase 2's param, PR #3528)
7. Test sign-in end-to-end on dev.trashmob.eco with each IDP

Once dev is validated, the same shape applies to prod: enable \`ciamAuthDomain\`/\`ciamTenantHost\` on \`release_frontdoor-tm-pr.yml\` and \`entraAuthDomain\` on \`release_ca-tm-pr-westus2.yml\`.

## Test plan

- [ ] Merge → workflow runs on \`main\` push
- [ ] \`az deployment group create\` succeeds, creates \`fd-tm-dev\`, \`fde-tm-dev\`, \`og-containerapp\`, \`og-ciam\`, \`route-default\`, \`route-ciam\`, custom domain resource for \`auth-dev.trashmob.eco\`
- [ ] "DNS setup instructions" step outputs the CNAME target + validation token commands
- [ ] Existing \`dev.trashmob.eco\` traffic (direct-to-ACA) unaffected
- [ ] After manual DNS + portal work (above), test sign-in on dev with all IDPs

## Risk assessment

- **Prod:** zero risk — only dev workflow added, prod bicep + workflow behavior identical
- **Dev customer traffic:** zero risk — dev.trashmob.eco stays bound to ACA directly; new AFD doesn't intercept it
- **Dev CIAM traffic:** unaffected until step 6 above (workflow env change); today's ciamlogin.com URLs keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)