### PR TITLE
E6: flip dev CIAM authority to auth-dev.trashmob.eco

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -34,6 +34,12 @@ env:
   CUSTOM_DOMAIN_NAME: dev.trashmob.eco
   MANAGED_CERTIFICATE_NAME: dev-trashmob-eco-cert
   STRAPI_CONTAINER_APP_NAME: ca-strapi-tm-dev-westus2
+  # E6 — branded auth authority for TrashMobEcoDev CIAM tenant. Backend +
+  # SPA read AzureAdEntra__Instance from the Container App; when this env
+  # var is passed to containerApp.bicep, the ternary in the bicep
+  # overrides the default trashmobecodev.ciamlogin.com URL. See
+  # Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6 and PR #3528.
+  ENTRA_AUTH_DOMAIN: auth-dev.trashmob.eco
 
 jobs:
   build-and-deploy:
@@ -106,6 +112,7 @@ jobs:
               maxReplicas=3 \
               customDomainName=${{ env.CUSTOM_DOMAIN_NAME }} \
               managedCertificateName=${{ env.MANAGED_CERTIFICATE_NAME }} \
+              entraAuthDomain=${{ env.ENTRA_AUTH_DOMAIN }} \
               strapiBaseUrl="${{ steps.get-strapi.outputs.strapi_url }}"
 
       # Note: Azure AD Entra External ID configuration is set via environment variables in containerApp.bicep


### PR DESCRIPTION
## Summary

The moment of truth for E6 on dev. Passes \`entraAuthDomain=auth-dev.trashmob.eco\` through to \`Deploy/containerApp.bicep\` on the next dev deploy — the bicep ternary from #3528 will then set:

\`\`\`
AzureAdEntra__Instance = https://auth-dev.trashmob.eco/
\`\`\`

instead of the default \`https://trashmobecodev.ciamlogin.com/\`.

## What flips automatically from this one env change

| Surface | Where the change lands | Code change needed? |
|---|---|---|
| Backend JWT validation authority | \`AzureAdEntra:Instance\` config key → Program.cs / auth handler | **No** |
| Web SPA MSAL authority | \`AzureAdEntra:Instance\` → \`ConfigV2Controller.GetConfig()\` derives \`authority\`/\`authorityDomain\` → \`GET /api/v2/config\` → \`AuthStore.tsx\` MSAL init | **No** |
| Mobile authority | Hardcoded at compile time in \`AuthConstants.cs\` | Deferred — separate PR + app store release |

## Diff

\`\`\`diff
 env:
   ...
   MANAGED_CERTIFICATE_NAME: dev-trashmob-eco-cert
   STRAPI_CONTAINER_APP_NAME: ca-strapi-tm-dev-westus2
+  ENTRA_AUTH_DOMAIN: auth-dev.trashmob.eco   # + comment

               customDomainName=\${{ env.CUSTOM_DOMAIN_NAME }}                managedCertificateName=\${{ env.MANAGED_CERTIFICATE_NAME }} +              entraAuthDomain=\${{ env.ENTRA_AUTH_DOMAIN }}                strapiBaseUrl="..."
\`\`\`

## Prereqs already in place (verified 2026-07-27)

- ✅ \`auth-dev.trashmob.eco\` resolves publicly to AFD anycast (13.107.x.x) — PRs #3531/#3532/#3534
- ✅ AFD custom domain \`auth-dev-trashmob-eco\`: \`state=Approved\`, \`deploymentStatus=Succeeded\`
- ✅ Entra TrashMobEcoDev tenant: domain verified + associated as Custom URL Domain
- ✅ OIDC discovery via \`https://auth-dev.trashmob.eco/{tenantId}/v2.0/.well-known/openid-configuration\` returns 200 with branded \`authorization_endpoint\` / \`token_endpoint\` / \`jwks_uri\` — validated via \`curl --resolve\`

## Trigger + rollback

- **Trigger:** merge to main. Workflow paths already include \`Deploy/containerApp.bicep\` — but this PR only edits the workflow itself, which is also in the workflow's own trigger path. Merging kicks off a dev deploy that flips the authority.
- **Rollback:** revert this commit. The bicep ternary falls back to the ciamlogin.com default and the next deploy restores prior behavior. No stateful changes on the Container App — flip is atomic per revision.

## Test plan

After merge + dev deploy completes:

- [ ] \`GET https://dev.trashmob.eco/api/v2/config\` returns \`authorityDomain: "auth-dev.trashmob.eco"\` and \`authority: "https://auth-dev.trashmob.eco/{tenantId}"\`
- [ ] Sign-in flow on \`dev.trashmob.eco\` initiates against \`auth-dev.trashmob.eco\` (verify in browser address bar during redirect)
- [ ] Email/OTP sign-in completes successfully
- [ ] Google sign-in completes (expect brief \`ciamlogin.com\` flash during Google OAuth round-trip per [Microsoft's known caveat](https://learn.microsoft.com/en-us/answers/questions/5892252/entra-external-id-how-to-replace-ciamlogin-com-wit) — that's expected, not a bug)
- [ ] Apple sign-in completes (same caveat)
- [ ] Microsoft sign-in completes (same caveat)
- [ ] Backend JWT validation accepts tokens from the branded authority (any authenticated API call succeeds)

Ref: [\`Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md\` §E6](Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md#L1701-L1738) items 202–204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)