### PR TITLE
Preserve unattributed apex TXT value on trashmob.eco (unblocks E6 DNS deploy)

### DIFF
--- a/Deploy/dnsZone.bicep
+++ b/Deploy/dnsZone.bicep
@@ -233,7 +233,24 @@ resource mxRecord 'Microsoft.Network/dnsZones/MX@2023-07-01-preview' = {
   }
 }
 
-// SPF record for email authentication
+// Apex TXT record set for trashmob.eco. Holds:
+//   1. SPF for Outlook / M365 email authentication
+//   2. `_mn729nlts6vg16hckcss91bxyub7qvz` — a domain-verification-shaped
+//      token added out-of-band more than 3 months ago. Provenance is
+//      unknown: the format matches an AFD custom-domain validation
+//      token, but neither of our current AFD custom domains (apex,
+//      www) matches this value — their live tokens are correctly at
+//      `_dnsauth` and `_dnsauth.www`. Not referenced anywhere in this
+//      repo. Preserved defensively because we don't know which service
+//      (if any) relies on it, and it's been in prod for months without
+//      issue.
+//
+// A prior version of this file declared only the SPF value, which
+// would have caused ARM Incremental to strip the mystery token on any
+// re-apply (discovered via `az deployment group what-if` on 2026-07-26
+// while preparing to publish the E6 auth-dev records). If the mystery
+// token's owner is ever identified and confirmed obsolete, delete the
+// second array entry below and this comment block.
 resource spfRecord 'Microsoft.Network/dnsZones/TXT@2023-07-01-preview' = {
   parent: dnsZone
   name: '@'
@@ -242,6 +259,9 @@ resource spfRecord 'Microsoft.Network/dnsZones/TXT@2023-07-01-preview' = {
     TXTRecords: [
       {
         value: ['v=spf1 include:spf.protection.outlook.com -all']
+      }
+      {
+        value: ['_mn729nlts6vg16hckcss91bxyub7qvz']
       }
     ]
   }


### PR DESCRIPTION
## Summary

Blocks a latent trap in \`dnsZone.bicep\` that would strip a live production DNS record on the next deploy. Discovered while preparing to run the deploy for **PR #3531** (E6 auth-dev DNS records).

**Merge order matters:** this PR must merge and the corresponding deploy must succeed **before** #3531's deploy is safe to run.

## The problem

\`az deployment group what-if\` on the merged \`dnsZone.bicep\` template revealed an unexpected \`~ Modify\` on the apex \`@\` TXT record set:

\`\`\`
~ Microsoft.Network/dnsZones/trashmob.eco/TXT/@
    ~ properties.TXTRecords: [
      - 1: value: [0: "_mn729nlts6vg16hckcss91bxyub7qvz"]
    ]
\`\`\`

The apex \`@\` TXT set in production has **two** live values today, but the bicep declared only one (the SPF record). ARM Incremental would strip the second on any \`az deployment group create\`.

## Investigation

| Check | Result |
|---|---|
| Format | Matches AFD custom-domain validation token (\`_\` + 32-hex) |
| Match current AFD tokens? | ❌ No — apex + www AFD tokens live correctly at \`_dnsauth\` and \`_dnsauth.www\` with different values |
| Repo references | ❌ None (grep clean) |
| Activity log (last 89 days) | ❌ Empty — token was added >3 months ago, no writes since |

Conclusion: unknown provenance, but has been in prod for 3+ months without issue. Preserving defensively is safer than removing.

## What changed

Single edit to [\`Deploy/dnsZone.bicep\`](Deploy/dnsZone.bicep) — extends \`spfRecord\`'s \`TXTRecords\` array to include the mystery token as a second entry, with a prominent comment block explaining what we know and don't know.

**Hardcoded, not parameterized.** Parameterization would recreate exactly the "future deployer forgets the param" trap that caused this discovery. Once codified, the token survives any future re-deploy.

If provenance is ever identified and the token confirmed obsolete, delete the second array entry and the comment block.

## Verification

\`\`\`
$ az bicep build Deploy/dnsZone.bicep
No errors

$ az deployment group what-if -g rg-trashmob-pr-westus2 --template-file Deploy/dnsZone.bicep     --parameters zoneName=trashmob.eco environment=pr     authDevFrontDoorHostname=fde-tm-dev-esbqhudgavf8fxgg.z01.azurefd.net     authDevDnsAuthToken=_lhugwu61i2irku474c9fw5edldn02zq

Resource changes: 2 to create, 0 to modify, 8 no change.
    + CNAME auth-dev
    + TXT _dnsauth.auth-dev
\`\`\`

The \`~ Modify\` on apex \`@\` is gone. Only the two intended auth-dev records get created.

## Post-merge sequence

1. Merge this PR
2. Run the same \`az deployment group create\` command from #3531's PR body (values unchanged) — will now apply cleanly, adding just the two auth-dev records
3. Wait for the dev AFD custom-domain to flip \`Pending\` → \`Approved\` (a few minutes)
4. Continue with Entra portal association + redirect URI updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)