### PR TITLE
E6: switch auth-dev DNS from CNAME to explicit AFD anycast A records

### DIFF
--- a/Deploy/dnsZone.bicep
+++ b/Deploy/dnsZone.bicep
@@ -52,30 +52,54 @@ param apexDnsAuthToken string = ''
 param wwwDnsAuthToken string = ''
 
 // E6 (custom auth domain) — dev-tier records for auth-dev.trashmob.eco.
+//
 // The DEV Front Door lives in the Sandbox subscription (rg-trashmob-dev-westus2)
-// but the DNS zone is here in TrashMobProd. That cross-sub setup means these
-// records have to be declared explicitly with the dev AFD's values — there's
-// no way to reference them from a Bicep resource in another sub.
+// but the DNS zone is here in TrashMobProd. That cross-sub setup means we can't
+// reference the dev AFD resource from a Bicep symbolic name in this file — the
+// only auth-dev-specific value we need to pass in from outside is the AFD
+// validation token (for the _dnsauth.auth-dev TXT). The routing record (the A
+// record below) uses fixed anycast IPs and doesn't need any dev-side lookup.
 //
-// Fetch the current expected values (from the Sandbox sub) with:
+// EXPLICIT A RECORDS, NOT A CNAME. See the parallel discussion on apexARecord
+// below (Azure DNS alias-record inconsistency). The auth-dev case surfaced its
+// own variant of the same problem on 2026-07-27 while validating E6:
+//
+//   1. `auth-dev.trashmob.eco` was originally a CNAME to the dev AFD endpoint
+//      hostname `fde-tm-dev-<random>.z01.azurefd.net`.
+//   2. After the Custom URL Domain association was made on the TrashMobEcoDev
+//      Entra tenant, the AFD endpoint hostname's own upstream CNAME chain
+//      (`mr-z01.tm-azurefd.net` → `www.tm.a.prd.aadg.akadns.net`) started
+//      redirecting global recursive-resolver lookups to Microsoft's Entra AAD
+//      Gateway (aadg) fleet IPs (20.190.x.x, 40.126.x.x) instead of AFD's
+//      edge (150.171.x.x).
+//   3. The aadg fleet serves a multi-tenant Microsoft platform cert
+//      (`graph.windows.net`, `*.b2clogin.com`, etc.) that does NOT include
+//      `auth-dev.trashmob.eco` in its SANs, so browser TLS fails with a
+//      trust-relationship error even though AFD itself is serving the correct
+//      managed cert on its own edge IPs.
+//   4. Pinning A records directly to AFD's classic anycast pair sidesteps the
+//      entire Microsoft-side CNAME chain and forces resolution to hit AFD.
+//      AFD's edge terminates TLS with the right custom-domain cert
+//      independent of profile SKU (Classic/Standard/Premium all share the
+//      same anycast infrastructure).
+//
+// This is the same defensive pattern the apex uses. See apexARecord for the
+// original apex-outage story that established the anycast-pair values.
+//
+// Fetch the current AFD validation token (from the Sandbox sub) with:
 //   az account set --subscription <Sandbox>
-//   az afd endpoint show --resource-group rg-trashmob-dev-westus2 --profile-name fd-tm-dev \
-//     --endpoint-name fde-tm-dev --query hostName -o tsv
-//   az afd custom-domain show --resource-group rg-trashmob-dev-westus2 --profile-name fd-tm-dev \
-//     --custom-domain-name auth-dev-trashmob-eco --query validationProperties.validationToken -o tsv
+//   az afd custom-domain show --resource-group rg-trashmob-dev-westus2 \
+//     --profile-name fd-tm-dev --custom-domain-name auth-dev-trashmob-eco \
+//     --query validationProperties.validationToken -o tsv
 //
-// Then pass them here, e.g.:
+// Then pass it here:
 //   az deployment group create --template-file .\dnsZone.bicep -g rg-trashmob-pr-westus2 \
 //     --parameters zoneName=trashmob.eco environment=pr \
-//                  authDevFrontDoorHostname=fde-tm-dev-<random>.z01.azurefd.net \
 //                  authDevDnsAuthToken=_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 //
