### PR TITLE
Give SalesReps a scoped Site Administration entry point

### DIFF
--- a/TrashMob.Models/Poco/V2/UserDto.cs
+++ b/TrashMob.Models/Poco/V2/UserDto.cs
@@ -95,6 +95,12 @@ namespace TrashMob.Models.Poco.V2
         public bool IsSiteAdmin { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the user holds the SalesRep role (see <see cref="TrashMob.Shared.Managers.RoleNames"/>).
+        /// Grants access to the prospect CRM and sales reports admin pages, nothing else.
+        /// </summary>
+        public bool IsSalesRep { get; set; }
+
+        /// <summary>
         /// Gets or sets the date when the user agreed to the TrashMob waiver.
         /// </summary>
         public DateTimeOffset? DateAgreedToTrashMobWaiver { get; set; }

--- a/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
@@ -153,6 +153,44 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         }
 
         [Fact]
+        public async Task GetUser_SetsIsSalesRep_WhenUserHoldsSalesRepRole()
+        {
+            var userId = Guid.NewGuid();
+            var user = new User { Id = userId, UserName = "salesuser" };
+
+            userManager
+                .Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(user);
+            userRoleService
+                .Setup(s => s.HasRoleAsync(userId, "SalesRep", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.GetUser(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserDto>(okResult.Value);
+            Assert.True(dto.IsSalesRep);
+        }
+
+        [Fact]
+        public async Task GetUser_IsSalesRepFalse_WhenUserHasNoRoles()
+        {
+            var userId = Guid.NewGuid();
+            var user = new User { Id = userId, UserName = "plainuser" };
+
+            userManager
+                .Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(user);
+            // Default userRoleService mock returns false for HasRoleAsync.
+
+            var result = await controller.GetUser(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserDto>(okResult.Value);
+            Assert.False(dto.IsSalesRep);
+        }
+
+        [Fact]
         public async Task GetUser_ReturnsNotFound_WhenUserDoesNotExist()
         {
             var userId = Guid.NewGuid();

--- a/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
+++ b/TrashMob.Shared.Tests/Controllers/V2/UsersV2ControllerTests.cs
@@ -153,6 +153,29 @@ namespace TrashMob.Shared.Tests.Controllers.V2
         }
 
         [Fact]
+        public async Task GetUser_SetsIsSiteAdmin_WhenUserHoldsSiteAdminRoleViaRoleGrantOnly()
+        {
+            // Legacy IsSiteAdmin column is false — the user was promoted via the
+            // Project 64 Roles UI (POST /users/{id}/roles), which only writes a
+            // UserRole row and never touches the column.
+            var userId = Guid.NewGuid();
+            var user = new User { Id = userId, UserName = "rolegrantedadmin", IsSiteAdmin = false };
+
+            userManager
+                .Setup(m => m.GetAsync(userId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(user);
+            userRoleService
+                .Setup(s => s.HasRoleAsync(userId, "SiteAdmin", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var result = await controller.GetUser(userId, CancellationToken.None);
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<UserDto>(okResult.Value);
+            Assert.True(dto.IsSiteAdmin);
+        }
+
+        [Fact]
         public async Task GetUser_SetsIsSalesRep_WhenUserHoldsSalesRepRole()
         {
             var userId = Guid.NewGuid();

--- a/TrashMob/Controllers/V2/UsersV2Controller.cs
+++ b/TrashMob/Controllers/V2/UsersV2Controller.cs
@@ -51,12 +51,22 @@ namespace TrashMob.Controllers.V2
 
         /// <summary>
         /// Maps a <see cref="User"/> to a <see cref="UserDto"/> and populates role-derived
-        /// fields (<see cref="UserDto.IsSalesRep"/>) that the entity-only mapping can't compute
-        /// since role membership requires a database lookup.
+        /// fields that the entity-only mapping can't compute since role membership requires
+        /// a database lookup.
         /// </summary>
+        /// <remarks>
+        /// <see cref="UserDto.IsSiteAdmin"/> is recomputed via <c>HasRoleAsync</c> rather than
+        /// trusting <c>User.ToV2Dto()</c>'s raw column read: a SiteAdmin grant made through the
+        /// Project 64 Roles UI (<c>POST /users/{id}/roles</c>) only writes a <c>UserRole</c> row
+        /// and never touches the legacy <c>IsSiteAdmin</c> column, so the entity-only mapping
+        /// would under-report admin status for anyone promoted that way. <c>HasRoleAsync</c>
+        /// already bridges both the legacy boolean and the new role table — see
+        /// <see cref="TrashMob.Shared.Managers.UserRoleService.GetRoleNamesAsync"/>.
+        /// </remarks>
         private async Task<UserDto> ToUserDtoAsync(User user, CancellationToken cancellationToken)
         {
             var dto = user.ToV2Dto();
+            dto.IsSiteAdmin = await userRoleService.HasRoleAsync(user.Id, RoleNames.SiteAdmin, cancellationToken);
             dto.IsSalesRep = await userRoleService.HasRoleAsync(user.Id, RoleNames.SalesRep, cancellationToken);
             return dto;
         }

--- a/TrashMob/Controllers/V2/UsersV2Controller.cs
+++ b/TrashMob/Controllers/V2/UsersV2Controller.cs
@@ -50,6 +50,18 @@ namespace TrashMob.Controllers.V2
             userRoleService.HasRoleAsync(UserId, RoleNames.SiteAdmin, cancellationToken);
 
         /// <summary>
+        /// Maps a <see cref="User"/> to a <see cref="UserDto"/> and populates role-derived
+        /// fields (<see cref="UserDto.IsSalesRep"/>) that the entity-only mapping can't compute
+        /// since role membership requires a database lookup.
+        /// </summary>
+        private async Task<UserDto> ToUserDtoAsync(User user, CancellationToken cancellationToken)
+        {
+            var dto = user.ToV2Dto();
+            dto.IsSalesRep = await userRoleService.HasRoleAsync(user.Id, RoleNames.SalesRep, cancellationToken);
+            return dto;
+        }
+
+        /// <summary>
         /// Gets a paginated list of users with optional filtering.
         /// </summary>
         /// <param name="filter">Query parameters for pagination and filtering.</param>
@@ -96,7 +108,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            return Ok(user.ToV2Dto());
+            return Ok(await ToUserDtoAsync(user, cancellationToken));
         }
 
         /// <summary>
@@ -115,7 +127,7 @@ namespace TrashMob.Controllers.V2
 
             var user = userDto.ToEntity();
             var result = await userManager.AddAsync(user, UserId, cancellationToken);
-            return CreatedAtAction(nameof(GetUser), new { id = result.Id }, result.ToV2Dto());
+            return CreatedAtAction(nameof(GetUser), new { id = result.Id }, await ToUserDtoAsync(result, cancellationToken));
         }
 
         /// <summary>
@@ -165,7 +177,7 @@ namespace TrashMob.Controllers.V2
                 user.CreatedDate = currentUser.CreatedDate;
 
                 var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
-                return Ok(updatedUser.ToV2Dto());
+                return Ok(await ToUserDtoAsync(updatedUser, cancellationToken));
             }
             catch (DbUpdateConcurrencyException)
             {
@@ -200,7 +212,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            return Ok(user.ToV2Dto());
+            return Ok(await ToUserDtoAsync(user, cancellationToken));
         }
 
         /// <summary>
@@ -225,7 +237,7 @@ namespace TrashMob.Controllers.V2
                 return NotFound();
             }
 
-            return Ok(user.ToV2Dto());
+            return Ok(await ToUserDtoAsync(user, cancellationToken));
         }
 
         /// <summary>
@@ -293,7 +305,7 @@ namespace TrashMob.Controllers.V2
             user.ProfilePhotoUrl = imageUrl;
 
             var updatedUser = await userManager.UpdateAsync(user, cancellationToken);
-            return Ok(updatedUser.ToV2Dto());
+            return Ok(await ToUserDtoAsync(updatedUser, cancellationToken));
         }
 
         /// <summary>

--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -543,7 +543,7 @@ const AuthSideAdminLayout = () => {
                 <Loader2 className='animate-spin mr-2' /> Loading
             </div>
         );
-    if (isUserLoaded && !currentUser.isSiteAdmin) return <em>Access Denied</em>;
+    if (isUserLoaded && !currentUser.isSiteAdmin && !currentUser.isSalesRep) return <em>Access Denied</em>;
 
     return (
         <MsalAuthenticationTemplate

--- a/TrashMob/client-app/src/components/Models/UserData.tsx
+++ b/TrashMob/client-app/src/components/Models/UserData.tsx
@@ -31,6 +31,8 @@ class UserData {
 
     isSiteAdmin: boolean = false;
 
+    isSalesRep: boolean = false;
+
     givenName: string = '';
 
     surname: string = '';

--- a/TrashMob/client-app/src/components/SiteHeader/UserNav.tsx
+++ b/TrashMob/client-app/src/components/SiteHeader/UserNav.tsx
@@ -131,6 +131,10 @@ export const UserNav = (props: UserNavProps) => {
                                     <span className='text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full w-fit'>
                                         Site Admin
                                     </span>
+                                ) : currentUser.isSalesRep ? (
+                                    <span className='text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full w-fit'>
+                                        Sales Rep
+                                    </span>
                                 ) : null}
                             </div>
                         </HoverCardContent>
@@ -146,6 +150,13 @@ export const UserNav = (props: UserNavProps) => {
                                     <Link to='/siteadmin'>
                                         <IdCard />
                                         <span>Site Administration</span>
+                                    </Link>
+                                </DropdownMenuItem>
+                            ) : currentUser.isSalesRep ? (
+                                <DropdownMenuItem asChild>
+                                    <Link to='/siteadmin/prospects'>
+                                        <IdCard />
+                                        <span>Sales Portal</span>
                                     </Link>
                                 </DropdownMenuItem>
                             ) : null}

--- a/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/_layout.tsx
@@ -34,6 +34,7 @@ import {
     CalendarDays,
 } from 'lucide-react';
 import { SidebarNav, NavGroup } from '@/components/ui/sidebar-nav';
+import { useLogin } from '@/hooks/useLogin';
 
 const pathPrefix = '/siteadmin';
 
@@ -97,14 +98,34 @@ const navGroups: NavGroup[] = [
     },
 ];
 
+// SalesRep holders get the municipal sales pipeline CRM and reports, and nothing else
+// (see Project 64 / Project 63 — they must not see user admin, waivers, or moderation surfaces).
+const salesRepNavGroups: NavGroup[] = [
+    {
+        title: 'Sales Pipeline',
+        items: [
+            { name: 'Prospects', href: `${pathPrefix}/prospects`, icon: Target },
+            { name: 'Discovery', href: `${pathPrefix}/prospects/discovery`, icon: Search },
+            { name: 'Import CSV', href: `${pathPrefix}/prospects/import`, icon: Upload },
+            { name: 'Pipeline Analytics', href: `${pathPrefix}/prospects/analytics`, icon: BarChart3 },
+            { name: 'Weekly Report', href: `${pathPrefix}/prospects/reports/weekly`, icon: CalendarClock },
+            { name: 'Monthly Report', href: `${pathPrefix}/prospects/reports/monthly`, icon: CalendarDays },
+            { name: 'Report Subscribers', href: `${pathPrefix}/prospects/reports/subscribers`, icon: Mail },
+        ],
+    },
+];
+
 export const SiteAdminLayout = () => {
+    const { currentUser } = useLogin();
+    const groups = currentUser.isSiteAdmin ? navGroups : salesRepNavGroups;
+
     return (
         <div className='container mx-auto py-6'>
             <h1 className='scroll-m-20 pb-6 text-3xl font-light tracking-tight'>Site Administration</h1>
             <div className='flex flex-col gap-6 lg:flex-row'>
                 <aside className='w-full shrink-0 lg:w-64'>
                     <div className='sticky top-4 rounded-lg border bg-card p-4'>
-                        <SidebarNav groups={navGroups} />
+                        <SidebarNav groups={groups} />
                     </div>
                 </aside>
                 <main className='min-w-0 flex-1'>


### PR DESCRIPTION
## Summary
- Granting the `SalesRep` role (Project 64 RBAC) only writes a `UserRole` row — the frontend had no way to know a user held it. `Site Administration` in the profile dropdown and the `/siteadmin` route guard were both hardwired to `IsSiteAdmin`, so a SalesRep had backend API access to the prospect CRM / sales reports but no UI path to reach them (the reported bug).
- **Verified the same bug also existed for the `SiteAdmin` role itself.** Granting `SiteAdmin` through the new Roles UI (`POST /users/{id}/roles`) only writes a `UserRole` row too — it never touches the legacy `IsSiteAdmin` column. Backend authorization was already fine (`UserIsAdminAuthHandler` checks the role-aware `HasRoleAsync`, which bridges both), but `UserDto.IsSiteAdmin` was mapped straight from the raw column in `ToV2Dto()`. So a user promoted via the intended new Roles workflow (rather than the legacy boolean) would see no "Site Administration" menu item and get blocked by the `/siteadmin` route guard entirely — despite every backend call they made succeeding.
- Backend: `UserDto.IsSalesRep` added; `ToUserDtoAsync` in `UsersV2Controller` now recomputes **both** `IsSiteAdmin` and `IsSalesRep` via `IUserRoleService.HasRoleAsync` (not the raw entity column) wherever a `UserDto` is returned to the caller (`GetUser`, `GetUserByEmail`, `GetUserByObjectId`, `AddUser`, `UpdateUser`, `UploadProfilePhoto`).
- Frontend: `UserData.isSalesRep` added; `UserNav` shows a "Sales Portal" link (→ `/siteadmin/prospects`) for SalesReps who aren't also SiteAdmins; the `/siteadmin` route guard admits SalesReps; `SiteAdminLayout` shows a restricted "Sales Pipeline" sidebar (Prospects, Discovery, Import CSV, Pipeline Analytics, weekly/monthly reports, report subscribers) instead of the full admin nav for SalesRep-only users.
- This matches the scope documented in `Planning/Projects/Project_64_Roles_and_RBAC_Refactor.md`: SalesReps get the prospect CRM and sales reports, and nothing else (no user admin, waivers, moderation, or fundraising surfaces).

**Known follow-up (not fixed here, out of scope):** the paginated `GET /api/v2/users` list (used by the SiteAdmin Users list page) still maps `IsSiteAdmin` from the raw column via the sync `u.ToV2Dto()` selector — making that role-aware would require a batch role lookup or join to avoid N+1 queries per row. The "Site Admin" badge on that list page can under-report for role-granted-only admins. Flagging for a separate PR if it matters.

## Test plan
- [x] `dotnet test TrashMob.Shared.Tests` — full suite, 1218/1218 pass, including 3 new tests (`IsSalesRep` population, and `IsSiteAdmin` population when granted via role-only with the legacy column false)
- [x] `dotnet build` — succeeds
- [x] `npx eslint` / `npx prettier --check` on all edited frontend files — clean
- [ ] Manually grant a test user the `SalesRep` role and confirm they see "Sales Portal" (not "Site Administration") in the profile dropdown, and that the sidebar only shows the Sales Pipeline group
- [ ] Manually grant a test user the `SiteAdmin` role via `/siteadmin/roles` (not the legacy DB column) and confirm they immediately see the full "Site Administration" menu and full sidebar
- [ ] Confirm an existing legacy `IsSiteAdmin=true` user still sees the full "Site Administration" menu and full sidebar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)