-// Leave both empty on a re-apply that only means to update non-auth-dev
-// records — ARM Incremental will preserve whatever records exist, same as
-// the apex/www _dnsauth pattern above.
-@description('E6: Dev Front Door endpoint hostname (e.g. fde-tm-dev-<random>.z01.azurefd.net). Empty skips the auth-dev CNAME record.')
-param authDevFrontDoorHostname string = ''
-
+// Leave empty on a re-apply that only means to update non-auth-dev records —
+// ARM Incremental will preserve the existing token TXT, same as the apex/www
+// _dnsauth pattern above.
 @description('E6: Dev Front Door managed-cert validation token for the auth-dev custom-domain. Empty skips the _dnsauth.auth-dev TXT record.')
 param authDevDnsAuthToken string = ''
 
@@ -156,18 +180,26 @@ resource devRecord 'Microsoft.Network/dnsZones/CNAME@2023-07-01-preview' = if (e
   }
 }
 
-// E6 — auth-dev subdomain CNAME (routes dev CIAM sign-in through the dev
-// Front Door). Guarded on the param so a re-apply that doesn't pass the
-// hostname doesn't clobber the record with an empty cname (same trap as
-// wwwRecord above).
-resource authDevRecord 'Microsoft.Network/dnsZones/CNAME@2023-07-01-preview' = if (authDevFrontDoorHostname != '') {
+// E6 — auth-dev subdomain A records pinned to AFD's classic anycast pair.
+// See the long E6 comment block above the params for the full story on why
+// this is A records instead of a CNAME to the dev AFD endpoint. Short version:
+// the CNAME chain from `fde-tm-<hash>.z01.azurefd.net` transits through
+// `mr-z01.tm-azurefd.net` → `www.tm.a.prd.aadg.akadns.net` and lands on
+// Microsoft's aadg fleet, which serves a platform SNI cert that doesn't
+// include auth-dev.trashmob.eco. Pinning A records to the AFD anycast pair
+// bypasses that chain entirely.
+//
+// Same anycast IPs as apexARecord below. Unconditional (no guard param) —
+// values are static, no reason to skip on re-apply.
+resource authDevRecord 'Microsoft.Network/dnsZones/A@2023-07-01-preview' = {
   parent: dnsZone
   name: 'auth-dev'
   properties: {
     TTL: 300
-    CNAMERecord: {
-      cname: authDevFrontDoorHostname
-    }
+    ARecords: [
+      { ipv4Address: '13.107.226.70' }
+      { ipv4Address: '13.107.253.70' }
+    ]
   }
 }
 
@@ -317,11 +349,16 @@ DNS Migration Steps:
 6. Fetch the tokens via `az afd custom-domain show ... --query validationProperties.validationToken` and re-run this template with apexDnsAuthToken / wwwDnsAuthToken set to those values.
 7. Verify email still works (MX, SPF, DKIM records included)
 
-E6 auth-dev subdomain (parameters are in a separate subscription — see param docstrings above):
+E6 auth-dev subdomain:
 8. Deploy dev Front Door via .github/workflows/container_frontdoor-tm-dev-westus2.yml.
-9. From the Sandbox subscription, fetch:
-   - AFD endpoint hostname (fde-tm-dev-<random>.z01.azurefd.net)
-   - Custom-domain validation token for auth-dev-trashmob-eco
-10. Re-run this template with authDevFrontDoorHostname + authDevDnsAuthToken set to those values.
+9. From the Sandbox subscription, fetch the AFD custom-domain validation token:
+   az afd custom-domain show --resource-group rg-trashmob-dev-westus2 \
+     --profile-name fd-tm-dev --custom-domain-name auth-dev-trashmob-eco \
+     --query validationProperties.validationToken -o tsv
+10. Re-run this template with authDevDnsAuthToken set to that value. The auth-dev A records
+    to AFD anycast (13.107.226.70, 13.107.253.70) deploy unconditionally — no lookup needed.
 11. Wait a few minutes for the token TXT to propagate; the dev Front Door custom domain will flip from Pending -> Approved.
+12. In the Entra admin center on the TrashMobEcoDev tenant, add auth-dev.trashmob.eco under
+    Identity > Domain names > Custom domain names (requires TXT MS=<token> verification), then
+    associate it under Entra ID > Domain names > Custom URL domains.
 '''


### PR DESCRIPTION
## Summary

Codifies the DNS change I made by hand this morning to unblock E6 dev auth-domain testing. `auth-dev.trashmob.eco` is now A records to AFD's classic anycast pair (`13.107.226.70`, `13.107.253.70`) instead of a CNAME to the dev AFD endpoint hostname. **Bicep now matches live DNS** — `what-if` shows 9 no-change, 0 modify, 0 delete.

## Why we can't use a CNAME anymore

The CNAME to `fde-tm-dev-<hash>.z01.azurefd.net` worked at first-visit but broke after we associated `auth-dev.trashmob.eco` as a Custom URL Domain on the TrashMobEcoDev Entra tenant. The failure mode:

\`\`\`
CNAME chain that recursive resolvers followed:
  auth-dev.trashmob.eco
    -> fde-tm-dev-<hash>.z01.azurefd.net          (our CNAME)
    -> mr-z01.tm-azurefd.net                        (AFD platform)
    -> www.tm.a.prd.aadg.akadns.net                 (Entra AAD Gateway TM)
    -> 20.190.x.x / 40.126.x.x                      (aadg fleet)
\`\`\`

The **aadg fleet** serves a multi-tenant Microsoft platform cert (`graph.windows.net`, `*.b2clogin.com`, `*.login.microsoftonline.com`, ...) — **no SAN for our branded domain**. Every browser hitting `auth-dev.trashmob.eco` got the wrong cert and TLS failed with a trust-relationship error, even though AFD's own edge (`150.171.x.x`) was healthy and serving the correct per-domain managed cert.

Direct verification proving AFD itself was healthy:

\`\`\`
$ # Bypass DNS entirely — connect to AFD anycast IP directly with SNI
$ openssl s_client -connect 13.107.226.70:443 -servername auth-dev.trashmob.eco
Subject: CN=auth-dev.trashmob.eco
Issuer: CN=GeoTrust TLS RSA CA G1  (managed cert, correct)
$ curl --resolve auth-dev.trashmob.eco:443:13.107.226.70 https://auth-dev.trashmob.eco/ -I
HTTP/1.1 200 OK
\`\`\`

Pinning A records to AFD's classic anycast pair bypasses the entire CNAME chain and lands directly on AFD's edge, which terminates TLS with the correct per-domain cert regardless of profile SKU. Same pattern the apex already uses to sidestep an analogous Azure-DNS-alias trap ([`APEX_FIRST_VISIT_INVESTIGATION.md`](Deploy/APEX_FIRST_VISIT_INVESTIGATION.md)).

## What changed

Only [\`Deploy/dnsZone.bicep\`](Deploy/dnsZone.bicep) (+66 / -29):

- **Removed** \`authDevFrontDoorHostname\` param — no longer needed. The routing record uses hardcoded anycast IPs; no cross-sub lookup required.
- **Kept** \`authDevDnsAuthToken\` param — still needed for the \`_dnsauth.auth-dev\` TXT record that validates AFD's managed cert.
- **Rewrote** \`authDevRecord\` from a conditional CNAME to an unconditional A record set targeting \`13.107.226.70\` + \`13.107.253.70\` (same values apexARecord uses).
- **Expanded** the E6 comment block with the full aadg-CNAME-chain story so future maintainers don't re-CNAME this and re-break it.
- **Updated** the \`migrationInstructions\` output to reflect the new param surface.

## What-if against live DNS

\`\`\`
Resource changes: 9 no change, 0 to modify, 0 to delete, 28 to ignore.
    = Microsoft.Network/dnsZones/trashmob.eco/A/auth-dev  [no change]
\`\`\`

Zero drift. Bicep captures reality.

## Prod parallel

When we get to the prod cutover for \`auth.trashmob.eco\`, we'll need the same pattern: pinned A records to the anycast pair instead of a CNAME to the prod AFD endpoint. Worth doing that scaffolding proactively in a follow-up so we don't repeat the discovery pain when Custom URL Domain gets associated on TrashMobEcoPr.

## Test plan

- [x] \`az bicep build\` compiles cleanly
- [x] \`az deployment group what-if\` shows 0 modify / 0 delete
- [ ] After merge: \`az deployment group create\` succeeds without touching any live DNS record (should be a no-op)
- [ ] Once Cloudflare cache (TTL 3600) expires, \`Invoke-WebRequest https://auth-dev.trashmob.eco/\` returns HTTP 200 without TLS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)